### PR TITLE
Reorder ProjectFileParameter and video extract outputs

### DIFF
--- a/griptape_nodes_library/image/add_text_to_existing_image.py
+++ b/griptape_nodes_library/image/add_text_to_existing_image.py
@@ -81,8 +81,6 @@ class AddTextToExistingImage(SuccessFailureNode):
 
         self._cached_render_signature: _RenderSignature | None = None
         self._cached_render_png_bytes: bytes | None = None
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="text_overlay.png")
-        self._output_file.add_parameter()
 
         self.add_parameter(
             ParameterImage(
@@ -179,6 +177,9 @@ class AddTextToExistingImage(SuccessFailureNode):
             result_details_placeholder="Details on the text rendering will be presented here.",
             parameter_group_initially_collapsed=True,
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="text_overlay.png")
+        self._output_file.add_parameter()
 
     def _expand_text_template(self, template: str, template_values: Any) -> _TextExpansionResult:
         template_value = template or ""

--- a/griptape_nodes_library/image/apply_mask.py
+++ b/griptape_nodes_library/image/apply_mask.py
@@ -25,9 +25,6 @@ class ApplyMask(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="apply_mask.png")
-        self._output_file.add_parameter()
-
         self.add_parameter(
             ParameterImage(
                 name="input_image",
@@ -71,6 +68,9 @@ class ApplyMask(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="apply_mask.png")
+        self._output_file.add_parameter()
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = []

--- a/griptape_nodes_library/image/color_match.py
+++ b/griptape_nodes_library/image/color_match.py
@@ -60,9 +60,6 @@ class ColorMatch(SuccessFailureNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="colormatch.png")
-        self._output_file.add_parameter()
-
         # Reference image input (FIRST - the source of the color palette)
         self.add_parameter(
             ParameterImage(
@@ -137,6 +134,9 @@ class ColorMatch(SuccessFailureNode):
             result_details_placeholder="Details on the color matching will be presented here.",
             parameter_group_initially_collapsed=True,
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="colormatch.png")
+        self._output_file.add_parameter()
 
     def _process_images(self, target_pil: Image.Image, ref_pil: Image.Image) -> Image.Image:
         """Process the PIL images by applying color transfer.

--- a/griptape_nodes_library/image/combine_masks.py
+++ b/griptape_nodes_library/image/combine_masks.py
@@ -27,9 +27,6 @@ class CombineMasks(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="combined_mask.png")
-        self._output_file.add_parameter()
-
         self.add_parameter(
             ParameterList(
                 name="masks",
@@ -56,6 +53,9 @@ class CombineMasks(DataNode):
                 ui_options={"expander": True, "edit_mask": True, "edit_mask_paint_mask": True},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="combined_mask.png")
+        self._output_file.add_parameter()
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions: list[Exception] = []

--- a/griptape_nodes_library/image/create_color_bars.py
+++ b/griptape_nodes_library/image/create_color_bars.py
@@ -74,9 +74,6 @@ class CreateColorBars(BaseNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="color_bars.png")
-        self._output_file.add_parameter()
-
         # Add color bar type selector
         self.add_parameter(
             ParameterString(
@@ -151,6 +148,9 @@ class CreateColorBars(BaseNode):
                 ui_options={"expander": True},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="color_bars.png")
+        self._output_file.add_parameter()
 
     def _generate_smpte_219_100_bars(self, width: int, height: int) -> Image.Image:
         """Generate SMPTE 219-100 Bars (HDTV Color Bars)."""

--- a/griptape_nodes_library/image/display_channel.py
+++ b/griptape_nodes_library/image/display_channel.py
@@ -26,6 +26,10 @@ class DisplayChannel(DisplayMask):
             )
         )
 
+        # Re-append project file output so it stays below the image output (super() registers it after output_mask).
+        self.remove_parameter_element_by_name("output_file")
+        self._output_file.add_parameter()
+
         # Change default channel to red
         channel_param = self.get_parameter_by_name("channel")
         if channel_param is not None:

--- a/griptape_nodes_library/image/display_mask.py
+++ b/griptape_nodes_library/image/display_mask.py
@@ -20,9 +20,6 @@ class DisplayMask(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="display_mask.png")
-        self._output_file.add_parameter()
-
         # Default output parameter name
         self._output_param_name = "output_mask"
 
@@ -53,6 +50,9 @@ class DisplayMask(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="display_mask.png")
+        self._output_file.add_parameter()
 
     def _set_output_parameter_name(self, name: str) -> None:
         """Set the name of the output parameter. Must be called before adding the output parameter."""

--- a/griptape_nodes_library/image/extend_canvas.py
+++ b/griptape_nodes_library/image/extend_canvas.py
@@ -115,11 +115,6 @@ class ExtendCanvas(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="extended.png")
-        self._output_file.add_parameter()
-        self._mask_file = ProjectFileParameter(node=self, name="mask_file", default_filename="mask.png")
-        self._mask_file.add_parameter()
-
         self.category = "Image"
         self.description = "Extend canvas around an image to fit target aspect ratios or custom dimensions"
 
@@ -220,6 +215,9 @@ class ExtendCanvas(ControlNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="extended.png")
+        self._output_file.add_parameter()
+
         # Output mask
         self.add_parameter(
             ParameterImage(
@@ -229,6 +227,9 @@ class ExtendCanvas(ControlNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._mask_file = ProjectFileParameter(node=self, name="mask_file", default_filename="mask.png")
+        self._mask_file.add_parameter()
 
     def process(self) -> None:
         input_image = self.get_parameter_value("input_image")

--- a/griptape_nodes_library/image/gaussian_edge_fade.py
+++ b/griptape_nodes_library/image/gaussian_edge_fade.py
@@ -28,9 +28,6 @@ class GaussianEdgeFade(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="edge_fade.png")
-        self._output_file.add_parameter()
-
         self.category = "Image"
         self.description = "Apply Gaussian blur fade to image edges for smooth compositing"
 
@@ -144,6 +141,9 @@ class GaussianEdgeFade(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="edge_fade.png")
+        self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Update UI when fade_mode changes."""

--- a/griptape_nodes_library/image/images_to_pdf.py
+++ b/griptape_nodes_library/image/images_to_pdf.py
@@ -41,13 +41,6 @@ class ImagesToPdf(ControlNode):
         )
         self.add_parameter(self.images)
 
-        self._output_file = ProjectFileParameter(
-            node=self,
-            name="output_file",
-            default_filename="output.pdf",
-        )
-        self._output_file.add_parameter()
-
         # Output parameter showing final path
         self.output = Parameter(
             name="output",
@@ -57,6 +50,13 @@ class ImagesToPdf(ControlNode):
             allowed_modes={ParameterMode.OUTPUT},
         )
         self.add_parameter(self.output)
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="output.pdf",
+        )
+        self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Normalize image inputs when the list is set."""

--- a/griptape_nodes_library/image/invert_mask.py
+++ b/griptape_nodes_library/image/invert_mask.py
@@ -19,9 +19,6 @@ class InvertMask(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="inverted_mask.png")
-        self._output_file.add_parameter()
-
         self.add_parameter(
             ParameterImage(
                 name="input_mask",
@@ -40,6 +37,9 @@ class InvertMask(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="inverted_mask.png")
+        self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter.name == "input_mask" and value is not None:

--- a/griptape_nodes_library/image/load_image.py
+++ b/griptape_nodes_library/image/load_image.py
@@ -96,14 +96,6 @@ class LoadImage(SuccessFailureNode):
         )
         self.add_parameter(channel_param)
 
-        self._mask_output_file = ProjectFileParameter(
-            node=self,
-            name="mask_output_file",
-            default_filename="mask.png",
-            ui_options={"hide": True},
-        )
-        self._mask_output_file.add_parameter()
-
         self.add_parameter(
             Parameter(
                 name="output_mask",
@@ -124,6 +116,14 @@ class LoadImage(SuccessFailureNode):
             result_details_tooltip="Details about the image loading operation result",
             result_details_placeholder="Details on the load attempt will be presented here.",
         )
+
+        self._mask_output_file = ProjectFileParameter(
+            node=self,
+            name="mask_output_file",
+            default_filename="mask.png",
+            ui_options={"hide": True},
+        )
+        self._mask_output_file.add_parameter()
 
     def after_incoming_connection(
         self,

--- a/griptape_nodes_library/image/merge_images.py
+++ b/griptape_nodes_library/image/merge_images.py
@@ -26,9 +26,6 @@ class MergeImages(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="merged.png")
-        self._output_file.add_parameter()
-
         self.LAYOUT_METHODS = {
             "horizontal": self._process_horizontal_layout,
             "vertical": self._process_vertical_layout,
@@ -70,6 +67,9 @@ class MergeImages(ControlNode):
                 ui_options={"pulse_on_run": True},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="merged.png")
+        self._output_file.add_parameter()
 
     def get_images(self) -> list:
         images = self.get_parameter_value("Images")

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -50,18 +50,18 @@ class SaveImage(SuccessFailureNode):
             )
         )
 
+        # Add status parameters using the helper method
+        self._create_status_parameters(
+            result_details_tooltip="Details about the image save operation result",
+            result_details_placeholder="Details on the save attempt will be presented here.",
+        )
+
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_nodes.png",
         )
         self._output_file.add_parameter()
-
-        # Add status parameters using the helper method
-        self._create_status_parameters(
-            result_details_tooltip="Details about the image save operation result",
-            result_details_placeholder="Details on the save attempt will be presented here.",
-        )
 
     def _extract_format_from_artifact(self, image_artifact: Any) -> str | None:
         """Extract format from image artifact.

--- a/griptape_nodes_library/image/set_color_to_transparent.py
+++ b/griptape_nodes_library/image/set_color_to_transparent.py
@@ -44,9 +44,6 @@ class SetColorToTransparent(DataNode):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="transparent.png")
-        self._output_file.add_parameter()
-
         # Input image
         self.add_parameter(
             ParameterImage(
@@ -118,6 +115,9 @@ class SetColorToTransparent(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="transparent.png")
+        self._output_file.add_parameter()
 
     def process(self) -> None:
         """Process the image and replace the specified color with transparency."""

--- a/griptape_nodes_library/video/base_video_processor.py
+++ b/griptape_nodes_library/video/base_video_processor.py
@@ -84,19 +84,12 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
         speed_param.add_trait(Options(choices=["fast", "balanced", "quality"]))
         self.add_parameter(speed_param)
 
-        self.add_parameter(
-            ParameterVideo(
-                name="output",
-                allowed_modes={ParameterMode.OUTPUT},
-                tooltip="The processed video",
-                ui_options={"pulse_on_run": True, "expander": True, "display_name": "Processed Video"},
-            )
-        )
+        self._register_primary_output_parameter()
 
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
-            default_filename="output.mp4",
+            default_filename=self._get_output_file_default_filename(),
         )
         self._output_file.add_parameter()
 
@@ -111,6 +104,24 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
     @abstractmethod
     def _setup_custom_parameters(self) -> None:
         """Setup custom parameters specific to this video processor. Override in subclasses."""
+
+    def _register_primary_output_parameter(self) -> None:
+        """Register the main output artifact (video, audio, image, etc.) before the project file path."""
+        self.add_parameter(
+            ParameterVideo(
+                name="output",
+                allowed_modes={ParameterMode.OUTPUT},
+                tooltip="The processed video",
+                ui_options={"pulse_on_run": True, "expander": True, "display_name": "Processed Video"},
+            )
+        )
+
+    def _get_output_file_default_filename(self) -> str:
+        """Default filename for the project file save path; subclasses may set OUTPUT_FILE_DEFAULT_FILENAME."""
+        candidate = getattr(type(self), "OUTPUT_FILE_DEFAULT_FILENAME", None)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+        return "output.mp4"
 
     @abstractmethod
     def _get_processing_description(self) -> str:

--- a/griptape_nodes_library/video/extract_audio.py
+++ b/griptape_nodes_library/video/extract_audio.py
@@ -34,9 +34,8 @@ class ExtractAudio(BaseVideoProcessor):
         # Hide parameters that aren't relevant for audio extraction
         self.hide_parameter_by_name("output_frame_rate")
         self.hide_parameter_by_name("processing_speed")
-        self.hide_parameter_by_name("output")
 
-        # Add audio output parameter
+    def _register_primary_output_parameter(self) -> None:
         self.add_parameter(
             ParameterAudio(
                 name="extracted_audio",

--- a/griptape_nodes_library/video/extract_last_frame.py
+++ b/griptape_nodes_library/video/extract_last_frame.py
@@ -1,11 +1,10 @@
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult
-from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from PIL import Image
 
@@ -16,18 +15,16 @@ from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
 class ExtractLastFrame(BaseVideoProcessor):
     """Extract the last frame from a video and output it as an ImageUrlArtifact."""
 
+    OUTPUT_FILE_DEFAULT_FILENAME: ClassVar[str] = "last_frame.png"
+
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
-
-        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="last_frame.png")
-        self.set_parameter_value("output_file", "last_frame.png")
 
         # Hide parameters that aren't relevant for frame extraction
         self.hide_parameter_by_name("output_frame_rate")
         self.hide_parameter_by_name("processing_speed")
-        self.hide_parameter_by_name("output")
 
-        # Add image output parameter
+    def _register_primary_output_parameter(self) -> None:
         self.add_parameter(
             ParameterImage(
                 name="last_frame_image",


### PR DESCRIPTION
fixes: https://github.com/griptape-ai/griptape-nodes/issues/4382

## Summary

Moves `ProjectFileParameter` registration so project file outputs appear after the primary artifact outputs (and after status where applicable), matching the pattern used elsewhere (e.g. crop/invert image). **Extend Canvas** interleaves `output_file` after `extended_image` and `mask_file` after `canvas_mask`.

Refactors **BaseVideoProcessor** so subclasses register their primary output via `_register_primary_output_parameter()` **before** the project file path, fixing **Extract Audio** and **Extract Last Frame** so the file control sits under the real output (audio / image) instead of the unused video `output` slot.

## Nodes / classes touched

### Image library
| Node | File |
|------|------|
| **AddTextToExistingImage** | `image/add_text_to_existing_image.py` |
| **ApplyMask** | `image/apply_mask.py` |
| **ColorMatch** | `image/color_match.py` |
| **CombineMasks** | `image/combine_masks.py` |
| **CreateColorBars** | `image/create_color_bars.py` |
| **DisplayMask** | `image/display_mask.py` |
| **DisplayChannel** | `image/display_channel.py` (re-append `output_file` after subclass output) |
| **ExtendCanvas** | `image/extend_canvas.py` |
| **GaussianEdgeFade** | `image/gaussian_edge_fade.py` |
| **ImagesToPdf** | `image/images_to_pdf.py` |
| **InvertMask** | `image/invert_mask.py` |
| **LoadImage** | `image/load_image.py` |
| **MergeImages** | `image/merge_images.py` |
| **SaveImage** | `image/save_image.py` |
| **SetColorToTransparent** | `image/set_color_to_transparent.py` |

### Video library
| Class / node | File |
|--------------|------|
| **BaseVideoProcessor** (hook for primary output + default filename) | `video/base_video_processor.py` |
| **ExtractAudio** | `video/extract_audio.py` |
| **ExtractLastFrame** | `video/extract_last_frame.py` |

Other **BaseVideoProcessor** subclasses inherit the new registration order for default processed-video output → project file → logs → status.

## Notes
- No intentional API or runtime behavior change beyond parameter UI order and the extract-audio / extract-last-frame output wiring described above.


Made with [Cursor](https://cursor.com)