### PR TITLE
feat: add RunwayML video and image generation nodes

### DIFF
--- a/.claude/skills/impl-proxy-node/SKILL.md
+++ b/.claude/skills/impl-proxy-node/SKILL.md
@@ -47,6 +47,7 @@ Based on the spec's media type, read the closest existing node:
 - **Audio**: `griptape_nodes_library/audio/eleven_labs_music_generation.py` (simple, raw bytes result)
 - **Image**: `griptape_nodes_library/image/flux_2_image_generation.py` (model mapping, URL-based result, image download)
 - **Video**: `griptape_nodes_library/video/kling_text_to_video_generation.py` (async, video result)
+- **Image/video input handling**: `griptape_nodes_library/video/kling_image_to_video_generation.py` (data URI conversion pattern with `_prepare_image_data_url_async` and `_coerce_image_url_or_data_uri`)
 
 Study the patterns for:
 - Parameter definition in `__init__`
@@ -57,17 +58,23 @@ Study the patterns for:
 
 ### Media Input Handling (if the node accepts image/video/audio inputs)
 
-**Check the spec's "Media Input Requirements" section first.** Choose the approach based on what the API accepts:
+**Check the spec's "Media Input Requirements" section first.** The approach depends on what the API accepts:
 
-1. **If the API accepts URLs:** Use `PublicArtifactUrlParameter` to provide a public URL for the media input.
+1. **If the API validates Content-Type headers on fetched URLs:** Do NOT use `PublicArtifactUrlParameter`. The public artifact URL serves files with `application/octet-stream` Content-Type, which many APIs reject. Use data URIs instead.
 
-2. **If the API requires data URIs:** Use the Kling pattern from `kling_image_to_video_generation.py`:
+2. **If the API accepts data URIs:** Use the proven Kling pattern from `kling_image_to_video_generation.py`:
    - `_coerce_image_url_or_data_uri(val)` - static method that extracts a URL or data URI from any input type (`str`, `ImageArtifact`, `ImageUrlArtifact`, local file paths)
    - `_prepare_image_data_url_async(image_input)` - async method that calls the coerce method, then downloads bytes via `File().aread_bytes()` for non-data-URI inputs and encodes to base64
    - Import `File` and `FileLoadError` from `griptape_nodes.files.file`
    - Import `base64`
 
 3. **If the API has a size limit on data URIs:** Add compression before encoding using `shrink_image_to_size` from `griptape_nodes_library.utils.image_utils`. Calculate the max raw bytes based on the API's character limit (base64 encoding expands ~33%, plus the `data:image/...;base64,` prefix).
+
+4. **If the API has a dedicated upload endpoint for large files:** Implement upload logic and use the returned URI.
+
+5. **Only use `PublicArtifactUrlParameter`** if the API is confirmed to accept URLs with any Content-Type, or if the API does not fetch URLs server-side (i.e., it accepts arbitrary URL strings as references without fetching them during request validation).
+
+**Key principle:** Always test media input handling with realistically-sized images (1024x1024+), not tiny synthetic images. Small test images may hide Content-Type and size limit issues.
 
 ## 5. Create the Node File
 
@@ -216,8 +223,10 @@ async def _build_payload(self) -> dict[str, Any]:
         # ... map to the request schema from the spec ...
     }
 
-    # For image inputs, convert to data URI:
-    # data_uri = await File(image_url).aread_data_uri(fallback_mime="image/png")
+    # For image inputs, use the data URI pattern (see "Media Input Handling" above):
+    # image_data_uri = await self._prepare_image_data_url_async(self.get_parameter_value("image"))
+    # if image_data_uri:
+    #     payload["image"] = image_data_uri
 
     return payload
 ```
@@ -338,6 +347,12 @@ The test should:
 3. Wire up connections between nodes
 4. Provide minimal valid input via `StartFlow` parameters
 5. Execute and verify a file was produced
+
+### Testing media inputs
+
+If the node accepts image/video/audio inputs, the integration test MUST:
+- **Use a realistically-sized test image** (at least 512x512). Use `CreateColorBars` or a similar node to generate a synthetic image at a realistic resolution, not a tiny placeholder. Small images (e.g. 4x4 pixels) will hide Content-Type validation and size limit issues that only appear with real images.
+- **Assert the media input was actually used**, not just that output was produced. For example, if the node should use `image_to_video` when an image is provided, verify the request went to the correct endpoint. At minimum, verify the node didn't silently fall back to a text-only mode.
 
 Study the existing test carefully and replicate its structure. Key patterns:
 - Script metadata header with `# /// script` block

--- a/.claude/skills/impl-proxy-node/SKILL.md
+++ b/.claude/skills/impl-proxy-node/SKILL.md
@@ -30,7 +30,7 @@ git checkout -b feat/<service-name>-proxy-node
 
 ## 3. Read the Base Class
 
-Read `griptape_nodes_library/griptape_proxy_node.py` to understand the interface. The three abstract methods you must implement:
+Read `griptape_nodes_library/proxy/griptape_proxy_node.py` to understand the interface. The three abstract methods you must implement:
 
 - `async _build_payload(self) -> dict[str, Any]` - Build the request JSON
 - `async _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None` - Parse result and set outputs
@@ -107,7 +107,7 @@ from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage 
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.proxy import GriptapeProxyNode
 ```
 
 Only import what you actually need.

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -2886,6 +2886,28 @@
         "icon": "palette",
         "group": "edit"
       }
+    },
+    {
+      "class_name": "RunwayMLVideoGeneration",
+      "file_path": "griptape_nodes_library/video/runway_ml_video_generation.py",
+      "metadata": {
+        "category": "video",
+        "description": "Generate video using RunwayML Gen-4 models via Griptape Cloud model proxy.",
+        "display_name": "RunwayML Video Generation",
+        "icon": "Sparkles",
+        "group": "create"
+      }
+    },
+    {
+      "class_name": "RunwayMLImageGeneration",
+      "file_path": "griptape_nodes_library/image/runway_ml_image_generation.py",
+      "metadata": {
+        "category": "image",
+        "description": "Generate images using RunwayML Gen-4 Image models via Griptape Cloud model proxy.",
+        "display_name": "RunwayML Image Generation",
+        "icon": "Sparkles",
+        "group": "create"
+      }
     }
   ],
   "workflows": [

--- a/griptape_nodes_library/image/runway_ml_image_generation.py
+++ b/griptape_nodes_library/image/runway_ml_image_generation.py
@@ -17,7 +17,7 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.proxy import GriptapeProxyNode
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/image/runway_ml_image_generation.py
+++ b/griptape_nodes_library/image/runway_ml_image_generation.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from griptape.artifacts import ImageUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["RunwayMLImageGeneration"]
+
+# Model mapping from user-friendly names to API model IDs
+MODEL_MAPPING: dict[str, str] = {
+    "Gen-4 Image": "gen4_image",
+    "Gen-4 Image Turbo": "gen4_image_turbo",
+}
+MODEL_OPTIONS = list(MODEL_MAPPING.keys())
+DEFAULT_MODEL = MODEL_OPTIONS[0]
+
+# Ratio options available for image generation
+RATIO_OPTIONS = [
+    "1024:1024",
+    "1080:1080",
+    "1168:880",
+    "1360:768",
+    "1440:1080",
+    "1080:1440",
+    "1808:768",
+    "1920:1080",
+    "1080:1920",
+    "2112:912",
+    "1280:720",
+    "720:1280",
+    "720:720",
+    "960:720",
+    "720:960",
+    "1680:720",
+]
+DEFAULT_RATIO = "1360:768"
+
+# Seed constraints
+MAX_SEED = 4294967295
+
+
+class RunwayMLImageGeneration(GriptapeProxyNode):
+    """Generate images using RunwayML Gen-4 Image models via Griptape Cloud model proxy.
+
+    Inputs:
+        - model (str): RunwayML image generation model
+        - prompt_text (str): Text description of the desired image (1-1000 chars)
+        - reference_image (ImageUrlArtifact): Reference image for generation (required)
+        - ratio (str): Output image resolution
+        - seed (int): Random seed for reproducibility
+
+    Outputs:
+        - generation_id (str): Generation ID from the API
+        - provider_response (dict): Verbatim response from Griptape model proxy
+        - image_url (ImageUrlArtifact): Generated image as URL artifact
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate images using RunwayML Gen-4 Image models via Griptape Cloud model proxy"
+
+        # --- INPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="model",
+                default_value=DEFAULT_MODEL,
+                tooltip="RunwayML image generation model",
+                allow_output=False,
+                traits={Options(choices=MODEL_OPTIONS)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="prompt_text",
+                tooltip="Text description of the desired image (1-1000 characters)",
+                multiline=True,
+                placeholder_text="Describe the image you want to generate...",
+                allow_output=False,
+                ui_options={"display_name": "Prompt"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="reference_image",
+                tooltip="Reference image for generation (required, min 2x2 pixels)",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={
+                    "display_name": "Reference Image",
+                    "expander": True,
+                },
+            )
+        )
+
+        with ParameterGroup(name="Generation Settings") as gen_settings_group:
+            ParameterString(
+                name="ratio",
+                default_value=DEFAULT_RATIO,
+                tooltip="Output image resolution",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=RATIO_OPTIONS)},
+                ui_options={"display_name": "Ratio"},
+            )
+
+            ParameterInt(
+                name="seed",
+                default_value=0,
+                tooltip="Random seed for reproducibility (0 = random). Range: 0-4294967295",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                min_val=0,
+                max_val=MAX_SEED,
+                ui_options={"display_name": "Seed"},
+            )
+
+        self.add_node_element(gen_settings_group)
+
+        # --- OUTPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID from the API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="image_url",
+                tooltip="Generated image as URL artifact",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                pulse_on_run=True,
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runway_image.png",
+        )
+        self._output_file.add_parameter()
+
+        # Status parameters MUST be last
+        self._create_status_parameters(
+            result_details_tooltip="Details about the image generation result or any errors",
+            result_details_placeholder="Generation status will appear here...",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _log(self, message: str) -> None:
+        with suppress(Exception):
+            logger.info(message)
+
+    def _get_api_model_id(self) -> str:
+        """Map user-friendly model name to API model ID."""
+        model = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(str(model), str(model))
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for RunwayML image generation."""
+        prompt_text = self.get_parameter_value("prompt_text") or ""
+        ratio = self.get_parameter_value("ratio") or DEFAULT_RATIO
+        seed = self.get_parameter_value("seed") or 0
+        reference_image = self.get_parameter_value("reference_image")
+
+        payload: dict[str, Any] = {
+            "promptText": prompt_text.strip(),
+            "ratio": ratio,
+        }
+
+        # Include seed only if non-zero
+        if seed and int(seed) > 0:
+            payload["seed"] = int(seed)
+
+        # Build referenceImages array (required by the API)
+        if reference_image:
+            data_uri = self._image_to_data_uri(reference_image)
+            if data_uri:
+                payload["referenceImages"] = [{"uri": data_uri}]
+
+        return payload
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the RunwayML result and download the image.
+
+        The proxy client returns the output array from the RunwayML task response.
+        The output is an array of signed CloudFront URLs.
+        """
+        # Look for output URLs in various possible response shapes
+        output = result_json.get("output")
+        if isinstance(output, list) and output:
+            image_url = output[0]
+        elif isinstance(output, str):
+            image_url = output
+        else:
+            image_url = result_json.get("image_url") or result_json.get("url")
+
+        if not image_url or not isinstance(image_url, str):
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no image URL was found in the response.",
+            )
+            return
+
+        # Download and save the image
+        try:
+            image_bytes = await self._download_bytes_from_url(image_url)
+            if image_bytes:
+                dest = self._output_file.build_file()
+                saved = await dest.awrite_bytes(image_bytes)
+                self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
+                self._log(f"Saved image as {saved.name}")
+                self._set_status_results(
+                    was_successful=True,
+                    result_details=f"Image generated successfully and saved as {saved.name}.",
+                )
+            else:
+                self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
+                self._set_status_results(
+                    was_successful=True,
+                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
+                )
+        except Exception as e:
+            self._log(f"Failed to save image: {e}")
+            self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"Image generated successfully. Using provider URL (could not save to storage: {e}).",
+            )
+
+    @staticmethod
+    def _image_to_data_uri(image_input: Any) -> str | None:
+        """Convert an image parameter value to a data URI for RunwayML.
+
+        RunwayML requires images as data URIs or publicly-accessible URLs with
+        proper Content-Type headers. Data URIs are the most reliable option.
+        """
+        if image_input is None:
+            return None
+
+        # String input
+        if isinstance(image_input, str):
+            v = image_input.strip()
+            if not v:
+                return None
+            if v.startswith("data:image/"):
+                return v
+            if v.startswith(("http://", "https://")):
+                return v
+            return f"data:image/png;base64,{v}"
+
+        # ImageUrlArtifact: .value holds a URL string
+        value = getattr(image_input, "value", None)
+        if isinstance(value, str) and value.startswith(("http://", "https://", "data:image/")):
+            return value
+
+        # ImageArtifact: .base64 holds base64-encoded image data
+        b64 = getattr(image_input, "base64", None)
+        if isinstance(b64, str) and b64:
+            return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
+
+        return None
+
+    def _set_safe_defaults(self) -> None:
+        """Clear output parameters on error."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["image_url"] = None
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Extract error message from RunwayML error responses.
+
+        RunwayML errors follow the structure: {"error": "...", "issues": [...]}
+        """
+        if not response_json:
+            return f"{self.name} generation failed with no error details provided by API."
+
+        # Try RunwayML-specific error format
+        error = response_json.get("error")
+        issues = response_json.get("issues")
+        if error and isinstance(error, str):
+            msg = f"{self.name}: {error}"
+            if issues and isinstance(issues, list):
+                issue_messages = []
+                for issue in issues:
+                    if isinstance(issue, dict):
+                        issue_msg = issue.get("message", "")
+                        issue_path = issue.get("path", [])
+                        if issue_msg:
+                            path_str = ".".join(str(p) for p in issue_path) if issue_path else ""
+                            issue_messages.append(f"  {path_str}: {issue_msg}" if path_str else f"  {issue_msg}")
+                if issue_messages:
+                    msg += "\n" + "\n".join(issue_messages)
+            return msg
+
+        # Fall back to base class extraction
+        return super()._extract_error_message(response_json)
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Validate parameters before execution."""
+        exceptions = super().validate_before_node_run() or []
+
+        prompt_text = self.get_parameter_value("prompt_text") or ""
+        if not prompt_text.strip():
+            exceptions.append(ValueError(f"{self.name} requires a prompt to generate an image."))
+        elif len(prompt_text) > 1000:
+            exceptions.append(
+                ValueError(f"{self.name} prompt exceeds 1000 characters (got: {len(prompt_text)} characters).")
+            )
+
+        reference_image = self.get_parameter_value("reference_image")
+        if not reference_image:
+            exceptions.append(ValueError(f"{self.name} requires a reference image for image generation."))
+
+        return exceptions if exceptions else None

--- a/griptape_nodes_library/image/runway_ml_image_generation.py
+++ b/griptape_nodes_library/image/runway_ml_image_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 from contextlib import suppress
 from typing import Any
@@ -7,6 +8,9 @@ from typing import Any
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File, FileLoadError
+
+from griptape_nodes_library.utils.image_utils import shrink_image_to_size
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
@@ -201,7 +205,7 @@ class RunwayMLImageGeneration(GriptapeProxyNode):
 
         # Build referenceImages array (required by the API)
         if reference_image:
-            data_uri = self._image_to_data_uri(reference_image)
+            data_uri = await self._prepare_image_data_uri(reference_image)
             if data_uri:
                 payload["referenceImages"] = [{"uri": data_uri}]
 
@@ -256,36 +260,57 @@ class RunwayMLImageGeneration(GriptapeProxyNode):
                 result_details=f"Image generated successfully. Using provider URL (could not save to storage: {e}).",
             )
 
-    @staticmethod
-    def _image_to_data_uri(image_input: Any) -> str | None:
-        """Convert an image parameter value to a data URI for RunwayML.
+    async def _prepare_image_data_uri(self, image_input: Any) -> str | None:
+        """Convert image input to a data URI, downloading from local paths if needed.
 
         RunwayML requires images as data URIs or publicly-accessible URLs with
         proper Content-Type headers. Data URIs are the most reliable option.
         """
-        if image_input is None:
+        if not image_input:
             return None
 
-        # String input
-        if isinstance(image_input, str):
-            v = image_input.strip()
+        image_url = self._coerce_image_url_or_data_uri(image_input)
+        if not image_url:
+            return None
+
+        if image_url.startswith("data:image/"):
+            return image_url
+
+        try:
+            image_bytes = await File(image_url).aread_bytes()
+        except FileLoadError as e:
+            logger.debug("%s failed to load image from %s: %s", self.name, image_url, e)
+            return None
+
+        # RunwayML data URIs are limited to 5,242,880 characters.
+        # The base64 prefix is ~22 chars, so raw bytes must encode to under ~3.9MB.
+        max_raw_bytes = 3_900_000
+        if len(image_bytes) > max_raw_bytes:
+            image_bytes = shrink_image_to_size(image_bytes, max_raw_bytes, context_name=self.name)
+
+        return f"data:image/png;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
+
+    @staticmethod
+    def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Convert various image input types to a URL or data URI string."""
+        if val is None:
+            return None
+
+        if isinstance(val, str):
+            v = val.strip()
             if not v:
                 return None
-            if v.startswith("data:image/"):
-                return v
-            if v.startswith(("http://", "https://")):
-                return v
-            return f"data:image/png;base64,{v}"
+            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
 
-        # ImageUrlArtifact: .value holds a URL string
-        value = getattr(image_input, "value", None)
-        if isinstance(value, str) and value.startswith(("http://", "https://", "data:image/")):
-            return value
-
-        # ImageArtifact: .base64 holds base64-encoded image data
-        b64 = getattr(image_input, "base64", None)
+        # ImageArtifact: .base64 holds raw or data-URI
+        b64 = getattr(val, "base64", None)
         if isinstance(b64, str) and b64:
             return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
+
+        # ImageUrlArtifact or similar: .value holds URL or local path
+        v = getattr(val, "value", None)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
 
         return None
 

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -85,6 +85,11 @@ WORLD_LABS = ProxyApiKeyProviderConfig(
     provider_name="World Labs",
     api_key_url="https://platform.worldlabs.ai/api-keys",
 )
+RUNWAYML = ProxyApiKeyProviderConfig(
+    api_key_name="RUNWAYML_API_KEY",
+    provider_name="RunwayML",
+    api_key_url="https://app.runwayml.com/",
+)
 
 _NODE_PROVIDER_CONFIGS = {
     "ElevenLabsMusicGeneration": ELEVENLABS,
@@ -113,6 +118,8 @@ _NODE_PROVIDER_CONFIGS = {
     "QwenImageEdit": DASHSCOPE,
     "QwenImageGeneration": DASHSCOPE,
     "Rodin23DGeneration": RODIN,
+    "RunwayMLImageGeneration": RUNWAYML,
+    "RunwayMLVideoGeneration": RUNWAYML,
     "SeedanceVideoGeneration": SEED,
     "SeedreamImageGeneration": SEED,
     "SeedVRImageUpscale": SEED,

--- a/griptape_nodes_library/video/runway_ml_video_generation.py
+++ b/griptape_nodes_library/video/runway_ml_video_generation.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any, ClassVar
+
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["RunwayMLVideoGeneration"]
+
+# Model mapping from user-friendly names to API model IDs
+MODEL_MAPPING: dict[str, str] = {
+    "Gen-4.5": "gen4.5",
+    "Gen-4 Turbo": "gen4_turbo",
+    "Gen-3 Alpha Turbo": "gen3a_turbo",
+}
+MODEL_OPTIONS = list(MODEL_MAPPING.keys())
+DEFAULT_MODEL = MODEL_OPTIONS[0]
+
+# Ratio options per model
+RATIO_OPTIONS: dict[str, list[str]] = {
+    "gen4.5": ["1280:720", "720:1280", "1104:832", "960:960", "832:1104", "1584:672"],
+    "gen4_turbo": ["1280:720", "720:1280", "1104:832", "960:960", "832:1104", "1584:672"],
+    "gen3a_turbo": [
+        "1280:720",
+        "720:1280",
+        "1104:832",
+        "960:960",
+        "832:1104",
+        "1584:672",
+        "848:480",
+        "640:480",
+    ],
+}
+
+# Text-only ratio options for gen4.5 (text_to_video endpoint)
+TEXT_ONLY_RATIO_OPTIONS = ["1280:720", "720:1280"]
+
+# Models that require an input image
+MODELS_REQUIRING_IMAGE = {"gen4_turbo", "gen3a_turbo"}
+
+# Duration constraints
+MIN_DURATION = 2
+MAX_DURATION = 10
+DEFAULT_DURATION = 5
+
+# Seed constraints
+MAX_SEED = 4294967295
+
+
+class RunwayMLVideoGeneration(GriptapeProxyNode):
+    """Generate video using RunwayML models via Griptape Cloud model proxy.
+
+    Supports text-to-video (Gen-4.5 only) and image-to-video generation.
+
+    Inputs:
+        - model (str): RunwayML model to use
+        - prompt_text (str): Text description of the desired video (1-1000 chars)
+        - prompt_image (ImageUrlArtifact): Input image for image-to-video generation
+        - ratio (str): Output video resolution
+        - duration (int): Video duration in seconds (2-10)
+        - seed (int): Random seed for reproducibility
+
+    Outputs:
+        - generation_id (str): Generation ID from the API
+        - provider_response (dict): Verbatim response from Griptape model proxy
+        - video_url (VideoUrlArtifact): Generated video as URL artifact
+    """
+
+    # Ratio options vary by model
+    RATIO_OPTIONS: ClassVar[dict[str, list[str]]] = RATIO_OPTIONS
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate video using RunwayML models via Griptape Cloud model proxy"
+
+        # --- INPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="model",
+                default_value=DEFAULT_MODEL,
+                tooltip="RunwayML video generation model",
+                allow_output=False,
+                traits={Options(choices=MODEL_OPTIONS)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="prompt_text",
+                tooltip="Text description of the desired video (1-1000 characters)",
+                multiline=True,
+                placeholder_text="Describe the video you want to generate...",
+                allow_output=False,
+                ui_options={"display_name": "Prompt"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="prompt_image",
+                tooltip="Input image for image-to-video generation (required for Gen-4 Turbo and Gen-3 Alpha Turbo)",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={
+                    "display_name": "Input Image",
+                    "expander": True,
+                },
+            )
+        )
+
+        with ParameterGroup(name="Generation Settings") as gen_settings_group:
+            ParameterString(
+                name="ratio",
+                default_value="1280:720",
+                tooltip="Output video resolution",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=RATIO_OPTIONS["gen4.5"])},
+                ui_options={"display_name": "Ratio"},
+            )
+
+            ParameterInt(
+                name="duration",
+                default_value=DEFAULT_DURATION,
+                tooltip="Video duration in seconds",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                min_val=MIN_DURATION,
+                max_val=MAX_DURATION,
+                ui_options={"display_name": "Duration (seconds)"},
+            )
+
+            ParameterInt(
+                name="seed",
+                default_value=0,
+                tooltip="Random seed for reproducibility (0 = random). Range: 0-4294967295",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                min_val=0,
+                max_val=MAX_SEED,
+                ui_options={"display_name": "Seed"},
+            )
+
+        self.add_node_element(gen_settings_group)
+
+        # --- OUTPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID from the API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="video_url",
+                tooltip="Generated video as URL artifact",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="runway_video.mp4",
+        )
+        self._output_file.add_parameter()
+
+        # Status parameters MUST be last
+        self._create_status_parameters(
+            result_details_tooltip="Details about the video generation result or any errors",
+            result_details_placeholder="Generation status will appear here...",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _log(self, message: str) -> None:
+        with suppress(Exception):
+            logger.info(message)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Update ratio choices when the model changes."""
+        super().after_value_set(parameter, value)
+
+        if parameter.name == "model":
+            api_model_id = MODEL_MAPPING.get(str(value), str(value))
+            new_choices = self.RATIO_OPTIONS.get(api_model_id, RATIO_OPTIONS["gen4.5"])
+            current_ratio = self.get_parameter_value("ratio")
+            if current_ratio not in new_choices:
+                default_ratio = "1280:720" if "1280:720" in new_choices else new_choices[0]
+                self._update_option_choices("ratio", new_choices, default_ratio)
+            else:
+                self._update_option_choices("ratio", new_choices, current_ratio)
+
+    def _get_api_model_id(self) -> str:
+        """Map user-friendly model name to API model ID."""
+        model = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(str(model), str(model))
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for RunwayML video generation.
+
+        Determines whether to use image_to_video or text_to_video endpoint
+        based on whether an input image is provided.
+        """
+        prompt_text = self.get_parameter_value("prompt_text") or ""
+        ratio = self.get_parameter_value("ratio") or "1280:720"
+        duration = self.get_parameter_value("duration") or DEFAULT_DURATION
+        seed = self.get_parameter_value("seed") or 0
+        prompt_image = self.get_parameter_value("prompt_image")
+
+        api_model_id = self._get_api_model_id()
+
+        payload: dict[str, Any] = {
+            "promptText": prompt_text.strip(),
+            "ratio": ratio,
+            "duration": int(duration),
+        }
+
+        # Include seed only if non-zero
+        if seed and int(seed) > 0:
+            payload["seed"] = int(seed)
+
+        # Determine endpoint based on image presence
+        if prompt_image:
+            data_uri = self._image_to_data_uri(prompt_image)
+            if data_uri:
+                payload["promptImage"] = data_uri
+                payload["_endpoint"] = "image_to_video"
+            else:
+                payload["_endpoint"] = "text_to_video"
+        else:
+            # text_to_video endpoint (gen4.5 only)
+            payload["_endpoint"] = "text_to_video"
+
+        # Validate ratio for text_to_video mode
+        if payload.get("_endpoint") == "text_to_video" and api_model_id == "gen4.5":
+            if ratio not in TEXT_ONLY_RATIO_OPTIONS:
+                payload["ratio"] = "1280:720"
+
+        return payload
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the RunwayML result and download the video.
+
+        The proxy client returns the output array from the RunwayML task response.
+        The output is an array of signed CloudFront URLs.
+        """
+        # Handle binary response
+        if "raw_bytes" in result_json:
+            await self._handle_video_bytes(result_json["raw_bytes"])
+            return
+
+        # Look for output URLs in various possible response shapes
+        output = result_json.get("output")
+        if isinstance(output, list) and output:
+            video_url = output[0]
+        elif isinstance(output, str):
+            video_url = output
+        else:
+            # Try direct URL fields
+            video_url = result_json.get("video_url") or result_json.get("url")
+
+        if not video_url or not isinstance(video_url, str):
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Generation completed but no video URL was found in the response.",
+            )
+            return
+
+        await self._handle_video_url(video_url)
+
+    async def _handle_video_url(self, video_url: str) -> None:
+        """Download video from URL and save it."""
+        try:
+            video_bytes = await self._download_bytes_from_url(video_url)
+        except Exception as e:
+            self._log(f"Failed to download video: {e}")
+            video_bytes = None
+
+        if video_bytes:
+            await self._handle_video_bytes(video_bytes)
+        else:
+            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
+            self._set_status_results(
+                was_successful=True,
+                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
+            )
+
+    async def _handle_video_bytes(self, video_bytes: bytes) -> None:
+        """Save video bytes to file and set output parameters."""
+        if not video_bytes:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details="Received empty video data from API.",
+            )
+            return
+
+        try:
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(video_bytes)
+            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
+            self._log(f"Saved video as {saved.name}")
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"Video generated successfully and saved as {saved.name}.",
+            )
+        except Exception as e:
+            self._log(f"Failed to save video: {e}")
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Video generation completed but failed to save: {e}",
+            )
+
+    @staticmethod
+    def _image_to_data_uri(image_input: Any) -> str | None:
+        """Convert an image parameter value to a data URI for RunwayML.
+
+        RunwayML requires images as data URIs or publicly-accessible URLs with
+        proper Content-Type headers. Data URIs are the most reliable option.
+        """
+        if image_input is None:
+            return None
+
+        # String input
+        if isinstance(image_input, str):
+            v = image_input.strip()
+            if not v:
+                return None
+            if v.startswith("data:image/"):
+                return v
+            if v.startswith(("http://", "https://")):
+                return v
+            return f"data:image/png;base64,{v}"
+
+        # ImageUrlArtifact: .value holds a URL string
+        value = getattr(image_input, "value", None)
+        if isinstance(value, str) and value.startswith(("http://", "https://", "data:image/")):
+            return value
+
+        # ImageArtifact: .base64 holds base64-encoded image data
+        b64 = getattr(image_input, "base64", None)
+        if isinstance(b64, str) and b64:
+            return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
+
+        return None
+
+    def _set_safe_defaults(self) -> None:
+        """Clear output parameters on error."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["video_url"] = None
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Extract error message from RunwayML error responses.
+
+        RunwayML errors follow the structure: {"error": "...", "issues": [...]}
+        """
+        if not response_json:
+            return f"{self.name} generation failed with no error details provided by API."
+
+        # Try RunwayML-specific error format
+        error = response_json.get("error")
+        issues = response_json.get("issues")
+        if error and isinstance(error, str):
+            msg = f"{self.name}: {error}"
+            if issues and isinstance(issues, list):
+                issue_messages = []
+                for issue in issues:
+                    if isinstance(issue, dict):
+                        issue_msg = issue.get("message", "")
+                        issue_path = issue.get("path", [])
+                        if issue_msg:
+                            path_str = ".".join(str(p) for p in issue_path) if issue_path else ""
+                            issue_messages.append(f"  {path_str}: {issue_msg}" if path_str else f"  {issue_msg}")
+                if issue_messages:
+                    msg += "\n" + "\n".join(issue_messages)
+            return msg
+
+        # Fall back to base class extraction
+        return super()._extract_error_message(response_json)
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Validate parameters before execution."""
+        exceptions = super().validate_before_node_run() or []
+
+        prompt_text = self.get_parameter_value("prompt_text") or ""
+        if not prompt_text.strip():
+            exceptions.append(ValueError(f"{self.name} requires a prompt to generate video."))
+        elif len(prompt_text) > 1000:
+            exceptions.append(
+                ValueError(f"{self.name} prompt exceeds 1000 characters (got: {len(prompt_text)} characters).")
+            )
+
+        api_model_id = self._get_api_model_id()
+        prompt_image = self.get_parameter_value("prompt_image")
+
+        # gen4_turbo and gen3a_turbo require an input image
+        if api_model_id in MODELS_REQUIRING_IMAGE and not prompt_image:
+            exceptions.append(
+                ValueError(
+                    f"{self.name}: {self.get_parameter_value('model')} requires an input image for video generation."
+                )
+            )
+
+        duration = self.get_parameter_value("duration")
+        if duration is not None and (int(duration) < MIN_DURATION or int(duration) > MAX_DURATION):
+            exceptions.append(
+                ValueError(f"{self.name}: duration must be between {MIN_DURATION} and {MAX_DURATION} seconds.")
+            )
+
+        return exceptions if exceptions else None

--- a/griptape_nodes_library/video/runway_ml_video_generation.py
+++ b/griptape_nodes_library/video/runway_ml_video_generation.py
@@ -18,7 +18,7 @@ from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.image_utils import shrink_image_to_size
 
-from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.proxy import GriptapeProxyNode
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/video/runway_ml_video_generation.py
+++ b/griptape_nodes_library/video/runway_ml_video_generation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 from contextlib import suppress
 from typing import Any, ClassVar
@@ -12,7 +13,10 @@ from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.image_utils import shrink_image_to_size
 
 from griptape_nodes_library.griptape_proxy_node import GriptapeProxyNode
 
@@ -247,7 +251,7 @@ class RunwayMLVideoGeneration(GriptapeProxyNode):
 
         # Determine endpoint based on image presence
         if prompt_image:
-            data_uri = self._image_to_data_uri(prompt_image)
+            data_uri = await self._prepare_image_data_uri(prompt_image)
             if data_uri:
                 payload["promptImage"] = data_uri
                 payload["_endpoint"] = "image_to_video"
@@ -339,36 +343,57 @@ class RunwayMLVideoGeneration(GriptapeProxyNode):
                 result_details=f"Video generation completed but failed to save: {e}",
             )
 
-    @staticmethod
-    def _image_to_data_uri(image_input: Any) -> str | None:
-        """Convert an image parameter value to a data URI for RunwayML.
+    async def _prepare_image_data_uri(self, image_input: Any) -> str | None:
+        """Convert image input to a data URI, downloading from local paths if needed.
 
         RunwayML requires images as data URIs or publicly-accessible URLs with
         proper Content-Type headers. Data URIs are the most reliable option.
         """
-        if image_input is None:
+        if not image_input:
             return None
 
-        # String input
-        if isinstance(image_input, str):
-            v = image_input.strip()
+        image_url = self._coerce_image_url_or_data_uri(image_input)
+        if not image_url:
+            return None
+
+        if image_url.startswith("data:image/"):
+            return image_url
+
+        try:
+            image_bytes = await File(image_url).aread_bytes()
+        except FileLoadError as e:
+            logger.debug("%s failed to load image from %s: %s", self.name, image_url, e)
+            return None
+
+        # RunwayML data URIs are limited to 5,242,880 characters.
+        # The base64 prefix is ~22 chars, so raw bytes must encode to under ~3.9MB.
+        max_raw_bytes = 3_900_000
+        if len(image_bytes) > max_raw_bytes:
+            image_bytes = shrink_image_to_size(image_bytes, max_raw_bytes, context_name=self.name)
+
+        return f"data:image/png;base64,{base64.b64encode(image_bytes).decode('utf-8')}"
+
+    @staticmethod
+    def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Convert various image input types to a URL or data URI string."""
+        if val is None:
+            return None
+
+        if isinstance(val, str):
+            v = val.strip()
             if not v:
                 return None
-            if v.startswith("data:image/"):
-                return v
-            if v.startswith(("http://", "https://")):
-                return v
-            return f"data:image/png;base64,{v}"
+            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
 
-        # ImageUrlArtifact: .value holds a URL string
-        value = getattr(image_input, "value", None)
-        if isinstance(value, str) and value.startswith(("http://", "https://", "data:image/")):
-            return value
-
-        # ImageArtifact: .base64 holds base64-encoded image data
-        b64 = getattr(image_input, "base64", None)
+        # ImageArtifact: .base64 holds raw or data-URI
+        b64 = getattr(val, "base64", None)
         if isinstance(b64, str) and b64:
             return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
+
+        # ImageUrlArtifact or similar: .value holds URL or local path
+        v = getattr(val, "value", None)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
 
         return None
 

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -18,4 +18,5 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_elevenlabs_text_to_speech_generation.py": {"Start Flow": {"prompt": "Hello world"}},
     "test_elevenlabs_sound_effect_generation.py": {"Start Flow": {"prompt": "Thunder clap"}},
     "test_elevenlabs_music_generation.py": {"Start Flow": {"prompt": "Upbeat jazz"}},
+    "test_runway_ml_video_generation.py": {"Start Flow": {"prompt": "A ball bouncing"}},
 }

--- a/tests/integration/test_runway_ml_image_generation.py
+++ b/tests/integration/test_runway_ml_image_generation.py
@@ -1,0 +1,201 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_runway_ml_image_generation"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.68.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "RunwayMLImageGeneration"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import asyncio
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="RunwayMLImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="RunwayMLImageGeneration",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="reference_image",
+            initial_setup=True,
+        )
+    )
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt_text",
+                node_name=gen_node,
+                value="A serene mountain landscape at sunrise",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    workflow_output = execute_workflow(input={})
+    print(workflow_output)

--- a/tests/integration/test_runway_ml_video_generation.py
+++ b/tests/integration/test_runway_ml_video_generation.py
@@ -1,0 +1,227 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_runway_ml_video_generation"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.68.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "RunwayMLVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Testing Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="RunwayMLVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="RunwayMLVideoGeneration",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt_text",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.prompt is not None:
+            flow_input["Start Flow"]["prompt"] = args.prompt
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)


### PR DESCRIPTION
Adds `RunwayMLVideoGeneration` and `RunwayMLImageGeneration` proxy nodes for generating video and images through the Griptape Cloud model proxy.

The video node supports three models: Gen-4.5 (text-to-video and image-to-video), Gen-4 Turbo (image-to-video), and Gen-3 Alpha Turbo (image-to-video). It automatically selects the `text_to_video` or `image_to_video` endpoint based on whether an input image is provided. Ratio options update dynamically when the model changes.

The image node supports Gen-4 Image and Gen-4 Image Turbo models via the `text_to_image` endpoint. It requires a reference image, which is converted to a data URI before being sent to the API. Both nodes use data URIs for media inputs rather than `PublicArtifactUrlParameter` because RunwayML rejects URLs that have an `application/octet-stream` Content-Type header.

Depends on the proxy client PR: https://github.com/griptape-ai/griptape-cloud/pull/1920

## Sources

- https://docs.dev.runwayml.com/api
- RunwayML rejects publicly-hosted URLs with incorrect Content-Type headers, so all image inputs are converted to data URIs inline

## Testing with the engine

To test the node end-to-end in the Griptape Nodes UI:

1. Check out both branches:
   - This repo: `feat/runwayml-proxy-node`
   - griptape-cloud: the proxy client branch (see linked PR above)
2. Start the local griptape-cloud: `cd griptape-cloud && make up/debug`
3. Create DB records for the model config (see proxy client PR for setup steps)
4. Start the engine with proxy overrides:
   ```bash
   GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local make run/watch
   ```
5. In the Nodes UI, add a `RunwayML Video Generation` or `RunwayML Image Generation` node and connect it to a workflow
6. Set the prompt and any other parameters, then run the workflow
7. Verify the output video/image appears in the node's output

## Integration test

To run the automated integration tests:

```bash
GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local GT_CLOUD_API_KEY=fake \
  uv run python -m pytest tests/workflows/test_integration_workflows.py -v -k "runway_ml"
```