### PR TITLE
update: Allows describe_image node to take string input for images

### DIFF
--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -67,7 +67,7 @@ class DescribeImage(ControlNode):
         self.add_parameter(
             ParameterList(
                 name="images",
-                input_types=["ImageUrlArtifact", "ImageArtifact"],
+                input_types=["ImageUrlArtifact", "ImageArtifact", "str"],
                 default_value=None,
                 tooltip="The image(s) to be described",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},


### PR DESCRIPTION
fixes: https://github.com/griptape-ai/griptape-nodes-library-standard/issues/106