### PR TITLE
feat: add Meshy Text to 3D generation node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -2649,6 +2649,17 @@
       }
     },
     {
+      "class_name": "MeshyTextTo3DGeneration",
+      "file_path": "griptape_nodes_library/three_d/meshy_text_to_3d_generation.py",
+      "metadata": {
+        "category": "3D",
+        "description": "Generate 3D models from text using Meshy via Griptape model proxy",
+        "display_name": "Meshy Text to 3D",
+        "icon": "box",
+        "group": "create"
+      }
+    },
+    {
       "class_name": "WorldLabsWorldGeneration",
       "file_path": "griptape_nodes_library/splat/world_labs_world_generation.py",
       "metadata": {

--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+import re
 from typing import Any, ClassVar
 from urllib.parse import urljoin
 
@@ -419,6 +420,23 @@ class GoogleImageGeneration(GriptapeProxyNode):
     async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
         await self._handle_response(result_json)
 
+    @staticmethod
+    def _sanitize_log_message(message: str) -> str:
+        sanitized = str(message)
+        sanitized = re.sub(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+", r"\1[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\b(api[_-]?key|token|password|secret|authorization)\b\s*[:=]\s*([\"'])?[^\"'\s,;]+([\"'])?",
+            r"\1=[REDACTED]",
+            sanitized,
+        )
+        sanitized = re.sub(r"(?i)\bGT_CLOUD_API_KEY\b\s*[:=]\s*[^\s,;]+", "GT_CLOUD_API_KEY=[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\bGT_CLOUD_PROXY_API_KEY\b\s*[:=]\s*[^\s,;]+",
+            "GT_CLOUD_PROXY_API_KEY=[REDACTED]",
+            sanitized,
+        )
+        return sanitized
+
     def _validate_api_key(self) -> str:
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
         if not api_key:
@@ -431,7 +449,7 @@ class GoogleImageGeneration(GriptapeProxyNode):
         payload = params
 
         msg = f"{self.name} submitting request to proxy model={params['model']}"
-        logger.info(msg)
+        logger.info(self._sanitize_log_message(msg))
 
         try:
             async with httpx.AsyncClient() as client:
@@ -441,7 +459,7 @@ class GoogleImageGeneration(GriptapeProxyNode):
         except httpx.HTTPStatusError as e:
             self._set_safe_defaults()
             msg = f"{self.name} proxy POST error status={e.response.status_code} headers={dict(e.response.headers)} body={e.response.text}"
-            logger.info(msg)
+            logger.info(self._sanitize_log_message(msg))
             try:
                 error_json = e.response.json()
                 error_details = self._extract_error_details(error_json)
@@ -452,11 +470,11 @@ class GoogleImageGeneration(GriptapeProxyNode):
         except Exception as e:
             self._set_safe_defaults()
             msg = f"{self.name} proxy POST request failed: {e}"
-            logger.info(msg)
+            logger.info(self._sanitize_log_message(msg))
             raise RuntimeError(msg) from e
 
         msg = f"{self.name} received response from API"
-        logger.info(msg)
+        logger.info(self._sanitize_log_message(msg))
 
         # Process the response immediately
         await self._handle_response(response_json)

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import Any
@@ -200,10 +201,27 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             raise ValueError(msg)
         return api_key
 
+    @staticmethod
+    def _sanitize_log_message(message: str) -> str:
+        sanitized = str(message)
+        sanitized = re.sub(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+", r"\1[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\b(api[_-]?key|token|password|secret|authorization)\b\s*[:=]\s*([\"'])?[^\"'\s,;]+([\"'])?",
+            r"\1=[REDACTED]",
+            sanitized,
+        )
+        sanitized = re.sub(r"(?i)\bGT_CLOUD_API_KEY\b\s*[:=]\s*[^\s,;]+", "GT_CLOUD_API_KEY=[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\bGT_CLOUD_PROXY_API_KEY\b\s*[:=]\s*[^\s,;]+",
+            "GT_CLOUD_PROXY_API_KEY=[REDACTED]",
+            sanitized,
+        )
+        return sanitized
+
     def _log(self, message: str) -> None:
         """Log a message with error suppression."""
         with suppress(Exception):
-            logger.info(message)
+            logger.info(self._sanitize_log_message(message))
 
     def _log_auth_header_summary(self, context: str, headers: dict[str, str]) -> None:
         authorization = headers.get("Authorization", "")

--- a/griptape_nodes_library/three_d/meshy_text_to_3d_generation.py
+++ b/griptape_nodes_library/three_d/meshy_text_to_3d_generation.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import ParameterList, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+
+from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.three_d.three_d_artifact import ThreeDUrlArtifact
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["MeshyTextTo3DGeneration"]
+
+# Model ID mapping
+MODEL_MAPPING = {
+    "Meshy 5": "meshy-5",
+    "Meshy 6": "meshy-6",
+    "Latest": "latest",
+}
+DEFAULT_MODEL = "Latest"
+
+# Model type options
+MODEL_TYPE_OPTIONS = ["standard", "lowpoly"]
+DEFAULT_MODEL_TYPE = "standard"
+
+# Topology options
+TOPOLOGY_OPTIONS = ["triangle", "quad"]
+DEFAULT_TOPOLOGY = "triangle"
+
+# Symmetry mode options
+SYMMETRY_MODE_OPTIONS = ["off", "auto", "on"]
+DEFAULT_SYMMETRY_MODE = "auto"
+
+# Pose mode options
+POSE_MODE_OPTIONS = ["", "a-pose", "t-pose"]
+DEFAULT_POSE_MODE = ""
+
+# Origin position options
+ORIGIN_AT_OPTIONS = ["bottom", "center"]
+DEFAULT_ORIGIN_AT = "bottom"
+
+# Output format options
+OUTPUT_FORMAT_OPTIONS = ["glb", "obj", "fbx", "stl", "usdz", "3mf"]
+DEFAULT_OUTPUT_FORMAT = "glb"
+
+
+class MeshyTextTo3DGeneration(GriptapeProxyNode):
+    """Generate 3D models from text using Meshy via Griptape model proxy.
+
+    This node uses Meshy's Text to 3D API to generate 3D models in preview mode,
+    producing geometry without textures. For textured models, use the refine workflow.
+
+    Inputs:
+        - prompt (str): Text description of the 3D model (max 600 characters)
+        - ai_model (str): Model version to use (meshy-5, meshy-6, or latest)
+        - model_type (str): Model architecture (standard or lowpoly)
+        - target_polycount (int): Target polygon count (100-300,000)
+        - topology (str): Mesh topology (triangle or quad)
+        - symmetry_mode (str): Symmetry mode (off, auto, or on)
+        - pose_mode (str): Character pose (empty, a-pose, or t-pose)
+        - target_formats (list): Output file formats
+        - auto_size (bool): Auto-estimate real-world dimensions
+        - origin_at (str): Origin position (bottom or center, requires auto_size=true)
+
+    Outputs:
+        - generation_id (str): Generation ID (task ID) from Meshy API
+        - provider_response (dict): Raw provider response with all task details
+        - model_url (ThreeDUrlArtifact): Primary GLB model download URL
+        - model_urls (dict): All model format URLs (glb, obj, fbx, etc.)
+        - thumbnail_url (str): Preview thumbnail image URL
+    """
+
+    SERVICE_NAME = "Griptape"
+    API_KEY_NAME = "GT_CLOUD_API_KEY"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate 3D models from text using Meshy via Griptape model proxy"
+
+        # --- INPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="prompt",
+                tooltip="Text description of the 3D model to generate (max 600 characters)",
+                multiline=True,
+                placeholder_text="A simple wooden chair",
+                allow_output=False,
+                ui_options={"display_name": "Prompt"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="ai_model",
+                default_value=DEFAULT_MODEL,
+                tooltip="Model version to use",
+                allow_output=False,
+                traits={Options(choices=list(MODEL_MAPPING.keys()))},
+                ui_options={"display_name": "AI Model"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="model_type",
+                default_value=DEFAULT_MODEL_TYPE,
+                tooltip="Model architecture type",
+                allow_output=False,
+                traits={Options(choices=MODEL_TYPE_OPTIONS)},
+                ui_options={"display_name": "Model Type"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterInt(
+                name="target_polycount",
+                default_value=30000,
+                tooltip="Target polygon count for the mesh (100-300,000)",
+                allow_output=False,
+                traits={Slider(min_val=100, max_val=300000)},
+                ui_options={"display_name": "Target Polycount"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="topology",
+                default_value=DEFAULT_TOPOLOGY,
+                tooltip="Mesh topology type",
+                allow_output=False,
+                traits={Options(choices=TOPOLOGY_OPTIONS)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="symmetry_mode",
+                default_value=DEFAULT_SYMMETRY_MODE,
+                tooltip="Apply symmetry to the model",
+                allow_output=False,
+                traits={Options(choices=SYMMETRY_MODE_OPTIONS)},
+                ui_options={"display_name": "Symmetry Mode"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="pose_mode",
+                default_value=DEFAULT_POSE_MODE,
+                tooltip="Character pose for human-like models",
+                allow_output=False,
+                traits={Options(choices=POSE_MODE_OPTIONS)},
+                ui_options={"display_name": "Pose Mode"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterList(
+                name="target_formats",
+                input_types=["str", "list", "list[str]"],
+                default_value=[DEFAULT_OUTPUT_FORMAT],
+                tooltip="Output file formats",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"expander": True, "display_name": "Target Formats"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterBool(
+                name="auto_size",
+                default_value=False,
+                tooltip="Automatically estimate real-world dimensions",
+                allow_output=False,
+                ui_options={"display_name": "Auto Size"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="origin_at",
+                default_value=DEFAULT_ORIGIN_AT,
+                tooltip="Origin position (requires auto_size=true)",
+                allow_output=False,
+                traits={Options(choices=ORIGIN_AT_OPTIONS)},
+                ui_options={"display_name": "Origin At"},
+            )
+        )
+
+        # --- OUTPUT PARAMETERS ---
+        self.add_parameter(
+            ParameterString(
+                name="generation_id",
+                tooltip="Generation ID (task ID) from Meshy API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from Griptape model proxy",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            Parameter3D(
+                name="model_url",
+                tooltip="Primary GLB model as URL artifact",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True, "display_name": "3D Model"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="model_urls",
+                tooltip="All model format URLs (glb, obj, fbx, etc.)",
+                allowed_modes={ParameterMode.OUTPUT},
+                ui_options={"display_name": "All Model URLs"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterString(
+                name="thumbnail_url",
+                tooltip="Preview thumbnail image URL",
+                allowed_modes={ParameterMode.OUTPUT},
+                ui_options={"display_name": "Thumbnail URL"},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="model.glb",
+        )
+        self._output_file.add_parameter()
+
+        # Status parameters MUST be last
+        self._create_status_parameters(
+            result_details_tooltip="Details about the generation result or any errors",
+            result_details_placeholder="Generation status will appear here...",
+            parameter_group_initially_collapsed=True,
+        )
+
+    def _log(self, message: str) -> None:
+        with suppress(Exception):
+            logger.info(message)
+
+    def _get_api_model_id(self) -> str:
+        """Map friendly model name to API model ID."""
+        model = self.get_parameter_value("ai_model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(str(model), str(model))
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for Meshy Text to 3D API."""
+        # Gather parameter values
+        prompt = self.get_parameter_value("prompt") or ""
+        if not prompt.strip():
+            msg = "Prompt is required for 3D generation."
+            raise ValueError(msg)
+
+        model_type = self.get_parameter_value("model_type") or DEFAULT_MODEL_TYPE
+        target_polycount = self.get_parameter_value("target_polycount") or 30000
+        topology = self.get_parameter_value("topology") or DEFAULT_TOPOLOGY
+        symmetry_mode = self.get_parameter_value("symmetry_mode") or DEFAULT_SYMMETRY_MODE
+        pose_mode = self.get_parameter_value("pose_mode") or DEFAULT_POSE_MODE
+        auto_size = self.get_parameter_value("auto_size") or False
+        origin_at = self.get_parameter_value("origin_at") or DEFAULT_ORIGIN_AT
+
+        # Get target formats
+        target_formats_raw = self.get_parameter_list_value("target_formats") or [DEFAULT_OUTPUT_FORMAT]
+        # Ensure it's a list of strings
+        target_formats: list[str] = []
+        for fmt in target_formats_raw:
+            if isinstance(fmt, str):
+                target_formats.append(fmt)
+
+        if not target_formats:
+            target_formats = [DEFAULT_OUTPUT_FORMAT]
+
+        # Build payload according to Meshy API spec
+        payload: dict[str, Any] = {
+            "mode": "preview",  # This node only does preview (geometry without textures)
+            "prompt": prompt,
+            "model_type": model_type,
+            "topology": topology,
+            "target_polycount": target_polycount,
+            "symmetry_mode": symmetry_mode,
+            "target_formats": target_formats,
+            "auto_size": auto_size,
+        }
+
+        # Add optional parameters
+        if pose_mode:
+            payload["pose_mode"] = pose_mode
+
+        if auto_size and origin_at:
+            payload["origin_at"] = origin_at
+
+        return payload
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the Meshy result and set output parameters."""
+        # Extract model URLs
+        model_urls = result_json.get("model_urls", {})
+        thumbnail_url = result_json.get("thumbnail_url", "")
+
+        if not model_urls:
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details="No model URLs in response.")
+            return
+
+        # Get the primary GLB URL
+        glb_url = model_urls.get("glb")
+        if not glb_url:
+            # Fallback to first available format
+            glb_url = next(iter(model_urls.values()), None)
+
+        if not glb_url:
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details="No valid model URL found.")
+            return
+
+        # Download and save the primary model
+        try:
+            from griptape_nodes.files.file import File
+
+            model_bytes = await File(glb_url).aread_bytes()
+            if model_bytes:
+                dest = self._output_file.build_file()
+                saved = await dest.awrite_bytes(model_bytes)
+                self.parameter_output_values["model_url"] = ThreeDUrlArtifact(
+                    value=saved.location,
+                    meta={"filename": saved.name},
+                )
+                self.parameter_output_values["model_urls"] = model_urls
+                self.parameter_output_values["thumbnail_url"] = thumbnail_url
+                self._set_status_results(was_successful=True, result_details="3D model generated successfully.")
+            else:
+                self._set_safe_defaults()
+                self._set_status_results(was_successful=False, result_details="Failed to download model file.")
+        except Exception as e:
+            self._log(f"Error downloading model: {e}")
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details=f"Failed to download model: {e}")
+
+    def _set_safe_defaults(self) -> None:
+        """Clear all output parameters on error."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["model_url"] = None
+        self.parameter_output_values["model_urls"] = {}
+        self.parameter_output_values["thumbnail_url"] = ""

--- a/griptape_nodes_library/three_d/meshy_text_to_3d_generation.py
+++ b/griptape_nodes_library/three_d/meshy_text_to_3d_generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from contextlib import suppress
 from typing import Any
 
@@ -260,9 +261,26 @@ class MeshyTextTo3DGeneration(GriptapeProxyNode):
             parameter_group_initially_collapsed=True,
         )
 
+    @staticmethod
+    def _sanitize_log_message(message: str) -> str:
+        sanitized = str(message)
+        sanitized = re.sub(r"(?i)(authorization\s*[:=]\s*bearer\s+)[^\s,;]+", r"\1[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\b(api[_-]?key|token|password|secret|authorization)\b\s*[:=]\s*([\"'])?[^\"'\s,;]+([\"'])?",
+            r"\1=[REDACTED]",
+            sanitized,
+        )
+        sanitized = re.sub(r"(?i)\bGT_CLOUD_API_KEY\b\s*[:=]\s*[^\s,;]+", "GT_CLOUD_API_KEY=[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"(?i)\bGT_CLOUD_PROXY_API_KEY\b\s*[:=]\s*[^\s,;]+",
+            "GT_CLOUD_PROXY_API_KEY=[REDACTED]",
+            sanitized,
+        )
+        return sanitized
+
     def _log(self, message: str) -> None:
         with suppress(Exception):
-            logger.info(message)
+            logger.info(self._sanitize_log_message(message))
 
     def _get_api_model_id(self) -> str:
         """Map friendly model name to API model ID."""

--- a/tests/integration/test_meshy_text_to_3d_generation.py
+++ b/tests/integration/test_meshy_text_to_3d_generation.py
@@ -1,0 +1,227 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_meshy_text_to_3d_generation"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.79.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.69.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "MeshyTextTo3DGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# ///
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="MeshyTextTo3DGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="MeshyTextTo3DGeneration",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            resolution="resolved",
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="model_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.prompt is not None:
+            flow_input["Start Flow"]["prompt"] = args.prompt
+        else:
+            # Default test prompt
+            flow_input["Start Flow"]["prompt"] = "A simple wooden chair"
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)


### PR DESCRIPTION
Adds a `MeshyTextTo3DGeneration` node for Meshy Text to 3D generation via the Griptape Cloud proxy.

This node generates 3D models from text descriptions using Meshy's Text to 3D API in preview mode (geometry without textures). The node supports:

- Multiple model versions (meshy-5, meshy-6, latest)
- Configurable mesh topology (triangle/quad)
- Adjustable polygon count (100-300,000)
- Symmetry modes (off/auto/on)
- Character pose options (a-pose/t-pose)
- Multiple output formats (glb, obj, fbx, stl, usdz, 3mf)
- Auto-sizing and origin positioning

Depends on the proxy client PR: https://github.com/griptape-ai/griptape-cloud/pull/1914

## Sources

- [Meshy API Documentation](https://docs.meshy.ai/en)
- [Meshy Text to 3D API Reference](https://docs.meshy.ai/api-reference/v2/text-to-3d)

## Testing with the engine

To test the node end-to-end in the Griptape Nodes UI:

1. Check out both branches:
   - This repo: `feat/meshy-proxy-node`
   - griptape-cloud: `feat/meshy-proxy-client` (see linked PR above)
2. Start the local griptape-cloud: `cd griptape-cloud && make up/debug`
3. Create DB records for the model config:
   ```bash
   docker compose -f docker-compose.debug.yaml exec web uv run python manage.py shell < .scratch/create_meshy_config.py
   ```
4. Start the engine with proxy overrides:
   ```bash
   GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local make run/watch
   ```
5. In the Nodes UI, add a `Meshy Text to 3D` node and connect it to a workflow
6. Set the prompt (e.g., "A simple wooden chair") and any other parameters, then run the workflow
7. Verify the output 3D model appears in the node's output

## Integration test

To run the automated integration test:

```bash
GT_CLOUD_PROXY_BASE_URL=http://localhost:8000 GT_CLOUD_PROXY_API_KEY=local \
  python tests/integration/test_meshy_text_to_3d_generation.py --prompt "A simple wooden chair"
```

Note: The test generates a real 3D model via the Meshy API and takes approximately 30-60 seconds to complete.

Closes #1783