### PR TITLE
fix: hide mask_output_file parameter by default in LoadImage

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.68.0",
-    "engine_version": "0.77.5",
+    "engine_version": "0.78.2",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/image/load_image.py
+++ b/griptape_nodes_library/image/load_image.py
@@ -100,7 +100,7 @@ class LoadImage(SuccessFailureNode):
             node=self,
             name="mask_output_file",
             default_filename="mask.png",
-            hide=True,
+            ui_options={"hide": True},
         )
         self._mask_output_file.add_parameter()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "pillow>=11.2.1",
   "asteval>=1.0.8",
   "color-matcher",
-  "griptape-nodes>=0.77.5",
+  "griptape-nodes>=0.78.2",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -3,24 +3,6 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
-name = "aiofiles"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
-]
-
-[[package]]
-name = "aioshutil"
-version = "1.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/bd/dcea5abb1792269e70cc75d5f9ae9adbdfba0f0d08a207eb788ec3b469b6/aioshutil-1.6.tar.gz", hash = "sha256:9eae342b9a4cacc2c2c5877877a2d2f7a2b66c62aa1ab57d7e95c8cfd4ede507", size = 7843, upload-time = "2025-10-21T08:42:23.742Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/92/7020e67ad83095ecc2ce751c24a63df332fb9a34ebfe14bc12a6b21b8f58/aioshutil-1.6-py3-none-any.whl", hash = "sha256:e0711de25ade421b70094b2a27c69bef6356127013744fec05f019f36732c1bd", size = 4705, upload-time = "2025-10-21T08:42:22.892Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -559,11 +541,10 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes"
-version = "0.77.5"
+version = "0.78.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiofiles" },
-    { name = "aioshutil" },
+    { name = "anyio" },
     { name = "asyncio-thread-runner" },
     { name = "binaryornot" },
     { name = "fastapi" },
@@ -583,6 +564,7 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "semver" },
     { name = "send2trash" },
+    { name = "tenacity" },
     { name = "tomlkit" },
     { name = "truststore" },
     { name = "typer" },
@@ -592,9 +574,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/cd/b04bb01bbfed269f350ce3847892add8008c068c3ad0a6c56bc7dd95ca82/griptape_nodes-0.77.5.tar.gz", hash = "sha256:a0c415c3349136054a2d25c2a48dc621702aae928bda00879715dd4ad39098a1", size = 678709, upload-time = "2026-03-19T22:14:53.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/ec/23758fce8c75ae8d851321b1e5b06558259c763ab327461f698876a3166a/griptape_nodes-0.78.2.tar.gz", hash = "sha256:d2e83cb59f6072fd148706469ab8468c14002195edb5e60928bf38fec1514c68", size = 684810, upload-time = "2026-03-24T21:35:47.025Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/1c/33cad667383f8c94bfd3b49856e87a4ca24badbb75d8d73391a44a0c17a7/griptape_nodes-0.77.5-py3-none-any.whl", hash = "sha256:a472fec76e5fc7283479fb66ec410f1dee1e7aac7f37870a0f6990d6cc63f4ef", size = 878593, upload-time = "2026-03-19T22:13:55.061Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/2f/5f5753e93548dc6c29166e31220cbcae8d82e23ed7252a8e65b75a5ff015/griptape_nodes-0.78.2-py3-none-any.whl", hash = "sha256:28329cd1938e49ee04e51a25a5afa860631711ff8021babfcf8d62dc5988dcf5", size = 884988, upload-time = "2026-03-24T21:35:48.361Z" },
 ]
 
 [[package]]
@@ -629,7 +611,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes", specifier = ">=0.77.5" },
+    { name = "griptape-nodes", specifier = ">=0.78.2" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
The `mask_output_file` parameter in `LoadImage` was visible by default, inconsistent with the other mask-related parameters (`mask_channel` and `output_mask`) which are hidden by default.

Uses the new `ui_options` argument added to `ProjectFileParameter` (griptape-ai/griptape-nodes#4246) to pass `{"hide": True}` at construction time.