### PR TITLE
Add Kling v3 video generation 4k mode

### DIFF
--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -34,6 +34,12 @@ MAX_PROMPT_LENGTH = 2500
 DEFAULT_DURATION_5S = 5
 MAX_MULTI_PROMPT_COUNT = 6
 V3_MODEL_ID = "kling-v3"
+MODE_STD = "std"
+MODE_PRO = "pro"
+MODE_4K = "4k"
+BASE_MODE_CHOICES = [MODE_STD, MODE_PRO]
+V3_MODE_CHOICES = [MODE_STD, MODE_PRO, MODE_4K]
+DEFAULT_MODE = MODE_PRO
 DEFAULT_MULTI_SHOTS = [{"name": "Shot1", "duration": 5, "description": ""}]
 
 
@@ -80,50 +86,50 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
     # Model capability definitions
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "kling-v3": {
-            "modes": ["std", "pro"],
+            "modes": V3_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
             "supports_multi_shot": True,
         },
         "kling-v1": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5],
             "supports_sound": False,
             "supports_tail_frame": False,
         },
         "kling-v1-5": {
-            "modes": ["pro"],
+            "modes": [MODE_PRO],
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
         },
         "kling-v2-master": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
         },
         "kling-v2-1": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": True,  # Only with pro mode
         },
         "kling-v2-1-master": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
         },
         "kling-v2-5-turbo": {
-            "modes": ["pro"],
+            "modes": [MODE_PRO],
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": True,  # Only with pro mode
         },
         "kling-v2-6": {
-            "modes": ["pro"],
+            "modes": [MODE_PRO],
             "durations": [5, 10],
             "supports_sound": True,
             "supports_tail_frame": False,
@@ -270,10 +276,10 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             )
             ParameterString(
                 name="mode",
-                default_value="pro",
-                tooltip="Video generation mode (std: Standard, pro: Professional)",
+                default_value=DEFAULT_MODE,
+                tooltip="Video generation mode. Supported modes vary by model; Kling v3.0 also supports 4k.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["std", "pro"])},
+                traits={Options(choices=V3_MODE_CHOICES)},
             )
             ParameterInt(
                 name="duration",
@@ -402,6 +408,9 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
     def _apply_generation_settings_visibility(self, model_id: str) -> None:
         """Apply mode/duration/sound visibility for selected model."""
+        capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+        self._update_mode_choices(capabilities.get("modes", BASE_MODE_CHOICES))
+
         if model_id == "kling-v1":
             self.show_parameter_by_name("mode")
             self.hide_parameter_by_name(["duration", "sound"])
@@ -427,6 +436,15 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         self.show_parameter_by_name(["mode", "duration"])
         self.hide_parameter_by_name("sound")
+
+    def _update_mode_choices(self, supported_modes: list[str]) -> None:
+        """Keep the mode dropdown aligned with the selected model."""
+        current_mode = self.get_parameter_value("mode")
+        next_mode = current_mode if current_mode in supported_modes else DEFAULT_MODE
+        if next_mode not in supported_modes:
+            next_mode = supported_modes[0]
+
+        self._update_option_choices("mode", supported_modes, next_mode)
 
     def _hide_multi_shot_inputs(self) -> None:
         """Hide multi-shot-specific UI inputs."""
@@ -573,7 +591,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         prompt = self.get_parameter_value("prompt") or ""
         negative_prompt = self.get_parameter_value("negative_prompt") or ""
         cfg_scale = self.get_parameter_value("cfg_scale") or 0.5
-        mode = self.get_parameter_value("mode") or "pro"
+        mode = self.get_parameter_value("mode") or DEFAULT_MODE
         duration = self.get_parameter_value("duration") or 5
         sound = self.get_parameter_value("sound") or "off"
         static_mask = await self._prepare_image_data_url_async(static_mask_input)
@@ -964,7 +982,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         # Validate model-specific constraints
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
-        if mode not in capabilities.get("modes", ["std", "pro"]):
+        if mode not in capabilities.get("modes", BASE_MODE_CHOICES):
             valid_modes = capabilities.get("modes", [])
             exceptions.append(
                 ValueError(

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -34,6 +34,11 @@ MAX_IMAGES_WITH_VIDEO = 4
 MAX_IMAGES_WITHOUT_VIDEO = 7
 MAX_IMAGES_FOR_END_FRAME = 2
 MAX_MULTI_PROMPT_COUNT = 6
+MODE_STD = "std"
+MODE_PRO = "pro"
+MODE_4K = "4k"
+BASE_MODE_CHOICES = [MODE_STD, MODE_PRO]
+DEFAULT_MODE = MODE_PRO
 
 
 MODEL_NAME_MAP: dict[str, dict[str, str]] = {
@@ -45,6 +50,10 @@ MODEL_NAME_MAP: dict[str, dict[str, str]] = {
         "api_model_id": "kling-v3-omni:omnivideo",
         "payload_model_name": "kling-v3-omni",
     },
+}
+MODEL_CAPABILITIES: dict[str, dict[str, Any]] = {
+    "kling-video-o1": {"modes": BASE_MODE_CHOICES, "supports_4k_with_reference_video": False},
+    "kling-v3-omni": {"modes": [MODE_STD, MODE_PRO, MODE_4K], "supports_4k_with_reference_video": False},
 }
 
 
@@ -223,10 +232,10 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             )
             ParameterString(
                 name="mode",
-                default_value="pro",
-                tooltip="Video generation mode (std: Standard, pro: Professional)",
+                default_value=DEFAULT_MODE,
+                tooltip="Video generation mode. Kling v3.0 Omni also supports 4k when reference_video is not set.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["std", "pro"])},
+                traits={Options(choices=[MODE_STD, MODE_PRO, MODE_4K])},
             )
             ParameterString(
                 name="aspect_ratio",
@@ -296,11 +305,15 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             result_details_placeholder="Generation status and details will appear here.",
             parameter_group_initially_collapsed=True,
         )
+        self._update_mode_choices()
         self._update_multi_shot_parameter_visibility()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Handle parameter value changes to normalize image inputs."""
         super().after_value_set(parameter, value)
+
+        if parameter.name in {"model_name", "reference_video"}:
+            self._update_mode_choices()
 
         if parameter.name in {"multi_shot", "shot_count"}:
             self._update_multi_shot_parameter_visibility()
@@ -310,6 +323,28 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             updated_list = normalize_artifact_list(value, ImageUrlArtifact, accepted_types=(ImageArtifact,))
             if updated_list != value:
                 self.set_parameter_value("reference_images", updated_list)
+
+    def _get_supported_modes(self) -> list[str]:
+        """Return the valid mode choices for the selected model and inputs."""
+        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
+        model_config = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])
+        capabilities = MODEL_CAPABILITIES.get(model_config["payload_model_name"], {"modes": BASE_MODE_CHOICES})
+        supported_modes = list(capabilities.get("modes", BASE_MODE_CHOICES))
+
+        if self.get_parameter_value("reference_video") and not capabilities.get("supports_4k_with_reference_video", True):
+            supported_modes = [mode for mode in supported_modes if mode != MODE_4K]
+
+        return supported_modes
+
+    def _update_mode_choices(self) -> None:
+        """Keep the mode dropdown aligned with the selected model and inputs."""
+        supported_modes = self._get_supported_modes()
+        current_mode = self.get_parameter_value("mode")
+        next_mode = current_mode if current_mode in supported_modes else DEFAULT_MODE
+        if next_mode not in supported_modes:
+            next_mode = supported_modes[0]
+
+        self._update_option_choices("mode", supported_modes, next_mode)
 
     def _update_multi_shot_parameter_visibility(self) -> None:
         """Toggle legacy prompt vs per-shot inputs based on multi-shot settings."""
@@ -471,7 +506,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             video_keep_sound = False
 
         video_refer_type = self.get_parameter_value("video_refer_type") or "base"
-        mode = self.get_parameter_value("mode") or "pro"
+        mode = self.get_parameter_value("mode") or DEFAULT_MODE
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "16:9"
         duration = self.get_parameter_value("duration") or 5
 
@@ -621,6 +656,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         element_ids = (self.get_parameter_value("element_ids") or "").strip()
         reference_video_param = self.get_parameter_value("reference_video")
         duration = self.get_parameter_value("duration") or 5
+        mode = self.get_parameter_value("mode") or DEFAULT_MODE
 
         if multi_shot:
             self._validate_customize_multi_shot(exceptions, shot_count, duration)
@@ -650,6 +686,22 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
 
         # Build video list
         has_video = bool(reference_video_param)
+        supported_modes = self._get_supported_modes()
+        if mode not in supported_modes:
+            if mode == MODE_4K and has_video:
+                exceptions.append(
+                    ValueError(
+                        f"{self.name}: Model Kling v3.0 Omni does not support mode '{MODE_4K}' when reference_video is set. "
+                        f"Valid modes: {', '.join(supported_modes)}"
+                    )
+                )
+            else:
+                exceptions.append(
+                    ValueError(
+                        f"{self.name}: Selected configuration does not support mode '{mode}'. "
+                        f"Valid modes: {', '.join(supported_modes)}"
+                    )
+                )
 
         # Get reference images (already a list from ParameterList)
         ref_images_input = reference_images

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -331,7 +331,9 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         capabilities = MODEL_CAPABILITIES.get(model_config["payload_model_name"], {"modes": BASE_MODE_CHOICES})
         supported_modes = list(capabilities.get("modes", BASE_MODE_CHOICES))
 
-        if self.get_parameter_value("reference_video") and not capabilities.get("supports_4k_with_reference_video", True):
+        if self.get_parameter_value("reference_video") and not capabilities.get(
+            "supports_4k_with_reference_video", True
+        ):
             supported_modes = [mode for mode in supported_modes if mode != MODE_4K]
 
         return supported_modes

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -26,6 +26,12 @@ __all__ = ["KlingTextToVideoGeneration"]
 MAX_PROMPT_LENGTH = 2500
 MAX_MULTI_PROMPT_COUNT = 6
 V3_MODEL_ID = "kling-v3"
+MODE_STD = "std"
+MODE_PRO = "pro"
+MODE_4K = "4k"
+BASE_MODE_CHOICES = [MODE_STD, MODE_PRO]
+V3_MODE_CHOICES = [MODE_STD, MODE_PRO, MODE_4K]
+DEFAULT_MODE = MODE_STD
 DEFAULT_MULTI_SHOTS = [{"name": "Shot1", "duration": 5, "description": ""}]
 
 
@@ -66,38 +72,38 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
     # Model capability definitions
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "kling-v3": {
-            "modes": ["std", "pro"],
+            "modes": V3_MODE_CHOICES,
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
             "supports_multi_shot": True,
         },
         "kling-v1-6": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-master": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-1-master": {
-            "modes": ["std", "pro"],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-5-turbo": {
-            "modes": ["pro"],
+            "modes": [MODE_PRO],
             "durations": [5, 10],
             "aspect_ratios": ["16:9"],
             "supports_sound": False,
         },
         "kling-v2-6": {
-            "modes": ["pro"],
+            "modes": [MODE_PRO],
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": True,
@@ -225,10 +231,10 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
             ParameterString(
                 name="mode",
-                default_value="std",
-                tooltip="Video generation mode (std: Standard, pro: Professional)",
+                default_value=DEFAULT_MODE,
+                tooltip="Video generation mode. Supported modes vary by model; Kling v3.0 also supports 4k.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["std", "pro"])},
+                traits={Options(choices=V3_MODE_CHOICES)},
             )
 
             ParameterString(
@@ -329,12 +335,11 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         """Update parameter visibility based on selected model."""
         # Map user-facing name to model ID
         model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+        self._update_mode_choices(capabilities.get("modes", BASE_MODE_CHOICES))
 
         if model_id == "kling-v2-5-turbo":
             self.hide_parameter_by_name(["mode", "aspect_ratio"])
-            current_mode = self.get_parameter_value("mode")
-            if current_mode != "pro":
-                self.set_parameter_value("mode", "pro")
             current_aspect = self.get_parameter_value("aspect_ratio")
             if current_aspect != "16:9":
                 self.set_parameter_value("aspect_ratio", "16:9")
@@ -345,9 +350,6 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         elif model_id == "kling-v2-6":
             self.hide_parameter_by_name("mode")
             self.show_parameter_by_name(["aspect_ratio", "duration", "sound"])
-            current_mode = self.get_parameter_value("mode")
-            if current_mode != "pro":
-                self.set_parameter_value("mode", "pro")
             current_duration = self.get_parameter_value("duration")
             if current_duration not in [5, 10]:
                 self.set_parameter_value("duration", 5)
@@ -365,6 +367,15 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             for shot_index in range(1, MAX_MULTI_PROMPT_COUNT + 1):
                 self.hide_parameter_by_name([f"shot_{shot_index}_prompt", f"shot_{shot_index}_duration"])
             self.show_parameter_by_name("prompt")
+
+    def _update_mode_choices(self, supported_modes: list[str]) -> None:
+        """Keep the mode dropdown aligned with the selected model."""
+        current_mode = self.get_parameter_value("mode")
+        next_mode = current_mode if current_mode in supported_modes else DEFAULT_MODE
+        if next_mode not in supported_modes:
+            next_mode = supported_modes[0]
+
+        self._update_option_choices("mode", supported_modes, next_mode)
 
     def _update_multi_shot_parameter_visibility(self) -> None:
         """Toggle prompt and shot inputs for v3 multi-shot configurations."""
@@ -606,7 +617,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
         negative_prompt = self.get_parameter_value("negative_prompt") or ""
         cfg_scale = self.get_parameter_value("cfg_scale")
-        mode = self.get_parameter_value("mode") or "std"
+        mode = self.get_parameter_value("mode") or DEFAULT_MODE
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "16:9"
         duration = self.get_parameter_value("duration") or 5
         sound = self.get_parameter_value("sound") or "off"
@@ -766,12 +777,12 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         # Validate model-specific constraints
         model_name = self.get_parameter_value("model_name") or "Kling v2.6"
         model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        mode = self.get_parameter_value("mode") or "std"
+        mode = self.get_parameter_value("mode") or DEFAULT_MODE
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "16:9"
 
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
-        if mode not in capabilities.get("modes", ["std", "pro"]):
+        if mode not in capabilities.get("modes", BASE_MODE_CHOICES):
             valid_modes = capabilities.get("modes", [])
             exceptions.append(
                 ValueError(

--- a/tests/unit/video/test_kling_video_mode_options.py
+++ b/tests/unit/video/test_kling_video_mode_options.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter
+
+from griptape_nodes_library.video.kling_image_to_video_generation import KlingImageToVideoGeneration
+from griptape_nodes_library.video.kling_omni_video_generation import KlingOmniVideoGeneration
+from griptape_nodes_library.video.kling_text_to_video_generation import KlingTextToVideoGeneration
+
+
+def _parameter_by_name(node: Any, parameter_name: str) -> Parameter:
+    return next(parameter for parameter in node.parameters if parameter.name == parameter_name)
+
+
+def _mode_choices(node: Any) -> list[str]:
+    return list(_parameter_by_name(node, "mode").ui_options["simple_dropdown"])
+
+
+def test_kling_text_v3_adds_4k_mode_choice() -> None:
+    node = KlingTextToVideoGeneration(name="KlingText")
+
+    assert _mode_choices(node) == ["std", "pro", "4k"]
+
+    node.set_parameter_value("mode", "4k")
+    node.set_parameter_value("model_name", "Kling v2.6")
+
+    assert _mode_choices(node) == ["pro"]
+    assert node.get_parameter_value("mode") == "pro"
+
+
+def test_kling_text_non_v3_models_do_not_accept_4k_mode() -> None:
+    node = KlingTextToVideoGeneration(name="KlingText")
+    node.set_parameter_value("model_name", "Kling v2 Master")
+    node.set_parameter_value("mode", "4k")
+
+    assert _mode_choices(node) == ["std", "pro"]
+    assert node.get_parameter_value("mode") == "std"
+
+
+def test_kling_image_v3_adds_4k_mode_choice() -> None:
+    node = KlingImageToVideoGeneration(name="KlingImage")
+
+    assert _mode_choices(node) == ["std", "pro", "4k"]
+
+    node.set_parameter_value("mode", "4k")
+    node.set_parameter_value("model_name", "Kling v2.6")
+
+    assert _mode_choices(node) == ["pro"]
+    assert node.get_parameter_value("mode") == "pro"
+
+
+def test_kling_omni_4k_mode_requires_no_reference_video() -> None:
+    node = KlingOmniVideoGeneration(name="KlingOmni")
+
+    assert _mode_choices(node) == ["std", "pro", "4k"]
+
+    node.set_parameter_value("mode", "4k")
+    node.set_parameter_value("reference_video", "https://example.com/reference.mp4")
+
+    assert _mode_choices(node) == ["std", "pro"]
+    assert node.get_parameter_value("mode") == "pro"
+
+    node.set_parameter_value("reference_video", "")
+
+    assert _mode_choices(node) == ["std", "pro", "4k"]
+
+
+def test_kling_omni_base_model_does_not_offer_4k_mode() -> None:
+    node = KlingOmniVideoGeneration(name="KlingOmni")
+    node.set_parameter_value("model_name", "Kling Omni")
+    node.set_parameter_value("mode", "4k")
+
+    assert _mode_choices(node) == ["std", "pro"]
+    assert node.get_parameter_value("mode") == "std"


### PR DESCRIPTION
Adds support for the "4k" mode for Kling v3 video generations.

closes #164 

supported by API changes merged in griptape-ai/griptape-cloud#1925