### PR TITLE
feat: add Recraft image generation node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1684,6 +1684,17 @@
       }
     },
     {
+      "class_name": "RecraftImageGeneration",
+      "file_path": "griptape_nodes_library/image/recraft_image_generation.py",
+      "metadata": {
+        "category": "image",
+        "description": "Generate images using Recraft models via Griptape model proxy",
+        "display_name": "Recraft Image Generation",
+        "group": "create",
+        "icon": "image"
+      }
+    },
+    {
       "class_name": "QwenImageEdit",
       "file_path": "griptape_nodes_library/image/qwen_image_edit.py",
       "metadata": {

--- a/griptape_nodes_library/image/recraft_image_generation.py
+++ b/griptape_nodes_library/image/recraft_image_generation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import suppress
-from typing import Any
+from typing import Any, ClassVar
 
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
@@ -139,8 +139,12 @@ class RecraftImageGeneration(GriptapeProxyNode):
     Outputs:
         - generation_id (str): Generation ID from the API
         - provider_response (dict): Verbatim provider response
-        - output_image (ImageUrlArtifact): First generated image
+        - image_url (ImageUrlArtifact): First generated image
+        - image_url_2 ... image_url_6 (ImageUrlArtifact): Additional images
     """
+
+    MIN_IMAGES: ClassVar[int] = 1
+    MAX_IMAGES: ClassVar[int] = 6
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -234,15 +238,17 @@ class RecraftImageGeneration(GriptapeProxyNode):
             )
         )
 
-        self.add_parameter(
-            ParameterImage(
-                name="output_image",
-                tooltip="Generated image",
-                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
-                settable=False,
-                ui_options={"pulse_on_run": True},
+        for i in range(1, self.MAX_IMAGES + 1):
+            param_name = "image_url" if i == 1 else f"image_url_{i}"
+            self.add_parameter(
+                ParameterImage(
+                    name=param_name,
+                    tooltip=f"Generated image {i}",
+                    allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                    settable=False,
+                    ui_options={"pulse_on_run": True, "hide": i > 1},
+                )
             )
-        )
 
         self._output_file = ProjectFileParameter(
             node=self,
@@ -310,14 +316,23 @@ class RecraftImageGeneration(GriptapeProxyNode):
 
         return payload
 
+    def _show_image_output_parameters(self, count: int) -> None:
+        """Show only the image output parameters that have results."""
+        for i in range(1, self.MAX_IMAGES + 1):
+            param_name = "image_url" if i == 1 else f"image_url_{i}"
+            if i <= count:
+                self.show_parameter_by_name(param_name)
+            else:
+                self.hide_parameter_by_name(param_name)
+
     async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
         """Parse the Recraft result and set output parameters.
 
         The proxy returns the raw Recraft API response:
         {"created": ..., "credits": ..., "data": [{"image_id": "...", "url": "..."}]}
         """
-        data = result_json.get("data")
-        if not data or not isinstance(data, list) or len(data) == 0:
+        data = result_json.get("data", [])
+        if not data:
             self._set_safe_defaults()
             self._set_status_results(
                 was_successful=False,
@@ -325,49 +340,66 @@ class RecraftImageGeneration(GriptapeProxyNode):
             )
             return
 
-        first_image = data[0]
-        url = first_image.get("url")
-        if not url:
+        # The recraftv2_vector model produces SVG files; all other models produce PNG files.
+        api_model_id = self._get_api_model_id()
+        extension = "svg" if api_model_id == "recraftv2_vector" else "png"
+        self.set_parameter_value("output_file", f"recraft_image.{extension}")
+
+        image_artifacts: list[ImageUrlArtifact] = []
+        for idx, image_data in enumerate(data):
+            image_url = image_data.get("url")
+            if not image_url:
+                continue
+
+            artifact = await self._save_single_image_from_url(image_url, generation_id, idx)
+            if artifact:
+                image_artifacts.append(artifact)
+
+        if not image_artifacts:
             self._set_safe_defaults()
             self._set_status_results(
                 was_successful=False,
-                result_details="Generation completed but no image URL was found in the response.",
+                result_details="Generation completed but no image URLs were found in the response.",
             )
             return
 
-        try:
-            self._log("Downloading image from URL")
-            image_bytes = await File(url).aread_bytes()
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["output_image"] = ImageUrlArtifact(saved.location)
-                self._log(f"Saved image as {saved.name}")
+        self._show_image_output_parameters(len(image_artifacts))
 
-                count = len(data)
-                details = f"Generated {count} image{'s' if count > 1 else ''} successfully."
-                if count > 1:
-                    details += " Only the first image is shown in the output."
-                self._set_status_results(was_successful=True, result_details=details)
-            else:
-                self.parameter_output_values["output_image"] = ImageUrlArtifact(value=url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
-                )
+        for idx, artifact in enumerate(image_artifacts, start=1):
+            param_name = "image_url" if idx == 1 else f"image_url_{idx}"
+            self.parameter_output_values[param_name] = artifact
+
+        filenames = [artifact.name for artifact in image_artifacts]
+        if len(image_artifacts) == 1:
+            details = f"Image generated successfully and saved as {filenames[0]}."
+        else:
+            details = f"Generated {len(image_artifacts)} images successfully: {', '.join(filenames)}."
+
+        self._set_status_results(was_successful=True, result_details=details)
+
+    async def _save_single_image_from_url(
+        self, image_url: str, generation_id: str | None = None, index: int = 0
+    ) -> ImageUrlArtifact | None:
+        """Download and save a single image from a URL."""
+        try:
+            image_bytes = await File(image_url).aread_bytes()
+            if not image_bytes:
+                return ImageUrlArtifact(value=image_url)
+
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(image_bytes)
+            return ImageUrlArtifact(value=saved.location, name=saved.name)
         except Exception as e:
-            self._log(f"Failed to save image from URL: {e}")
-            self.parameter_output_values["output_image"] = ImageUrlArtifact(value=url)
-            self._set_status_results(
-                was_successful=True,
-                result_details=f"Image generated successfully. Using provider URL (could not save to static storage: {e}).",
-            )
+            self._log(f"Failed to save image {index}: {e}")
+            return ImageUrlArtifact(value=image_url)
 
     def _set_safe_defaults(self) -> None:
         """Clear all output parameters on error."""
         self.parameter_output_values["generation_id"] = ""
         self.parameter_output_values["provider_response"] = None
-        self.parameter_output_values["output_image"] = None
+        for i in range(1, self.MAX_IMAGES + 1):
+            param_name = "image_url" if i == 1 else f"image_url_{i}"
+            self.parameter_output_values[param_name] = None
 
     def _extract_error_message(self, response_json: dict[str, Any]) -> str:
         """Extract error message from Recraft error response.

--- a/griptape_nodes_library/image/recraft_image_generation.py
+++ b/griptape_nodes_library/image/recraft_image_generation.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from griptape.artifacts import ImageUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["RecraftImageGeneration"]
+
+# Model mapping from user-friendly names to API model IDs
+MODEL_MAPPING = {
+    "Recraft V4": "recraftv4",
+    "Recraft V4 Pro": "recraftv4_pro",
+    "Recraft V4 Vector": "recraftv4_vector",
+    "Recraft V4 Pro Vector": "recraftv4_pro_vector",
+    "Recraft V3": "recraftv3",
+    "Recraft V3 Vector": "recraftv3_vector",
+    "Recraft V2": "recraftv2",
+    "Recraft V2 Vector": "recraftv2_vector",
+}
+MODEL_OPTIONS = list(MODEL_MAPPING.keys())
+DEFAULT_MODEL = "Recraft V4"
+
+# V2/V3 style presets
+STYLE_OPTIONS = [
+    "",
+    "any",
+    "realistic_image",
+    "digital_illustration",
+    "vector_illustration",
+    "icon",
+]
+
+# Aspect ratio options and their pixel mappings per model family
+ASPECT_RATIO_OPTIONS = [
+    "1:1",
+    "2:1",
+    "1:2",
+    "3:2",
+    "2:3",
+    "4:3",
+    "3:4",
+    "5:4",
+    "4:5",
+    "6:10",
+    "14:10",
+    "10:14",
+    "16:9",
+    "9:16",
+]
+
+SIZE_MAP_V4 = {
+    "1:1": "1024x1024",
+    "2:1": "1536x768",
+    "1:2": "768x1536",
+    "3:2": "1280x832",
+    "2:3": "832x1280",
+    "4:3": "1216x896",
+    "3:4": "896x1216",
+    "5:4": "1152x896",
+    "4:5": "896x1152",
+    "6:10": "832x1344",
+    "14:10": "1280x896",
+    "10:14": "896x1280",
+    "16:9": "1344x768",
+    "9:16": "768x1344",
+}
+
+SIZE_MAP_V4_PRO = {
+    "1:1": "2048x2048",
+    "2:1": "3072x1536",
+    "1:2": "1536x3072",
+    "3:2": "2560x1664",
+    "2:3": "1664x2560",
+    "4:3": "2432x1792",
+    "3:4": "1792x2432",
+    "5:4": "2304x1792",
+    "4:5": "1792x2304",
+    "6:10": "1664x2688",
+    "14:10": "2560x1792",
+    "10:14": "1792x2560",
+    "16:9": "2688x1536",
+    "9:16": "1536x2688",
+}
+
+SIZE_MAP_V2_V3 = {
+    "1:1": "1024x1024",
+    "2:1": "2048x1024",
+    "1:2": "1024x2048",
+    "3:2": "1536x1024",
+    "2:3": "1024x1536",
+    "4:3": "1365x1024",
+    "3:4": "1024x1365",
+    "5:4": "1280x1024",
+    "4:5": "1024x1280",
+    "6:10": "1024x1707",
+    "14:10": "1434x1024",
+    "10:14": "1024x1434",
+    "16:9": "1820x1024",
+    "9:16": "1024x1820",
+}
+
+# Models that support V2/V3-only features (style, negative_prompt)
+V2_V3_MODELS = {"recraftv3", "recraftv3_vector", "recraftv2", "recraftv2_vector"}
+
+# Models that use the V4 Pro size map
+V4_PRO_MODELS = {"recraftv4_pro", "recraftv4_pro_vector"}
+
+# Vector models use aspect ratios instead of pixel dimensions
+VECTOR_MODELS = {"recraftv4_vector", "recraftv4_pro_vector", "recraftv3_vector", "recraftv2_vector"}
+
+
+class RecraftImageGeneration(GriptapeProxyNode):
+    """Generate images using Recraft models via Griptape model proxy.
+
+    Supports raster and vector generation across Recraft V2, V3, and V4 model families.
+
+    Inputs:
+        - model (str): Recraft model to use (default: "Recraft V4")
+        - prompt (str): Text description of the image to generate
+        - aspect_ratio (str): Aspect ratio for the output image
+        - n (int): Number of images to generate (1-6)
+        - style (str): Style preset (V2/V3 models only)
+        - negative_prompt (str): Elements to exclude (V2/V3 models only)
+
+    Outputs:
+        - generation_id (str): Generation ID from the API
+        - provider_response (dict): Verbatim provider response
+        - output_image (ImageUrlArtifact): First generated image
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate images using Recraft models via Griptape model proxy"
+
+        # Model selection
+        self.add_parameter(
+            ParameterString(
+                name="model",
+                default_value=DEFAULT_MODEL,
+                tooltip="Select the Recraft model to use",
+                allow_output=False,
+                traits={Options(choices=MODEL_OPTIONS)},
+            )
+        )
+
+        # Prompt
+        self.add_parameter(
+            ParameterString(
+                name="prompt",
+                tooltip="Text description of the image to generate",
+                multiline=True,
+                placeholder_text="Describe the image you want to generate...",
+                allow_output=False,
+            )
+        )
+
+        # Aspect ratio
+        self.add_parameter(
+            ParameterString(
+                name="aspect_ratio",
+                default_value="1:1",
+                tooltip="Aspect ratio for the output image. Pixel dimensions are determined by the model.",
+                allow_output=False,
+                traits={Options(choices=ASPECT_RATIO_OPTIONS)},
+            )
+        )
+
+        # Number of images
+        self.add_parameter(
+            ParameterInt(
+                name="n",
+                default_value=1,
+                tooltip="Number of images to generate (1-6)",
+                allow_output=False,
+                min_val=1,
+                max_val=6,
+            )
+        )
+
+        # V2/V3 advanced settings
+        with ParameterGroup(name="V2/V3 Settings", ui_options={"collapsed": True}) as v2_v3_group:
+            ParameterString(
+                name="style",
+                default_value="",
+                tooltip="Style preset for generation (V2/V3 models only, ignored for V4)",
+                allow_output=False,
+                traits={Options(choices=STYLE_OPTIONS)},
+            )
+
+            ParameterString(
+                name="negative_prompt",
+                default_value="",
+                tooltip="Elements to exclude from generation (V2/V3 models only, ignored for V4)",
+                multiline=True,
+                placeholder_text="Elements to avoid in the image...",
+                allow_output=False,
+            )
+
+        self.add_node_element(v2_v3_group)
+
+        # OUTPUTS
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID from the API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="output_image",
+                tooltip="Generated image",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="recraft_image.png",
+        )
+        self._output_file.add_parameter()
+
+        # Status parameters (must be last)
+        self._create_status_parameters(
+            result_details_tooltip="Details about the image generation result or any errors",
+            result_details_placeholder="Generation status will appear here...",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _get_api_model_id(self) -> str:
+        """Map friendly model name to API model ID."""
+        model = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(str(model), str(model))
+
+    def _resolve_size(self, aspect_ratio: str, api_model_id: str) -> str:
+        """Resolve aspect ratio to the correct size string for the given model.
+
+        Vector models use aspect ratio strings directly. Raster models use
+        pixel dimensions that vary by model family.
+        """
+        if api_model_id in VECTOR_MODELS:
+            return aspect_ratio
+
+        if api_model_id in V4_PRO_MODELS:
+            size_map = SIZE_MAP_V4_PRO
+        elif api_model_id in V2_V3_MODELS:
+            size_map = SIZE_MAP_V2_V3
+        else:
+            size_map = SIZE_MAP_V4
+
+        return size_map.get(aspect_ratio, size_map.get("1:1", "1024x1024"))
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for Recraft image generation."""
+        prompt = self.get_parameter_value("prompt") or ""
+        aspect_ratio = self.get_parameter_value("aspect_ratio") or "1:1"
+        n = self.get_parameter_value("n") or 1
+
+        api_model_id = self._get_api_model_id()
+        size = self._resolve_size(aspect_ratio, api_model_id)
+
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "model": api_model_id,
+            "n": n,
+            "size": size,
+            "response_format": "url",
+        }
+
+        # Add V2/V3 specific parameters only when applicable
+        if api_model_id in V2_V3_MODELS:
+            style = self.get_parameter_value("style") or ""
+            if style:
+                payload["style"] = style
+
+            negative_prompt = self.get_parameter_value("negative_prompt") or ""
+            if negative_prompt:
+                payload["negative_prompt"] = negative_prompt
+
+        return payload
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the Recraft result and set output parameters.
+
+        The proxy returns the raw Recraft API response:
+        {"created": ..., "credits": ..., "data": [{"image_id": "...", "url": "..."}]}
+        """
+        data = result_json.get("data")
+        if not data or not isinstance(data, list) or len(data) == 0:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no image data was found in the response.",
+            )
+            return
+
+        first_image = data[0]
+        url = first_image.get("url")
+        if not url:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no image URL was found in the response.",
+            )
+            return
+
+        try:
+            self._log("Downloading image from URL")
+            image_bytes = await File(url).aread_bytes()
+            if image_bytes:
+                dest = self._output_file.build_file()
+                saved = await dest.awrite_bytes(image_bytes)
+                self.parameter_output_values["output_image"] = ImageUrlArtifact(saved.location)
+                self._log(f"Saved image as {saved.name}")
+
+                count = len(data)
+                details = f"Generated {count} image{'s' if count > 1 else ''} successfully."
+                if count > 1:
+                    details += " Only the first image is shown in the output."
+                self._set_status_results(was_successful=True, result_details=details)
+            else:
+                self.parameter_output_values["output_image"] = ImageUrlArtifact(value=url)
+                self._set_status_results(
+                    was_successful=True,
+                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
+                )
+        except Exception as e:
+            self._log(f"Failed to save image from URL: {e}")
+            self.parameter_output_values["output_image"] = ImageUrlArtifact(value=url)
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"Image generated successfully. Using provider URL (could not save to static storage: {e}).",
+            )
+
+    def _set_safe_defaults(self) -> None:
+        """Clear all output parameters on error."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["output_image"] = None
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Extract error message from Recraft error response.
+
+        Recraft errors use {"code": "...", "message": "..."} format.
+        """
+        if not response_json:
+            return super()._extract_error_message(response_json)
+
+        # Recraft-specific error format
+        message = response_json.get("message")
+        if message:
+            code = response_json.get("code", "")
+            if code:
+                return f"{self.name}: {message} (code: {code})"
+            return f"{self.name}: {message}"
+
+        return super()._extract_error_message(response_json)
+
+    def _log(self, message: str) -> None:
+        with suppress(Exception):
+            logger.info(message)

--- a/griptape_nodes_library/image/recraft_image_generation.py
+++ b/griptape_nodes_library/image/recraft_image_generation.py
@@ -14,7 +14,7 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes.files.file import File
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.proxy import GriptapeProxyNode
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -85,6 +85,11 @@ WORLD_LABS = ProxyApiKeyProviderConfig(
     provider_name="World Labs",
     api_key_url="https://platform.worldlabs.ai/api-keys",
 )
+RECRAFT = ProxyApiKeyProviderConfig(
+    api_key_name="RECRAFT_API_KEY",
+    provider_name="Recraft",
+    api_key_url="https://www.recraft.ai/",
+)
 
 _NODE_PROVIDER_CONFIGS = {
     "ElevenLabsMusicGeneration": ELEVENLABS,
@@ -112,6 +117,7 @@ _NODE_PROVIDER_CONFIGS = {
     "OmnihumanVideoGeneration": SEED,
     "QwenImageEdit": DASHSCOPE,
     "QwenImageGeneration": DASHSCOPE,
+    "RecraftImageGeneration": RECRAFT,
     "Rodin23DGeneration": RODIN,
     "SeedanceVideoGeneration": SEED,
     "SeedreamImageGeneration": SEED,

--- a/tests/integration/test_recraft_image_generation.py
+++ b/tests/integration/test_recraft_image_generation.py
@@ -1,0 +1,224 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_recraft_image_generation"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "RecraftImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="RecraftImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="RecraftImageGeneration",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output_image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.prompt is not None:
+            flow_input["Start Flow"]["prompt"] = args.prompt
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)

--- a/tests/integration/test_recraft_image_generation.py
+++ b/tests/integration/test_recraft_image_generation.py
@@ -132,7 +132,7 @@ with GriptapeNodes.ContextManager().flow(flow_name):
     GriptapeNodes.handle_request(
         CreateConnectionRequest(
             source_node_name=gen_node,
-            source_parameter_name="output_image",
+            source_parameter_name="image_url",
             target_node_name=to_text_node,
             target_parameter_name="from",
             initial_setup=True,


### PR DESCRIPTION
Adds a `RecraftImageGeneration` node for Recraft image generation via the Griptape Cloud proxy. The node supports all eight Recraft generation models across the V2, V3, and V4 families, including both raster and vector variants.

The node exposes `prompt`, `model`, `aspect_ratio`, and `n` (image count) as primary parameters. V2/V3-specific parameters (`style` and `negative_prompt`) are grouped in a collapsible section and only included in the payload when a V2/V3 model is selected. Aspect ratios are resolved to the correct pixel dimensions per model family (V4, V4 Pro, V2/V3), and vector models send aspect ratios directly as the API requires.

Depends on the proxy client PR: https://github.com/griptape-ai/griptape-cloud/pull/1896

## Sources

- https://www.recraft.ai/docs/api-reference/getting-started
- Recraft API spec from `.scratch/proxy-spec-rekraft/spec.md`

## Testing with the engine

To test the node end-to-end in the Griptape Nodes UI:

1. Check out both branches:
   - This repo: `feat/recraft-image-generation-proxy-node`
   - griptape-cloud: `feat/recraft-proxy-client` (see linked PR above)
2. Start the local griptape-cloud: `cd griptape-cloud && make up/debug`
3. Create DB records for the model config (see proxy client PR for setup steps)
4. Start the engine with proxy overrides:
   ```bash
   GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local make run/watch
   ```
5. In the Nodes UI, add a `Recraft Image Generation` node and connect it to a workflow
6. Set the prompt and any other parameters, then run the workflow
7. Verify the output image appears in the node's output

## Integration test

To run the automated integration test:

```bash
GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local GT_CLOUD_API_KEY=test \
  uv run python tests/integration/test_recraft_image_generation.py --prompt "a red apple on a white table"
```

Closes griptape-ai/griptape-nodes#4280