### PR TITLE
feat: add Rodin Bang! 3D edit node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -2618,6 +2618,17 @@
       }
     },
     {
+      "class_name": "RodinBang3DEdit",
+      "file_path": "griptape_nodes_library/three_d/rodin_bang_3d_edit.py",
+      "metadata": {
+        "category": "3D",
+        "description": "Split 3D models into parts using Rodin Bang! via Griptape model proxy",
+        "display_name": "Rodin Bang! 3D Edit",
+        "icon": "box",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "ForLoopStartNode",
       "file_path": "griptape_nodes_library/execution/for_loop_start.py",
       "metadata": {

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -72,6 +72,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
 
     Outputs:
         - generation_id (str): Generation ID from the API
+        - task_uuid (str): Task UUID from Rodin, usable as asset_id for Rodin Bang! 3D Edit
         - provider_response (dict): Verbatim provider response from the model proxy
         - model_url (ThreeDUrlArtifact): Generated 3D model as URL artifact
         - all_files (list): URLs of all generated files
@@ -264,6 +265,16 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 allow_input=False,
                 allow_property=False,
                 hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="task_uuid",
+                tooltip="Task UUID from Rodin. Can be used as the asset_id input for Rodin Bang! 3D Edit.",
+                allow_input=False,
+                allow_property=False,
+                ui_options={"display_name": "Task UUID"},
             )
         )
 
@@ -508,6 +519,9 @@ class Rodin23DGeneration(GriptapeProxyNode):
             return None
 
     async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
+        task_uuid = result_json.get("task_uuid", "") if isinstance(result_json, dict) else ""
+        self.parameter_output_values["task_uuid"] = task_uuid
+
         params = self._get_parameters()
         await self._handle_success(result_json, params)
 
@@ -655,6 +669,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
     def _set_safe_defaults(self) -> None:
         """Set safe default values for outputs."""
         self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["task_uuid"] = ""
         self.parameter_output_values["provider_response"] = None
         self.parameter_output_values["model_url"] = None
         self.parameter_output_values["all_files"] = []

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import asyncio
-import base64
 import json
 import logging
 from contextlib import suppress
-from io import BytesIO
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
@@ -21,7 +18,6 @@ from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
-from PIL import Image
 
 from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.three_d.three_d_artifact import ThreeDUrlArtifact
@@ -470,89 +466,46 @@ class Rodin23DGeneration(GriptapeProxyNode):
             if len(images) >= MAX_INPUT_IMAGES:
                 break
 
-            image_bytes = await self._get_image_bytes(image_input)
-            if image_bytes:
-                # Run CPU-bound PIL mime detection + base64 encode in a thread pool
-                data_uri = await asyncio.to_thread(self._make_image_data_uri, image_bytes)
+            data_uri = await self._prepare_image_data_uri(image_input)
+            if data_uri:
                 images.append(data_uri)
 
         return images
 
-    async def _get_image_bytes(self, image_input: Any) -> bytes | None:
-        """Get raw bytes from an image input."""
-        if not image_input:
-            return None
-
-        # Handle ImageArtifact with to_bytes() method
-        if hasattr(image_input, "to_bytes"):
-            try:
-                return image_input.to_bytes()
-            except Exception as e:
-                self._log(f"Failed to get bytes from ImageArtifact: {e}")
-                return None
-
-        # Extract string value from various input types
-        image_value: str | None = None
-
-        # Handle string inputs (URL or base64) - should be rare after normalization
+    def _extract_image_value(self, image_input: Any) -> str | None:
+        """Extract a string value (URL, file path, or base64) from an image input."""
         if isinstance(image_input, str):
-            image_value = image_input
-        # Handle ImageUrlArtifact
-        elif hasattr(image_input, "value"):
-            value = getattr(image_input, "value", None)
-            if isinstance(value, str):
-                image_value = value
-        # Handle ImageArtifact with base64 property
-        elif hasattr(image_input, "base64"):
-            b64 = getattr(image_input, "base64", None)
-            if isinstance(b64, str) and b64:
-                image_value = b64
+            return image_input
 
-        # Convert string value to bytes if we found one
-        if image_value:
-            return await self._string_to_bytes(image_value)
+        try:
+            if hasattr(image_input, "value"):
+                value = getattr(image_input, "value", None)
+                if isinstance(value, str):
+                    return value
+
+            if hasattr(image_input, "base64"):
+                b64 = getattr(image_input, "base64", None)
+                if isinstance(b64, str) and b64:
+                    return b64
+        except Exception:
+            return None
 
         return None
 
-    @staticmethod
-    def _detect_image_mime(image_bytes: bytes) -> str:
-        try:
-            with Image.open(BytesIO(image_bytes)) as image:
-                image_format = (image.format or "").upper()
-        except Exception:
-            return "image/png"
-
-        mime_map = {
-            "JPEG": "image/jpeg",
-            "JPG": "image/jpeg",
-            "PNG": "image/png",
-            "WEBP": "image/webp",
-            "BMP": "image/bmp",
-            "GIF": "image/gif",
-            "TIFF": "image/tiff",
-        }
-        return mime_map.get(image_format, "image/png")
-
-    @staticmethod
-    def _make_image_data_uri(image_bytes: bytes) -> str:
-        """Encode image bytes to a base64 data URI (CPU-bound, run in thread pool)."""
-        mime_type = Rodin23DGeneration._detect_image_mime(image_bytes)
-        b64 = base64.b64encode(image_bytes).decode("utf-8")
-        return f"data:{mime_type};base64,{b64}"
-
-    async def _string_to_bytes(self, value: str) -> bytes | None:
-        """Convert a string (URL, data URI, file path, or base64) to raw bytes."""
-        try:
-            return await File(value).aread_bytes()
-        except FileLoadError as e:
-            self._log(f"Failed to load bytes from {value}: {e}")
+    async def _prepare_image_data_uri(self, image_input: Any) -> str | None:
+        """Convert an image input to a data URI via File."""
+        if not image_input:
             return None
 
-    def _log_form_data(self, form_data: dict[str, Any], num_files: int) -> None:
-        """Log form data for debugging (without sensitive data)."""
-        with suppress(Exception):
-            self._log(f"Form data: {json.dumps(form_data, indent=2)}")
-            self._log(f"Number of image files: {num_files}")
+        image_value = self._extract_image_value(image_input)
+        if not image_value:
+            return None
+
+        try:
+            return await File(image_value).aread_data_uri(fallback_mime="image/png")
+        except FileLoadError:
+            logger.debug("%s failed to load image value: %s", self.name, image_value)
+            return None
 
     async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
         params = self._get_parameters()

--- a/griptape_nodes_library/three_d/rodin_bang_3d_edit.py
+++ b/griptape_nodes_library/three_d/rodin_bang_3d_edit.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.three_d.three_d_artifact import ThreeDUrlArtifact
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["RodinBang3DEdit"]
+
+# Output format options
+GEOMETRY_FORMAT_OPTIONS = ["glb", "usdz", "fbx", "obj", "stl"]
+DEFAULT_GEOMETRY_FORMAT = "glb"
+
+# Material options
+MATERIAL_OPTIONS = ["PBR", "Shaded", "None", "All"]
+DEFAULT_MATERIAL = "PBR"
+
+# Resolution options
+RESOLUTION_OPTIONS = ["Basic", "High"]
+DEFAULT_RESOLUTION = "Basic"
+
+# Strength range
+DEFAULT_STRENGTH = 5
+MIN_STRENGTH = 2
+MAX_STRENGTH = 12
+
+
+class RodinBang3DEdit(GriptapeProxyNode):
+    """Split 3D models into parts using Rodin Bang! via Griptape model proxy.
+
+    Takes a previously generated Rodin Gen-2 asset and splits it into
+    individual parts. Higher strength values produce more pieces.
+
+    Inputs:
+        - asset_id (str): UUID of a previous Rodin Gen-2 generation task
+        - strength (int): Splitting intensity (2-12). Higher values produce more pieces.
+        - geometry_file_format (str): Output 3D file format (glb, usdz, fbx, obj, stl)
+        - material (str): Material type (PBR, Shaded, None, All)
+        - resolution (str): Texture resolution (Basic=2K, High=4K)
+
+    Outputs:
+        - generation_id (str): Generation ID from the API
+        - provider_response (dict): Verbatim provider response from the model proxy
+        - model_url (ThreeDUrlArtifact): Primary generated 3D model part
+        - all_files (list): URLs of all generated part files
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Split 3D models into parts using Rodin Bang! via Griptape model proxy"
+
+        # --- INPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="asset_id",
+                tooltip="UUID of a previous Rodin Gen-2 generation task to split into parts",
+                placeholder_text="Enter a Rodin Gen-2 asset UUID...",
+                allow_output=False,
+                ui_options={"display_name": "Asset ID"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterInt(
+                name="strength",
+                default_value=DEFAULT_STRENGTH,
+                tooltip="Controls splitting intensity. Higher values produce more pieces.",
+                allow_output=False,
+                min_val=MIN_STRENGTH,
+                max_val=MAX_STRENGTH,
+                traits={Slider(min_val=MIN_STRENGTH, max_val=MAX_STRENGTH)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="geometry_file_format",
+                default_value=DEFAULT_GEOMETRY_FORMAT,
+                tooltip="Output 3D file format",
+                allow_output=False,
+                traits={Options(choices=GEOMETRY_FORMAT_OPTIONS)},
+                ui_options={"display_name": "File Format"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="material",
+                default_value=DEFAULT_MATERIAL,
+                tooltip="Material type: PBR (physically based), Shaded (baked lighting), None, or All",
+                allow_output=False,
+                traits={Options(choices=MATERIAL_OPTIONS)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="resolution",
+                default_value=DEFAULT_RESOLUTION,
+                tooltip="Texture resolution: Basic (2K) or High (4K)",
+                allow_output=False,
+                traits={Options(choices=RESOLUTION_OPTIONS)},
+            )
+        )
+
+        # --- OUTPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID from the API",
+                allow_input=False,
+                allow_property=False,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            Parameter3D(
+                name="model_url",
+                tooltip="Primary generated 3D model part",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True, "display_name": "3D Model"},
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="all_files",
+                output_type="list",
+                type="list",
+                tooltip="URLs of all generated part files",
+                allowed_modes={ParameterMode.OUTPUT},
+                ui_options={"display_name": "All Files"},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="model.glb",
+        )
+        self._output_file.add_parameter()
+
+        # Status parameters MUST be last
+        self._create_status_parameters(
+            result_details_tooltip="Details about the 3D edit result or any errors",
+            result_details_placeholder="Generation status and details will appear here.",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _log(self, message: str) -> None:
+        with suppress(Exception):
+            logger.info(message)
+
+    def _get_api_model_id(self) -> str:
+        return "rodin-bang"
+
+    async def _build_payload(self) -> dict[str, Any]:
+        asset_id = self.get_parameter_value("asset_id") or ""
+        if not asset_id.strip():
+            msg = "An asset_id is required. Provide the UUID of a previous Rodin Gen-2 generation."
+            raise ValueError(msg)
+
+        strength = self.get_parameter_value("strength") or DEFAULT_STRENGTH
+        geometry_file_format = self.get_parameter_value("geometry_file_format") or DEFAULT_GEOMETRY_FORMAT
+        material = self.get_parameter_value("material") or DEFAULT_MATERIAL
+        resolution = self.get_parameter_value("resolution") or DEFAULT_RESOLUTION
+
+        payload: dict[str, Any] = {
+            "asset_id": asset_id.strip(),
+            "strength": strength,
+            "geometry_file_format": geometry_file_format,
+            "material": material,
+            "resolution": resolution,
+        }
+
+        return payload
+
+    async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
+        self.parameter_output_values["provider_response"] = result_json
+
+        # Get download URLs - the proxy returns 'downloads' list at top level
+        files = result_json.get("downloads", [])
+        if not files:
+            # Try nested in result object
+            result = result_json.get("result", {})
+            if isinstance(result, dict):
+                files = result.get("downloads", [])
+
+        if not files:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no files were found in the response.",
+            )
+            return
+
+        await self._save_model_files(files)
+
+    async def _save_model_files(self, files: list[dict[str, Any]]) -> None:
+        """Download and save the generated 3D model part files."""
+        requested_format = self.get_parameter_value("geometry_file_format") or DEFAULT_GEOMETRY_FORMAT
+
+        all_file_urls: list[str] = []
+        primary_url: str | None = None
+        primary_filename: str | None = None
+
+        for idx, file_info in enumerate(files):
+            file_url = file_info.get("url")
+            file_name = file_info.get("name", f"part_{idx}.{requested_format}")
+
+            if not file_url:
+                continue
+
+            try:
+                self._log(f"Downloading file: {file_name}")
+                file_bytes = await self._download_bytes_from_url(file_url)
+
+                if file_bytes:
+                    dest = self._output_file.build_file()
+                    saved = await dest.awrite_bytes(file_bytes)
+                    all_file_urls.append(saved.location)
+                    self._log(f"Saved file: {saved.name}")
+
+                    # Track primary model file
+                    if file_name.lower().endswith(f".{requested_format}") and primary_url is None:
+                        primary_url = saved.location
+                        primary_filename = saved.name
+                    elif primary_url is None:
+                        primary_url = saved.location
+                        primary_filename = saved.name
+
+            except Exception as e:
+                self._log(f"Failed to save file {file_name}: {e}")
+
+        # Set outputs
+        self.parameter_output_values["all_files"] = all_file_urls
+
+        if primary_url:
+            self.parameter_output_values["model_url"] = ThreeDUrlArtifact(
+                value=primary_url,
+                meta={"filename": primary_filename, "format": requested_format},
+            )
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"3D model split successfully. Saved {len(all_file_urls)} file(s).",
+            )
+        else:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but failed to save model files.",
+            )
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Extract error message, handling Rodin's application-level error format."""
+        if not response_json:
+            return f"{self.name} generation failed with no error details provided by API."
+
+        # Rodin returns errors with "error" code and "message" description
+        error_code = response_json.get("error")
+        message = response_json.get("message")
+        if error_code and message:
+            if isinstance(message, list):
+                message = "; ".join(str(m) for m in message)
+            return f"{self.name}: {error_code}: {message}"
+
+        return super()._extract_error_message(response_json)
+
+    def _set_safe_defaults(self) -> None:
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["model_url"] = None
+        self.parameter_output_values["all_files"] = []
+
+    def _handle_payload_build_error(self, e: Exception) -> None:
+        if isinstance(e, ValueError):
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details=str(e))
+            self._handle_failure_exception(e)
+            return
+
+        super()._handle_payload_build_error(e)

--- a/tests/integration/test_rodin_bang_3d_edit.py
+++ b/tests/integration/test_rodin_bang_3d_edit.py
@@ -1,0 +1,186 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_rodin_bang_3d_edit"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "RodinBang3DEdit"], ["Griptape Nodes Library", "StartFlow"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="asset_id",
+                default_value="",
+                tooltip="Asset ID",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Asset ID"},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="RodinBang3DEdit",
+            specific_library_name="Griptape Nodes Library",
+            node_name="RodinBang3DEdit",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="asset_id",
+            target_node_name=gen_node,
+            target_parameter_name="asset_id",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--asset-id", default=None)
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.asset_id is not None:
+            flow_input["Start Flow"]["asset_id"] = args.asset_id
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)


### PR DESCRIPTION
Adds a `RodinBang3DEdit` node that splits 3D models into parts using the Rodin Bang! API via the Griptape Cloud proxy. The node takes a previously generated Rodin Gen-2 `asset_id` and splits the model into individual pieces. Users can control splitting intensity via the `strength` parameter (2-12), choose output format (`glb`, `usdz`, `fbx`, `obj`, `stl`), material type (`PBR`, `Shaded`, `None`, `All`), and texture resolution (`Basic` 2K or `High` 4K).

The node follows the same patterns as the existing `Rodin23DGeneration` node, using `ThreeDUrlArtifact` for the primary model output and a list of all file URLs. Error handling accounts for Rodin's application-level error format where errors can be returned with HTTP 201 status codes.

Depends on the proxy client PR: https://github.com/griptape-ai/griptape-cloud/pull/1889

## Sources

- https://developer.hyper3d.ai/api-specification/bang
- https://github.com/griptape-ai/griptape-cloud/issues/1805

## Testing with the engine

To test the node end-to-end in the Griptape Nodes UI:

1. Check out both branches:
   - This repo: `feat/rodin-edit-proxy-node`
   - griptape-cloud: `feat/rodin-bang-proxy-client` (see linked PR above)
2. Start the local griptape-cloud: `cd griptape-cloud && make up/debug`
3. Create DB records for the model config (see proxy client PR for setup steps)
4. Start the engine with proxy overrides:
   ```bash
   GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local make run/watch
   ```
5. In the Nodes UI, add a `Rodin Bang! 3D Edit` node and connect it to a workflow
6. Set the `asset_id` to a completed Rodin Gen-2 generation UUID, then run the workflow
7. Verify the output GLB file appears in the node's output

## Integration test

To run the automated integration test:

```bash
GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local GT_CLOUD_API_KEY=test \
  python tests/integration/test_rodin_bang_3d_edit.py --asset-id "<rodin-gen2-uuid>"
```