### PR TITLE
fix: handle missing metadata.dependencies in deps/sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ import tomllib, json; \
 pyproject = tomllib.load(open('pyproject.toml', 'rb')); \
 deps = [d for d in pyproject['project']['dependencies'] if not d.startswith('griptape-nodes')]; \
 lib = json.load(open('griptape_nodes_library.json')); \
-lib['metadata']['dependencies']['pip_dependencies'] = deps; \
+lib['metadata'].setdefault('dependencies', {})['pip_dependencies'] = deps; \
 open('griptape_nodes_library.json', 'w').write(json.dumps(lib, indent=2) + '\n'); \
 print(f'Synced {len(deps)} dependencies to griptape_nodes_library.json')"
 


### PR DESCRIPTION
## Summary

- `deps/sync` now uses `.setdefault('dependencies', {})` instead of direct key access, so it works on library JSONs that don't yet have a `metadata.dependencies` block (e.g. fresh libraries created from the template)

## Test plan

- [x] `make deps/sync` runs correctly on the standard library (has existing `metadata.dependencies`)
- [x] `make deps/sync` runs correctly on a library JSON without a `metadata.dependencies` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)