### PR TITLE
feat: add Wan 2.7 image generation proxy node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1695,6 +1695,17 @@
       }
     },
     {
+      "class_name": "WanImageGeneration",
+      "file_path": "griptape_nodes_library/image/wan_image_generation.py",
+      "metadata": {
+        "category": "image",
+        "description": "Generate images using Wan 2.7 models via Griptape model proxy",
+        "display_name": "Wan Image Generation",
+        "group": "create",
+        "icon": "Sparkles"
+      }
+    },
+    {
       "class_name": "AddTextToImage",
       "file_path": "griptape_nodes_library/image/add_text_to_image.py",
       "metadata": {

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from griptape.artifacts import ImageUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["WanImageGeneration"]
+
+# Model mapping from user-friendly names to API model IDs
+MODEL_MAPPING = {
+    "Wan 2.7 Image Pro": "wan2.7-image-pro",
+    "Wan 2.7 Image": "wan2.7-image",
+}
+MODEL_OPTIONS = list(MODEL_MAPPING.keys())
+DEFAULT_MODEL = MODEL_OPTIONS[0]
+
+# Size options
+SIZE_OPTIONS = ["1K", "2K", "4K"]
+DEFAULT_SIZE = "2K"
+
+# Seed range
+MAX_SEED = 2147483647
+
+
+class WanImageGeneration(GriptapeProxyNode):
+    """Generate images using Wan 2.7 models via Griptape model proxy.
+
+    Documentation: https://www.alibabacloud.com/help/en/model-studio/wan-image-generation-and-editing-api-reference
+
+    Inputs:
+        - model (str): Wan model to use (default: "Wan 2.7 Image Pro")
+        - prompt (str): Text description of the image to generate (max 5000 chars)
+        - size (str): Output image resolution shortcut (default: "2K")
+        - n (int): Number of images to generate (default: 1, range 1-4)
+        - thinking_mode (bool): Enable thinking mode for better quality (default: True)
+        - watermark (bool): Add AI-generated watermark (default: False)
+        - seed (int): Random seed for reproducibility (default: None)
+
+    Outputs:
+        - generation_id (str): Generation ID from the API
+        - provider_response (dict): Verbatim provider response from the model proxy
+        - image_url_1 through image_url_4 (ImageUrlArtifact): Generated images (shown based on actual count)
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate images using Wan 2.7 models via Griptape model proxy"
+
+        # Model selection
+        self.add_parameter(
+            ParameterString(
+                name="model",
+                default_value=DEFAULT_MODEL,
+                tooltip="Select the Wan model to use",
+                allow_output=False,
+                traits={Options(choices=MODEL_OPTIONS)},
+            )
+        )
+
+        # Core parameters
+        self.add_parameter(
+            ParameterString(
+                name="prompt",
+                tooltip="Text description of the image to generate (max 5000 characters)",
+                multiline=True,
+                placeholder_text="Describe the image you want to generate...",
+                allow_output=False,
+                ui_options={
+                    "display_name": "Prompt",
+                },
+            )
+        )
+
+        # Size parameter
+        self.add_parameter(
+            ParameterString(
+                name="size",
+                default_value=DEFAULT_SIZE,
+                tooltip="Output image resolution. 1K=1024x1024, 2K=2048x2048, 4K=4096x4096 (4K only for Pro model, text-to-image only)",
+                allow_output=False,
+                traits={Options(choices=SIZE_OPTIONS)},
+            )
+        )
+
+        # Number of images
+        self.add_parameter(
+            ParameterInt(
+                name="n",
+                default_value=1,
+                tooltip="Number of images to generate (1-4)",
+                allow_output=False,
+                min_val=1,
+                max_val=4,
+            )
+        )
+
+        with ParameterGroup(name="Generation Settings", ui_options={"collapsed": True}) as generation_settings_group:
+            ParameterBool(
+                name="thinking_mode",
+                default_value=True,
+                tooltip="Enable thinking mode for better quality (adds latency). Only works without sequential mode and without image input.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+
+            ParameterBool(
+                name="watermark",
+                default_value=False,
+                tooltip="Add 'AI generated' watermark to bottom-right corner",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+
+            ParameterInt(
+                name="seed",
+                default_value=None,
+                tooltip="Random seed for reproducibility (leave empty for random). Range: 0-2147483647",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                min_val=0,
+                max_val=MAX_SEED,
+            )
+
+        self.add_node_element(generation_settings_group)
+
+        # OUTPUTS
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID from the API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        # Create all image output parameters upfront (1-4)
+        # Only the first is visible initially; others are shown when API returns multiple images
+        for i in range(1, 5):
+            self.add_parameter(
+                ParameterImage(
+                    name=f"image_url_{i}",
+                    tooltip=f"Generated image {i}",
+                    allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                    settable=False,
+                    ui_options={"is_full_width": True, "pulse_on_run": True, "hide": i > 1},
+                )
+            )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="wan_image.png",
+        )
+        self._output_file.add_parameter()
+
+        # Create status parameters for success/failure tracking (at the end)
+        self._create_status_parameters(
+            result_details_tooltip="Details about the image generation result or any errors",
+            result_details_placeholder="Generation status and details will appear here.",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _get_api_model_id(self) -> str:
+        """Map friendly model name to API model ID."""
+        model = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(str(model), str(model))
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for Wan image generation.
+
+        The payload uses the DashScope messages format with input/parameters structure.
+        The model field is not included here as the base class handles routing.
+        """
+        prompt = self.get_parameter_value("prompt") or ""
+        size = self.get_parameter_value("size") or DEFAULT_SIZE
+        n = self.get_parameter_value("n") or 1
+        thinking_mode = self.get_parameter_value("thinking_mode")
+        watermark = self.get_parameter_value("watermark") or False
+        seed = self.get_parameter_value("seed")
+
+        # Default thinking_mode to True if not explicitly set
+        if thinking_mode is None:
+            thinking_mode = True
+
+        # Build the messages structure
+        content = [{"text": prompt}]
+
+        payload: dict[str, Any] = {
+            "input": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": content,
+                    }
+                ]
+            },
+            "parameters": {
+                "size": size,
+                "n": n,
+                "thinking_mode": thinking_mode,
+                "watermark": watermark,
+            },
+        }
+
+        # Only include seed if explicitly set
+        if seed is not None:
+            payload["parameters"]["seed"] = seed
+
+        return payload
+
+    def _show_image_output_parameters(self, count: int) -> None:
+        """Show image output parameters based on actual result count.
+
+        All 4 image parameters are created during initialization but hidden except image_url.
+        This method shows the appropriate number based on the API response.
+
+        Args:
+            count: Total number of images returned from API (1-4)
+        """
+        for i in range(1, 5):
+            param_name = f"image_url_{i}"
+            if i <= count:
+                self.show_parameter_by_name(param_name)
+            else:
+                self.hide_parameter_by_name(param_name)
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the Wan image generation result and save images.
+
+        The proxy client returns the full DashScope response. Image URLs are at:
+        output.choices[*].message.content[*].image
+        """
+        # Extract image URLs from all choices
+        output = result_json.get("output", {})
+        choices = output.get("choices", [])
+
+        if not choices:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no choices found in the response.",
+            )
+            return
+
+        # Collect image URLs from all choices
+        image_urls: list[str] = []
+        for choice in choices:
+            message = choice.get("message", {})
+            content_items = message.get("content", [])
+            for item in content_items:
+                if isinstance(item, dict) and item.get("image"):
+                    image_urls.append(item["image"])
+
+        if not image_urls:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no image URLs were found in the response.",
+            )
+            return
+
+        # Download and save all images
+        image_artifacts: list[ImageUrlArtifact] = []
+        for index, url in enumerate(image_urls):
+            artifact = await self._save_single_image_from_url(url, index)
+            if artifact:
+                image_artifacts.append(artifact)
+
+        if not image_artifacts:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no images could be saved.",
+            )
+            return
+
+        # Show the appropriate number of image output parameters
+        self._show_image_output_parameters(len(image_artifacts))
+
+        # Set individual image output parameters
+        for idx, artifact in enumerate(image_artifacts, start=1):
+            param_name = f"image_url_{idx}"
+            self.parameter_output_values[param_name] = artifact
+
+        # Set success status
+        count = len(image_artifacts)
+        filenames = [artifact.name for artifact in image_artifacts]
+        if count == 1:
+            details = f"Image generated successfully and saved as {filenames[0]}."
+        else:
+            details = f"Generated {count} images successfully: {', '.join(filenames)}."
+        self._set_status_results(was_successful=True, result_details=details)
+
+    async def _save_single_image_from_url(self, image_url: str, index: int = 0) -> ImageUrlArtifact | None:
+        """Download and save a single image from the provided URL.
+
+        Args:
+            image_url: URL of the image to download
+            index: Index of the image in multi-image response
+
+        Returns:
+            ImageUrlArtifact with saved image, or None if download/save fails
+        """
+        try:
+            logger.info("Downloading image %d from URL", index)
+            image_bytes = await File(image_url).aread_bytes()
+            if not image_bytes:
+                logger.warning("Could not download image %d, using provider URL", index)
+                return ImageUrlArtifact(value=image_url)
+
+            dest = self._output_file.build_file(_index=index)
+            saved = await dest.awrite_bytes(image_bytes)
+            logger.info("Saved image %d as %s", index, saved.name)
+            return ImageUrlArtifact(value=saved.location, name=saved.name)
+        except Exception as e:
+            logger.error("Failed to save image %d from URL: %s", index, e)
+            return ImageUrlArtifact(value=image_url)
+
+    def _set_safe_defaults(self) -> None:
+        """Set safe default values for outputs."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+
+        # Clear all image output parameters
+        for i in range(1, 5):
+            param_name = f"image_url_{i}"
+            self.parameter_output_values[param_name] = None
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Extract error message from DashScope error responses.
+
+        DashScope errors may include a 'code' and 'message' field at the top level,
+        or nested within the response structure.
+        """
+        if not response_json:
+            return f"{self.name} generation failed with no error details provided by API."
+
+        # Try DashScope-specific error format: {"code": "...", "message": "..."}
+        code = response_json.get("code")
+        message = response_json.get("message")
+        if code and message:
+            return f"{self.name}: {code}: {message}"
+
+        # Fall back to the base class error extraction
+        return super()._extract_error_message(response_json)

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -14,7 +14,7 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes.files.file import File
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.proxy import GriptapeProxyNode
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -121,6 +121,7 @@ _NODE_PROVIDER_CONFIGS = {
     "TopazImageEnhance": TOPAZ,
     "Veo3VideoGeneration": GOOGLE,
     "WanAnimateGeneration": DASHSCOPE,
+    "WanImageGeneration": DASHSCOPE,
     "WanImageToVideoGeneration": DASHSCOPE,
     "WanReferenceToVideoGeneration": DASHSCOPE,
     "WanTextToVideoGeneration": DASHSCOPE,

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -15,6 +15,7 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_wan_text_to_video_generation.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_minimax_hailuo_video_generation.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_video_generation.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_wan_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_elevenlabs_text_to_speech_generation.py": {"Start Flow": {"prompt": "Hello world"}},
     "test_elevenlabs_sound_effect_generation.py": {"Start Flow": {"prompt": "Thunder clap"}},
     "test_elevenlabs_music_generation.py": {"Start Flow": {"prompt": "Upbeat jazz"}},

--- a/tests/integration/test_wan_image_generation.py
+++ b/tests/integration/test_wan_image_generation.py
@@ -1,0 +1,224 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_wan_image_generation"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.78.2"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.68.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="WanImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="WanImageGeneration",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url_1",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.prompt is not None:
+            flow_input["Start Flow"]["prompt"] = args.prompt
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)


### PR DESCRIPTION
Adds a `WanImageGeneration` node for DashScope Wan 2.7 image generation via the Griptape Cloud proxy.

The node supports two models: `wan2.7-image-pro` (professional, supports 4K output and thinking mode) and `wan2.7-image` (standard, faster, up to 2K output). It exposes prompt, size (1K/2K/4K), number of images, thinking mode, watermark, and seed parameters. The payload uses the DashScope `input.messages` format and parses image URLs from `output.choices[].message.content[].image` in the proxy response.

Depends on the proxy client PR in griptape-cloud (the `DashScopeWanImageClient` is already merged).

## Sources

- https://www.alibabacloud.com/help/en/model-studio/wan-image-generation-and-editing-api-reference
- The `DashScopeWanImageClient` in griptape-cloud uses the async task endpoint (`/services/aigc/image-generation/generation`) with `X-DashScope-Async: enable` header
- Default `n=4` in the API generates 4 images, so the node defaults to `n=1` to avoid unexpected billing
- 4K size is only available for `wan2.7-image-pro` in text-to-image mode (no image input)
- Image URLs from DashScope expire after 24 hours, so the node downloads and saves images to local storage

## Testing with the engine

To test the node end-to-end in the Griptape Nodes UI:

1. Check out this branch
2. Start the local griptape-cloud: `cd griptape-cloud && make up/debug`
3. Create DB records for the DashScope model config
4. Start the engine with proxy overrides:
   ```bash
   GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local make run/watch
   ```
5. In the Nodes UI, add a `Wan Image Generation` node and connect it to a workflow
6. Set the prompt and any other parameters, then run the workflow
7. Verify the output image appears in the node's output

## Integration test

To run the automated integration test:

```bash
GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local GT_CLOUD_API_KEY=test \
  uv run python -m pytest tests/workflows/test_integration_workflows.py -v -k "test_wan_image_generation"
```