### PR TITLE
Fix clearing behavior on image input params

### DIFF
--- a/griptape_nodes_library/image/grok_image_edit.py
+++ b/griptape_nodes_library/image/grok_image_edit.py
@@ -82,7 +82,7 @@ class GrokImageEdit(GriptapeProxyNode):
                 name="image",
                 default_value="",
                 tooltip="Input image to edit",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Image"},
             )
         )

--- a/griptape_nodes_library/video/grok_video_generation.py
+++ b/griptape_nodes_library/video/grok_video_generation.py
@@ -90,7 +90,7 @@ class GrokVideoGeneration(GriptapeProxyNode):
                 name="image",
                 default_value="",
                 tooltip="Optional first frame image",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Input Image"},
             )
         )

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -243,7 +243,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="image",
                 tooltip="Start frame image (required). Accepts ImageArtifact, ImageUrlArtifact, URL, or Base64.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Start Frame"},
             )
         )
@@ -251,7 +251,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="image_tail",
                 tooltip="End frame image (optional). Supported on kling-v2-1 and kling-v2-5-turbo with pro mode.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "End Frame"},
             )
         )
@@ -294,7 +294,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
                 name="static_mask",
                 default_value=None,
                 tooltip="Static brush application area. Accepts ImageArtifact, ImageUrlArtifact, URL, or Base64.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
             )
             ParameterString(
                 name="dynamic_masks",

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -150,7 +150,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="first_frame_image",
                 tooltip="First frame image (optional). Accepts ImageArtifact, ImageUrlArtifact, URL, or Base64.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "first frame"},
             )
         )
@@ -158,7 +158,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="end_frame_image",
                 tooltip="End frame image (optional). Requires first frame to be set.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "end frame"},
             )
         )

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -101,7 +101,7 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
                 name="image_url",
                 default_value="",
                 tooltip="Source image URL.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"placeholder_text": "https://example.com/image.jpg"},
             ),
             disclaimer_message="The OmniHuman service utilizes this URL to access the image for video generation.",

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -119,7 +119,7 @@ class WanAnimateGeneration(GriptapeProxyNode):
                 name="image_url",
                 default_value="",
                 tooltip="Source image to animate",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Image URL"},
             ),
             disclaimer_message="The WAN Animate service utilizes this URL to access the image for animation.",


### PR DESCRIPTION
Addresses a complaint regarding some nodes not 'clearing' image inputs when connections are deleted. The implemented fix is to remove `ParameterMode.PROPERTY` on image inputs, ensuring the image will go away when the connection is removed and this data is not submitted with subsequent node executions.