### PR TITLE
fix: resolve pasted absolute paths to macro paths in load nodes

### DIFF
--- a/griptape_nodes_library/audio/load_audio.py
+++ b/griptape_nodes_library/audio/load_audio.py
@@ -107,6 +107,12 @@ class LoadAudio(DataNode):
 
         if parameter == self.audio_parameter:
             self._update_audio_controls(value)
+        elif parameter == self.path_parameter and value:
+            result = resolve_to_macro_path(value)
+            if not result.is_external and result.resolved_path != value:
+                self.set_parameter_value("path", result.resolved_path)
+            else:
+                self._update_audio_controls(AudioUrlArtifact(value))
 
         return super().after_value_set(parameter, value)
 

--- a/griptape_nodes_library/image/load_image.py
+++ b/griptape_nodes_library/image/load_image.py
@@ -155,6 +155,12 @@ class LoadImage(SuccessFailureNode):
 
         if parameter == self.image_parameter:
             self._update_image_controls(value)
+        elif parameter == self.path_parameter and value:
+            result = resolve_to_macro_path(value)
+            if not result.is_external and result.resolved_path != value:
+                self.set_parameter_value("path", result.resolved_path)
+            else:
+                self._update_image_controls(ImageUrlArtifact(value))
 
         return super().after_value_set(parameter, value)
 

--- a/griptape_nodes_library/video/load_video.py
+++ b/griptape_nodes_library/video/load_video.py
@@ -107,6 +107,12 @@ class LoadVideo(DataNode):
 
         if parameter == self.video_parameter:
             self._update_video_controls(value)
+        elif parameter == self.path_parameter and value:
+            result = resolve_to_macro_path(value)
+            if not result.is_external and result.resolved_path != value:
+                self.set_parameter_value("path", result.resolved_path)
+            else:
+                self._update_video_controls(VideoUrlArtifact(value))
 
         return super().after_value_set(parameter, value)
 


### PR DESCRIPTION
Closes #87

When a user pastes an absolute file path into the `path` parameter of `LoadImage`, `LoadVideo`, or `LoadAudio`, the path now auto-resolves to a project macro path (e.g. `{inputs}/image.png`) if the file is inside the project. For paths outside the project, the external file warning and copy-to-project button appear as expected.

The root cause was that `_update_*_controls()` was only called when the artifact parameter (image/video/audio) was set, not when the path parameter was set directly. An earlier attempt to fix this by calling `_update_*_controls` and `publish_update_to_parameter` was insufficient because `_emit_parameter_lifecycle_event` fires after `after_value_set` completes and reads from `parameter_values` (the stored value), overwriting the UI update with the original unresolved path.

The fix resolves the path in `after_value_set` when the path parameter is set, and if it maps to a macro path, calls `set_parameter_value("path", resolved)` to update the stored value before `_emit_parameter_lifecycle_event` fires. The recursive `after_value_set` call terminates safely because a macro path like `{inputs}/...` resolves to itself and skips the update.