### PR TITLE
Feat/video frame extractor

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -60,6 +60,11 @@
       "name": "MaskAdjustmentPreview",
       "path": "widgets/MaskAdjustmentPreview.js",
       "description": "Interactive preview for mask adjustment with timeline scrubbing and dilation/erosion controls."
+    },
+    {
+      "name": "VideoPlayerFrameSelector",
+      "path": "griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js",
+      "description": "Video player with frame selection capabilities for precise video manipulation nodes."
     }
   ],
   "categories": [

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -768,6 +768,17 @@
       }
     },
     {
+      "class_name": "VideoFrameExtractor",
+      "file_path": "griptape_nodes_library/video/extract_frames.py",
+      "metadata": {
+        "category": "video",
+        "description": "Import video, inspect frame-by-frame, and extract selected frames as images.",
+        "display_name": "Video Frame Extractor",
+        "icon": "film",
+        "group": "edit"
+      }
+    },
+    {
       "class_name": "SeedanceVideoGeneration",
       "file_path": "griptape_nodes_library/video/seedance_video_generation.py",
       "metadata": {

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -775,7 +775,7 @@
       "metadata": {
         "category": "video",
         "description": "Import video, inspect frame-by-frame, and extract selected frames as images.",
-        "display_name": "Video Frame Extractor",
+        "display_name": "Extract Video Frames",
         "icon": "film",
         "group": "edit"
       }

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -768,7 +768,7 @@
       }
     },
     {
-      "class_name": "VideoFrameExtractor",
+      "class_name": "ExtractFrames",
       "file_path": "griptape_nodes_library/video/extract_frames.py",
       "metadata": {
         "category": "video",

--- a/griptape_nodes_library/video/base_video_input_node.py
+++ b/griptape_nodes_library/video/base_video_input_node.py
@@ -109,11 +109,7 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
 
     @abstractmethod
     def _get_output_file_default_filename(self) -> str:
-        """Return the default filename for the output_file parameter.
-
-        Subclasses may declare OUTPUT_FILE_DEFAULT_FILENAME as a class variable
-        instead of overriding this method.
-        """
+        """Return the default filename for the output_file parameter."""
 
     def _setup_logging_group(self) -> None:
         with ParameterGroup(name="Logs") as logs_group:

--- a/griptape_nodes_library/video/base_video_input_node.py
+++ b/griptape_nodes_library/video/base_video_input_node.py
@@ -1,0 +1,277 @@
+import json
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+# static_ffmpeg is dynamically installed by the library loader at runtime
+# into the library's own virtual environment, but not available during type checking
+import static_ffmpeg.run  # type: ignore[import-untyped]
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.files.file import File
+
+from griptape_nodes_library.utils.file_utils import generate_filename
+from griptape_nodes_library.utils.video_utils import (
+    detect_video_format,
+    dict_to_video_url_artifact,
+    to_video_artifact,
+    validate_url,
+)
+
+
+class BaseVideoInputNode(SuccessFailureNode, ABC):
+    """Abstract base for nodes that take a video as input.
+
+    Provides video input parameter, ffprobe utilities, URL validation, logging,
+    status parameters, and temp file helpers — without assuming video output.
+    Subclass this when your node produces something other than a video (images,
+    audio, metadata, etc.).  For video-to-video processing, subclass
+    BaseVideoProcessor instead.
+    """
+
+    DEFAULT_FRAME_RATE = 30.0
+    DEFAULT_WIDTH = 1920
+    DEFAULT_HEIGHT = 1080
+    DEFAULT_DURATION = 0.0
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+        self.add_parameter(
+            ParameterVideo(
+                name="video",
+                tooltip="The video to process",
+                clickable_file_browser=True,
+                ui_options={
+                    "expander": True,
+                    "display_name": "Video or Path to Video",
+                },
+                converters=[self._convert_video_input],
+            )
+        )
+
+        self._setup_custom_parameters()
+
+        # Hook: lets BaseVideoProcessor insert frame-rate / speed params here,
+        # between custom params and the primary output param, preserving UI order.
+        self._setup_pre_output_parameters()
+
+        self._register_primary_output_parameter()
+
+        # Separate hook so subclasses can co-locate their output file setup with
+        # _register_primary_output_parameter() if they prefer, while still keeping
+        # the two steps distinct in __init__.
+        self._register_output_file_parameter()
+
+        self._setup_logging_group()
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the processing operation result",
+            result_details_placeholder="Details on the processing attempt will be presented here.",
+        )
+
+    @abstractmethod
+    def _setup_custom_parameters(self) -> None:
+        """Setup parameters specific to this node. Override in subclasses."""
+
+    def _setup_pre_output_parameters(self) -> None:
+        """Hook called after custom params and before the primary output param.
+
+        Override in subclasses that need to insert additional parameters at
+        this position (e.g., BaseVideoProcessor adds frame rate and speed here).
+        """
+
+    @abstractmethod
+    def _register_primary_output_parameter(self) -> None:
+        """Register the node's primary output artifact parameter (image, audio, list, etc.)."""
+
+    def _register_output_file_parameter(self) -> None:
+        """Register the output_file project-file parameter used for saving results.
+
+        Called immediately after _register_primary_output_parameter() so the two
+        are adjacent in the UI.  Override to customise the default filename or to
+        skip the parameter entirely for nodes that don't produce a saved file.
+        """
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename=self._get_output_file_default_filename(),
+        )
+        self._output_file.add_parameter()
+
+    @abstractmethod
+    def _get_processing_description(self) -> str:
+        """Short human-readable description of what this node does."""
+
+    @abstractmethod
+    def _get_output_file_default_filename(self) -> str:
+        """Return the default filename for the output_file parameter.
+
+        Subclasses may declare OUTPUT_FILE_DEFAULT_FILENAME as a class variable
+        instead of overriding this method.
+        """
+
+    def _setup_logging_group(self) -> None:
+        with ParameterGroup(name="Logs") as logs_group:
+            Parameter(
+                name="logs",
+                type="str",
+                tooltip="Displays processing logs and detailed events if enabled.",
+                ui_options={"multiline": True, "placeholder_text": "Logs"},
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        logs_group.ui_options = {"hide": True}
+        self.add_node_element(logs_group)
+
+    def _get_ffmpeg_paths(self) -> tuple[str, str]:
+        """Return (ffmpeg_path, ffprobe_path)."""
+        try:
+            ffmpeg_path, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
+            return ffmpeg_path, ffprobe_path  # noqa: TRY300
+        except Exception as e:
+            error_msg = f"FFmpeg not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
+            raise ValueError(error_msg) from e
+
+    def _detect_video_properties(self, input_url: str, ffprobe_path: str) -> tuple[float, tuple[int, int], float]:
+        """Detect (frame_rate, (width, height), duration) from a video."""
+        try:
+            cmd = [
+                ffprobe_path,
+                "-v", "quiet",
+                "-print_format", "json",
+                "-show_streams",
+                "-select_streams", "v:0",
+                input_url,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+            streams_data = json.loads(result.stdout)
+
+            if streams_data.get("streams") and len(streams_data["streams"]) > 0:
+                video_stream = streams_data["streams"][0]
+
+                fps_str = video_stream.get("r_frame_rate", "30/1")
+                if "/" in fps_str:
+                    num, den = map(int, fps_str.split("/"))
+                    frame_rate = num / den
+                else:
+                    frame_rate = float(fps_str)
+
+                width = int(video_stream.get("width", self.DEFAULT_WIDTH))
+                height = int(video_stream.get("height", self.DEFAULT_HEIGHT))
+
+                duration_str = video_stream.get("duration", "0")
+                duration = float(duration_str) if duration_str != "N/A" else self.DEFAULT_DURATION
+
+                return frame_rate, (width, height), duration
+            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION  # noqa: TRY300
+
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Could not detect video properties, using defaults: {e}\n")
+            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION
+
+    def _detect_audio_stream(self, input_url: str, ffprobe_path: str) -> bool:
+        """Return True if the video contains an audio stream."""
+        try:
+            cmd = [
+                ffprobe_path,
+                "-v", "quiet",
+                "-select_streams", "a",
+                "-show_entries", "stream=codec_type",
+                "-of", "csv=p=0",
+                input_url,
+            ]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+            return "audio" in result.stdout.strip()
+        except subprocess.CalledProcessError:
+            return False
+        except Exception:
+            return False
+
+    def _convert_video_input(self, value: Any) -> Any:
+        """Convert dict inputs to VideoUrlArtifact (string paths handled by ParameterVideo)."""
+        if isinstance(value, dict):
+            return dict_to_video_url_artifact(value)
+        return value
+
+    def _validate_video_input(self) -> list[Exception] | None:
+        exceptions = []
+        video = self.parameter_values.get("video")
+        if not video:
+            msg = f"{self.name}: Video parameter is required"
+            exceptions.append(ValueError(msg))
+        if not isinstance(video, VideoUrlArtifact):
+            msg = f"{self.name}: Video parameter must be a VideoUrlArtifact"
+            exceptions.append(ValueError(msg))
+        if hasattr(video, "value") and not video.value:  # type: ignore  # noqa: PGH003
+            msg = f"{self.name}: Video parameter must have a value"
+            exceptions.append(ValueError(msg))
+        return exceptions if exceptions else None
+
+    def _validate_url_safety(self, url: str) -> None:
+        if not validate_url(url):
+            msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
+            raise ValueError(msg)
+
+    def _get_video_input_data(self) -> tuple[str, str]:
+        """Return (resolved_url, detected_format) for the video input."""
+        video = self.parameter_values.get("video")
+        video_artifact = to_video_artifact(video)
+        input_url = File(video_artifact.value).resolve()
+        detected_format = detect_video_format(video) or "mp4"
+        return input_url, detected_format
+
+    def _create_temp_output_file(self, format_extension: str) -> tuple[str, Path]:
+        with tempfile.NamedTemporaryFile(suffix=f".{format_extension}", delete=False) as output_file:
+            output_path = Path(output_file.name)
+        return str(output_path), output_path
+
+    def _run_ffmpeg_command(self, cmd: list[str], timeout: int = 300) -> None:
+        self.append_value_to_parameter("logs", f"Running ffmpeg command: {' '.join(cmd)}\n")
+        try:
+            result = subprocess.run(  # noqa: S603
+                cmd, capture_output=True, text=True, check=True, timeout=timeout
+            )
+            self.append_value_to_parameter("logs", f"FFmpeg stdout: {result.stdout}\n")
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"FFmpeg process timed out after {timeout} seconds"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+        except subprocess.CalledProcessError as e:
+            error_msg = f"FFmpeg error: {e.stderr}"
+            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
+            raise ValueError(error_msg) from e
+
+    def _cleanup_temp_file(self, file_path: Path) -> None:
+        try:
+            file_path.unlink(missing_ok=True)
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: Failed to clean up temporary file: {e}\n")
+
+    def _log_video_properties(self, frame_rate: float, resolution: tuple[int, int], duration: float) -> None:
+        self.append_value_to_parameter(
+            "logs", f"Detected video: {resolution[0]}x{resolution[1]} @ {frame_rate}fps, duration: {duration}s\n"
+        )
+
+    def _log_format_detection(self, detected_format: str) -> None:
+        self.append_value_to_parameter("logs", f"Detected video format: {detected_format}\n")
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        """Override in subclasses to add custom validation."""
+        return None
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        exceptions = []
+        base_exceptions = self._validate_video_input()
+        if base_exceptions:
+            exceptions.extend(base_exceptions)
+        custom_exceptions = self._validate_custom_parameters()
+        if custom_exceptions:
+            exceptions.extend(custom_exceptions)
+        return exceptions if exceptions else None
+
+    def _generate_filename(self, suffix: str = "", extension: str = "") -> str:
+        return generate_filename(node_name=self.name, suffix=suffix, extension=extension)

--- a/griptape_nodes_library/video/base_video_input_node.py
+++ b/griptape_nodes_library/video/base_video_input_node.py
@@ -98,6 +98,7 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
+            allowed_modes={ParameterMode.OUTPUT},
             default_filename=self._get_output_file_default_filename(),
         )
         self._output_file.add_parameter()

--- a/griptape_nodes_library/video/base_video_input_node.py
+++ b/griptape_nodes_library/video/base_video_input_node.py
@@ -137,10 +137,13 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
         try:
             cmd = [
                 ffprobe_path,
-                "-v", "quiet",
-                "-print_format", "json",
+                "-v",
+                "quiet",
+                "-print_format",
+                "json",
                 "-show_streams",
-                "-select_streams", "v:0",
+                "-select_streams",
+                "v:0",
                 input_url,
             ]
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
@@ -174,10 +177,14 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
         try:
             cmd = [
                 ffprobe_path,
-                "-v", "quiet",
-                "-select_streams", "a",
-                "-show_entries", "stream=codec_type",
-                "-of", "csv=p=0",
+                "-v",
+                "quiet",
+                "-select_streams",
+                "a",
+                "-show_entries",
+                "stream=codec_type",
+                "-of",
+                "csv=p=0",
                 input_url,
             ]
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603

--- a/griptape_nodes_library/video/base_video_input_node.py
+++ b/griptape_nodes_library/video/base_video_input_node.py
@@ -34,6 +34,7 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
     BaseVideoProcessor instead.
     """
 
+    # Default video properties constants
     DEFAULT_FRAME_RATE = 30.0
     DEFAULT_WIDTH = 1920
     DEFAULT_HEIGHT = 1080
@@ -62,13 +63,11 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
 
         self._register_primary_output_parameter()
 
-        # Separate hook so subclasses can co-locate their output file setup with
-        # _register_primary_output_parameter() if they prefer, while still keeping
-        # the two steps distinct in __init__.
         self._register_output_file_parameter()
 
         self._setup_logging_group()
 
+        # Add status parameters using the helper method
         self._create_status_parameters(
             result_details_tooltip="Details about the processing operation result",
             result_details_placeholder="Details on the processing attempt will be presented here.",
@@ -120,7 +119,7 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
                 ui_options={"multiline": True, "placeholder_text": "Logs"},
                 allowed_modes={ParameterMode.OUTPUT},
             )
-        logs_group.ui_options = {"hide": True}
+        logs_group.ui_options = {"hide": True}  # Hide the logs group by default
         self.add_node_element(logs_group)
 
     def _get_ffmpeg_paths(self) -> tuple[str, str]:
@@ -146,12 +145,14 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
                 "v:0",
                 input_url,
             ]
+            # URL is validated via _validate_url_safety() before this call
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
             streams_data = json.loads(result.stdout)
 
             if streams_data.get("streams") and len(streams_data["streams"]) > 0:
                 video_stream = streams_data["streams"][0]
 
+                # Get frame rate
                 fps_str = video_stream.get("r_frame_rate", "30/1")
                 if "/" in fps_str:
                     num, den = map(int, fps_str.split("/"))
@@ -159,9 +160,11 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
                 else:
                     frame_rate = float(fps_str)
 
+                # Get resolution
                 width = int(video_stream.get("width", self.DEFAULT_WIDTH))
                 height = int(video_stream.get("height", self.DEFAULT_HEIGHT))
 
+                # Get duration
                 duration_str = video_stream.get("duration", "0")
                 duration = float(duration_str) if duration_str != "N/A" else self.DEFAULT_DURATION
 
@@ -188,30 +191,45 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
                 input_url,
             ]
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+            # If there are audio streams, ffprobe will return "audio" for each stream
             return "audio" in result.stdout.strip()
         except subprocess.CalledProcessError:
+            # If ffprobe fails, assume no audio
             return False
         except Exception:
+            # If any other error, assume no audio
             return False
 
     def _convert_video_input(self, value: Any) -> Any:
-        """Convert dict inputs to VideoUrlArtifact (string paths handled by ParameterVideo)."""
+        """Convert video input (dict or VideoUrlArtifact) to VideoUrlArtifact.
+
+        Note: String paths are automatically normalized to VideoUrlArtifact
+        by ParameterVideo's normalize_video_input converter (runs before this).
+        """
         if isinstance(value, dict):
             return dict_to_video_url_artifact(value)
         return value
 
     def _validate_video_input(self) -> list[Exception] | None:
+        """Common video input validation."""
         exceptions = []
+
+        # Validate that we have a video
         video = self.parameter_values.get("video")
         if not video:
             msg = f"{self.name}: Video parameter is required"
             exceptions.append(ValueError(msg))
+
+        # Make sure it's a video artifact (converter should have handled dict conversion)
         if not isinstance(video, VideoUrlArtifact):
             msg = f"{self.name}: Video parameter must be a VideoUrlArtifact"
             exceptions.append(ValueError(msg))
+
+        # Make sure it has a value
         if hasattr(video, "value") and not video.value:  # type: ignore  # noqa: PGH003
             msg = f"{self.name}: Video parameter must have a value"
             exceptions.append(ValueError(msg))
+
         return exceptions if exceptions else None
 
     def _validate_url_safety(self, url: str) -> None:
@@ -267,13 +285,19 @@ class BaseVideoInputNode(SuccessFailureNode, ABC):
         return None
 
     def validate_before_node_run(self) -> list[Exception] | None:
+        """Common video input validation."""
         exceptions = []
+
+        # Use base class validation for video input
         base_exceptions = self._validate_video_input()
         if base_exceptions:
             exceptions.extend(base_exceptions)
+
+        # Add custom validation from subclasses
         custom_exceptions = self._validate_custom_parameters()
         if custom_exceptions:
             exceptions.extend(custom_exceptions)
+
         return exceptions if exceptions else None
 
     def _generate_filename(self, suffix: str = "", extension: str = "") -> str:

--- a/griptape_nodes_library/video/base_video_processor.py
+++ b/griptape_nodes_library/video/base_video_processor.py
@@ -22,6 +22,7 @@ class BaseVideoProcessor(BaseVideoInputNode):
     subclass BaseVideoInputNode directly instead.
     """
 
+    # Common frame rate options for different platforms
     FRAME_RATE_OPTIONS: ClassVar[dict[str, str]] = {
         "auto": "Auto (use input frame rate)",
         "24": "24 fps (Film)",
@@ -33,10 +34,12 @@ class BaseVideoProcessor(BaseVideoInputNode):
         "60": "60 fps (YouTube, Web HD)",
     }
 
+    # Frame rate tolerance for comparison (in fps)
     FRAME_RATE_TOLERANCE: ClassVar[float] = 0.01
 
     def _setup_pre_output_parameters(self) -> None:
         """Insert frame-rate and processing-speed controls before the output param."""
+        # Add frame rate parameter
         frame_rate_param = ParameterString(
             name="output_frame_rate",
             default_value="auto",
@@ -45,6 +48,7 @@ class BaseVideoProcessor(BaseVideoInputNode):
         frame_rate_param.add_trait(Options(choices=list(self.FRAME_RATE_OPTIONS.keys())))
         self.add_parameter(frame_rate_param)
 
+        # Add processing speed parameter
         speed_param = ParameterString(
             name="processing_speed",
             default_value="balanced",
@@ -76,29 +80,42 @@ class BaseVideoProcessor(BaseVideoInputNode):
     def _get_processing_speed_settings(self) -> tuple[str, str, int]:
         """Return (preset, pixel_format, crf) based on processing_speed parameter."""
         speed = self.get_parameter_value("processing_speed") or "balanced"
+
         if speed == "fast":
-            return "ultrafast", "yuv420p", 30
+            return "ultrafast", "yuv420p", 30  # Fastest encoding, lower quality
         if speed == "quality":
-            return "slow", "yuv420p", 18
-        return "medium", "yuv420p", 23
+            return "slow", "yuv420p", 18  # Slowest encoding, highest quality
+        # balanced
+        return "medium", "yuv420p", 23  # Balanced speed and quality
 
     def _get_frame_rate_filter(self, input_frame_rate: float) -> str:
         """Return an ffmpeg fps filter string, or empty string if no conversion needed."""
         output_frame_rate = self.get_parameter_value("output_frame_rate") or "auto"
+
         if output_frame_rate == "auto":
-            return ""
+            return ""  # No frame rate conversion needed
+
+        # Convert string to float
         target_fps = float(output_frame_rate)
+
+        # If target is same as input (within tolerance), no conversion needed
         if abs(target_fps - input_frame_rate) < self.FRAME_RATE_TOLERANCE:
             return ""
+
+        # Return fps filter for frame rate conversion
         return f"fps=fps={target_fps}:round=up"
 
     def _combine_video_filters(self, custom_filter: str, input_frame_rate: float) -> str:
         """Combine a custom vf filter with the frame-rate filter."""
         frame_rate_filter = self._get_frame_rate_filter(input_frame_rate)
+
         if not frame_rate_filter:
             return custom_filter
+
         if not custom_filter or custom_filter == "null":
             return frame_rate_filter
+
+        # Combine filters with comma separator
         return f"{custom_filter},{frame_rate_filter}"
 
     def _save_video_artifact(self, video_bytes: bytes, format_extension: str, suffix: str = "") -> VideoUrlArtifact:
@@ -107,11 +124,21 @@ class BaseVideoProcessor(BaseVideoInputNode):
         return VideoUrlArtifact(saved.location)
 
     def _process_video(self, input_url: str, output_path: str, **kwargs) -> None:
+        """Process video using the custom FFmpeg command from subclasses."""
         try:
+            # Validate URL before using in subprocess
             self._validate_url_safety(input_url)
+
+            # Get FFmpeg paths
             _ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+
+            # Detect input video properties for frame rate handling
             input_frame_rate, _, _ = self._detect_video_properties(input_url, ffprobe_path)
+
+            # Build the FFmpeg command using the subclass implementation
             cmd = self._build_ffmpeg_command(input_url, output_path, input_frame_rate=input_frame_rate, **kwargs)
+
+            # Use base class method to run FFmpeg command
             self._run_ffmpeg_command(cmd, timeout=300)
         except Exception as e:
             error_msg = f"Error during video processing: {e!s}"
@@ -119,20 +146,31 @@ class BaseVideoProcessor(BaseVideoInputNode):
             raise ValueError(error_msg) from e
 
     def _process(self, input_url: str, detected_format: str, **kwargs) -> None:
+        """Common processing wrapper."""
+        # Create temporary output file using base class method
         output_path, output_path_obj = self._create_temp_output_file(detected_format)
+
         try:
             self.append_value_to_parameter("logs", f"{self._get_processing_description()}\n")
+
+            # Process video using the custom implementation
             self._process_video(input_url, output_path, **kwargs)
 
+            # Read processed video
             with output_path_obj.open("rb") as f:
                 output_bytes = f.read()
 
+            # Get output suffix from subclass
             suffix = self._get_output_suffix(**kwargs)
+
+            # Save processed video artifact
             output_artifact = self._save_video_artifact(output_bytes, detected_format, suffix)
 
             self.append_value_to_parameter(
                 "logs", f"Successfully processed video with suffix: {suffix}.{detected_format}\n"
             )
+
+            # Save to parameter
             self.parameter_output_values["output"] = output_artifact
         except Exception as e:
             error_message = str(e)
@@ -140,6 +178,7 @@ class BaseVideoProcessor(BaseVideoInputNode):
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
             raise ValueError(msg) from e
         finally:
+            # Clean up temporary file using base class method
             self._cleanup_temp_file(output_path_obj)
 
     def _get_output_suffix(self, **kwargs) -> str:  # noqa: ARG002
@@ -149,18 +188,27 @@ class BaseVideoProcessor(BaseVideoInputNode):
         return {}
 
     def process(self) -> AsyncResult[None]:
+        """Common async processing entry point."""
+        # Clear execution status at start
         self._clear_execution_status()
+
+        # Get video input data
         input_url, detected_format = self._get_video_input_data()
         self._log_format_detection(detected_format)
+
+        # Get custom parameters from subclasses
         custom_params = self._get_custom_parameters()
 
+        # Initialize logs
         self.append_value_to_parameter("logs", f"[Processing {self._get_processing_description()}..]\n")
 
         try:
+            # Run the video processing asynchronously
             self.append_value_to_parameter("logs", "[Started video processing..]\n")
             yield lambda: self._process(input_url, detected_format, **custom_params)
             self.append_value_to_parameter("logs", "[Finished video processing.]\n")
 
+            # Report success
             result_details = f"Successfully processed video: {self._get_processing_description()}"
             self._set_status_results(was_successful=True, result_details=result_details)
 
@@ -168,6 +216,10 @@ class BaseVideoProcessor(BaseVideoInputNode):
             error_message = str(e)
             msg = f"{self.name}: Error processing video: {error_message}"
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+
+            # Report failure
             failure_details = f"Video processing failed: {error_message}"
             self._set_status_results(was_successful=False, result_details=failure_details)
+
+            # Handle failure exception (raises if no failure output connected)
             self._handle_failure_exception(ValueError(msg))

--- a/griptape_nodes_library/video/base_video_processor.py
+++ b/griptape_nodes_library/video/base_video_processor.py
@@ -1,40 +1,27 @@
-import subprocess
-import tempfile
-from abc import ABC, abstractmethod
-from pathlib import Path
+from abc import abstractmethod
 from typing import Any, ClassVar
 
-# static_ffmpeg is dynamically installed by the library loader at runtime
-# into the library's own virtual environment, but not available during type checking
-import static_ffmpeg.run  # type: ignore[import-untyped]
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
-from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
-from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.core_types import ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
-from griptape_nodes.files.file import File
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.utils.file_utils import generate_filename
-from griptape_nodes_library.utils.video_utils import (
-    detect_video_format,
-    dict_to_video_url_artifact,
-    to_video_artifact,
-    validate_url,
-)
+from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNode
 
 
-class BaseVideoProcessor(SuccessFailureNode, ABC):
-    """Base class for video processing nodes with common functionality."""
+class BaseVideoProcessor(BaseVideoInputNode):
+    """Base class for video-to-video processing nodes.
 
-    # Default video properties constants
-    DEFAULT_FRAME_RATE = 30.0
-    DEFAULT_WIDTH = 1920
-    DEFAULT_HEIGHT = 1080
-    DEFAULT_DURATION = 0.0
+    Extends BaseVideoInputNode with output frame-rate control, processing-speed
+    control, the video output parameter, and the standard async processing
+    pipeline (_process_video → _process → process).
 
-    # Common frame rate options for different platforms
+    For nodes that produce something other than a video (images, audio, etc.),
+    subclass BaseVideoInputNode directly instead.
+    """
+
     FRAME_RATE_OPTIONS: ClassVar[dict[str, str]] = {
         "auto": "Auto (use input frame rate)",
         "24": "24 fps (Film)",
@@ -46,27 +33,10 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
         "60": "60 fps (YouTube, Web HD)",
     }
 
-    # Frame rate tolerance for comparison (in fps)
     FRAME_RATE_TOLERANCE: ClassVar[float] = 0.01
 
-    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
-        super().__init__(name, metadata)
-        self.add_parameter(
-            ParameterVideo(
-                name="video",
-                tooltip="The video to process",
-                clickable_file_browser=True,
-                ui_options={
-                    "expander": True,
-                    "display_name": "Video or Path to Video",
-                },
-                converters=[self._convert_video_input],
-            )
-        )
-
-        self._setup_custom_parameters()
-
-        # Add frame rate parameter
+    def _setup_pre_output_parameters(self) -> None:
+        """Insert frame-rate and processing-speed controls before the output param."""
         frame_rate_param = ParameterString(
             name="output_frame_rate",
             default_value="auto",
@@ -75,7 +45,6 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
         frame_rate_param.add_trait(Options(choices=list(self.FRAME_RATE_OPTIONS.keys())))
         self.add_parameter(frame_rate_param)
 
-        # Add processing speed parameter
         speed_param = ParameterString(
             name="processing_speed",
             default_value="balanced",
@@ -84,29 +53,13 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
         speed_param.add_trait(Options(choices=["fast", "balanced", "quality"]))
         self.add_parameter(speed_param)
 
-        self._register_primary_output_parameter()
-
-        self._output_file = ProjectFileParameter(
-            node=self,
-            name="output_file",
-            default_filename=self._get_output_file_default_filename(),
-        )
-        self._output_file.add_parameter()
-
-        self._setup_logging_group()
-
-        # Add status parameters using the helper method
-        self._create_status_parameters(
-            result_details_tooltip="Details about the video processing operation result",
-            result_details_placeholder="Details on the processing attempt will be presented here.",
-        )
-
-    @abstractmethod
-    def _setup_custom_parameters(self) -> None:
-        """Setup custom parameters specific to this video processor. Override in subclasses."""
+    def _get_output_file_default_filename(self) -> str:
+        candidate = getattr(type(self), "OUTPUT_FILE_DEFAULT_FILENAME", None)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+        return "output.mp4"
 
     def _register_primary_output_parameter(self) -> None:
-        """Register the main output artifact (video, audio, image, etc.) before the project file path."""
         self.add_parameter(
             ParameterVideo(
                 name="output",
@@ -116,323 +69,70 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
             )
         )
 
-    def _get_output_file_default_filename(self) -> str:
-        """Default filename for the project file save path; subclasses may set OUTPUT_FILE_DEFAULT_FILENAME."""
-        candidate = getattr(type(self), "OUTPUT_FILE_DEFAULT_FILENAME", None)
-        if isinstance(candidate, str) and candidate:
-            return candidate
-        return "output.mp4"
-
-    @abstractmethod
-    def _get_processing_description(self) -> str:
-        """Get a description of what this processor does. Override in subclasses."""
-
     @abstractmethod
     def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         """Build the FFmpeg command for this processor. Override in subclasses."""
 
-    def _setup_logging_group(self) -> None:
-        """Setup the common logging parameter group."""
-        with ParameterGroup(name="Logs") as logs_group:
-            Parameter(
-                name="logs",
-                type="str",
-                tooltip="Displays processing logs and detailed events if enabled.",
-                ui_options={"multiline": True, "placeholder_text": "Logs"},
-                allowed_modes={ParameterMode.OUTPUT},
-            )
-        logs_group.ui_options = {"hide": True}  # Hide the logs group by default
-        self.add_node_element(logs_group)
-
-    def _get_ffmpeg_paths(self) -> tuple[str, str]:
-        """Get FFmpeg and FFprobe executable paths."""
-        try:
-            ffmpeg_path, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
-            return ffmpeg_path, ffprobe_path  # noqa: TRY300
-        except Exception as e:
-            error_msg = f"FFmpeg not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
-            raise ValueError(error_msg) from e
-
     def _get_processing_speed_settings(self) -> tuple[str, str, int]:
-        """Get FFmpeg settings based on processing speed preference."""
+        """Return (preset, pixel_format, crf) based on processing_speed parameter."""
         speed = self.get_parameter_value("processing_speed") or "balanced"
-
         if speed == "fast":
-            return "ultrafast", "yuv420p", 30  # Fastest encoding, lower quality
+            return "ultrafast", "yuv420p", 30
         if speed == "quality":
-            return "slow", "yuv420p", 18  # Slowest encoding, highest quality
-        # balanced
-        return "medium", "yuv420p", 23  # Balanced speed and quality
+            return "slow", "yuv420p", 18
+        return "medium", "yuv420p", 23
 
     def _get_frame_rate_filter(self, input_frame_rate: float) -> str:
-        """Get frame rate filter based on output frame rate setting."""
+        """Return an ffmpeg fps filter string, or empty string if no conversion needed."""
         output_frame_rate = self.get_parameter_value("output_frame_rate") or "auto"
-
         if output_frame_rate == "auto":
-            return ""  # No frame rate conversion needed
-
-        # Convert string to float
+            return ""
         target_fps = float(output_frame_rate)
-
-        # If target is same as input (within tolerance), no conversion needed
         if abs(target_fps - input_frame_rate) < self.FRAME_RATE_TOLERANCE:
             return ""
-
-        # Return fps filter for frame rate conversion
         return f"fps=fps={target_fps}:round=up"
 
     def _combine_video_filters(self, custom_filter: str, input_frame_rate: float) -> str:
-        """Combine custom video filter with frame rate filter if needed."""
+        """Combine a custom vf filter with the frame-rate filter."""
         frame_rate_filter = self._get_frame_rate_filter(input_frame_rate)
-
         if not frame_rate_filter:
             return custom_filter
-
         if not custom_filter or custom_filter == "null":
             return frame_rate_filter
-
-        # Combine filters with comma separator
         return f"{custom_filter},{frame_rate_filter}"
 
-    def _detect_video_properties(self, input_url: str, ffprobe_path: str) -> tuple[float, tuple[int, int], float]:
-        """Detect video frame rate, resolution, and duration."""
-        try:
-            cmd = [
-                ffprobe_path,
-                "-v",
-                "quiet",
-                "-print_format",
-                "json",
-                "-show_streams",
-                "-select_streams",
-                "v:0",
-                input_url,
-            ]
-
-            # URL is validated via _validate_url_safety() before this call
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
-            import json
-
-            streams_data = json.loads(result.stdout)
-
-            if streams_data.get("streams") and len(streams_data["streams"]) > 0:
-                video_stream = streams_data["streams"][0]
-
-                # Get frame rate
-                fps_str = video_stream.get("r_frame_rate", "30/1")
-                if "/" in fps_str:
-                    num, den = map(int, fps_str.split("/"))
-                    frame_rate = num / den
-                else:
-                    frame_rate = float(fps_str)
-
-                # Get resolution
-                width = int(video_stream.get("width", self.DEFAULT_WIDTH))
-                height = int(video_stream.get("height", self.DEFAULT_HEIGHT))
-
-                # Get duration
-                duration_str = video_stream.get("duration", "0")
-                duration = float(duration_str) if duration_str != "N/A" else self.DEFAULT_DURATION
-
-                return frame_rate, (width, height), duration
-            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION  # noqa: TRY300
-
-        except Exception as e:
-            self.append_value_to_parameter("logs", f"Warning: Could not detect video properties, using defaults: {e}\n")
-            return self.DEFAULT_FRAME_RATE, (self.DEFAULT_WIDTH, self.DEFAULT_HEIGHT), self.DEFAULT_DURATION
-
-    def _detect_audio_stream(self, input_url: str, ffprobe_path: str) -> bool:
-        """Detect if the video has an audio stream."""
-        try:
-            cmd = [
-                ffprobe_path,
-                "-v",
-                "quiet",
-                "-select_streams",
-                "a",
-                "-show_entries",
-                "stream=codec_type",
-                "-of",
-                "csv=p=0",
-                input_url,
-            ]
-
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
-            # If there are audio streams, ffprobe will return "audio" for each stream
-            return "audio" in result.stdout.strip()
-        except subprocess.CalledProcessError:
-            # If ffprobe fails, assume no audio
-            return False
-        except Exception:
-            # If any other error, assume no audio
-            return False
-
-    def _convert_video_input(self, value: Any) -> Any:
-        """Convert video input (dict or VideoUrlArtifact) to VideoUrlArtifact.
-
-        Note: String paths are automatically normalized to VideoUrlArtifact
-        by ParameterVideo's normalize_video_input converter (runs before this).
-        """
-        if isinstance(value, dict):
-            return dict_to_video_url_artifact(value)
-        return value
-
-    def _validate_video_input(self) -> list[Exception] | None:
-        """Common video input validation."""
-        exceptions = []
-
-        # Validate that we have a video
-        video = self.parameter_values.get("video")
-        if not video:
-            msg = f"{self.name}: Video parameter is required"
-            exceptions.append(ValueError(msg))
-
-        # Make sure it's a video artifact (converter should have handled dict conversion)
-        if not isinstance(video, VideoUrlArtifact):
-            msg = f"{self.name}: Video parameter must be a VideoUrlArtifact"
-            exceptions.append(ValueError(msg))
-
-        # Make sure it has a value
-        if hasattr(video, "value") and not video.value:  # type: ignore  # noqa: PGH003
-            msg = f"{self.name}: Video parameter must have a value"
-            exceptions.append(ValueError(msg))
-
-        return exceptions if exceptions else None
-
-    def _validate_url_safety(self, url: str) -> None:
-        """Validate that the URL is safe for ffmpeg processing."""
-        if not validate_url(url):
-            msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
-            raise ValueError(msg)
-
-    def _get_video_input_data(self) -> tuple[str, str]:
-        """Get video input URL and detected format."""
-        video = self.parameter_values.get("video")
-        video_artifact = to_video_artifact(video)
-        input_url = File(video_artifact.value).resolve()
-
-        detected_format = detect_video_format(video)
-        if not detected_format:
-            detected_format = "mp4"  # default fallback
-
-        return input_url, detected_format
-
-    def _create_temp_output_file(self, format_extension: str) -> tuple[str, Path]:
-        """Create a temporary output file and return path."""
-        with tempfile.NamedTemporaryFile(suffix=f".{format_extension}", delete=False) as output_file:
-            output_path = Path(output_file.name)
-        return str(output_path), output_path
-
     def _save_video_artifact(self, video_bytes: bytes, format_extension: str, suffix: str = "") -> VideoUrlArtifact:
-        """Save video bytes and return VideoUrlArtifact."""
         dest = self._output_file.build_file()
         saved = dest.write_bytes(video_bytes)
         return VideoUrlArtifact(saved.location)
 
-    def _run_ffmpeg_command(self, cmd: list[str], timeout: int = 300) -> None:
-        """Run FFmpeg command with common error handling."""
-        self.append_value_to_parameter("logs", f"Running ffmpeg command: {' '.join(cmd)}\n")
-
-        try:
-            result = subprocess.run(  # noqa: S603
-                cmd, capture_output=True, text=True, check=True, timeout=timeout
-            )
-            self.append_value_to_parameter("logs", f"FFmpeg stdout: {result.stdout}\n")
-        except subprocess.TimeoutExpired as e:
-            error_msg = f"FFmpeg process timed out after {timeout} seconds"
-            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
-            raise ValueError(error_msg) from e
-        except subprocess.CalledProcessError as e:
-            error_msg = f"FFmpeg error: {e.stderr}"
-            self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
-            raise ValueError(error_msg) from e
-
-    def _cleanup_temp_file(self, file_path: Path) -> None:
-        """Clean up temporary file with error handling."""
-        try:
-            file_path.unlink(missing_ok=True)
-        except Exception as e:
-            self.append_value_to_parameter("logs", f"Warning: Failed to clean up temporary file: {e}\n")
-
-    def _log_video_properties(self, frame_rate: float, resolution: tuple[int, int], duration: float) -> None:
-        """Log detected video properties."""
-        self.append_value_to_parameter(
-            "logs", f"Detected video: {resolution[0]}x{resolution[1]} @ {frame_rate}fps, duration: {duration}s\n"
-        )
-
-    def _log_format_detection(self, detected_format: str) -> None:
-        """Log detected video format."""
-        self.append_value_to_parameter("logs", f"Detected video format: {detected_format}\n")
-
-    def validate_before_node_run(self) -> list[Exception] | None:
-        """Common video input validation."""
-        exceptions = []
-
-        # Use base class validation for video input
-        base_exceptions = self._validate_video_input()
-        if base_exceptions:
-            exceptions.extend(base_exceptions)
-
-        # Add custom validation from subclasses
-        custom_exceptions = self._validate_custom_parameters()
-        if custom_exceptions:
-            exceptions.extend(custom_exceptions)
-
-        return exceptions if exceptions else None
-
-    def _validate_custom_parameters(self) -> list[Exception] | None:
-        """Validate custom parameters. Override in subclasses if needed."""
-        return None
-
     def _process_video(self, input_url: str, output_path: str, **kwargs) -> None:
-        """Process video using the custom FFmpeg command from subclasses."""
         try:
-            # Validate URL before using in subprocess
             self._validate_url_safety(input_url)
-
-            # Get FFmpeg paths
             _ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
-
-            # Detect input video properties for frame rate handling
             input_frame_rate, _, _ = self._detect_video_properties(input_url, ffprobe_path)
-
-            # Build the FFmpeg command using the subclass implementation
             cmd = self._build_ffmpeg_command(input_url, output_path, input_frame_rate=input_frame_rate, **kwargs)
-
-            # Use base class method to run FFmpeg command
             self._run_ffmpeg_command(cmd, timeout=300)
-
         except Exception as e:
             error_msg = f"Error during video processing: {e!s}"
             self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
             raise ValueError(error_msg) from e
 
     def _process(self, input_url: str, detected_format: str, **kwargs) -> None:
-        """Common processing wrapper."""
-        # Create temporary output file using base class method
         output_path, output_path_obj = self._create_temp_output_file(detected_format)
-
         try:
             self.append_value_to_parameter("logs", f"{self._get_processing_description()}\n")
-
-            # Process video using the custom implementation
             self._process_video(input_url, output_path, **kwargs)
 
-            # Read processed video
             with output_path_obj.open("rb") as f:
                 output_bytes = f.read()
 
-            # Get output suffix from subclass
             suffix = self._get_output_suffix(**kwargs)
-
-            # Use base class method to save video artifact
             output_artifact = self._save_video_artifact(output_bytes, detected_format, suffix)
 
             self.append_value_to_parameter(
                 "logs", f"Successfully processed video with suffix: {suffix}.{detected_format}\n"
             )
-
-            # Save to parameter
             self.parameter_output_values["output"] = output_artifact
         except Exception as e:
             error_message = str(e)
@@ -440,35 +140,27 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
             raise ValueError(msg) from e
         finally:
-            # Clean up temporary file using base class method
             self._cleanup_temp_file(output_path_obj)
 
     def _get_output_suffix(self, **kwargs) -> str:  # noqa: ARG002
-        """Get the output filename suffix. Override in subclasses if needed."""
         return ""
 
-    def process(self) -> AsyncResult[None]:
-        """Common async processing entry point."""
-        # Clear execution status at start
-        self._clear_execution_status()
+    def _get_custom_parameters(self) -> dict[str, Any]:
+        return {}
 
-        # Get video input data
+    def process(self) -> AsyncResult[None]:
+        self._clear_execution_status()
         input_url, detected_format = self._get_video_input_data()
         self._log_format_detection(detected_format)
-
-        # Get custom parameters from subclasses
         custom_params = self._get_custom_parameters()
 
-        # Initialize logs
         self.append_value_to_parameter("logs", f"[Processing {self._get_processing_description()}..]\n")
 
         try:
-            # Run the video processing asynchronously
             self.append_value_to_parameter("logs", "[Started video processing..]\n")
             yield lambda: self._process(input_url, detected_format, **custom_params)
             self.append_value_to_parameter("logs", "[Finished video processing.]\n")
 
-            # Report success
             result_details = f"Successfully processed video: {self._get_processing_description()}"
             self._set_status_results(was_successful=True, result_details=result_details)
 
@@ -476,22 +168,6 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
             error_message = str(e)
             msg = f"{self.name}: Error processing video: {error_message}"
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
-
-            # Report failure
             failure_details = f"Video processing failed: {error_message}"
             self._set_status_results(was_successful=False, result_details=failure_details)
-
-            # Handle failure exception (raises if no failure output connected)
             self._handle_failure_exception(ValueError(msg))
-
-    def _get_custom_parameters(self) -> dict[str, Any]:
-        """Get custom parameters for processing. Override in subclasses if needed."""
-        return {}
-
-    def _generate_filename(self, suffix: str = "", extension: str = "mp4") -> str:
-        """Generate a meaningful filename based on workflow and node information."""
-        return generate_filename(
-            node_name=self.name,
-            suffix=suffix,
-            extension=extension,
-        )

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -1,0 +1,312 @@
+"""Video Frame Extractor node — frame-accurate scrubbing and extraction."""
+import json
+import logging
+import pathlib
+import typing
+import subprocess
+
+
+from griptape_nodes_library.utils.video_utils import seconds_to_ts
+from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNode
+
+
+import griptape_nodes.exe_types.core_types as core_types
+import griptape_nodes.exe_types.node_types as node_types
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+import griptape_nodes.traits.widget as widget
+from griptape_nodes.retained_mode import griptape_nodes
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlFromPathResultSuccess,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# TODO:
+# 1. Display selected frames in widget
+# 2. Frame extraction
+# 3. Output extracted frames as ImageArtifacts with staticfiles-backed URLs and paths
+
+
+
+"""
+Algo:
+- get extraction type
+- get output formats
+    - file format (png, jpg)
+    - rename?
+    - padding
+    - prefix
+- if a list, iterate over this list, if every Nth, iterate over generator
+- for each frame to extract, seek to frame, read frame, convert to image artifact, save to staticfiles dir, output path/url/artifact
+
+"""
+
+class VideoFrameExtractor(BaseVideoInputNode):
+    """Extract specific frames from a video and save them as images."""
+
+    def __init__(self, name: str, metadata: dict[str, typing.Any] | None = None, **kwargs) -> None:
+        node_metadata = {
+            "category": "video",
+            "description": "Import video, move frame-by-frame, and extract current frame as image.",
+        }
+        if metadata:
+            node_metadata.update(metadata)
+        super().__init__(name=name, metadata=node_metadata, **kwargs)
+        self.set_initial_node_size(width=980, height=880)
+
+    def _register_primary_output_parameter(self) -> None:
+        self.add_parameter(
+            core_types.Parameter(
+                name="output_paths",
+                type="list[ImageArtifact]|list[str|pathlib.Path]",
+                allowed_modes={core_types.ParameterMode.OUTPUT},
+                tooltip="Paths to the extracted frame images",
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+    def _setup_custom_parameters(self) -> None:
+        # Input parameters
+
+        self.add_parameter(core_types.Parameter(
+            name="input_video",
+            input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
+            type="VideoUrlArtifact",
+            output_type="VideoUrlArtifact",
+            default_value=None,
+            allowed_modes={core_types.ParameterMode.INPUT},
+            ui_options={"display_name": "Video Input", "hide_property": True},
+            tooltip="Connect a video source here.",
+        ))
+
+        self.add_parameter(core_types.Parameter(
+            name="video_player",
+            type="str",
+            output_type="str",
+            default_value="",
+            allowed_modes={core_types.ParameterMode.PROPERTY},
+            tooltip="Video player for precise frame selection.",
+            traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
+        ))
+
+        self.add_parameter(core_types.Parameter(
+            name="input_frame_numbers",
+            output_type="str",
+            tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
+            allowed_modes={core_types.ParameterMode.INPUT},
+        ))
+
+        # Output parameters
+
+        self.add_parameter(core_types.Parameter(
+            name="extracted_frames",
+            output_type="list[ImageArtifact]",
+            tooltip="Extracted frame as ImageArtifact.",
+            allowed_modes={core_types.ParameterMode.OUTPUT},
+            ui_options={"hide_property": True},
+        ))
+
+        self.add_parameter(core_types.Parameter(
+            name="extracted_frame_paths",
+            output_type="list[str]",
+            tooltip="Paths to the extracted frame images.",
+            allowed_modes={core_types.ParameterMode.OUTPUT},
+            ui_options={"hide_property": True},
+        ))
+
+
+        self.add_parameter(core_types.ParameterList(
+            name="extraction_output_formats",
+            input_types=["List[str]", "str"],
+            output_type="dict",
+            tooltip="Output format options for extracted frames, including file format (png, jpg), renaming pattern, padding, and prefix.",
+            allowed_modes={core_types.ParameterMode.PROPERTY, core_types.ParameterMode.INPUT},
+        ))
+
+        self.add_parameter(
+            core_types.Parameter(
+                name="frames",
+                type="list",
+                tooltip="1-based frame numbers to extract (e.g. [1, 10, 50])",
+                ui_options={"placeholder_text": "[1, 10, 50]"},
+            )
+        )
+        self.add_parameter(
+            ParameterString(
+                name="output_dir",
+                default_value="",
+                tooltip="Directory to save extracted frames. Defaults to a temp directory.",
+            )
+        )
+        self.add_parameter(
+            ParameterString(
+                name="output_prefix",
+                default_value="frame",
+                tooltip="Filename prefix for each saved frame (e.g. 'frame' → 'frame000001.png')",
+            )
+        )
+        self.add_parameter(
+            core_types.Parameter(
+                name="frame_padding",
+                type="int",
+                default_value=6,
+                tooltip="Zero-padding width for the frame number in the output filename",
+            )
+        )
+        self.add_parameter(
+            ParameterString(
+                name="output_format",
+                default_value="png",
+                tooltip="Image format for extracted frames: png, jpg, or webp",
+            )
+        )
+
+    def _get_processing_description(self) -> str:
+        return "extracting frames from video"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
+        # Single-frame extraction; timestamp is passed via kwargs
+        ffmpeg_path, _ = self._get_ffmpeg_paths()
+        timestamp: str = kwargs.get("timestamp", "00:00:00.000")
+        return [
+            ffmpeg_path,
+            "-ss", timestamp,
+            "-i", input_url,
+            "-vframes", "1",
+            "-y",
+            output_path,
+        ]
+
+    def _resolve_video_url(self, raw_value: typing.Any) -> str | None:
+        file_path = str(raw_value) if raw_value is not None else ""
+        if not file_path:
+            return None
+        if file_path.startswith(("http://", "https://", "blob:", "data:")):
+            return file_path
+        try:
+            result = griptape_nodes.GriptapeNodes.handle_request(
+                CreateStaticFileDownloadUrlFromPathRequest(file_path=file_path)
+            )
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                logger.info("Resolved video URL: %s → %s", file_path, result.url)
+                return result.url
+        except Exception:
+            logger.warning("Failed to resolve video URL for: %s", file_path, exc_info=True)
+        return None
+
+    def _get_output_suffix(self, **kwargs) -> str:
+        frame_number: int = kwargs.get("frame_number", 0)
+        frame_padding: int = kwargs.get("frame_padding", 6)
+        return f"_{str(frame_number).zfill(frame_padding)}"
+
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        frames = self.get_parameter_value("frames")
+        if not frames:
+            return [ValueError(f"{self.name}: 'frames' must be a non-empty list of frame numbers")]
+        if not all(isinstance(f, int) and f >= 1 for f in frames):
+            return [ValueError(f"{self.name}: all frame numbers must be integers >= 1")]
+        return None
+
+    def _detect_frame_rate(self, input_url: str) -> float:
+        """Detect frame rate from the video; falls back to 30.0 on failure."""
+        _, ffprobe_path = self._get_ffmpeg_paths()
+        cmd = [
+            ffprobe_path,
+            "-v", "quiet",
+            "-print_format", "json",
+            "-show_streams",
+            "-select_streams", "v:0",
+            input_url,
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+            streams_data = json.loads(result.stdout)
+            fps_str = streams_data["streams"][0].get("r_frame_rate", "30/1")
+            num, den = map(int, fps_str.split("/"))
+            return num / den
+        except Exception as e:
+            self.append_value_to_parameter("logs", f"Warning: could not detect frame rate, defaulting to 30fps: {e}\n")
+            return 30.0
+
+    def _extract_all_frames(self, input_url: str) -> list[pathlib.Path]:
+        """Extract each requested frame and return their saved paths."""
+        self._validate_url_safety(input_url)
+
+        frames: list[int] = self.get_parameter_value("frames")
+        output_format: str = self.get_parameter_value("output_format") or "png"
+        output_prefix: str = self.get_parameter_value("output_prefix") or "frame"
+        frame_padding: int = self.get_parameter_value("frame_padding") or 6
+        output_dir_str: str = self.get_parameter_value("output_dir") or ""
+
+        output_dir = pathlib.Path(output_dir_str) if output_dir_str else self._output_file.build_file().parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        frame_rate = self._detect_frame_rate(input_url)
+        self.append_value_to_parameter("logs", f"Detected frame rate: {frame_rate:.3f} fps\n")
+
+        saved_paths: list[pathlib.Path] = []
+        for frame_number in frames:
+            zero_based = max(frame_number - 1, 0)
+            timestamp = seconds_to_ts(zero_based / frame_rate)
+
+            padded = str(frame_number).zfill(frame_padding)
+            output_path = output_dir / f"{output_prefix}{padded}.{output_format}"
+
+            cmd = self._build_ffmpeg_command(
+                input_url,
+                str(output_path),
+                frame_rate,
+                timestamp=timestamp,
+                frame_number=frame_number,
+                frame_padding=frame_padding,
+            )
+
+            self.append_value_to_parameter("logs", f"Extracting frame {frame_number} at {timestamp}...\n")
+            self._run_ffmpeg_command(cmd, timeout=60)
+
+            if not output_path.exists() or output_path.stat().st_size == 0:
+                msg = f"FFmpeg did not produce output for frame {frame_number}"
+                raise ValueError(msg)
+
+            saved_paths.append(output_path)
+            self.append_value_to_parameter("logs", f"Saved frame {frame_number} → {output_path}\n")
+
+        return saved_paths
+    
+    def after_value_set(self, parameter: core_types.Parameter, value: typing.Any) -> None:
+        """Automatically update video_player URL when input_video changes."""
+        if parameter.name == "input_video":
+            url = self._resolve_video_url(value)
+            current = self.parameter_values.get("video_player", "")
+            current_base = str(current).split("?")[0] if current else ""
+            if url:
+                new_base = url.split("?")[0]
+                if new_base != current_base:
+                    self.set_parameter_value("video_player", url)
+            elif current_base:
+                self.set_parameter_value("video_player", "")
+        return super().after_value_set(parameter, value)
+
+
+    def process(self) -> node_types.AsyncResult[None]:
+        self._clear_execution_status()
+        input_url, detected_format = self._get_video_input_data()
+        self._log_format_detection(detected_format)
+        self.append_value_to_parameter("logs", "[Started frame extraction..]\n")
+
+        try:
+            yield lambda: self._run_extraction(input_url)
+            self.append_value_to_parameter("logs", "[Finished frame extraction.]\n")
+            self._set_status_results(was_successful=True, result_details="Frames extracted successfully")
+        except Exception as e:
+            error_message = str(e)
+            msg = f"{self.name}: Error extracting frames: {error_message}"
+            self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
+            self._set_status_results(was_successful=False, result_details=f"Frame extraction failed: {error_message}")
+            self._handle_failure_exception(ValueError(msg))
+
+    def _run_extraction(self, input_url: str) -> None:
+        saved_paths = self._extract_all_frames(input_url)
+        self.parameter_output_values["output_paths"] = [str(p) for p in saved_paths]

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -1,4 +1,5 @@
 """Video Frame Extractor node — frame-accurate scrubbing and extraction."""
+
 import json
 import logging
 import pathlib
@@ -29,7 +30,6 @@ logger = logging.getLogger(__name__)
 # 3. Output extracted frames as ImageArtifacts with staticfiles-backed URLs and paths
 
 
-
 """
 Algo:
 - get extraction type
@@ -43,18 +43,22 @@ Algo:
 
 """
 
+
 class VideoFrameExtractor(BaseVideoInputNode):
     """Extract specific frames from a video and save them as images."""
 
     def __init__(self, name: str, metadata: dict[str, typing.Any] | None = None, **kwargs) -> None:
         node_metadata = {
             "category": "video",
-            "description": "Import video, move frame-by-frame, and extract current frame as image.",
+            "description": "Import video, inspect frame-by-frame, and extract selected frames as images.",
         }
         if metadata:
             node_metadata.update(metadata)
         super().__init__(name=name, metadata=node_metadata, **kwargs)
         self.set_initial_node_size(width=980, height=880)
+
+    def _get_output_file_default_filename(self) -> str:
+        return "output_##.png"
 
     def _register_primary_output_parameter(self) -> None:
         self.add_parameter(
@@ -70,60 +74,71 @@ class VideoFrameExtractor(BaseVideoInputNode):
     def _setup_custom_parameters(self) -> None:
         # Input parameters
 
-        self.add_parameter(core_types.Parameter(
-            name="input_video",
-            input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
-            type="VideoUrlArtifact",
-            output_type="VideoUrlArtifact",
-            default_value=None,
-            allowed_modes={core_types.ParameterMode.INPUT},
-            ui_options={"display_name": "Video Input", "hide_property": True},
-            tooltip="Connect a video source here.",
-        ))
+        self.add_parameter(
+            core_types.Parameter(
+                name="input_video",
+                input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
+                type="VideoUrlArtifact",
+                output_type="VideoUrlArtifact",
+                default_value=None,
+                allowed_modes={core_types.ParameterMode.INPUT},
+                ui_options={"display_name": "Video Input", "hide_property": True},
+                tooltip="Connect a video source here.",
+            )
+        )
 
-        self.add_parameter(core_types.Parameter(
-            name="video_player",
-            type="str",
-            output_type="str",
-            default_value="",
-            allowed_modes={core_types.ParameterMode.PROPERTY},
-            tooltip="Video player for precise frame selection.",
-            traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
-        ))
+        self.add_parameter(
+            core_types.Parameter(
+                name="video_player",
+                type="str",
+                output_type="str",
+                default_value="",
+                allowed_modes={core_types.ParameterMode.PROPERTY},
+                tooltip="Video player for precise frame selection.",
+                traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
+            )
+        )
 
-        self.add_parameter(core_types.Parameter(
-            name="input_frame_numbers",
-            output_type="str",
-            tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
-            allowed_modes={core_types.ParameterMode.INPUT},
-        ))
+        self.add_parameter(
+            core_types.Parameter(
+                name="input_frame_numbers",
+                output_type="str",
+                tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
+                allowed_modes={core_types.ParameterMode.INPUT},
+            )
+        )
 
         # Output parameters
 
-        self.add_parameter(core_types.Parameter(
-            name="extracted_frames",
-            output_type="list[ImageArtifact]",
-            tooltip="Extracted frame as ImageArtifact.",
-            allowed_modes={core_types.ParameterMode.OUTPUT},
-            ui_options={"hide_property": True},
-        ))
+        self.add_parameter(
+            core_types.Parameter(
+                name="extracted_frames",
+                output_type="list[ImageArtifact]",
+                tooltip="Extracted frame as ImageArtifact.",
+                allowed_modes={core_types.ParameterMode.OUTPUT},
+                ui_options={"hide_property": True},
+            )
+        )
 
-        self.add_parameter(core_types.Parameter(
-            name="extracted_frame_paths",
-            output_type="list[str]",
-            tooltip="Paths to the extracted frame images.",
-            allowed_modes={core_types.ParameterMode.OUTPUT},
-            ui_options={"hide_property": True},
-        ))
+        self.add_parameter(
+            core_types.Parameter(
+                name="extracted_frame_paths",
+                output_type="list[str]",
+                tooltip="Paths to the extracted frame images.",
+                allowed_modes={core_types.ParameterMode.OUTPUT},
+                ui_options={"hide_property": True},
+            )
+        )
 
-
-        self.add_parameter(core_types.ParameterList(
-            name="extraction_output_formats",
-            input_types=["List[str]", "str"],
-            output_type="dict",
-            tooltip="Output format options for extracted frames, including file format (png, jpg), renaming pattern, padding, and prefix.",
-            allowed_modes={core_types.ParameterMode.PROPERTY, core_types.ParameterMode.INPUT},
-        ))
+        self.add_parameter(
+            core_types.ParameterList(
+                name="extraction_output_formats",
+                input_types=["List[str]", "str"],
+                output_type="dict",
+                tooltip="Output format options for extracted frames, including file format (png, jpg), renaming pattern, padding, and prefix.",
+                allowed_modes={core_types.ParameterMode.PROPERTY, core_types.ParameterMode.INPUT},
+            )
+        )
 
         self.add_parameter(
             core_types.Parameter(
@@ -172,9 +187,12 @@ class VideoFrameExtractor(BaseVideoInputNode):
         timestamp: str = kwargs.get("timestamp", "00:00:00.000")
         return [
             ffmpeg_path,
-            "-ss", timestamp,
-            "-i", input_url,
-            "-vframes", "1",
+            "-ss",
+            timestamp,
+            "-i",
+            input_url,
+            "-vframes",
+            "1",
             "-y",
             output_path,
         ]
@@ -214,10 +232,13 @@ class VideoFrameExtractor(BaseVideoInputNode):
         _, ffprobe_path = self._get_ffmpeg_paths()
         cmd = [
             ffprobe_path,
-            "-v", "quiet",
-            "-print_format", "json",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
             "-show_streams",
-            "-select_streams", "v:0",
+            "-select_streams",
+            "v:0",
             input_url,
         ]
         try:
@@ -274,7 +295,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
             self.append_value_to_parameter("logs", f"Saved frame {frame_number} → {output_path}\n")
 
         return saved_paths
-    
+
     def after_value_set(self, parameter: core_types.Parameter, value: typing.Any) -> None:
         """Automatically update video_player URL when input_video changes."""
         if parameter.name == "input_video":
@@ -288,7 +309,6 @@ class VideoFrameExtractor(BaseVideoInputNode):
             elif current_base:
                 self.set_parameter_value("video_player", "")
         return super().after_value_set(parameter, value)
-
 
     def process(self) -> node_types.AsyncResult[None]:
         self._clear_execution_status()

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -2,16 +2,25 @@
 
 import logging
 import pathlib
+import re
 import tempfile
 import typing
+from urllib.parse import urlparse
 
 from griptape.artifacts import ImageArtifact
 from PIL import Image
 
 import griptape_nodes.exe_types.core_types as core_types
 import griptape_nodes.exe_types.node_types as node_types
+from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode import griptape_nodes
+from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    AttemptMapAbsolutePathToProjectResultSuccess,
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
+)
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
     CreateStaticFileDownloadUrlFromPathResultSuccess,
@@ -240,6 +249,27 @@ class VideoFrameExtractor(BaseVideoInputNode):
             logger.warning("Failed to resolve video URL for: %s", file_path, exc_info=True)
         return None
 
+    def _resolve_output_dir(self, video_url: str) -> pathlib.Path:
+        """Resolve the project output directory: outputs/{NodeName}/{VideoStem}/.
+
+        Falls back to a temp directory when no project is loaded.
+        """
+        video_stem = pathlib.Path(urlparse(video_url).path).stem or "video"
+        video_stem = re.sub(r"[^\w-]", "_", video_stem)
+        sub_dirs = f"{self.name}/{video_stem}"
+
+        result = griptape_nodes.GriptapeNodes.handle_request(
+            GetPathForMacroRequest(
+                parsed_macro=ParsedMacro("{outputs}/{sub_dirs}"),
+                variables={"sub_dirs": sub_dirs},
+            )
+        )
+        if isinstance(result, GetPathForMacroResultSuccess):
+            return pathlib.Path(result.absolute_path)
+
+        logger.warning("Could not resolve project output directory; falling back to temp dir")
+        return pathlib.Path(tempfile.mkdtemp())
+
     def _get_video_input_data(self) -> tuple[str, str]:
         """Return (resolved_url, format) for the video input.
 
@@ -317,7 +347,21 @@ class VideoFrameExtractor(BaseVideoInputNode):
     def _run_extraction(self, input_url: str, output_format: str) -> None:
         saved_paths = self._extract_all_frames(input_url, output_format)
 
-        self.parameter_output_values["output_paths"] = [str(p) for p in saved_paths]
+        # Map absolute paths to portable project macro paths (e.g. "{outputs}/NodeName/video/frame.png")
+        output_paths: list[str] = []
+        for p in saved_paths:
+            map_result = griptape_nodes.GriptapeNodes.handle_request(
+                AttemptMapAbsolutePathToProjectRequest(absolute_path=p)
+            )
+            if (
+                isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess)
+                and map_result.mapped_path is not None
+            ):
+                output_paths.append(map_result.mapped_path)
+            else:
+                output_paths.append(str(p))
+
+        self.parameter_output_values["output_paths"] = output_paths
         self.parameter_output_values["extracted_frames"] = [
             self._path_to_image_artifact(p, output_format) for p in saved_paths
         ]
@@ -330,7 +374,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
         frame_padding = self.get_parameter_value("frame_padding") or self.DEFAULT_FRAME_PADDING
         output_dir_str = self.get_parameter_value("output_dir") or ""
 
-        output_dir = pathlib.Path(output_dir_str) if output_dir_str else pathlib.Path(tempfile.mkdtemp())
+        output_dir = pathlib.Path(output_dir_str) if output_dir_str else self._resolve_output_dir(input_url)
         output_dir.mkdir(parents=True, exist_ok=True)
 
         ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -186,6 +186,27 @@ class VideoFrameExtractor(BaseVideoInputNode):
     def _get_processing_description(self) -> str:
         return "extracting frames from video"
 
+    def _get_video_input_data(self) -> tuple[str, str]:
+        url = self.get_parameter_value("input_video") or ""
+        if not url:
+            raise ValueError(f"{self.name}: No video loaded in 'input_video'")
+        if not str(url).startswith(("http://", "https://", "blob:", "data:")):
+            resolved = self._resolve_video_url(url)
+            if not resolved:
+                raise ValueError(f"{self.name}: Could not resolve video URL: {url}")
+            url = resolved
+        return url, "mp4"
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        exceptions = []
+        raw = self.get_parameter_value("input_video") or ""
+        if not str(raw).strip():
+            exceptions.append(ValueError(f"{self.name}: 'input_video' is required"))
+        custom = self._validate_custom_parameters()
+        if custom:
+            exceptions.extend(custom)
+        return exceptions if exceptions else None
+
     def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
         # Single-frame extraction; timestamp is passed via kwargs
         ffmpeg_path, _ = self._get_ffmpeg_paths()
@@ -203,17 +224,26 @@ class VideoFrameExtractor(BaseVideoInputNode):
         ]
 
     def _resolve_video_url(self, raw_value: typing.Any) -> str | None:
-        file_path = str(raw_value) if raw_value is not None else ""
+        """Resolve a video artifact or path to a browser-accessible presigned URL.
+
+        Follows the same pattern as AdjustMaskSize._resolve_video_url — accesses
+        .value from artifacts, then resolves via CreateStaticFileDownloadUrlFromPathRequest.
+        """
+        if not raw_value:
+            return None
+
+        file_path = raw_value.value if hasattr(raw_value, "value") else str(raw_value)
         if not file_path:
             return None
-        if file_path.startswith(("http://", "https://", "blob:", "data:")):
+
+        if isinstance(file_path, str) and file_path.startswith(("http://", "https://")):
             return file_path
+
         try:
             result = griptape_nodes.GriptapeNodes.handle_request(
                 CreateStaticFileDownloadUrlFromPathRequest(file_path=file_path)
             )
             if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
-                logger.info("Resolved video URL: %s → %s", file_path, result.url)
                 return result.url
         except Exception:
             logger.warning("Failed to resolve video URL for: %s", file_path, exc_info=True)
@@ -319,7 +349,6 @@ class VideoFrameExtractor(BaseVideoInputNode):
         return saved_paths
 
     def after_value_set(self, parameter: core_types.Parameter, value: typing.Any) -> None:
-        """Automatically update video_player URL when input_video changes."""
         if parameter.name == "input_video":
             url = self._resolve_video_url(value)
             current = self.parameter_values.get("input_video", "")

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -1,28 +1,27 @@
 """Video Frame Extractor node — frame-accurate scrubbing and extraction."""
 
-import json
 import logging
 import pathlib
+import tempfile
 import typing
-import subprocess
 
-
-from griptape_nodes_library.utils.video_utils import seconds_to_ts
-from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNode
-
+from griptape.artifacts import ImageArtifact
+from PIL import Image
 
 import griptape_nodes.exe_types.core_types as core_types
 import griptape_nodes.exe_types.node_types as node_types
-
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.file_system_picker import FileSystemPicker
-import griptape_nodes.traits.widget as widget
-from griptape_nodes.traits import options
 from griptape_nodes.retained_mode import griptape_nodes
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
     CreateStaticFileDownloadUrlFromPathResultSuccess,
 )
+from griptape_nodes.traits import options
+from griptape_nodes.traits.file_system_picker import FileSystemPicker
+import griptape_nodes.traits.widget as widget
+
+from griptape_nodes_library.utils.video_utils import seconds_to_ts
+from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNode
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +61,10 @@ def parse_frame_string(frame_str: str) -> list[int]:
 class VideoFrameExtractor(BaseVideoInputNode):
     """Extract specific frames from a video and save them as images."""
 
+    DEFAULT_OUTPUT_PREFIX = "frame"
+    DEFAULT_FRAME_PADDING = 4
+    DEFAULT_OUTPUT_FILE_FORMAT = "png"
+
     def __init__(self, name: str, metadata: dict[str, typing.Any] | None = None, **kwargs) -> None:
         node_metadata = {
             "category": "video",
@@ -70,12 +73,17 @@ class VideoFrameExtractor(BaseVideoInputNode):
         if metadata:
             node_metadata.update(metadata)
         super().__init__(name=name, metadata=node_metadata, **kwargs)
-        self.remove_parameter_element_by_name("video")  # Remove the default video output param from BaseVideoInputNode
-        self.set_initial_node_size(width=980, height=480)
+        self.remove_parameter_element_by_name("video")
+        # self.set_initial_node_size(width=980, height=480)
         self.hide_parameter_by_name("every_n")
 
+    # ── Parameter setup ────────────────────────────────────────────────────────
+
     def _get_output_file_default_filename(self) -> str:
-        return "output.####.png"
+        return f"{self.DEFAULT_OUTPUT_PREFIX}.{'#' * self.DEFAULT_FRAME_PADDING}.{self.DEFAULT_OUTPUT_FILE_FORMAT}"
+
+    def _get_processing_description(self) -> str:
+        return "extracting frames from video"
 
     def _register_primary_output_parameter(self) -> None:
         self.add_parameter(
@@ -91,16 +99,13 @@ class VideoFrameExtractor(BaseVideoInputNode):
             core_types.Parameter(
                 name="extracted_frames",
                 output_type="list[ImageArtifact]",
-                tooltip="Extracted frame as ImageArtifact.",
+                tooltip="Extracted frames as ImageArtifacts.",
                 allowed_modes={core_types.ParameterMode.OUTPUT},
                 ui_options={"hide_property": True},
             )
         )
 
     def _setup_custom_parameters(self) -> None:
-        """Set up parameters specific to frame extraction, such as frame selection"""
-
-        # Input video and widget for frame selection
         self.add_parameter(
             core_types.Parameter(
                 name="input_video",
@@ -121,14 +126,25 @@ class VideoFrameExtractor(BaseVideoInputNode):
                 default_value="list",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
                 traits={options.Options(choices=["list", "every_Nth"])},
-                tooltip="Mode for selecting frames to extract. 'list' for specific frame numbers, 'every_Nth' for regular intervals. For list, use comma-separated integers and ranges: `1,4,5-9,11`",
+                tooltip=(
+                    "Mode for selecting frames to extract. 'list' for specific frame numbers, "
+                    "'every_Nth' for regular intervals. "
+                    "For list, use comma-separated integers and ranges: `1,4,5-9,11`"
+                ),
             )
         )
         self.add_parameter(
             core_types.Parameter(
                 name="input_frame_numbers",
                 output_type="str",
-                tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
+                tooltip=(
+                    "Frames to extract, as a comma-separated list of numbers or ranges (e.g. 1,4,5-9,11).\n\n"
+                    "In the video player above:\n"
+                    "• Double-click the marker zone to add a single-frame marker\n"
+                    "• Double-click and drag to create a range\n"
+                    "• Drag an existing marker triangle to move it\n"
+                    "• Alt+click a marker to remove it"
+                ),
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
         )
@@ -147,98 +163,73 @@ class VideoFrameExtractor(BaseVideoInputNode):
         ) as settings_group:
             ParameterString(
                 name="output_format",
-                default_value="png",
+                default_value=self.DEFAULT_OUTPUT_FILE_FORMAT,
                 input_types=["List[str]", "str"],
                 output_type="str",
-                tooltip="Processing mode",
+                tooltip="Output image format for extracted frames.",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
                 traits={options.Options(choices=["png", "jpg", "exr"])},
             )
-
             ParameterString(
                 name="output_dir",
                 default_value="",
-                tooltip="Directory to save extracted frames. Defaults to a temp directory.",
+                tooltip="Directory to save extracted frames. Defaults to the project output directory.",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
-                traits={
-                    FileSystemPicker(
-                        allow_files=False,
-                        allow_directories=True,
-                        multiple=False,
-                    )
-                },
+                traits={FileSystemPicker(allow_files=False, allow_directories=True, multiple=False)},
             )
             ParameterString(
                 name="output_prefix",
-                default_value="frame",
-                tooltip="Filename prefix for each saved frame (e.g. 'frame' → 'frame000001.png')",
+                default_value=self.DEFAULT_OUTPUT_PREFIX,
+                tooltip="Filename prefix for each saved frame (e.g. 'frame' → 'frame.0001.png')",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
             core_types.Parameter(
                 name="frame_padding",
                 type="int",
-                default_value=6,
-                tooltip="Zero-padding width for the frame number in the output filename",
+                default_value=self.DEFAULT_FRAME_PADDING,
+                tooltip="Zero-padding width for the frame number in the output filename.",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
         self.add_node_element(settings_group)
 
-    def _get_processing_description(self) -> str:
-        return "extracting frames from video"
-
-    def _get_video_input_data(self) -> tuple[str, str]:
-        url = self.get_parameter_value("input_video") or ""
-        if not url:
-            raise ValueError(f"{self.name}: No video loaded in 'input_video'")
-        if not str(url).startswith(("http://", "https://", "blob:", "data:")):
-            resolved = self._resolve_video_url(url)
-            if not resolved:
-                raise ValueError(f"{self.name}: Could not resolve video URL: {url}")
-            url = resolved
-        return url, "mp4"
+    # ── Validation ─────────────────────────────────────────────────────────────
 
     def validate_before_node_run(self) -> list[Exception] | None:
-        exceptions = []
-        raw = self.get_parameter_value("input_video") or ""
-        if not str(raw).strip():
+        exceptions: list[Exception] = []
+        if not str(self.get_parameter_value("input_video") or "").strip():
             exceptions.append(ValueError(f"{self.name}: 'input_video' is required"))
         custom = self._validate_custom_parameters()
         if custom:
             exceptions.extend(custom)
-        return exceptions if exceptions else None
+        return exceptions or None
 
-    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:
-        # Single-frame extraction; timestamp is passed via kwargs
-        ffmpeg_path, _ = self._get_ffmpeg_paths()
-        timestamp: str = kwargs.get("timestamp", "00:00:00.000")
-        return [
-            ffmpeg_path,
-            "-ss",
-            timestamp,
-            "-i",
-            input_url,
-            "-vframes",
-            "1",
-            "-y",
-            output_path,
-        ]
+    def _validate_custom_parameters(self) -> list[Exception] | None:
+        mode = self.get_parameter_value("frame_selection_mode") or "list"
+        if mode == "list":
+            if not parse_frame_string(self.get_parameter_value("input_frame_numbers") or ""):
+                return [ValueError(
+                    f"{self.name}: 'input_frame_numbers' must specify at least one frame (e.g. '1,4,5-9')"
+                )]
+        elif mode == "every_Nth":
+            if (self.get_parameter_value("every_n") or 1) < 1:
+                return [ValueError(f"{self.name}: 'every_n' must be >= 1")]
+        return None
+
+    # ── URL resolution ─────────────────────────────────────────────────────────
 
     def _resolve_video_url(self, raw_value: typing.Any) -> str | None:
         """Resolve a video artifact or path to a browser-accessible presigned URL.
 
-        Follows the same pattern as AdjustMaskSize._resolve_video_url — accesses
-        .value from artifacts, then resolves via CreateStaticFileDownloadUrlFromPathRequest.
+        Follows the AdjustMaskSize pattern — accesses .value from artifacts,
+        then resolves via CreateStaticFileDownloadUrlFromPathRequest.
         """
         if not raw_value:
             return None
-
         file_path = raw_value.value if hasattr(raw_value, "value") else str(raw_value)
         if not file_path:
             return None
-
         if isinstance(file_path, str) and file_path.startswith(("http://", "https://")):
             return file_path
-
         try:
             result = griptape_nodes.GriptapeNodes.handle_request(
                 CreateStaticFileDownloadUrlFromPathRequest(file_path=file_path)
@@ -249,104 +240,37 @@ class VideoFrameExtractor(BaseVideoInputNode):
             logger.warning("Failed to resolve video URL for: %s", file_path, exc_info=True)
         return None
 
-    def _get_output_suffix(self, **kwargs) -> str:
-        frame_number: int = kwargs.get("frame_number", 0)
-        frame_padding: int = kwargs.get("frame_padding", 6)
-        return f"_{str(frame_number).zfill(frame_padding)}"
+    def _get_video_input_data(self) -> tuple[str, str]:
+        """Return (resolved_url, format) for the video input.
 
-    def _validate_custom_parameters(self) -> list[Exception] | None:
-        mode = self.get_parameter_value("frame_selection_mode") or "list"
-        if mode == "list":
-            frame_str = self.get_parameter_value("input_frame_numbers") or ""
-            frames = parse_frame_string(frame_str)
-            if not frames:
-                return [
-                    ValueError(f"{self.name}: 'input_frame_numbers' must specify at least one frame (e.g. '1,4,5-9')")
-                ]
-        elif mode == "every_Nth":
-            every_n = self.get_parameter_value("every_n") or 1
-            if every_n < 1:
-                return [ValueError(f"{self.name}: 'every_n' must be >= 1")]
-        return None
+        Format is always the user-chosen output format since the source format
+        is irrelevant to the extraction process.
+        """
+        url = self.get_parameter_value("input_video") or ""
+        if not url:
+            raise ValueError(f"{self.name}: No video loaded in 'input_video'")
+        if not str(url).startswith(("http://", "https://", "blob:", "data:")):
+            resolved = self._resolve_video_url(url)
+            if not resolved:
+                raise ValueError(f"{self.name}: Could not resolve video URL: {url}")
+            url = resolved
+        output_format = self.get_parameter_value("output_format") or self.DEFAULT_OUTPUT_FILE_FORMAT
+        return url, output_format
 
-    def _detect_frame_rate(self, input_url: str) -> float:
-        """Detect frame rate from the video; falls back to 30.0 on failure."""
-        _, ffprobe_path = self._get_ffmpeg_paths()
-        cmd = [
-            ffprobe_path,
-            "-v",
-            "quiet",
-            "-print_format",
-            "json",
-            "-show_streams",
-            "-select_streams",
-            "v:0",
-            input_url,
-        ]
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
-            streams_data = json.loads(result.stdout)
-            fps_str = streams_data["streams"][0].get("r_frame_rate", "30/1")
-            num, den = map(int, fps_str.split("/"))
-            return num / den
-        except Exception as e:
-            self.append_value_to_parameter("logs", f"Warning: could not detect frame rate, defaulting to 30fps: {e}\n")
-            return 30.0
+    # ── Output filename display ────────────────────────────────────────────────
 
-    def _extract_all_frames(self, input_url: str) -> list[pathlib.Path]:
-        """Extract each requested frame and return their saved paths."""
-        self._validate_url_safety(input_url)
+    def _build_output_filename_pattern(self) -> str:
+        prefix = self.get_parameter_value("output_prefix") or self.DEFAULT_OUTPUT_PREFIX
+        padding = self.get_parameter_value("frame_padding") or self.DEFAULT_FRAME_PADDING
+        fmt = self.get_parameter_value("output_format") or self.DEFAULT_OUTPUT_FILE_FORMAT
+        return f"{prefix}.{'#' * padding}.{fmt}"
 
-        output_format: str = self.get_parameter_value("output_format") or "png"
-        output_prefix: str = self.get_parameter_value("output_prefix") or "frame"
-        frame_padding: int = self.get_parameter_value("frame_padding") or 6
-        output_dir_str: str = self.get_parameter_value("output_dir") or ""
+    def _sync_output_file_display(self) -> None:
+        filename = self._build_output_filename_pattern()
+        self.set_parameter_value("output_file", filename)
+        self.publish_update_to_parameter("output_file", filename)
 
-        output_dir = pathlib.Path(output_dir_str) if output_dir_str else self._output_file.build_file().parent
-        output_dir.mkdir(parents=True, exist_ok=True)
-
-        frame_rate = self._detect_frame_rate(input_url)
-        self.append_value_to_parameter("logs", f"Detected frame rate: {frame_rate:.3f} fps\n")
-
-        mode = self.get_parameter_value("frame_selection_mode") or "list"
-        if mode == "every_Nth":
-            every_n = max(1, self.get_parameter_value("every_n") or 1)
-            _, ffprobe_path = self._get_ffmpeg_paths()
-            _, _, vid_duration = self._detect_video_properties(input_url, ffprobe_path)
-            total_frames = max(1, round(vid_duration * frame_rate))
-            frames = list(range(1, total_frames + 1, every_n))
-        else:
-            frame_str = self.get_parameter_value("input_frame_numbers") or ""
-            frames = parse_frame_string(frame_str)
-
-        saved_paths: list[pathlib.Path] = []
-        for frame_number in frames:
-            zero_based = max(frame_number - 1, 0)
-            timestamp = seconds_to_ts(zero_based / frame_rate)
-
-            padded = str(frame_number).zfill(frame_padding)
-            output_path = output_dir / f"{output_prefix}{padded}.{output_format}"
-
-            cmd = self._build_ffmpeg_command(
-                input_url,
-                str(output_path),
-                frame_rate,
-                timestamp=timestamp,
-                frame_number=frame_number,
-                frame_padding=frame_padding,
-            )
-
-            self.append_value_to_parameter("logs", f"Extracting frame {frame_number} at {timestamp}...\n")
-            self._run_ffmpeg_command(cmd, timeout=60)
-
-            if not output_path.exists() or output_path.stat().st_size == 0:
-                msg = f"FFmpeg did not produce output for frame {frame_number}"
-                raise ValueError(msg)
-
-            saved_paths.append(output_path)
-            self.append_value_to_parameter("logs", f"Saved frame {frame_number} → {output_path}\n")
-
-        return saved_paths
+    # ── Lifecycle hooks ────────────────────────────────────────────────────────
 
     def after_value_set(self, parameter: core_types.Parameter, value: typing.Any) -> None:
         if parameter.name == "input_video":
@@ -354,13 +278,12 @@ class VideoFrameExtractor(BaseVideoInputNode):
             current = self.parameter_values.get("input_video", "")
             current_base = str(current).split("?")[0] if current else ""
             if url:
-                new_base = url.split("?")[0]
-                if new_base != current_base:
+                if url.split("?")[0] != current_base:
                     self.set_parameter_value("input_video", url)
             elif current_base:
                 self.set_parameter_value("input_video", "")
 
-        if parameter.name == "frame_selection_mode":
+        elif parameter.name == "frame_selection_mode":
             mode = self.parameter_values.get("frame_selection_mode")
             if mode == "every_Nth":
                 self.hide_parameter_by_name("input_frame_numbers")
@@ -369,25 +292,90 @@ class VideoFrameExtractor(BaseVideoInputNode):
                 self.show_parameter_by_name("input_frame_numbers")
                 self.hide_parameter_by_name("every_n")
 
+        elif parameter.name in ("output_format", "output_prefix", "frame_padding"):
+            self._sync_output_file_display()
+
         return super().after_value_set(parameter, value)
+
+    # ── Execution ──────────────────────────────────────────────────────────────
 
     def process(self) -> node_types.AsyncResult[None]:
         self._clear_execution_status()
-        input_url, detected_format = self._get_video_input_data()
-        self._log_format_detection(detected_format)
-        self.append_value_to_parameter("logs", "[Started frame extraction..]\n")
-
+        input_url, output_format = self._get_video_input_data()
+        self._log_format_detection(output_format)
+        self.append_value_to_parameter("logs", "[Started frame extraction]\n")
         try:
-            yield lambda: self._run_extraction(input_url)
-            self.append_value_to_parameter("logs", "[Finished frame extraction.]\n")
+            yield lambda: self._run_extraction(input_url, output_format)
+            self.append_value_to_parameter("logs", "[Finished frame extraction]\n")
             self._set_status_results(was_successful=True, result_details="Frames extracted successfully")
         except Exception as e:
-            error_message = str(e)
-            msg = f"{self.name}: Error extracting frames: {error_message}"
+            msg = f"{self.name}: Error extracting frames: {e}"
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
-            self._set_status_results(was_successful=False, result_details=f"Frame extraction failed: {error_message}")
+            self._set_status_results(was_successful=False, result_details=str(e))
             self._handle_failure_exception(ValueError(msg))
 
-    def _run_extraction(self, input_url: str) -> None:
-        saved_paths = self._extract_all_frames(input_url)
+    def _run_extraction(self, input_url: str, output_format: str) -> None:
+        saved_paths = self._extract_all_frames(input_url, output_format)
+
         self.parameter_output_values["output_paths"] = [str(p) for p in saved_paths]
+        self.parameter_output_values["extracted_frames"] = [
+            self._path_to_image_artifact(p, output_format) for p in saved_paths
+        ]
+
+    def _extract_all_frames(self, input_url: str, output_format: str) -> list[pathlib.Path]:
+        """Extract each requested frame via ffmpeg and return the saved paths."""
+        self._validate_url_safety(input_url)
+
+        output_prefix = self.get_parameter_value("output_prefix") or self.DEFAULT_OUTPUT_PREFIX
+        frame_padding = self.get_parameter_value("frame_padding") or self.DEFAULT_FRAME_PADDING
+        output_dir_str = self.get_parameter_value("output_dir") or ""
+
+        output_dir = pathlib.Path(output_dir_str) if output_dir_str else pathlib.Path(tempfile.mkdtemp())
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
+        frame_rate, _, vid_duration = self._detect_video_properties(input_url, ffprobe_path)
+        self.append_value_to_parameter("logs", f"Detected frame rate: {frame_rate:.3f} fps\n")
+
+        frames = self._build_frame_list(frame_rate, vid_duration)
+        self.append_value_to_parameter("logs", f"Extracting {len(frames)} frame(s)...\n")
+
+        saved_paths: list[pathlib.Path] = []
+        for frame_number in frames:
+            timestamp = seconds_to_ts(max(frame_number - 1, 0) / frame_rate)
+            output_path = output_dir / f"{output_prefix}{str(frame_number).zfill(frame_padding)}.{output_format}"
+
+            cmd = self._build_ffmpeg_command(ffmpeg_path, input_url, str(output_path), timestamp)
+            self.append_value_to_parameter("logs", f"Extracting frame {frame_number} at {timestamp}...\n")
+            self._run_ffmpeg_command(cmd, timeout=60)
+
+            if not output_path.exists() or output_path.stat().st_size == 0:
+                raise ValueError(f"FFmpeg did not produce output for frame {frame_number}")
+
+            saved_paths.append(output_path)
+            self.append_value_to_parameter("logs", f"Saved frame {frame_number} → {output_path}\n")
+
+        return saved_paths
+
+    def _build_frame_list(self, frame_rate: float, vid_duration: float) -> list[int]:
+        """Return the ordered list of 1-based frame numbers to extract."""
+        mode = self.get_parameter_value("frame_selection_mode") or "list"
+        if mode == "every_Nth":
+            every_n = max(1, self.get_parameter_value("every_n") or 1)
+            total_frames = max(1, round(vid_duration * frame_rate))
+            return list(range(1, total_frames + 1, every_n))
+        frame_str = self.get_parameter_value("input_frame_numbers") or ""
+        return parse_frame_string(frame_str)
+
+    def _build_ffmpeg_command(
+        self, ffmpeg_path: str, input_url: str, output_path: str, timestamp: str
+    ) -> list[str]:
+        """Build the ffmpeg command to extract a single frame at the given timestamp."""
+        return [ffmpeg_path, "-ss", timestamp, "-i", input_url, "-vframes", "1", "-y", output_path]
+
+    @staticmethod
+    def _path_to_image_artifact(path: pathlib.Path, fmt: str) -> ImageArtifact:
+        """Read a saved frame file and wrap it as an ImageArtifact."""
+        with Image.open(path) as img:
+            w, h = img.size
+        return ImageArtifact(value=path.read_bytes(), format=fmt, width=w, height=h)

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -13,8 +13,11 @@ from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNod
 
 import griptape_nodes.exe_types.core_types as core_types
 import griptape_nodes.exe_types.node_types as node_types
+
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.file_system_picker import FileSystemPicker
 import griptape_nodes.traits.widget as widget
+from griptape_nodes.traits import options
 from griptape_nodes.retained_mode import griptape_nodes
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
@@ -24,24 +27,36 @@ from griptape_nodes.retained_mode.events.static_file_events import (
 logger = logging.getLogger(__name__)
 
 
-# TODO:
-# 1. Display selected frames in widget
-# 2. Frame extraction
-# 3. Output extracted frames as ImageArtifacts with staticfiles-backed URLs and paths
+def parse_frame_string(frame_str: str) -> list[int]:
+    """Parse a comma-separated frame specification into a sorted, deduplicated list.
 
-
-"""
-Algo:
-- get extraction type
-- get output formats
-    - file format (png, jpg)
-    - rename?
-    - padding
-    - prefix
-- if a list, iterate over this list, if every Nth, iterate over generator
-- for each frame to extract, seek to frame, read frame, convert to image artifact, save to staticfiles dir, output path/url/artifact
-
-"""
+    Supports individual frames and inclusive ranges: ``"1,4,5-9,11"`` → ``[1, 4, 5, 6, 7, 8, 9, 11]``.
+    Values < 1 are silently discarded.
+    """
+    if not frame_str or not frame_str.strip():
+        return []
+    result: set[int] = set()
+    for token in frame_str.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        if "-" in token:
+            parts = token.split("-", 1)
+            try:
+                start, end = int(parts[0]), int(parts[1])
+            except ValueError:
+                continue
+            if start > end or start < 1:
+                continue
+            result.update(range(start, end + 1))
+        else:
+            try:
+                n = int(token)
+            except ValueError:
+                continue
+            if n >= 1:
+                result.add(n)
+    return sorted(result)
 
 
 class VideoFrameExtractor(BaseVideoInputNode):
@@ -55,61 +70,23 @@ class VideoFrameExtractor(BaseVideoInputNode):
         if metadata:
             node_metadata.update(metadata)
         super().__init__(name=name, metadata=node_metadata, **kwargs)
-        self.set_initial_node_size(width=980, height=880)
+        self.remove_parameter_element_by_name("video")  # Remove the default video output param from BaseVideoInputNode
+        self.set_initial_node_size(width=980, height=480)
+        self.hide_parameter_by_name("every_n")
 
     def _get_output_file_default_filename(self) -> str:
-        return "output_##.png"
+        return "output.####.png"
 
     def _register_primary_output_parameter(self) -> None:
         self.add_parameter(
             core_types.Parameter(
                 name="output_paths",
-                type="list[ImageArtifact]|list[str|pathlib.Path]",
+                type="list[str]",
                 allowed_modes={core_types.ParameterMode.OUTPUT},
                 tooltip="Paths to the extracted frame images",
                 ui_options={"pulse_on_run": True},
             )
         )
-
-    def _setup_custom_parameters(self) -> None:
-        # Input parameters
-
-        self.add_parameter(
-            core_types.Parameter(
-                name="input_video",
-                input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
-                type="VideoUrlArtifact",
-                output_type="VideoUrlArtifact",
-                default_value=None,
-                allowed_modes={core_types.ParameterMode.INPUT},
-                ui_options={"display_name": "Video Input", "hide_property": True},
-                tooltip="Connect a video source here.",
-            )
-        )
-
-        self.add_parameter(
-            core_types.Parameter(
-                name="video_player",
-                type="str",
-                output_type="str",
-                default_value="",
-                allowed_modes={core_types.ParameterMode.PROPERTY},
-                tooltip="Video player for precise frame selection.",
-                traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
-            )
-        )
-
-        self.add_parameter(
-            core_types.Parameter(
-                name="input_frame_numbers",
-                output_type="str",
-                tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
-                allowed_modes={core_types.ParameterMode.INPUT},
-            )
-        )
-
-        # Output parameters
-
         self.add_parameter(
             core_types.Parameter(
                 name="extracted_frames",
@@ -120,63 +97,91 @@ class VideoFrameExtractor(BaseVideoInputNode):
             )
         )
 
+    def _setup_custom_parameters(self) -> None:
+        """Set up parameters specific to frame extraction, such as frame selection"""
+
+        # Input video and widget for frame selection
         self.add_parameter(
             core_types.Parameter(
-                name="extracted_frame_paths",
-                output_type="list[str]",
-                tooltip="Paths to the extracted frame images.",
-                allowed_modes={core_types.ParameterMode.OUTPUT},
-                ui_options={"hide_property": True},
+                name="input_video",
+                type="str",
+                output_type="str",
+                input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
+                default_value="",
+                allowed_modes={core_types.ParameterMode.INPUT},
+                tooltip="Video player for precise frame selection. Connect a video source here.",
+                ui_options={"display_name": "Video Input"},
+                traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
+            )
+        )
+        self.add_parameter(
+            core_types.Parameter(
+                name="frame_selection_mode",
+                type="str",
+                default_value="list",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
+                traits={options.Options(choices=["list", "every_Nth"])},
+                tooltip="Mode for selecting frames to extract. 'list' for specific frame numbers, 'every_Nth' for regular intervals. For list, use comma-separated integers and ranges: `1,4,5-9,11`",
+            )
+        )
+        self.add_parameter(
+            core_types.Parameter(
+                name="input_frame_numbers",
+                output_type="str",
+                tooltip="Comma-separated list of frame numbers or ranges to extract from the video.",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            core_types.Parameter(
+                name="every_n",
+                type="int",
+                default_value=1,
+                tooltip="Interval for extracting frames when 'every_Nth' mode is selected.",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
         )
 
-        self.add_parameter(
-            core_types.ParameterList(
-                name="extraction_output_formats",
+        with core_types.ParameterGroup(
+            name="settings", ui_options={"collapsed": True, "display_name": "Output format settings"}
+        ) as settings_group:
+            ParameterString(
+                name="output_format",
+                default_value="png",
                 input_types=["List[str]", "str"],
-                output_type="dict",
-                tooltip="Output format options for extracted frames, including file format (png, jpg), renaming pattern, padding, and prefix.",
-                allowed_modes={core_types.ParameterMode.PROPERTY, core_types.ParameterMode.INPUT},
+                output_type="str",
+                tooltip="Processing mode",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
+                traits={options.Options(choices=["png", "jpg", "exr"])},
             )
-        )
 
-        self.add_parameter(
-            core_types.Parameter(
-                name="frames",
-                type="list",
-                tooltip="1-based frame numbers to extract (e.g. [1, 10, 50])",
-                ui_options={"placeholder_text": "[1, 10, 50]"},
-            )
-        )
-        self.add_parameter(
             ParameterString(
                 name="output_dir",
                 default_value="",
                 tooltip="Directory to save extracted frames. Defaults to a temp directory.",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
+                traits={
+                    FileSystemPicker(
+                        allow_files=False,
+                        allow_directories=True,
+                        multiple=False,
+                    )
+                },
             )
-        )
-        self.add_parameter(
             ParameterString(
                 name="output_prefix",
                 default_value="frame",
                 tooltip="Filename prefix for each saved frame (e.g. 'frame' → 'frame000001.png')",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
-        )
-        self.add_parameter(
             core_types.Parameter(
                 name="frame_padding",
                 type="int",
                 default_value=6,
                 tooltip="Zero-padding width for the frame number in the output filename",
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
-        )
-        self.add_parameter(
-            ParameterString(
-                name="output_format",
-                default_value="png",
-                tooltip="Image format for extracted frames: png, jpg, or webp",
-            )
-        )
+        self.add_node_element(settings_group)
 
     def _get_processing_description(self) -> str:
         return "extracting frames from video"
@@ -220,11 +225,18 @@ class VideoFrameExtractor(BaseVideoInputNode):
         return f"_{str(frame_number).zfill(frame_padding)}"
 
     def _validate_custom_parameters(self) -> list[Exception] | None:
-        frames = self.get_parameter_value("frames")
-        if not frames:
-            return [ValueError(f"{self.name}: 'frames' must be a non-empty list of frame numbers")]
-        if not all(isinstance(f, int) and f >= 1 for f in frames):
-            return [ValueError(f"{self.name}: all frame numbers must be integers >= 1")]
+        mode = self.get_parameter_value("frame_selection_mode") or "list"
+        if mode == "list":
+            frame_str = self.get_parameter_value("input_frame_numbers") or ""
+            frames = parse_frame_string(frame_str)
+            if not frames:
+                return [
+                    ValueError(f"{self.name}: 'input_frame_numbers' must specify at least one frame (e.g. '1,4,5-9')")
+                ]
+        elif mode == "every_Nth":
+            every_n = self.get_parameter_value("every_n") or 1
+            if every_n < 1:
+                return [ValueError(f"{self.name}: 'every_n' must be >= 1")]
         return None
 
     def _detect_frame_rate(self, input_url: str) -> float:
@@ -255,7 +267,6 @@ class VideoFrameExtractor(BaseVideoInputNode):
         """Extract each requested frame and return their saved paths."""
         self._validate_url_safety(input_url)
 
-        frames: list[int] = self.get_parameter_value("frames")
         output_format: str = self.get_parameter_value("output_format") or "png"
         output_prefix: str = self.get_parameter_value("output_prefix") or "frame"
         frame_padding: int = self.get_parameter_value("frame_padding") or 6
@@ -266,6 +277,17 @@ class VideoFrameExtractor(BaseVideoInputNode):
 
         frame_rate = self._detect_frame_rate(input_url)
         self.append_value_to_parameter("logs", f"Detected frame rate: {frame_rate:.3f} fps\n")
+
+        mode = self.get_parameter_value("frame_selection_mode") or "list"
+        if mode == "every_Nth":
+            every_n = max(1, self.get_parameter_value("every_n") or 1)
+            _, ffprobe_path = self._get_ffmpeg_paths()
+            _, _, vid_duration = self._detect_video_properties(input_url, ffprobe_path)
+            total_frames = max(1, round(vid_duration * frame_rate))
+            frames = list(range(1, total_frames + 1, every_n))
+        else:
+            frame_str = self.get_parameter_value("input_frame_numbers") or ""
+            frames = parse_frame_string(frame_str)
 
         saved_paths: list[pathlib.Path] = []
         for frame_number in frames:
@@ -300,14 +322,24 @@ class VideoFrameExtractor(BaseVideoInputNode):
         """Automatically update video_player URL when input_video changes."""
         if parameter.name == "input_video":
             url = self._resolve_video_url(value)
-            current = self.parameter_values.get("video_player", "")
+            current = self.parameter_values.get("input_video", "")
             current_base = str(current).split("?")[0] if current else ""
             if url:
                 new_base = url.split("?")[0]
                 if new_base != current_base:
-                    self.set_parameter_value("video_player", url)
+                    self.set_parameter_value("input_video", url)
             elif current_base:
-                self.set_parameter_value("video_player", "")
+                self.set_parameter_value("input_video", "")
+
+        if parameter.name == "frame_selection_mode":
+            mode = self.parameter_values.get("frame_selection_mode")
+            if mode == "every_Nth":
+                self.hide_parameter_by_name("input_frame_numbers")
+                self.show_parameter_by_name("every_n")
+            elif mode == "list":
+                self.show_parameter_by_name("input_frame_numbers")
+                self.hide_parameter_by_name("every_n")
+
         return super().after_value_set(parameter, value)
 
     def process(self) -> node_types.AsyncResult[None]:

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -140,6 +140,16 @@ class ExtractFrames(BaseVideoInputNode):
         )
         self.add_parameter(
             core_types.Parameter(
+                name="_video_fps",
+                type="float",
+                default_value=0.0,
+                allowed_modes={core_types.ParameterMode.PROPERTY},
+                ui_options={"hide_property": True},
+                tooltip="Native frame rate detected from the video (set automatically).",
+            )
+        )
+        self.add_parameter(
+            core_types.Parameter(
                 name="frame_selection_mode",
                 type="str",
                 default_value="list",
@@ -159,10 +169,10 @@ class ExtractFrames(BaseVideoInputNode):
                 tooltip=(
                     "Frames to extract, as a comma-separated list of numbers or ranges (e.g. 1,4,5-9,11).\n\n"
                     "In the video player above:\n"
-                    "• Double-click the marker zone to add a single-frame marker\n"
-                    "• Double-click and drag to create a range\n"
+                    "• Hover the area above the timeline to reveal +, click to add a marker\n"
+                    "• Click and drag the + to create a range\n"
                     "• Drag an existing marker triangle to move it\n"
-                    "• Alt+click a marker to remove it"
+                    "• Hover a marker and click the trash icon to remove it"
                 ),
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
             )
@@ -299,6 +309,13 @@ class ExtractFrames(BaseVideoInputNode):
             if url:
                 if url.split("?")[0] != current_base:
                     self.set_parameter_value("input_video", url)
+                    try:
+                        _, ffprobe_path = self._get_ffmpeg_paths()
+                        frame_rate, _, _ = self._detect_video_properties(url, ffprobe_path)
+                        self.set_parameter_value("_video_fps", frame_rate)
+                        self.publish_update_to_parameter("_video_fps", frame_rate)
+                    except Exception:
+                        logger.warning("Could not detect video FPS", exc_info=True)
             elif current_base:
                 self.set_parameter_value("input_video", "")
 

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -1,5 +1,6 @@
 """Video Frame Extractor node — frame-accurate scrubbing and extraction."""
 
+import asyncio
 import logging
 import pathlib
 import typing
@@ -7,7 +8,6 @@ import typing
 from griptape.artifacts import ImageUrlArtifact
 
 import griptape_nodes.exe_types.core_types as core_types
-import griptape_nodes.exe_types.node_types as node_types
 from griptape_nodes.exe_types.core_types import NodeMessageResult
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -318,13 +318,13 @@ class VideoFrameExtractor(BaseVideoInputNode):
 
     # ── Execution ──────────────────────────────────────────────────────────────
 
-    def process(self) -> node_types.AsyncResult[None]:
+    async def aprocess(self) -> None:
         self._clear_execution_status()
         self.append_value_to_parameter("logs", "[Started frame extraction]\n")
         try:
             input_url, output_format = self._get_video_input_data()
             self._log_format_detection(output_format)
-            yield lambda: self._run_extraction(input_url, output_format)
+            await asyncio.to_thread(self._run_extraction, input_url, output_format)
             self.append_value_to_parameter("logs", "[Finished frame extraction]\n")
             n = len(self.parameter_output_values.get("output_paths") or [])
             out_dir = str(self._last_output_dir) if self._last_output_dir else "unknown"

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -10,6 +10,7 @@ import griptape_nodes.traits.widget as widget
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import NodeMessageResult
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode import griptape_nodes
@@ -177,9 +178,8 @@ class ExtractFrames(BaseVideoInputNode):
             )
         )
         self.add_parameter(
-            core_types.Parameter(
+            ParameterInt(
                 name="every_n",
-                type="int",
                 default_value=1,
                 tooltip="Interval for extracting frames when 'every_Nth' mode is selected.",
                 allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -359,9 +359,7 @@ class ExtractFrames(BaseVideoInputNode):
         saved_paths = self._extract_all_frames(input_url, output_format)
 
         self.parameter_output_values["output_paths"] = [str(p) for p in saved_paths]
-        self.parameter_output_values["extracted_frames"] = [
-            self._path_to_image_url_artifact(p) for p in saved_paths
-        ]
+        self.parameter_output_values["extracted_frames"] = [self._path_to_image_url_artifact(p) for p in saved_paths]
 
         # Store the output directory and enable the "Open Output Folder" button
         if saved_paths:

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -2,29 +2,20 @@
 
 import logging
 import pathlib
-import re
-import tempfile
 import typing
-from urllib.parse import urlparse
 
 from griptape.artifacts import ImageUrlArtifact
 
 import griptape_nodes.exe_types.core_types as core_types
 import griptape_nodes.exe_types.node_types as node_types
-from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.exe_types.core_types import NodeMessageResult
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode import griptape_nodes
 from griptape_nodes.retained_mode.events.os_events import (
     OpenAssociatedFileRequest,
     OpenAssociatedFileResultSuccess,
-)
-from griptape_nodes.retained_mode.events.project_events import (
-    AttemptMapAbsolutePathToProjectRequest,
-    AttemptMapAbsolutePathToProjectResultSuccess,
-    GetPathForMacroRequest,
-    GetPathForMacroResultSuccess,
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
@@ -106,6 +97,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
             core_types.Parameter(
                 name="output_paths",
                 type="list[str]",
+                output_type="list[str]",
                 allowed_modes={core_types.ParameterMode.OUTPUT},
                 tooltip="Paths to the extracted frame images",
                 ui_options={"pulse_on_run": True},
@@ -114,6 +106,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
         self.add_parameter(
             core_types.Parameter(
                 name="extracted_frames",
+                type="list[ImageUrlArtifact]",
                 output_type="list[ImageUrlArtifact]",
                 tooltip="Extracted frames as ImageUrlArtifacts.",
                 allowed_modes={core_types.ParameterMode.OUTPUT},
@@ -233,9 +226,9 @@ class VideoFrameExtractor(BaseVideoInputNode):
         mode = self.get_parameter_value("frame_selection_mode") or "list"
         if mode == "list":
             if not parse_frame_string(self.get_parameter_value("input_frame_numbers") or ""):
-                return [ValueError(
-                    f"{self.name}: 'input_frame_numbers' must specify at least one frame (e.g. '1,4,5-9')"
-                )]
+                return [
+                    ValueError(f"{self.name}: 'input_frame_numbers' must specify at least one frame (e.g. '1,4,5-9')")
+                ]
         elif mode == "every_Nth":
             if (self.get_parameter_value("every_n") or 1) < 1:
                 return [ValueError(f"{self.name}: 'every_n' must be >= 1")]
@@ -265,27 +258,6 @@ class VideoFrameExtractor(BaseVideoInputNode):
         except Exception:
             logger.warning("Failed to resolve video URL for: %s", file_path, exc_info=True)
         return None
-
-    def _resolve_output_dir(self, video_url: str) -> pathlib.Path:
-        """Resolve the project output directory: outputs/{NodeName}/{VideoStem}/.
-
-        Falls back to a temp directory when no project is loaded.
-        """
-        video_stem = pathlib.Path(urlparse(video_url).path).stem or "video"
-        video_stem = re.sub(r"[^\w-]", "_", video_stem)
-        sub_dirs = f"{self.name}/{video_stem}"
-
-        result = griptape_nodes.GriptapeNodes.handle_request(
-            GetPathForMacroRequest(
-                parsed_macro=ParsedMacro("{outputs}/{sub_dirs}"),
-                variables={"sub_dirs": sub_dirs},
-            )
-        )
-        if isinstance(result, GetPathForMacroResultSuccess):
-            return pathlib.Path(result.absolute_path)
-
-        logger.warning("Could not resolve project output directory; falling back to temp dir")
-        return pathlib.Path(tempfile.mkdtemp())
 
     def _get_video_input_data(self) -> tuple[str, str]:
         """Return (resolved_url, format) for the video input.
@@ -348,37 +320,28 @@ class VideoFrameExtractor(BaseVideoInputNode):
 
     def process(self) -> node_types.AsyncResult[None]:
         self._clear_execution_status()
-        input_url, output_format = self._get_video_input_data()
-        self._log_format_detection(output_format)
         self.append_value_to_parameter("logs", "[Started frame extraction]\n")
         try:
+            input_url, output_format = self._get_video_input_data()
+            self._log_format_detection(output_format)
             yield lambda: self._run_extraction(input_url, output_format)
             self.append_value_to_parameter("logs", "[Finished frame extraction]\n")
-            self._set_status_results(was_successful=True, result_details="Frames extracted successfully")
+            n = len(self.parameter_output_values.get("output_paths") or [])
+            out_dir = str(self._last_output_dir) if self._last_output_dir else "unknown"
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"SUCCESS: Extracted {n} frame(s) to {out_dir}",
+            )
         except Exception as e:
             msg = f"{self.name}: Error extracting frames: {e}"
             self.append_value_to_parameter("logs", f"ERROR: {msg}\n")
-            self._set_status_results(was_successful=False, result_details=str(e))
+            self._set_status_results(was_successful=False, result_details=f"FAILURE: {msg}")
             self._handle_failure_exception(ValueError(msg))
 
     def _run_extraction(self, input_url: str, output_format: str) -> None:
         saved_paths = self._extract_all_frames(input_url, output_format)
 
-        # Map absolute paths to portable project macro paths (e.g. "{outputs}/NodeName/video/frame.png")
-        output_paths: list[str] = []
-        for p in saved_paths:
-            map_result = griptape_nodes.GriptapeNodes.handle_request(
-                AttemptMapAbsolutePathToProjectRequest(absolute_path=p)
-            )
-            if (
-                isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess)
-                and map_result.mapped_path is not None
-            ):
-                output_paths.append(map_result.mapped_path)
-            else:
-                output_paths.append(str(p))
-
-        self.parameter_output_values["output_paths"] = output_paths
+        self.parameter_output_values["output_paths"] = [str(p) for p in saved_paths]
         self.parameter_output_values["extracted_frames"] = [
             self._path_to_image_url_artifact(p) for p in saved_paths
         ]
@@ -414,15 +377,12 @@ class VideoFrameExtractor(BaseVideoInputNode):
         )
 
     def _extract_all_frames(self, input_url: str, output_format: str) -> list[pathlib.Path]:
-        """Extract each requested frame via ffmpeg and return the saved paths."""
+        """Extract each requested frame via ffmpeg and return the saved absolute paths."""
         self._validate_url_safety(input_url)
 
         output_prefix = self.get_parameter_value("output_prefix") or self.DEFAULT_OUTPUT_PREFIX
         frame_padding = self.get_parameter_value("frame_padding") or self.DEFAULT_FRAME_PADDING
         output_dir_str = self.get_parameter_value("output_dir") or ""
-
-        output_dir = pathlib.Path(output_dir_str) if output_dir_str else self._resolve_output_dir(input_url)
-        output_dir.mkdir(parents=True, exist_ok=True)
 
         ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
         frame_rate, _, vid_duration = self._detect_video_properties(input_url, ffprobe_path)
@@ -434,7 +394,19 @@ class VideoFrameExtractor(BaseVideoInputNode):
         saved_paths: list[pathlib.Path] = []
         for frame_number in frames:
             timestamp = seconds_to_ts(max(frame_number - 1, 0) / frame_rate)
-            output_path = output_dir / f"{output_prefix}{str(frame_number).zfill(frame_padding)}.{output_format}"
+            filename = f"{output_prefix}.{str(frame_number).zfill(frame_padding)}.{output_format}"
+
+            if output_dir_str:
+                output_path = pathlib.Path(output_dir_str) / filename
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+            else:
+                dest = ProjectFileDestination.from_situation(
+                    filename,
+                    "save_node_output",
+                    sub_dirs=self.name,
+                )
+                output_path = pathlib.Path(dest.resolve())
+                output_path.parent.mkdir(parents=True, exist_ok=True)
 
             cmd = self._build_ffmpeg_command(ffmpeg_path, input_url, str(output_path), timestamp)
             self.append_value_to_parameter("logs", f"Extracting frame {frame_number} at {timestamp}...\n")
@@ -458,9 +430,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
         frame_str = self.get_parameter_value("input_frame_numbers") or ""
         return parse_frame_string(frame_str)
 
-    def _build_ffmpeg_command(
-        self, ffmpeg_path: str, input_url: str, output_path: str, timestamp: str
-    ) -> list[str]:
+    def _build_ffmpeg_command(self, ffmpeg_path: str, input_url: str, output_path: str, timestamp: str) -> list[str]:
         """Build the ffmpeg command to extract a single frame at the given timestamp."""
         return [ffmpeg_path, "-ss", timestamp, "-i", input_url, "-vframes", "1", "-y", output_path]
 

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -7,14 +7,19 @@ import tempfile
 import typing
 from urllib.parse import urlparse
 
-from griptape.artifacts import ImageArtifact
-from PIL import Image
+from griptape.artifacts import ImageUrlArtifact
 
 import griptape_nodes.exe_types.core_types as core_types
 import griptape_nodes.exe_types.node_types as node_types
 from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.exe_types.core_types import NodeMessageResult
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode import griptape_nodes
+from griptape_nodes.retained_mode.events.os_events import (
+    OpenAssociatedFileRequest,
+    OpenAssociatedFileResultSuccess,
+)
 from griptape_nodes.retained_mode.events.project_events import (
     AttemptMapAbsolutePathToProjectRequest,
     AttemptMapAbsolutePathToProjectResultSuccess,
@@ -26,6 +31,7 @@ from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathResultSuccess,
 )
 from griptape_nodes.traits import options
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 import griptape_nodes.traits.widget as widget
 
@@ -85,6 +91,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
         self.remove_parameter_element_by_name("video")
         # self.set_initial_node_size(width=980, height=480)
         self.hide_parameter_by_name("every_n")
+        self._last_output_dir: pathlib.Path | None = None
 
     # ── Parameter setup ────────────────────────────────────────────────────────
 
@@ -107,10 +114,20 @@ class VideoFrameExtractor(BaseVideoInputNode):
         self.add_parameter(
             core_types.Parameter(
                 name="extracted_frames",
-                output_type="list[ImageArtifact]",
-                tooltip="Extracted frames as ImageArtifacts.",
+                output_type="list[ImageUrlArtifact]",
+                tooltip="Extracted frames as ImageUrlArtifacts.",
                 allowed_modes={core_types.ParameterMode.OUTPUT},
                 ui_options={"hide_property": True},
+            )
+        )
+        self.add_parameter(
+            ParameterButton(
+                name="open_output_folder",
+                label="Open Output Folder",
+                variant="secondary",
+                icon="folder-open",
+                on_click=self._on_open_output_folder,
+                ui_options={"disabled": True},
             )
         )
 
@@ -122,7 +139,7 @@ class VideoFrameExtractor(BaseVideoInputNode):
                 output_type="str",
                 input_types=["VideoUrlArtifact", "VideoArtifact", "str"],
                 default_value="",
-                allowed_modes={core_types.ParameterMode.INPUT},
+                allowed_modes={core_types.ParameterMode.INPUT, core_types.ParameterMode.PROPERTY},
                 tooltip="Video player for precise frame selection. Connect a video source here.",
                 ui_options={"display_name": "Video Input"},
                 traits={widget.Widget(name="VideoPlayerFrameSelector", library="Griptape Nodes Library")},
@@ -363,8 +380,38 @@ class VideoFrameExtractor(BaseVideoInputNode):
 
         self.parameter_output_values["output_paths"] = output_paths
         self.parameter_output_values["extracted_frames"] = [
-            self._path_to_image_artifact(p, output_format) for p in saved_paths
+            self._path_to_image_url_artifact(p) for p in saved_paths
         ]
+
+        # Store the output directory and enable the "Open Output Folder" button
+        if saved_paths:
+            self._last_output_dir = saved_paths[0].parent
+            self.set_parameter_value("open_output_folder", {"disabled": False})
+            self.publish_update_to_parameter("open_output_folder", {"disabled": False})
+
+    def _on_open_output_folder(
+        self,
+        _button: Button,
+        button_details: ButtonDetailsMessagePayload,
+    ) -> NodeMessageResult:
+        """Open the last output folder in the OS file manager."""
+        if not self._last_output_dir or not self._last_output_dir.exists():
+            return NodeMessageResult(
+                success=False,
+                details="No output folder available yet — run the node first.",
+                response=button_details,
+                altered_workflow_state=False,
+            )
+        result = griptape_nodes.GriptapeNodes.handle_request(
+            OpenAssociatedFileRequest(path_to_file=str(self._last_output_dir))
+        )
+        success = isinstance(result, OpenAssociatedFileResultSuccess)
+        return NodeMessageResult(
+            success=success,
+            details=str(self._last_output_dir) if success else f"Could not open folder: {result}",
+            response=button_details,
+            altered_workflow_state=False,
+        )
 
     def _extract_all_frames(self, input_url: str, output_format: str) -> list[pathlib.Path]:
         """Extract each requested frame via ffmpeg and return the saved paths."""
@@ -417,9 +464,14 @@ class VideoFrameExtractor(BaseVideoInputNode):
         """Build the ffmpeg command to extract a single frame at the given timestamp."""
         return [ffmpeg_path, "-ss", timestamp, "-i", input_url, "-vframes", "1", "-y", output_path]
 
-    @staticmethod
-    def _path_to_image_artifact(path: pathlib.Path, fmt: str) -> ImageArtifact:
-        """Read a saved frame file and wrap it as an ImageArtifact."""
-        with Image.open(path) as img:
-            w, h = img.size
-        return ImageArtifact(value=path.read_bytes(), format=fmt, width=w, height=h)
+    def _path_to_image_url_artifact(self, path: pathlib.Path) -> ImageUrlArtifact:
+        """Resolve a saved frame path to an ImageUrlArtifact (no binary payload)."""
+        try:
+            result = griptape_nodes.GriptapeNodes.handle_request(
+                CreateStaticFileDownloadUrlFromPathRequest(file_path=str(path))
+            )
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                return ImageUrlArtifact(result.url)
+        except Exception:
+            logger.warning("Failed to resolve URL for frame: %s", path, exc_info=True)
+        return ImageUrlArtifact(str(path))

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -5,9 +5,9 @@ import logging
 import pathlib
 import typing
 
-from griptape.artifacts import ImageUrlArtifact
-
 import griptape_nodes.exe_types.core_types as core_types
+import griptape_nodes.traits.widget as widget
+from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import NodeMessageResult
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -24,7 +24,6 @@ from griptape_nodes.retained_mode.events.static_file_events import (
 from griptape_nodes.traits import options
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
-import griptape_nodes.traits.widget as widget
 
 from griptape_nodes_library.utils.video_utils import seconds_to_ts
 from griptape_nodes_library.video.base_video_input_node import BaseVideoInputNode

--- a/griptape_nodes_library/video/extract_frames.py
+++ b/griptape_nodes_library/video/extract_frames.py
@@ -64,7 +64,7 @@ def parse_frame_string(frame_str: str) -> list[int]:
     return sorted(result)
 
 
-class VideoFrameExtractor(BaseVideoInputNode):
+class ExtractFrames(BaseVideoInputNode):
     """Extract specific frames from a video and save them as images."""
 
     DEFAULT_OUTPUT_PREFIX = "frame"

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -1,0 +1,706 @@
+/**
+ * VideoPlayerWidget — vanilla JS
+ * Controls: step back | play back | pause | play forward | step forward
+ * Timeline: click to seek, Shift+click to add/remove a marker
+ * Enlarge button opens a fullscreen dialog with a canvas mirror of the video.
+ */
+
+const SESSIONS = new Map();
+
+/* ─── Icons ──────────────────────────────────────────────────────────────── */
+
+const _svg = (d) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="${d}"/></svg>`;
+
+const ICONS = {
+  stepBack:  _svg('M16 5L4 12l12 7zM18 5h2v14h-2z'),
+  playBack:  _svg('M16 5v14L5 12z'),
+  pause:     _svg('M6 19h4V5H6v14zm8-14v14h4V5h-4z'),
+  playFwd:   _svg('M8 5v14l11-7z'),
+  stepFwd:   _svg('M4 5h2v14H4zm4 0l12 7-12 7z'),
+  enlarge:   `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>`,
+};
+
+/* ─── CSS (injected once into document.head) ─────────────────────────────── */
+
+const CSS_ID = 'vpw-global-styles';
+const CSS = `
+  .vpw-btn {
+    background:none; border:none;
+    color:#555; width:34px; height:34px;
+    display:flex; align-items:center; justify-content:center;
+    cursor:pointer; flex-shrink:0; border-radius:4px;
+    transition:color .12s;
+  }
+  .vpw-btn:hover:not([disabled]) { color:#bbb; }
+  .vpw-btn:active:not([disabled]) { color:#fff; }
+  .vpw-btn[disabled] { opacity:.2; cursor:not-allowed; pointer-events:none; }
+  .vpw-timecode {
+    color:#666; font-size:11px; padding:0 10px; white-space:nowrap;
+    font-variant-numeric:tabular-nums;
+    font-family:'SF Mono','Monaco','Menlo',monospace;
+    text-align:center;
+  }
+  .vpw-num {
+    background:#1a1a1a; border:1px solid #333; border-radius:5px;
+    color:#ccc; padding:4px 8px; font-size:11px; text-align:center;
+  }
+  .vpw-num:focus { outline:none; border-color:#4a7aaa; }
+  .vpw-num[disabled] { opacity:.3; }
+  .vpw-timeline {
+    position:relative; height:36px;
+    cursor:pointer; user-select:none; touch-action:none;
+  }
+  .vpw-tl-track {
+    position:absolute; bottom:10px; left:0; right:0; height:3px;
+    background:#252525; border-radius:2px; pointer-events:none;
+  }
+  .vpw-tl-fill {
+    position:absolute; bottom:10px; left:0; height:3px;
+    background:#2d5a8a; border-radius:2px; pointer-events:none;
+  }
+  .vpw-tl-seeker {
+    position:absolute; bottom:8px; width:1px; height:calc(100% - 8px);
+    background:#777; transform:translateX(-50%); pointer-events:none; z-index:3;
+  }
+  .vpw-tl-seeker::after {
+    content:''; position:absolute; bottom:-1px; left:50%;
+    width:9px; height:9px; background:#bbb; border:1px solid #444;
+    transform:translateX(-50%) rotate(45deg); border-radius:1px;
+  }
+  .vpw-tl-marker {
+    position:absolute; bottom:8px;
+    width:9px; height:9px; background:#c07800;
+    transform:translateX(-50%) rotate(45deg);
+    pointer-events:none; z-index:2; border-radius:1px;
+  }
+  /* Dialog */
+  .vpw-dialog-backdrop {
+    position:fixed; inset:0; background:rgba(0,0,0,.8);
+    z-index:9999; backdrop-filter:blur(3px);
+    display:flex; align-items:center; justify-content:center;
+  }
+  .vpw-dialog-box {
+    background:#111; border:1px solid #2d2d2d; border-radius:14px;
+    padding:20px; width:96vw; max-height:96vh; overflow-y:auto;
+    position:relative; display:flex; flex-direction:column; gap:10px;
+    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+    font-size:12px; color:#ddd;
+  }
+  .vpw-dialog-title {
+    margin:0; color:#888; font-size:13px;
+    padding-right:40px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  }
+  .vpw-dialog-close {
+    position:absolute; top:14px; right:14px;
+    background:#222; border:1px solid #444; border-radius:6px;
+    color:#aaa; width:28px; height:28px;
+    display:flex; align-items:center; justify-content:center;
+    cursor:pointer; font-size:15px;
+  }
+  .vpw-dialog-close:hover { background:#333; color:#eee; }
+  .vpw-dialog-canvas-wrap {
+    background:#000; border-radius:8px; overflow:hidden;
+    min-height:180px; display:flex; align-items:center; justify-content:center;
+  }
+  .vpw-dialog-canvas { display:block; width:100%; height:auto; max-height:78vh; }
+  .vpw-dialog-placeholder { color:#3a3a3a; font-size:13px; }
+`;
+
+function injectGlobalStyles() {
+  if (document.getElementById(CSS_ID)) return;
+  const el = document.createElement('style');
+  el.id = CSS_ID;
+  el.textContent = CSS;
+  document.head.appendChild(el);
+}
+
+/* ─── HTML helpers ───────────────────────────────────────────────────────── */
+
+function controlsHtml(pfx) {
+  return `
+    <div style="display:flex;justify-content:center;">
+      <div style="display:inline-flex;align-items:center;gap:4px;">
+        <button class="${pfx}step-back vpw-btn" title="Back one frame">${ICONS.stepBack}</button>
+        <button class="${pfx}play-back vpw-btn" title="Play backwards">${ICONS.playBack}</button>
+        <button class="${pfx}pause-back vpw-btn" title="Pause" style="display:none;">${ICONS.pause}</button>
+        <span class="${pfx}timecode vpw-timecode">00:00:00 / 00:00:00</span>
+        <button class="${pfx}play-fwd vpw-btn" title="Play forwards">${ICONS.playFwd}</button>
+        <button class="${pfx}pause-fwd vpw-btn" title="Pause" style="display:none;">${ICONS.pause}</button>
+        <button class="${pfx}step-fwd vpw-btn" title="Forward one frame">${ICONS.stepFwd}</button>
+      </div>
+    </div>`;
+}
+
+function timelineHtml(id) {
+  return `
+    <div class="vpw-timeline nowheel" data-tl="${id}" title="Drag to seek · Shift+click to add/remove marker">
+      <div class="vpw-tl-track"></div>
+      <div class="vpw-tl-fill"   data-tl-fill="${id}"></div>
+      <div class="vpw-tl-seeker" data-tl-seeker="${id}"></div>
+    </div>`;
+}
+
+function bottomHtml(pfx, initFps) {
+  return `
+    <div style="display:flex;justify-content:center;align-items:center;gap:12px;">
+      <label style="display:flex;align-items:center;gap:6px;color:#666;">
+        FPS <input class="${pfx}fps vpw-num" type="number" min="1" max="240" step="0.001" value="${initFps}" style="width:58px;">
+      </label>
+      <label style="display:flex;align-items:center;gap:6px;color:#666;">
+        Frame <input class="${pfx}frame vpw-num" type="number" min="0" value="0" style="width:72px;">
+      </label>
+      <span class="${pfx}total" style="color:#484848;">/ 0</span>
+    </div>`;
+}
+
+/* ─── Widget ─────────────────────────────────────────────────────────────── */
+
+export default function VideoPlayerWidget(container, props) {
+  injectGlobalStyles();
+
+  const { value, onChange, disabled, height } = props;
+
+  const MIN_FPS = 1, MAX_FPS = 240, DEFAULT_FPS = 24;
+  const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+
+  const sessionKey = String(props?.node_id || props?.nodeId || props?.id || 'vpw-default');
+  const session = SESSIONS.get(sessionKey) || {
+    fps: null, nativeFps: null, frameIndex: 0, currentTime: 0, markedFrames: [],
+    videoSrc: null,
+  };
+  SESSIONS.set(sessionKey, session);
+
+  const initFps = (() => {
+    const s = Number(session.fps), v = Number(value?.fps);
+    if (Number.isFinite(s) && s > 0) return clamp(s, MIN_FPS, MAX_FPS);
+    if (Number.isFinite(v) && v > 0) return clamp(v, MIN_FPS, MAX_FPS);
+    return DEFAULT_FPS;
+  })();
+
+  const vpH = height && height > 0 ? Math.max(180, height - 380) : 280;
+
+  /* ── Main HTML ──────────────────────────────────────────────────────────── */
+
+  container.innerHTML = `
+    <div class="nodrag" style="
+      display:flex;flex-direction:column;gap:10px;
+      background:#111;border-radius:10px;padding:10px;color:#ddd;
+      font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:12px;">
+
+      <div style="display:flex;justify-content:flex-end;">
+        <button class="vpw-enlarge" style="background:none;border:1px solid #2a4560;border-radius:6px;color:#5090c0;padding:4px 8px;cursor:pointer;display:flex;align-items:center;gap:4px;font-size:11px;white-space:nowrap;">
+          ${ICONS.enlarge} Enlarge
+        </button>
+      </div>
+
+      <div style="position:relative;background:#000;border-radius:8px;overflow:hidden;height:${vpH}px;">
+        <video class="vpw-video" style="width:100%;height:100%;object-fit:contain;" playsinline preload="metadata"
+          ${session.videoSrc ? `src="${session.videoSrc}"` : ''}></video>
+        <div class="vpw-overlay" style="position:absolute;inset:0;display:${session.videoSrc ? 'none' : 'flex'};align-items:center;justify-content:center;color:#3a3a3a;font-size:13px;pointer-events:none;">
+          No video loaded
+        </div>
+      </div>
+
+      ${timelineHtml('main')}
+      ${controlsHtml('vpw-m-')}
+      ${bottomHtml('vpw-m-', initFps)}
+    </div>`;
+
+  /* ── Dialog HTML (appended to body to escape stacking context) ──────────── */
+
+  const backdrop = document.createElement('div');
+  backdrop.className = 'vpw-dialog-backdrop';
+  backdrop.style.display = 'none';
+  backdrop.innerHTML = `
+    <div class="vpw-dialog-box">
+      <p class="vpw-dialog-title">Video Player</p>
+      <button class="vpw-dialog-close">✕</button>
+      <div class="vpw-dialog-canvas-wrap">
+        <canvas class="vpw-dcanvas vpw-dialog-canvas"></canvas>
+        <span class="vpw-dno-video vpw-dialog-placeholder" style="display:none;">No video loaded</span>
+      </div>
+      ${timelineHtml('dialog')}
+      ${controlsHtml('vpw-d-')}
+      ${bottomHtml('vpw-d-', initFps)}
+    </div>`;
+  document.body.appendChild(backdrop);
+
+  /* ── DOM refs ────────────────────────────────────────────────────────────── */
+
+  const q  = (sel) => container.querySelector(sel);
+  const qd = (sel) => backdrop.querySelector(sel);
+
+  const enlargeBtn  = q('.vpw-enlarge');
+  const video       = q('.vpw-video');
+  const overlay     = q('.vpw-overlay');
+
+  const tl          = q('[data-tl="main"]');
+  const tlFill      = q('[data-tl-fill="main"]');
+  const tlSeeker    = q('[data-tl-seeker="main"]');
+
+  const mStepBack   = q('.vpw-m-step-back');
+  const mPlayBack   = q('.vpw-m-play-back');
+  const mPauseBack  = q('.vpw-m-pause-back');
+  const mPlayFwd    = q('.vpw-m-play-fwd');
+  const mPauseFwd   = q('.vpw-m-pause-fwd');
+  const mStepFwd    = q('.vpw-m-step-fwd');
+  const mFpsInput   = q('.vpw-m-fps');
+  const mFrameInput = q('.vpw-m-frame');
+  const mTotalEl    = q('.vpw-m-total');
+
+  const dialogTitleEl = qd('.vpw-dialog-title');
+  const dialogClose   = qd('.vpw-dialog-close');
+  const dialogCanvas  = qd('.vpw-dcanvas');
+  const dNoVideo      = qd('.vpw-dno-video');
+
+  const dtl          = qd('[data-tl="dialog"]');
+  const dtlFill      = qd('[data-tl-fill="dialog"]');
+  const dtlSeeker    = qd('[data-tl-seeker="dialog"]');
+
+  const dStepBack    = qd('.vpw-d-step-back');
+  const dPlayBack    = qd('.vpw-d-play-back');
+  const dPauseBack   = qd('.vpw-d-pause-back');
+  const dPlayFwd     = qd('.vpw-d-play-fwd');
+  const dPauseFwd    = qd('.vpw-d-pause-fwd');
+  const dStepFwd     = qd('.vpw-d-step-fwd');
+  const dFpsInput    = qd('.vpw-d-fps');
+  const dFrameInput  = qd('.vpw-d-frame');
+  const dTotalEl     = qd('.vpw-d-total');
+  const mTimecode    = q('.vpw-m-timecode');
+  const dTimecode    = qd('.vpw-d-timecode');
+
+  /* ── State ──────────────────────────────────────────────────────────────── */
+
+  let nativeFps    = Number.isFinite(Number(session.nativeFps)) && Number(session.nativeFps) > 0
+                     ? Number(session.nativeFps) : initFps;
+  let fps          = initFps;
+  let duration     = 0;
+  let totalFrames  = 0;
+  let frameIndex   = 0;
+  let markedFrames = Array.isArray(session.markedFrames) ? [...session.markedFrames] : [];
+  let videoName    = '';
+  let isLoaded     = false;
+  let backRafId    = null;
+  let canvasRafId  = null;
+  let currentSrc   = null;
+  let pollId       = null;
+
+  /* ── Helpers ─────────────────────────────────────────────────────────────── */
+
+  const computeTotal = () =>
+    duration > 0 && nativeFps > 0 ? Math.max(1, Math.round(duration * nativeFps)) : 0;
+
+  function fmtTime(s) {
+    if (!Number.isFinite(s) || s < 0) s = 0;
+    const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), ss = Math.floor(s % 60);
+    return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}:${String(ss).padStart(2,'0')}`;
+  }
+
+  function setTimecode(currentSecs, totalSecs) {
+    const t = `${fmtTime(currentSecs)} / ${fmtTime(totalSecs)}`;
+    mTimecode.textContent = t;
+    dTimecode.textContent = t;
+  }
+
+  function saveSession() {
+    session.fps          = fps;
+    session.nativeFps    = nativeFps;
+    session.frameIndex   = frameIndex;
+    session.currentTime  = Number.isFinite(video.currentTime) ? video.currentTime : 0;
+    session.markedFrames = [...markedFrames];
+  }
+
+  function renderMarkers(tlEl) {
+    tlEl.querySelectorAll('.vpw-tl-marker').forEach(m => m.remove());
+    if (totalFrames <= 1) return;
+    const max = totalFrames - 1;
+    for (const f of markedFrames) {
+      const m = document.createElement('div');
+      m.className = 'vpw-tl-marker';
+      m.style.left = `${(f / max) * 100}%`;
+      tlEl.appendChild(m);
+    }
+  }
+
+  function syncTimeline() {
+    const pct = totalFrames > 1 ? (frameIndex / (totalFrames - 1)) * 100 : 0;
+    tlFill.style.width   = `${pct}%`;
+    tlSeeker.style.left  = `${pct}%`;
+    dtlFill.style.width  = `${pct}%`;
+    dtlSeeker.style.left = `${pct}%`;
+    renderMarkers(tl);
+    renderMarkers(dtl);
+  }
+
+  function updateUi() {
+    totalFrames = computeTotal();
+    frameIndex  = clamp(frameIndex, 0, Math.max(0, totalFrames - 1));
+
+    const maxF   = Math.max(0, totalFrames - 1);
+    const canAct = isLoaded && totalFrames > 0 && !disabled;
+
+    for (const b of [mStepBack, mPlayBack, mPauseBack, mPlayFwd, mPauseFwd, mStepFwd,
+                      dStepBack, dPlayBack, dPauseBack, dPlayFwd, dPauseFwd, dStepFwd])
+      b.disabled = !canAct;
+    for (const inp of [mFrameInput, dFrameInput]) { inp.disabled = !canAct; inp.max = String(maxF); }
+    for (const inp of [mFpsInput, dFpsInput]) inp.disabled = !!disabled;
+
+    mFpsInput.value    = dFpsInput.value    = String(fps);
+    mFrameInput.value  = dFrameInput.value  = String(frameIndex);
+    mTotalEl.textContent = dTotalEl.textContent = `/ ${maxF}`;
+    dialogTitleEl.textContent = videoName || 'Video Player';
+    setTimecode(Number.isFinite(video.currentTime) ? video.currentTime : 0, duration);
+
+    syncTimeline();
+    saveSession();
+  }
+
+  /* ── Seek / playback ────────────────────────────────────────────────────── */
+
+  function seekToFrame(idx) {
+    const max = Math.max(0, totalFrames - 1);
+    frameIndex = clamp(Math.round(idx), 0, max);
+    if (isLoaded && nativeFps > 0) video.currentTime = frameIndex / nativeFps;
+    updateUi();
+  }
+
+  function stopBackward() {
+    if (backRafId) { cancelAnimationFrame(backRafId); backRafId = null; }
+  }
+
+  function showPlayState(direction) {
+    // direction: 'back', 'fwd', or null (paused/stopped)
+    for (const [play, pause] of [[mPlayBack, mPauseBack], [dPlayBack, dPauseBack]]) {
+      play.style.display  = direction === 'back' ? 'none' : '';
+      pause.style.display = direction === 'back' ? '' : 'none';
+    }
+    for (const [play, pause] of [[mPlayFwd, mPauseFwd], [dPlayFwd, dPauseFwd]]) {
+      play.style.display  = direction === 'fwd' ? 'none' : '';
+      pause.style.display = direction === 'fwd' ? '' : 'none';
+    }
+  }
+
+  function playBackward() {
+    if (!isLoaded) return;
+    video.pause();
+    stopBackward();
+    showPlayState('back');
+    const frameMs = 1000 / fps;
+    let last = null;
+    function step(ts) {
+      if (last === null) { last = ts; backRafId = requestAnimationFrame(step); return; }
+      if (ts - last >= frameMs) {
+        const next = video.currentTime - 1 / nativeFps;
+        if (next <= 0) { video.currentTime = 0; frameIndex = 0; showPlayState(null); updateUi(); return; }
+        video.currentTime = next;
+        last = ts;
+      }
+      backRafId = requestAnimationFrame(step);
+    }
+    backRafId = requestAnimationFrame(step);
+  }
+
+  function pause() { stopBackward(); video.pause(); showPlayState(null); }
+  function playForward() {
+    if (!isLoaded) return;
+    video.pause();
+    stopBackward();
+    showPlayState('fwd');
+    const frameMs = 1000 / fps;
+    let last = null;
+    function step(ts) {
+      if (last === null) { last = ts; backRafId = requestAnimationFrame(step); return; }
+      if (ts - last >= frameMs) {
+        const next = video.currentTime + 1 / nativeFps;
+        if (next >= duration) { video.currentTime = duration; frameIndex = Math.max(0, totalFrames - 1); showPlayState(null); updateUi(); return; }
+        video.currentTime = next;
+        last = ts;
+      }
+      backRafId = requestAnimationFrame(step);
+    }
+    backRafId = requestAnimationFrame(step);
+  }
+  function stepFrame(d) { pause(); seekToFrame(frameIndex + d); }
+
+  /* ── Dialog canvas mirror ───────────────────────────────────────────────── */
+
+  function startMirror() {
+    let hasDrawn = false;
+    function draw() {
+      if (video.readyState >= 2 && video.videoWidth > 0) {
+        if (dialogCanvas.width  !== video.videoWidth)  dialogCanvas.width  = video.videoWidth;
+        if (dialogCanvas.height !== video.videoHeight) dialogCanvas.height = video.videoHeight;
+        dialogCanvas.getContext('2d').drawImage(video, 0, 0);
+        if (!hasDrawn) {
+          dialogCanvas.style.display = 'block';
+          dNoVideo.style.display     = 'none';
+          hasDrawn = true;
+        }
+      } else if (!hasDrawn) {
+        dialogCanvas.style.display = 'none';
+        dNoVideo.style.display     = 'block';
+      }
+      canvasRafId = requestAnimationFrame(draw);
+    }
+    canvasRafId = requestAnimationFrame(draw);
+  }
+
+  function stopMirror() {
+    if (canvasRafId) { cancelAnimationFrame(canvasRafId); canvasRafId = null; }
+  }
+
+  function openDialog()  { backdrop.style.display = 'flex'; startMirror(); }
+  function closeDialog() { backdrop.style.display = 'none'; stopMirror(); }
+
+  /* ── Video loading ──────────────────────────────────────────────────────── */
+
+  // Read the latest `value` prop from GTN's React fiber tree without remounting.
+  // GTN updates propsRef.current on every render (SetParameterValueResultSuccess),
+  // but the widget mounts once. This traverses up to the WidgetLoader fiber to
+  // read the current value after GTN processes a connection or file selection.
+  function readLatestValueFromFiber() {
+    try {
+      const key = Object.keys(container).find(k => k.startsWith('__reactFiber$'));
+      if (!key) return undefined;
+      let f = container[key];
+      for (let i = 0; i < 6; i++) {
+        f = f?.return;
+        if (!f) break;
+        const p = f.memoizedProps;
+        if (p && 'onChange' in p && 'value' in p) return p.value;
+      }
+    } catch { /* ignore: different React version or internal change */ }
+    return undefined;
+  }
+
+  function urlBase(u) { return u ? u.split('?')[0] : ''; }
+
+  function loadUrl(url, restoreTime = 0) {
+    if (urlBase(url) === urlBase(currentSrc) && isLoaded) return;
+    currentSrc = url;
+    session.videoSrc = url;
+    videoName  = url.split('/').pop()?.split('?')[0] || 'video';
+    isLoaded   = false;
+    overlay.textContent = 'Loading…';
+    overlay.style.display = 'flex';
+    video.src = url;
+    video.load();
+    if (restoreTime > 0) {
+      video.addEventListener('loadedmetadata', () => { video.currentTime = restoreTime; }, { once: true });
+    }
+    updateUi();
+  }
+
+  function initFromProps() {
+    frameIndex   = session.frameIndex || 0;
+    markedFrames = Array.isArray(session.markedFrames) ? [...session.markedFrames] : [];
+
+    // Remount: session already has the video src baked into the HTML.
+    // Just restore the time position — no reload needed.
+    if (session.videoSrc && urlBase(session.videoSrc) === urlBase(video.src)) {
+      currentSrc = session.videoSrc;
+      videoName  = session.videoSrc.split('/').pop()?.split('?')[0] || 'video';
+      if (session.currentTime > 0) {
+        video.addEventListener('loadedmetadata', () => { video.currentTime = session.currentTime; }, { once: true });
+      }
+      return;
+    }
+
+    // First mount: load from props.value
+    const url = typeof value === 'string' && value.trim() ? value.trim() : null;
+    if (url) loadUrl(url, session.currentTime || 0);
+  }
+
+  function clearVideo() {
+    pause();
+    video.removeAttribute('src');
+    video.load();
+    currentSrc   = null;
+    session.videoSrc = null;
+    isLoaded     = false;
+    videoName    = '';
+    duration     = 0;
+    totalFrames  = 0;
+    frameIndex   = 0;
+    overlay.textContent = 'No video loaded';
+    overlay.style.display = 'flex';
+    updateUi();
+  }
+
+  function startValuePoll() {
+    pollId = setInterval(() => {
+      const latestValue = readLatestValueFromFiber();
+      if (latestValue === undefined) return;
+      const latestUrl = typeof latestValue === 'string' && latestValue.trim() ? latestValue.trim() : null;
+      if (latestUrl === null && currentSrc !== null) { clearVideo(); return; }
+      if (!latestUrl || urlBase(latestUrl) === urlBase(currentSrc)) return;
+      frameIndex   = 0;
+      markedFrames = [];
+      loadUrl(latestUrl, 0);
+    }, 500);
+  }
+
+  /* ── Timeline interaction ───────────────────────────────────────────────── */
+
+  function frameFromEvent(e, el) {
+    const r = el.getBoundingClientRect();
+    return Math.round(clamp((e.clientX - r.left) / r.width, 0, 1) * Math.max(0, totalFrames - 1));
+  }
+
+  function attachTimeline(tlEl) {
+    let dragging = false;
+    tlEl.addEventListener('pointerdown', (e) => {
+      tlEl.setPointerCapture(e.pointerId);
+      dragging = true;
+      const f = frameFromEvent(e, tlEl);
+      if (e.shiftKey) {
+        const i = markedFrames.indexOf(f);
+        if (i >= 0) markedFrames.splice(i, 1);
+        else { markedFrames.push(f); markedFrames.sort((a, b) => a - b); }
+        syncTimeline();
+      } else {
+        seekToFrame(f);
+      }
+    });
+    tlEl.addEventListener('pointermove', (e) => {
+      if (!dragging || e.shiftKey) return;
+      seekToFrame(frameFromEvent(e, tlEl));
+    });
+    tlEl.addEventListener('pointerup',     () => { dragging = false; });
+    tlEl.addEventListener('pointercancel', () => { dragging = false; });
+  }
+
+  attachTimeline(tl);
+  attachTimeline(dtl);
+
+  /* ── Video events ───────────────────────────────────────────────────────── */
+
+  video.addEventListener('loadedmetadata', () => {
+    const d = video.duration;
+    if (!Number.isFinite(d) || d <= 0) return;
+    duration    = d;
+    totalFrames = computeTotal();
+    isLoaded    = true;
+    overlay.style.display = 'none';
+    updateUi();
+  });
+
+  video.addEventListener('durationchange', () => {
+    const d = video.duration;
+    if (Number.isFinite(d) && d > 0) { duration = d; totalFrames = computeTotal(); updateUi(); }
+  });
+
+  video.addEventListener('canplay', () => {
+    isLoaded = true;
+    overlay.style.display = 'none';
+    updateUi();
+  });
+
+  video.addEventListener('timeupdate', () => {
+    if (!nativeFps || totalFrames === 0) return;
+    const max = Math.max(0, totalFrames - 1);
+    frameIndex = clamp(Math.round(video.currentTime * nativeFps), 0, max);
+    // Fast path: skip full updateUi during playback
+    const pct = totalFrames > 1 ? (frameIndex / max) * 100 : 0;
+    tlFill.style.width    = `${pct}%`;
+    tlSeeker.style.left   = `${pct}%`;
+    dtlFill.style.width   = `${pct}%`;
+    dtlSeeker.style.left  = `${pct}%`;
+    mFrameInput.value     = String(frameIndex);
+    dFrameInput.value     = String(frameIndex);
+    setTimecode(video.currentTime, duration);
+    saveSession();
+  });
+
+  video.addEventListener('seeked', () => updateUi());
+  video.addEventListener('ended',  () => { showPlayState(null); updateUi(); });
+
+  video.addEventListener('error', () => {
+    isLoaded = false;
+    const code = video.error?.code;
+    // MediaError codes: 1=aborted 2=network 3=decode 4=src_not_supported
+    const codeMsg = code ? ` (MediaError ${code})` : '';
+    console.warn('[VideoPlayerWidget] video error', code, video.error?.message, 'src:', video.src);
+    overlay.textContent = `Video could not be loaded${codeMsg}. Check console for URL details.`;
+    overlay.style.display = 'flex';
+    updateUi();
+  });
+
+  /* ── FPS input ──────────────────────────────────────────────────────────── */
+
+  function commitFps(inputEl, mirrorEl) {
+    const v = Number(inputEl.value);
+    if (Number.isFinite(v) && v >= MIN_FPS && v <= MAX_FPS) {
+      fps = v;
+      mirrorEl.value = String(fps);
+    } else {
+      inputEl.value = String(fps);
+    }
+  }
+
+  mFpsInput.addEventListener('change', () => commitFps(mFpsInput, dFpsInput));
+  mFpsInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFps(mFpsInput, dFpsInput));
+  dFpsInput.addEventListener('change', () => commitFps(dFpsInput, mFpsInput));
+  dFpsInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFps(dFpsInput, mFpsInput));
+
+  /* ── Frame input ────────────────────────────────────────────────────────── */
+
+  function commitFrame(inputEl) {
+    const n = parseInt(inputEl.value, 10);
+    if (Number.isFinite(n)) seekToFrame(n);
+    else inputEl.value = String(frameIndex);
+  }
+
+  mFrameInput.addEventListener('input',   () => commitFrame(mFrameInput));
+  mFrameInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFrame(mFrameInput));
+  dFrameInput.addEventListener('input',   () => commitFrame(dFrameInput));
+  dFrameInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFrame(dFrameInput));
+
+  /* ── Controls ───────────────────────────────────────────────────────────── */
+
+  mStepBack.addEventListener('click', () => stepFrame(-1));
+  mPlayBack.addEventListener('click',  playBackward);
+  mPauseBack.addEventListener('click', pause);
+  mPlayFwd.addEventListener('click',   playForward);
+  mPauseFwd.addEventListener('click',  pause);
+  mStepFwd.addEventListener('click',   () => stepFrame(1));
+
+  dStepBack.addEventListener('click',  () => stepFrame(-1));
+  dPlayBack.addEventListener('click',  playBackward);
+  dPauseBack.addEventListener('click', pause);
+  dPlayFwd.addEventListener('click',   playForward);
+  dPauseFwd.addEventListener('click',  pause);
+  dStepFwd.addEventListener('click',  () => stepFrame(1));
+
+  /* ── Dialog open/close ──────────────────────────────────────────────────── */
+
+  enlargeBtn.addEventListener('click', openDialog);
+  dialogClose.addEventListener('click', closeDialog);
+  backdrop.addEventListener('click', (e) => { if (e.target === backdrop) closeDialog(); });
+
+  /* ── Prevent node drag while using widget ───────────────────────────────── */
+
+  const root = container.firstElementChild;
+  root.addEventListener('pointerdown', (e) => e.stopPropagation());
+  root.addEventListener('mousedown',   (e) => e.stopPropagation());
+
+  if (disabled) root.style.opacity = '0.8';
+
+  /* ── Init ───────────────────────────────────────────────────────────────── */
+
+  initFromProps();
+  updateUi();
+  startValuePoll();
+
+  /* ── Cleanup ────────────────────────────────────────────────────────────── */
+
+  return () => {
+    stopBackward();
+    stopMirror();
+    closeDialog();
+    backdrop.remove();
+    if (pollId) clearInterval(pollId);
+    saveSession();
+  };
+}

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -1,8 +1,17 @@
 /**
- * VideoPlayerWidget — vanilla JS
- * Controls: step back | play back | pause | play forward | step forward
- * Timeline: click to seek, Shift+click to add/remove a marker
- * Enlarge button opens a fullscreen dialog with a canvas mirror of the video.
+ * VideoPlayerFrameSelector — vanilla JS widget for frame-accurate video scrubbing.
+ *
+ * Layout:
+ *   - Marker zone (upper 7px): double-click to add marker, drag to move, alt+click to remove
+ *   - Track bar  (lower 10px): click/drag to seek
+ *
+ * Visual:
+ *   - Seeker: thin 1px red vertical line, no decorations
+ *   - Markers: equilateral/right-triangle caps above track, gray dashes through track
+ *   - Playback buttons: borderless; text buttons (Enlarge, Clear): outlined
+ *
+ * Reads sibling parameters (input_frame_numbers, frame_selection_mode, every_n)
+ * via React fiber tree traversal. Writes back via handleParamChange.
  */
 
 const SESSIONS = new Map();
@@ -10,71 +19,189 @@ const SESSIONS = new Map();
 /* ─── Icons ──────────────────────────────────────────────────────────────── */
 
 const _svg = (d) =>
-  `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="${d}"/></svg>`;
+  `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="${d}"/></svg>`;
 
 const ICONS = {
-  stepBack:  _svg('M16 5L4 12l12 7zM18 5h2v14h-2z'),
+  stepBack:  _svg('M15 5L3 12l12 7z M20 5v14'),
   playBack:  _svg('M16 5v14L5 12z'),
-  pause:     _svg('M6 19h4V5H6v14zm8-14v14h4V5h-4z'),
+  pause:     _svg('M6 4h4v16H6z M14 4h4v16h-4z'),
   playFwd:   _svg('M8 5v14l11-7z'),
-  stepFwd:   _svg('M4 5h2v14H4zm4 0l12 7-12 7z'),
+  stepFwd:   _svg('M4 5v14 M9 5l12 7-12 7z'),
   enlarge:   `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>`,
 };
 
-/* ─── CSS (injected once into document.head) ─────────────────────────────── */
+/* ─── CSS ────────────────────────────────────────────────────────────────── */
 
 const CSS_ID = 'vpw-global-styles';
 const CSS = `
+  /* ── Playback buttons (no border) ────────────────────────────────────── */
   .vpw-btn {
-    background:none; border:none;
-    color:#555; width:34px; height:34px;
+    background:transparent; border:none; border-radius:4px;
+    color:#aaa; width:34px; height:34px;
     display:flex; align-items:center; justify-content:center;
-    cursor:pointer; flex-shrink:0; border-radius:4px;
-    transition:color .12s;
+    cursor:pointer; flex-shrink:0; transition:color .12s;
   }
-  .vpw-btn:hover:not([disabled]) { color:#bbb; }
+  .vpw-btn:hover:not([disabled]) { color:#ddd; }
   .vpw-btn:active:not([disabled]) { color:#fff; }
-  .vpw-btn[disabled] { opacity:.2; cursor:not-allowed; pointer-events:none; }
+  .vpw-btn[disabled] { opacity:.25; cursor:not-allowed; pointer-events:none; }
+
+  /* ── Text buttons (outlined) ─────────────────────────────────────────── */
+  .vpw-btn-text {
+    background:transparent; border:1px solid #aaa; border-radius:4px;
+    color:#aaa; padding:2px 8px; font-size:10px;
+    display:flex; align-items:center; gap:4px;
+    cursor:pointer; white-space:nowrap;
+    transition:color .12s, border-color .12s;
+  }
+  .vpw-btn-text:hover { color:#ddd; border-color:#ccc; }
+
+  /* ── Timecode ────────────────────────────────────────────────────────── */
   .vpw-timecode {
-    color:#666; font-size:11px; padding:0 10px; white-space:nowrap;
+    color:#aaa; font-size:11px; padding:0 10px; white-space:nowrap;
     font-variant-numeric:tabular-nums;
     font-family:'SF Mono','Monaco','Menlo',monospace;
     text-align:center;
   }
+
+  /* ── Numeric inputs ──────────────────────────────────────────────────── */
   .vpw-num {
-    background:#1a1a1a; border:1px solid #333; border-radius:5px;
-    color:#ccc; padding:4px 8px; font-size:11px; text-align:center;
+    background:transparent; border:1px solid #aaa; border-radius:5px;
+    color:#aaa; padding:4px 8px; font-size:11px; text-align:center;
+    transition:background .15s, border-color .15s;
   }
-  .vpw-num:focus { outline:none; border-color:#4a7aaa; }
+  .vpw-num:focus { outline:none; border-color:#ccc; }
   .vpw-num[disabled] { opacity:.3; }
+  .vpw-num.vpw-highlight { background:#1a3a5c; border-color:#4a7aaa; color:#ccc; }
+
+  /* ── Total frames (selectable, not editable) ─────────────────────────── */
+  .vpw-total {
+    color:#aaa; font-size:11px; user-select:all; cursor:text;
+    font-family:'SF Mono','Monaco','Menlo',monospace;
+  }
+
+  /* ── Timeline container (17px: 7px marker zone + 10px track) ──────── */
   .vpw-timeline {
-    position:relative; height:36px;
-    cursor:pointer; user-select:none; touch-action:none;
+    position:relative; height:17px;
+    user-select:none; touch-action:none;
   }
+
+  /* ── Marker interaction zone (top 7px, same height as triangles) ─────── */
+  .vpw-tl-marker-zone {
+    position:absolute; top:0; left:0; right:0; bottom:10px;
+    cursor:crosshair; z-index:4;
+  }
+
+  /* ── Track bar (dark gray, 10px) ─────────────────────────────────────── */
   .vpw-tl-track {
-    position:absolute; bottom:10px; left:0; right:0; height:3px;
-    background:#252525; border-radius:2px; pointer-events:none;
+    position:absolute; bottom:0; left:0; right:0; height:10px;
+    background:#333; border-radius:3px;
+    cursor:pointer; z-index:1; overflow:hidden;
   }
+
+  /* ── Played fill (medium gray) ───────────────────────────────────────── */
   .vpw-tl-fill {
-    position:absolute; bottom:10px; left:0; height:3px;
-    background:#2d5a8a; border-radius:2px; pointer-events:none;
+    position:absolute; bottom:0; left:0; height:10px;
+    background:#666; border-radius:3px;
+    pointer-events:none; z-index:2;
   }
+
+  /* ── Seeker (thin red vertical line, no triangles, no transform) ──────── */
   .vpw-tl-seeker {
-    position:absolute; bottom:8px; width:1px; height:calc(100% - 8px);
-    background:#777; transform:translateX(-50%); pointer-events:none; z-index:3;
+    position:absolute; bottom:0; width:1px; height:100%;
+    background:#cc3333;
+    pointer-events:none; z-index:5;
   }
-  .vpw-tl-seeker::after {
-    content:''; position:absolute; bottom:-1px; left:50%;
-    width:9px; height:9px; background:#bbb; border:1px solid #444;
-    transform:translateX(-50%) rotate(45deg); border-radius:1px;
+
+  /* ── Frame selection markers ─────────────────────────────────────────── */
+  .vpw-marker {
+    position:absolute; top:0; bottom:-10px; z-index:3; /* bottom:-10px = track height, extends marker to timeline bottom */
+    pointer-events:auto; cursor:grab;
   }
-  .vpw-tl-marker {
-    position:absolute; bottom:8px;
-    width:9px; height:9px; background:#c07800;
-    transform:translateX(-50%) rotate(45deg);
-    pointer-events:none; z-index:2; border-radius:1px;
+  .vpw-marker:active { cursor:grabbing; }
+
+  /* Vertical dash: starts at triangle bottom, extends to timeline bottom */
+  .vpw-marker-line {
+    position:absolute; top:7px; bottom:0; left:0; width:1px;
+    background:#aaa; pointer-events:none;
   }
-  /* Dialog */
+
+  /* Triangle base (shared): sits in marker zone, receives hover for highlight */
+  .vpw-marker-tri {
+    position:absolute; top:0; pointer-events:auto; cursor:grab;
+    width:0; height:0;
+  }
+
+  /* Single-frame: equilateral triangle pointing down, tip centered on dash */
+  .vpw-marker-tri-full {
+    left:0.5px; transform:translateX(-50%);
+    border-left:4px solid transparent;
+    border-right:4px solid transparent;
+    border-top:7px solid #aaa;
+  }
+
+  /* Range start: right-triangle pointing left (outward), vertical leg aligned with dash */
+  .vpw-marker-tri-start {
+    right:0;
+    border-right:4px solid #aaa;
+    border-bottom:7px solid transparent;
+  }
+
+  /* Range end: right-triangle pointing right (outward), vertical leg aligned with dash */
+  .vpw-marker-tri-end {
+    left:0;
+    border-left:4px solid #aaa;
+    border-bottom:7px solid transparent;
+  }
+
+  /* Marker hover/active states */
+  .vpw-marker:hover .vpw-marker-line { background:#d4a030; }
+  .vpw-marker:hover .vpw-marker-tri-full { border-top-color:#d4a030; }
+  .vpw-marker:hover .vpw-marker-tri-start { border-right-color:#d4a030; }
+  .vpw-marker:hover .vpw-marker-tri-end { border-left-color:#d4a030; }
+  .vpw-marker:active .vpw-marker-line { background:#e0a830; }
+  .vpw-marker:active .vpw-marker-tri-full { border-top-color:#e0a830; }
+  .vpw-marker:active .vpw-marker-tri-start { border-right-color:#e0a830; }
+  .vpw-marker:active .vpw-marker-tri-end { border-left-color:#e0a830; }
+
+  /* Range bar in marker zone (visual fill + hover target between start/end triangles) */
+  .vpw-marker-range-bar {
+    position:absolute; top:0; height:7px;
+    background:rgba(170,170,170,0.08);
+    pointer-events:auto; cursor:grab; z-index:2;
+  }
+  .vpw-marker-range-bar:hover { background:rgba(212,160,48,0.15); }
+
+  /* JS-applied class when hovering the range bar — highlights both markers */
+  .vpw-marker.vpw-range-hover .vpw-marker-line { background:#d4a030; }
+  .vpw-marker.vpw-range-hover .vpw-marker-tri-start { border-right-color:#d4a030; }
+  .vpw-marker.vpw-range-hover .vpw-marker-tri-end { border-left-color:#d4a030; }
+
+  /* Range fill on track (purely visual, non-interactive — track handles seeking) */
+  .vpw-range-fill {
+    position:absolute; bottom:0; height:10px;
+    background:rgba(170,170,170,0.2);
+    pointer-events:none; z-index:2;
+  }
+
+  /* ── Every-Nth tick marks (non-interactive) ──────────────────────────── */
+  .vpw-nth-tick {
+    position:absolute; bottom:0; width:1px; height:10px;
+    background:rgba(170,170,170,0.4);
+    pointer-events:none; z-index:2;
+  }
+
+  /* ── Error state (invalid input_frame_numbers) ──────────────────────── */
+  .vpw-root.vpw-error {
+    outline:2px solid #cc3333;
+    outline-offset:-2px;
+    animation:vpw-error-pulse 1.5s ease-in-out infinite alternate;
+  }
+  @keyframes vpw-error-pulse {
+    0%   { outline-color:rgba(204,51,51,0.8); }
+    100% { outline-color:rgba(204,51,51,0.25); }
+  }
+
+  /* ── Enlarged dialog ─────────────────────────────────────────────────── */
   .vpw-dialog-backdrop {
     position:fixed; inset:0; background:rgba(0,0,0,.8);
     z-index:9999; backdrop-filter:blur(3px);
@@ -93,12 +220,12 @@ const CSS = `
   }
   .vpw-dialog-close {
     position:absolute; top:14px; right:14px;
-    background:#222; border:1px solid #444; border-radius:6px;
-    color:#aaa; width:28px; height:28px;
+    background:transparent; border:1px solid #555; border-radius:6px;
+    color:#999; width:28px; height:28px;
     display:flex; align-items:center; justify-content:center;
     cursor:pointer; font-size:15px;
   }
-  .vpw-dialog-close:hover { background:#333; color:#eee; }
+  .vpw-dialog-close:hover { border-color:#888; color:#ccc; }
   .vpw-dialog-canvas-wrap {
     background:#000; border-radius:8px; overflow:hidden;
     min-height:180px; display:flex; align-items:center; justify-content:center;
@@ -108,11 +235,97 @@ const CSS = `
 `;
 
 function injectGlobalStyles() {
-  if (document.getElementById(CSS_ID)) return;
-  const el = document.createElement('style');
-  el.id = CSS_ID;
+  let el = document.getElementById(CSS_ID);
+  if (!el) {
+    el = document.createElement('style');
+    el.id = CSS_ID;
+    document.head.appendChild(el);
+  }
   el.textContent = CSS;
-  document.head.appendChild(el);
+}
+
+/* ─── Frame string parsing / generation ─────────────────────────────────── */
+
+/** Parse "1,4,5-9,11" → sorted array of {type:'single',frame} | {type:'range',start,end}. */
+function parseFrameString(str) {
+  if (!str || !str.trim()) return [];
+  const markers = [];
+  for (const token of str.split(',')) {
+    const t = token.trim();
+    if (!t) continue;
+    if (t.includes('-')) {
+      const [sStr, eStr] = t.split('-');
+      const s = parseInt(sStr, 10), e = parseInt(eStr, 10);
+      if (!Number.isFinite(s) || !Number.isFinite(e) || s < 1 || e < s) continue;
+      markers.push(s === e ? { type: 'single', frame: s } : { type: 'range', start: s, end: e });
+    } else {
+      const n = parseInt(t, 10);
+      if (Number.isFinite(n) && n >= 1) markers.push({ type: 'single', frame: n });
+    }
+  }
+  markers.sort((a, b) => (a.type === 'single' ? a.frame : a.start) - (b.type === 'single' ? b.frame : b.start));
+  return markers;
+}
+
+/** Return false if the string contains malformed tokens (used for error outline). */
+function validateFrameString(str) {
+  if (!str || !str.trim()) return true;
+  for (const token of str.split(',')) {
+    const t = token.trim();
+    if (!t) continue;
+    if (t.includes('-')) {
+      const parts = t.split('-');
+      if (parts.length !== 2) return false;
+      const s = parseInt(parts[0], 10), e = parseInt(parts[1], 10);
+      if (!Number.isFinite(s) || !Number.isFinite(e) || s < 1 || e < s) return false;
+    } else {
+      const n = parseInt(t, 10);
+      if (!Number.isFinite(n) || n < 1 || String(n) !== t.trim()) return false;
+    }
+  }
+  return true;
+}
+
+function markersToFrameString(markers) {
+  const sorted = [...markers].sort((a, b) =>
+    (a.type === 'single' ? a.frame : a.start) - (b.type === 'single' ? b.frame : b.start)
+  );
+  return sorted.map(m => m.type === 'single' ? String(m.frame) : `${m.start}-${m.end}`).join(',');
+}
+
+function isFrameSelected(frameNum, markers) {
+  for (const m of markers) {
+    if (m.type === 'single' && m.frame === frameNum) return true;
+    if (m.type === 'range' && frameNum >= m.start && frameNum <= m.end) return true;
+  }
+  return false;
+}
+
+function markerStart(m) { return m.type === 'single' ? m.frame : m.start; }
+function markerEnd(m)   { return m.type === 'single' ? m.frame : m.end; }
+
+/** Merge adjacent/overlapping markers into consolidated ranges. */
+function mergeOverlapping(arr) {
+  if (arr.length <= 1) return arr;
+  const sorted = [...arr].sort((a, b) => markerStart(a) - markerStart(b));
+  const result = [sorted[0]];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = result[result.length - 1];
+    const cur = sorted[i];
+    const pEnd = markerEnd(prev);
+    const cStart = markerStart(cur);
+    const cEnd = markerEnd(cur);
+    if (cStart <= pEnd + 1) {
+      const newEnd = Math.max(pEnd, cEnd);
+      const newStart = markerStart(prev);
+      result[result.length - 1] = newStart === newEnd
+        ? { type: 'single', frame: newStart }
+        : { type: 'range', start: newStart, end: newEnd };
+    } else {
+      result.push(cur);
+    }
+  }
+  return result;
 }
 
 /* ─── HTML helpers ───────────────────────────────────────────────────────── */
@@ -134,9 +347,10 @@ function controlsHtml(pfx) {
 
 function timelineHtml(id) {
   return `
-    <div class="vpw-timeline nowheel" data-tl="${id}" title="Drag to seek · Shift+click to add/remove marker">
-      <div class="vpw-tl-track"></div>
-      <div class="vpw-tl-fill"   data-tl-fill="${id}"></div>
+    <div class="vpw-timeline nowheel" data-tl="${id}">
+      <div class="vpw-tl-marker-zone" data-tl-mzone="${id}"></div>
+      <div class="vpw-tl-track" data-tl-track="${id}"></div>
+      <div class="vpw-tl-fill" data-tl-fill="${id}"></div>
       <div class="vpw-tl-seeker" data-tl-seeker="${id}"></div>
     </div>`;
 }
@@ -144,13 +358,14 @@ function timelineHtml(id) {
 function bottomHtml(pfx, initFps) {
   return `
     <div style="display:flex;justify-content:center;align-items:center;gap:12px;">
-      <label style="display:flex;align-items:center;gap:6px;color:#666;">
+      <label style="display:flex;align-items:center;gap:6px;color:#777;">
         FPS <input class="${pfx}fps vpw-num" type="number" min="1" max="240" step="0.001" value="${initFps}" style="width:58px;">
       </label>
-      <label style="display:flex;align-items:center;gap:6px;color:#666;">
+      <label style="display:flex;align-items:center;gap:6px;color:#777;">
         Frame <input class="${pfx}frame vpw-num" type="number" min="0" value="0" style="width:72px;">
       </label>
-      <span class="${pfx}total" style="color:#484848;">/ 0</span>
+      <span class="${pfx}total vpw-total">/ 0</span>
+      <button class="${pfx}clear-markers vpw-btn-text" title="Clear all markers">&#x2715; Markers</button>
     </div>`;
 }
 
@@ -166,7 +381,8 @@ export default function VideoPlayerWidget(container, props) {
 
   const sessionKey = String(props?.node_id || props?.nodeId || props?.id || 'vpw-default');
   const session = SESSIONS.get(sessionKey) || {
-    fps: null, nativeFps: null, frameIndex: 0, currentTime: 0, markedFrames: [],
+    fps: null, nativeFps: null, frameIndex: 0, currentTime: 0,
+    markers: [], selectedFramesStr: '', selectionMode: 'list', everyN: 1,
     videoSrc: null,
   };
   SESSIONS.set(sessionKey, session);
@@ -179,24 +395,24 @@ export default function VideoPlayerWidget(container, props) {
   })();
 
   const vpH = height && height > 0 ? Math.max(180, height - 380) : 280;
+  container.style.height = 'auto';
 
   /* ── Main HTML ──────────────────────────────────────────────────────────── */
 
   container.innerHTML = `
-    <div class="nodrag" style="
+    <div class="vpw-root nodrag" style="
       display:flex;flex-direction:column;gap:10px;
       background:#111;border-radius:10px;padding:10px;color:#ddd;
       font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;font-size:12px;">
 
       <div style="display:flex;justify-content:flex-end;">
-        <button class="vpw-enlarge" style="background:none;border:1px solid #2a4560;border-radius:6px;color:#5090c0;padding:4px 8px;cursor:pointer;display:flex;align-items:center;gap:4px;font-size:11px;white-space:nowrap;">
+        <button class="vpw-enlarge vpw-btn-text" style="gap:4px;">
           ${ICONS.enlarge} Enlarge
         </button>
       </div>
 
       <div style="position:relative;background:#000;border-radius:8px;overflow:hidden;height:${vpH}px;">
-        <video class="vpw-video" style="width:100%;height:100%;object-fit:contain;" playsinline preload="metadata"
-          ${session.videoSrc ? `src="${session.videoSrc}"` : ''}></video>
+        <video class="vpw-video" style="width:100%;height:100%;object-fit:contain;" playsinline preload="metadata"></video>
         <div class="vpw-overlay" style="position:absolute;inset:0;display:${session.videoSrc ? 'none' : 'flex'};align-items:center;justify-content:center;color:#3a3a3a;font-size:13px;pointer-events:none;">
           No video loaded
         </div>
@@ -207,7 +423,7 @@ export default function VideoPlayerWidget(container, props) {
       ${bottomHtml('vpw-m-', initFps)}
     </div>`;
 
-  /* ── Dialog HTML (appended to body to escape stacking context) ──────────── */
+  /* ── Dialog HTML ────────────────────────────────────────────────────────── */
 
   const backdrop = document.createElement('div');
   backdrop.className = 'vpw-dialog-backdrop';
@@ -231,44 +447,53 @@ export default function VideoPlayerWidget(container, props) {
   const q  = (sel) => container.querySelector(sel);
   const qd = (sel) => backdrop.querySelector(sel);
 
-  const enlargeBtn  = q('.vpw-enlarge');
-  const video       = q('.vpw-video');
-  const overlay     = q('.vpw-overlay');
+  const widgetRoot = q('.vpw-root');
+  const enlargeBtn = q('.vpw-enlarge');
+  const video      = q('.vpw-video');
+  const overlay    = q('.vpw-overlay');
 
-  const tl          = q('[data-tl="main"]');
-  const tlFill      = q('[data-tl-fill="main"]');
-  const tlSeeker    = q('[data-tl-seeker="main"]');
+  if (session.videoSrc) video.src = session.videoSrc;
 
-  const mStepBack   = q('.vpw-m-step-back');
-  const mPlayBack   = q('.vpw-m-play-back');
-  const mPauseBack  = q('.vpw-m-pause-back');
-  const mPlayFwd    = q('.vpw-m-play-fwd');
-  const mPauseFwd   = q('.vpw-m-pause-fwd');
-  const mStepFwd    = q('.vpw-m-step-fwd');
-  const mFpsInput   = q('.vpw-m-fps');
-  const mFrameInput = q('.vpw-m-frame');
-  const mTotalEl    = q('.vpw-m-total');
+  const tl         = q('[data-tl="main"]');
+  const tlTrack    = q('[data-tl-track="main"]');
+  const tlMzone    = q('[data-tl-mzone="main"]');
+  const tlFill     = q('[data-tl-fill="main"]');
+  const tlSeeker   = q('[data-tl-seeker="main"]');
+
+  const mStepBack  = q('.vpw-m-step-back');
+  const mPlayBack  = q('.vpw-m-play-back');
+  const mPauseBack = q('.vpw-m-pause-back');
+  const mPlayFwd   = q('.vpw-m-play-fwd');
+  const mPauseFwd  = q('.vpw-m-pause-fwd');
+  const mStepFwd   = q('.vpw-m-step-fwd');
+  const mFpsInput  = q('.vpw-m-fps');
+  const mFrameInput= q('.vpw-m-frame');
+  const mTotalEl   = q('.vpw-m-total');
+  const mClearBtn  = q('.vpw-m-clear-markers');
 
   const dialogTitleEl = qd('.vpw-dialog-title');
   const dialogClose   = qd('.vpw-dialog-close');
   const dialogCanvas  = qd('.vpw-dcanvas');
   const dNoVideo      = qd('.vpw-dno-video');
 
-  const dtl          = qd('[data-tl="dialog"]');
-  const dtlFill      = qd('[data-tl-fill="dialog"]');
-  const dtlSeeker    = qd('[data-tl-seeker="dialog"]');
+  const dtl        = qd('[data-tl="dialog"]');
+  const dtlTrack   = qd('[data-tl-track="dialog"]');
+  const dtlMzone   = qd('[data-tl-mzone="dialog"]');
+  const dtlFill    = qd('[data-tl-fill="dialog"]');
+  const dtlSeeker  = qd('[data-tl-seeker="dialog"]');
 
-  const dStepBack    = qd('.vpw-d-step-back');
-  const dPlayBack    = qd('.vpw-d-play-back');
-  const dPauseBack   = qd('.vpw-d-pause-back');
-  const dPlayFwd     = qd('.vpw-d-play-fwd');
-  const dPauseFwd    = qd('.vpw-d-pause-fwd');
-  const dStepFwd     = qd('.vpw-d-step-fwd');
-  const dFpsInput    = qd('.vpw-d-fps');
-  const dFrameInput  = qd('.vpw-d-frame');
-  const dTotalEl     = qd('.vpw-d-total');
-  const mTimecode    = q('.vpw-m-timecode');
-  const dTimecode    = qd('.vpw-d-timecode');
+  const dStepBack  = qd('.vpw-d-step-back');
+  const dPlayBack  = qd('.vpw-d-play-back');
+  const dPauseBack = qd('.vpw-d-pause-back');
+  const dPlayFwd   = qd('.vpw-d-play-fwd');
+  const dPauseFwd  = qd('.vpw-d-pause-fwd');
+  const dStepFwd   = qd('.vpw-d-step-fwd');
+  const dFpsInput  = qd('.vpw-d-fps');
+  const dFrameInput= qd('.vpw-d-frame');
+  const dTotalEl   = qd('.vpw-d-total');
+  const dClearBtn  = qd('.vpw-d-clear-markers');
+  const mTimecode  = q('.vpw-m-timecode');
+  const dTimecode  = qd('.vpw-d-timecode');
 
   /* ── State ──────────────────────────────────────────────────────────────── */
 
@@ -278,13 +503,97 @@ export default function VideoPlayerWidget(container, props) {
   let duration     = 0;
   let totalFrames  = 0;
   let frameIndex   = 0;
-  let markedFrames = Array.isArray(session.markedFrames) ? [...session.markedFrames] : [];
+  let markers      = Array.isArray(session.markers) && session.markers.length > 0
+                     ? session.markers.map(m => ({...m})) : [];
+  let selectedFramesStr = session.selectedFramesStr || '';
+  let selectionMode     = session.selectionMode || 'list';
+  let everyN            = session.everyN || 1;
   let videoName    = '';
   let isLoaded     = false;
-  let backRafId    = null;
+  let playRafId    = null;
   let canvasRafId  = null;
   let currentSrc   = null;
   let pollId       = null;
+  let hasError     = false;
+
+  /* ── React fiber helpers ────────────────────────────────────────────────── */
+  // These walk up the React component tree from this container's fiber node
+  // to read/write sibling parameter values (input_frame_numbers, etc.).
+  // This is necessary because the widget only receives its own parameter's
+  // value via props — sibling values must be read from the DynamicNode's
+  // data.elements array found higher in the fiber tree.
+
+  /** Read the widget's own value from the nearest ancestor with {value, onChange}. */
+  function readLatestValueFromFiber() {
+    try {
+      const key = Object.keys(container).find(k => k.startsWith('__reactFiber$'));
+      if (!key) return undefined;
+      let f = container[key];
+      for (let i = 0; i < 6; i++) {
+        f = f?.return;
+        if (!f) break;
+        const p = f.memoizedProps;
+        if (p && 'onChange' in p && 'value' in p) return p.value;
+      }
+    } catch { /* ignore */ }
+    return undefined;
+  }
+
+  /** Walk up to DynamicNode to get data.elements (all parameter values for this node). */
+  function readNodeElements() {
+    try {
+      const key = Object.keys(container).find(k => k.startsWith('__reactFiber$'));
+      if (!key) return undefined;
+      let f = container[key];
+      for (let i = 0; i < 50; i++) {
+        f = f?.return;
+        if (!f) break;
+        const p = f.memoizedProps;
+        if (p && p.data && Array.isArray(p.data.elements)) return p.data.elements;
+      }
+    } catch { /* ignore */ }
+    return undefined;
+  }
+
+  /** Read the current value of a sibling parameter by name. */
+  function readSiblingParamValue(paramName) {
+    const elements = readNodeElements();
+    if (!elements) return undefined;
+    const flat = flattenElements(elements);
+    const el = flat.find(e => e.name === paramName);
+    return el?.value;
+  }
+
+  function flattenElements(elements) {
+    const result = [];
+    for (const el of elements) {
+      if (el.name) result.push(el);
+      if (Array.isArray(el.children)) result.push(...flattenElements(el.children));
+    }
+    return result;
+  }
+
+  /** Find the handleParamChange callback from NodeParamDisplay in the fiber tree. */
+  function findHandleParamChange() {
+    try {
+      const key = Object.keys(container).find(k => k.startsWith('__reactFiber$'));
+      if (!key) return undefined;
+      let f = container[key];
+      for (let i = 0; i < 20; i++) {
+        f = f?.return;
+        if (!f) break;
+        const p = f.memoizedProps;
+        if (p && typeof p.handleParamChange === 'function') return p.handleParamChange;
+      }
+    } catch { /* ignore */ }
+    return undefined;
+  }
+
+  /** Write a value to a sibling parameter (triggers SetParameterValueRequest). */
+  function setSiblingParamValue(paramName, val) {
+    const fn = findHandleParamChange();
+    if (fn) fn(paramName, val);
+  }
 
   /* ── Helpers ─────────────────────────────────────────────────────────────── */
 
@@ -304,47 +613,159 @@ export default function VideoPlayerWidget(container, props) {
   }
 
   function saveSession() {
-    session.fps          = fps;
-    session.nativeFps    = nativeFps;
-    session.frameIndex   = frameIndex;
-    session.currentTime  = Number.isFinite(video.currentTime) ? video.currentTime : 0;
-    session.markedFrames = [...markedFrames];
+    session.fps             = fps;
+    session.nativeFps       = nativeFps;
+    session.frameIndex      = frameIndex;
+    session.currentTime     = Number.isFinite(video.currentTime) ? video.currentTime : 0;
+    session.markers         = markers.map(m => ({...m}));
+    session.selectedFramesStr = selectedFramesStr;
+    session.selectionMode   = selectionMode;
+    session.everyN          = everyN;
   }
 
-  function renderMarkers(tlEl) {
-    tlEl.querySelectorAll('.vpw-tl-marker').forEach(m => m.remove());
-    if (totalFrames <= 1) return;
-    const max = totalFrames - 1;
-    for (const f of markedFrames) {
-      const m = document.createElement('div');
-      m.className = 'vpw-tl-marker';
-      m.style.left = `${(f / max) * 100}%`;
-      tlEl.appendChild(m);
+  /* ── Error state ───────────────────────────────────────────────────────── */
+
+  /** Toggle the red pulsing outline when input_frame_numbers is malformed. */
+  function updateErrorState(rawStr) {
+    const isValid = validateFrameString(rawStr);
+    if (!isValid && rawStr && rawStr.trim()) {
+      if (!hasError) { widgetRoot.classList.add('vpw-error'); hasError = true; }
+    } else {
+      if (hasError) { widgetRoot.classList.remove('vpw-error'); hasError = false; }
     }
   }
 
-  function syncTimeline() {
+  /* ── Marker rendering ──────────────────────────────────────────────────── */
+
+  /** Create a marker DOM element with a triangle cap and vertical dash line. */
+  function createMarkerEl(leftPx, idx, triClass) {
+    const el = document.createElement('div');
+    el.className = 'vpw-marker';
+    el.style.left = leftPx;
+    el.dataset.markerIndex = String(idx);
+
+    const line = document.createElement('div');
+    line.className = 'vpw-marker-line';
+    el.appendChild(line);
+
+    const tri = document.createElement('div');
+    tri.className = `vpw-marker-tri ${triClass}`;
+    el.appendChild(tri);
+
+    return el;
+  }
+
+  /**
+   * Render marker/tick DOM elements into the given timeline.
+   * Positions are snapped to physical pixels via devicePixelRatio for uniform 1px rendering.
+   */
+  function renderMarkers(tlEl) {
+    tlEl.querySelectorAll('.vpw-marker, .vpw-range-fill, .vpw-marker-range-bar, .vpw-nth-tick').forEach(m => m.remove());
+
+    if (totalFrames <= 1) return;
+    const max = totalFrames - 1;
+    const mzone = tlEl.querySelector('[class*="vpw-tl-marker-zone"]');
+    const w = tlEl.offsetWidth || 0;
+    const dpr = window.devicePixelRatio || 1;
+    const snap = (pct) => w > 0 ? `${Math.round(pct / 100 * w * dpr) / dpr}px` : `${pct}%`;
+    const snapNum = (pct) => Math.round(pct / 100 * w * dpr) / dpr;
+
+    if (selectionMode === 'every_Nth' && everyN > 0) {
+      for (let frame = 0; frame < totalFrames; frame += everyN) {
+        const tick = document.createElement('div');
+        tick.className = 'vpw-nth-tick';
+        tick.style.left = snap((frame / max) * 100);
+        tlEl.appendChild(tick);
+      }
+      return;
+    }
+
+    if (selectionMode !== 'list') return;
+
+    for (let i = 0; i < markers.length; i++) {
+      const m = markers[i];
+      if (m.type === 'single') {
+        const pct = ((m.frame - 1) / max) * 100;
+        const el = createMarkerEl(snap(pct), i, 'vpw-marker-tri-full');
+        el.dataset.markerEdge = 'single';
+        if (mzone) mzone.appendChild(el); else tlEl.appendChild(el);
+      } else {
+        const startPct = ((m.start - 1) / max) * 100;
+        const endPct   = ((m.end - 1) / max) * 100;
+
+        const fill = document.createElement('div');
+        fill.className = 'vpw-range-fill';
+        fill.style.left  = snap(startPct);
+        fill.style.width = w > 0 ? `${snapNum(endPct) - snapNum(startPct)}px` : `${endPct - startPct}%`;
+        fill.dataset.markerIndex = String(i);
+        fill.dataset.markerEdge = 'fill';
+        tlEl.appendChild(fill);
+
+        const startEl = createMarkerEl(snap(startPct), i, 'vpw-marker-tri-start');
+        startEl.dataset.markerEdge = 'start';
+        if (mzone) mzone.appendChild(startEl); else tlEl.appendChild(startEl);
+
+        const endEl = createMarkerEl(snap(endPct), i, 'vpw-marker-tri-end');
+        endEl.dataset.markerEdge = 'end';
+        if (mzone) mzone.appendChild(endEl); else tlEl.appendChild(endEl);
+
+        const bar = document.createElement('div');
+        bar.className = 'vpw-marker-range-bar';
+        bar.style.left = snap(startPct);
+        bar.style.width = w > 0 ? `${snapNum(endPct) - snapNum(startPct)}px` : `${endPct - startPct}%`;
+        bar.addEventListener('mouseenter', () => { startEl.classList.add('vpw-range-hover'); endEl.classList.add('vpw-range-hover'); });
+        bar.addEventListener('mouseleave', () => { startEl.classList.remove('vpw-range-hover'); endEl.classList.remove('vpw-range-hover'); });
+        if (mzone) mzone.appendChild(bar); else tlEl.appendChild(bar);
+      }
+    }
+  }
+
+  /* ── Frame counter highlighting ────────────────────────────────────────── */
+
+  function updateFrameHighlight() {
+    const currentFrameNum = frameIndex + 1;
+    let highlight = false;
+    if (selectionMode === 'list') highlight = isFrameSelected(currentFrameNum, markers);
+    else if (selectionMode === 'every_Nth') highlight = everyN > 0 && (frameIndex % everyN === 0);
+
+    for (const inp of [mFrameInput, dFrameInput]) {
+      if (highlight) inp.classList.add('vpw-highlight');
+      else inp.classList.remove('vpw-highlight');
+    }
+  }
+
+  /* ── Timeline sync & UI ────────────────────────────────────────────────── */
+
+  /** Update only the seeker position and fill width — cheap, called on every frame. */
+  function syncSeeker() {
     const pct = totalFrames > 1 ? (frameIndex / (totalFrames - 1)) * 100 : 0;
     tlFill.style.width   = `${pct}%`;
     tlSeeker.style.left  = `${pct}%`;
     dtlFill.style.width  = `${pct}%`;
     dtlSeeker.style.left = `${pct}%`;
-    renderMarkers(tl);
-    renderMarkers(dtl);
+    updateFrameHighlight();
   }
 
+  /** Full timeline sync: seeker + markers. Call when markers change or layout shifts. */
+  function syncTimeline() {
+    syncSeeker();
+    renderMarkers(tl);
+    if (backdrop.style.display !== 'none') renderMarkers(dtl);
+  }
+
+  /** Refresh all UI state: button enabled/disabled, inputs, timecode, and full timeline. */
   function updateUi() {
     totalFrames = computeTotal();
     frameIndex  = clamp(frameIndex, 0, Math.max(0, totalFrames - 1));
 
-    const maxF   = Math.max(0, totalFrames - 1);
-    const canAct = isLoaded && totalFrames > 0 && !disabled;
+    const maxF    = Math.max(0, totalFrames - 1);
+    const canPlay = isLoaded && totalFrames > 0;
 
     for (const b of [mStepBack, mPlayBack, mPauseBack, mPlayFwd, mPauseFwd, mStepFwd,
                       dStepBack, dPlayBack, dPauseBack, dPlayFwd, dPauseFwd, dStepFwd])
-      b.disabled = !canAct;
-    for (const inp of [mFrameInput, dFrameInput]) { inp.disabled = !canAct; inp.max = String(maxF); }
-    for (const inp of [mFpsInput, dFpsInput]) inp.disabled = !!disabled;
+      b.disabled = !canPlay;
+    for (const inp of [mFrameInput, dFrameInput]) { inp.disabled = !canPlay; inp.max = String(maxF); }
+    for (const inp of [mFpsInput, dFpsInput]) inp.disabled = !canPlay;
 
     mFpsInput.value    = dFpsInput.value    = String(fps);
     mFrameInput.value  = dFrameInput.value  = String(frameIndex);
@@ -358,69 +779,68 @@ export default function VideoPlayerWidget(container, props) {
 
   /* ── Seek / playback ────────────────────────────────────────────────────── */
 
+  /** Seek to a specific frame index. Only moves the seeker — markers don't change. */
   function seekToFrame(idx) {
     const max = Math.max(0, totalFrames - 1);
     frameIndex = clamp(Math.round(idx), 0, max);
     if (isLoaded && nativeFps > 0) video.currentTime = frameIndex / nativeFps;
-    updateUi();
+    mFrameInput.value = dFrameInput.value = String(frameIndex);
+    setTimecode(Number.isFinite(video.currentTime) ? video.currentTime : 0, duration);
+    syncSeeker();
+    saveSession();
   }
 
-  function stopBackward() {
-    if (backRafId) { cancelAnimationFrame(backRafId); backRafId = null; }
+  function stopPlayback() {
+    if (playRafId) { cancelAnimationFrame(playRafId); playRafId = null; }
   }
 
   function showPlayState(direction) {
-    // direction: 'back', 'fwd', or null (paused/stopped)
-    for (const [play, pause] of [[mPlayBack, mPauseBack], [dPlayBack, dPauseBack]]) {
+    for (const [play, p] of [[mPlayBack, mPauseBack], [dPlayBack, dPauseBack]]) {
       play.style.display  = direction === 'back' ? 'none' : '';
-      pause.style.display = direction === 'back' ? '' : 'none';
+      p.style.display     = direction === 'back' ? '' : 'none';
     }
-    for (const [play, pause] of [[mPlayFwd, mPauseFwd], [dPlayFwd, dPauseFwd]]) {
+    for (const [play, p] of [[mPlayFwd, mPauseFwd], [dPlayFwd, dPauseFwd]]) {
       play.style.display  = direction === 'fwd' ? 'none' : '';
-      pause.style.display = direction === 'fwd' ? '' : 'none';
+      p.style.display     = direction === 'fwd' ? '' : 'none';
     }
   }
 
   function playBackward() {
     if (!isLoaded) return;
-    video.pause();
-    stopBackward();
-    showPlayState('back');
+    video.pause(); stopPlayback(); showPlayState('back');
     const frameMs = 1000 / fps;
     let last = null;
     function step(ts) {
-      if (last === null) { last = ts; backRafId = requestAnimationFrame(step); return; }
+      if (last === null) { last = ts; playRafId = requestAnimationFrame(step); return; }
       if (ts - last >= frameMs) {
         const next = video.currentTime - 1 / nativeFps;
         if (next <= 0) { video.currentTime = 0; frameIndex = 0; showPlayState(null); updateUi(); return; }
-        video.currentTime = next;
-        last = ts;
+        video.currentTime = next; last = ts;
       }
-      backRafId = requestAnimationFrame(step);
+      playRafId = requestAnimationFrame(step);
     }
-    backRafId = requestAnimationFrame(step);
+    playRafId = requestAnimationFrame(step);
   }
 
-  function pause() { stopBackward(); video.pause(); showPlayState(null); }
+  function pause() { stopPlayback(); video.pause(); showPlayState(null); }
+
   function playForward() {
     if (!isLoaded) return;
-    video.pause();
-    stopBackward();
-    showPlayState('fwd');
+    video.pause(); stopPlayback(); showPlayState('fwd');
     const frameMs = 1000 / fps;
     let last = null;
     function step(ts) {
-      if (last === null) { last = ts; backRafId = requestAnimationFrame(step); return; }
+      if (last === null) { last = ts; playRafId = requestAnimationFrame(step); return; }
       if (ts - last >= frameMs) {
         const next = video.currentTime + 1 / nativeFps;
         if (next >= duration) { video.currentTime = duration; frameIndex = Math.max(0, totalFrames - 1); showPlayState(null); updateUi(); return; }
-        video.currentTime = next;
-        last = ts;
+        video.currentTime = next; last = ts;
       }
-      backRafId = requestAnimationFrame(step);
+      playRafId = requestAnimationFrame(step);
     }
-    backRafId = requestAnimationFrame(step);
+    playRafId = requestAnimationFrame(step);
   }
+
   function stepFrame(d) { pause(); seekToFrame(frameIndex + d); }
 
   /* ── Dialog canvas mirror ───────────────────────────────────────────────── */
@@ -432,158 +852,299 @@ export default function VideoPlayerWidget(container, props) {
         if (dialogCanvas.width  !== video.videoWidth)  dialogCanvas.width  = video.videoWidth;
         if (dialogCanvas.height !== video.videoHeight) dialogCanvas.height = video.videoHeight;
         dialogCanvas.getContext('2d').drawImage(video, 0, 0);
-        if (!hasDrawn) {
-          dialogCanvas.style.display = 'block';
-          dNoVideo.style.display     = 'none';
-          hasDrawn = true;
-        }
-      } else if (!hasDrawn) {
-        dialogCanvas.style.display = 'none';
-        dNoVideo.style.display     = 'block';
-      }
+        if (!hasDrawn) { dialogCanvas.style.display = 'block'; dNoVideo.style.display = 'none'; hasDrawn = true; }
+      } else if (!hasDrawn) { dialogCanvas.style.display = 'none'; dNoVideo.style.display = 'block'; }
       canvasRafId = requestAnimationFrame(draw);
     }
     canvasRafId = requestAnimationFrame(draw);
   }
 
-  function stopMirror() {
-    if (canvasRafId) { cancelAnimationFrame(canvasRafId); canvasRafId = null; }
-  }
+  function stopMirror() { if (canvasRafId) { cancelAnimationFrame(canvasRafId); canvasRafId = null; } }
 
-  function openDialog()  { backdrop.style.display = 'flex'; startMirror(); }
-  function closeDialog() { backdrop.style.display = 'none'; stopMirror(); }
+  function onEscKey(e) { if (e.key === 'Escape') closeDialog(); }
+  function openDialog()  { backdrop.style.display = 'flex'; renderMarkers(dtl); startMirror(); document.addEventListener('keydown', onEscKey); }
+  function closeDialog() { backdrop.style.display = 'none'; stopMirror(); document.removeEventListener('keydown', onEscKey); }
 
   /* ── Video loading ──────────────────────────────────────────────────────── */
 
-  // Read the latest `value` prop from GTN's React fiber tree without remounting.
-  // GTN updates propsRef.current on every render (SetParameterValueResultSuccess),
-  // but the widget mounts once. This traverses up to the WidgetLoader fiber to
-  // read the current value after GTN processes a connection or file selection.
-  function readLatestValueFromFiber() {
-    try {
-      const key = Object.keys(container).find(k => k.startsWith('__reactFiber$'));
-      if (!key) return undefined;
-      let f = container[key];
-      for (let i = 0; i < 6; i++) {
-        f = f?.return;
-        if (!f) break;
-        const p = f.memoizedProps;
-        if (p && 'onChange' in p && 'value' in p) return p.value;
-      }
-    } catch { /* ignore: different React version or internal change */ }
-    return undefined;
-  }
-
   function urlBase(u) { return u ? u.split('?')[0] : ''; }
 
+  /** Extract a URL string from a value that may be a string, VideoUrlArtifact, or dict. */
+  function extractUrl(val) {
+    if (typeof val === 'string' && val.trim()) return val.trim();
+    if (val && typeof val === 'object') {
+      const u = val.value || val.url || val.src;
+      if (typeof u === 'string' && u.trim()) return u.trim();
+    }
+    return null;
+  }
+
+  /** Load a video URL into the <video> element. Skips if same base URL is already loaded. */
   function loadUrl(url, restoreTime = 0) {
     if (urlBase(url) === urlBase(currentSrc) && isLoaded) return;
-    currentSrc = url;
-    session.videoSrc = url;
-    videoName  = url.split('/').pop()?.split('?')[0] || 'video';
-    isLoaded   = false;
-    overlay.textContent = 'Loading…';
-    overlay.style.display = 'flex';
-    video.src = url;
-    video.load();
-    if (restoreTime > 0) {
-      video.addEventListener('loadedmetadata', () => { video.currentTime = restoreTime; }, { once: true });
-    }
+    currentSrc = url; session.videoSrc = url;
+    videoName = url.split('/').pop()?.split('?')[0] || 'video';
+    isLoaded = false;
+    overlay.textContent = 'Loading…'; overlay.style.display = 'flex';
+    video.src = url; video.load();
+    if (restoreTime > 0) video.addEventListener('loadedmetadata', () => { video.currentTime = restoreTime; }, { once: true });
     updateUi();
   }
 
   function initFromProps() {
-    frameIndex   = session.frameIndex || 0;
-    markedFrames = Array.isArray(session.markedFrames) ? [...session.markedFrames] : [];
+    frameIndex        = session.frameIndex || 0;
+    markers           = Array.isArray(session.markers) ? session.markers.map(m => ({...m})) : [];
+    selectedFramesStr = session.selectedFramesStr || '';
+    selectionMode     = session.selectionMode || 'list';
+    everyN            = session.everyN || 1;
 
-    // Remount: session already has the video src baked into the HTML.
-    // Just restore the time position — no reload needed.
     if (session.videoSrc && urlBase(session.videoSrc) === urlBase(video.src)) {
       currentSrc = session.videoSrc;
       videoName  = session.videoSrc.split('/').pop()?.split('?')[0] || 'video';
-      if (session.currentTime > 0) {
-        video.addEventListener('loadedmetadata', () => { video.currentTime = session.currentTime; }, { once: true });
-      }
+      if (session.currentTime > 0) video.addEventListener('loadedmetadata', () => { video.currentTime = session.currentTime; }, { once: true });
       return;
     }
-
-    // First mount: load from props.value
-    const url = typeof value === 'string' && value.trim() ? value.trim() : null;
+    const url = extractUrl(value);
     if (url) loadUrl(url, session.currentTime || 0);
   }
 
   function clearVideo() {
-    pause();
-    video.removeAttribute('src');
-    video.load();
-    currentSrc   = null;
-    session.videoSrc = null;
-    isLoaded     = false;
-    videoName    = '';
-    duration     = 0;
-    totalFrames  = 0;
-    frameIndex   = 0;
-    overlay.textContent = 'No video loaded';
-    overlay.style.display = 'flex';
+    pause(); video.removeAttribute('src'); video.load();
+    currentSrc = null; session.videoSrc = null; isLoaded = false;
+    videoName = ''; duration = 0; totalFrames = 0; frameIndex = 0;
+    markers = []; selectedFramesStr = '';
+    overlay.textContent = 'No video loaded'; overlay.style.display = 'flex';
     updateUi();
   }
 
+  /* ── Sibling parameter polling ─────────────────────────────────────────── */
+
+  /**
+   * Poll sibling parameter values every 500ms for bidirectional sync.
+   * Reads input_frame_numbers, frame_selection_mode, every_n from the fiber tree.
+   */
   function startValuePoll() {
     pollId = setInterval(() => {
       const latestValue = readLatestValueFromFiber();
-      if (latestValue === undefined) return;
-      const latestUrl = typeof latestValue === 'string' && latestValue.trim() ? latestValue.trim() : null;
-      if (latestUrl === null && currentSrc !== null) { clearVideo(); return; }
-      if (!latestUrl || urlBase(latestUrl) === urlBase(currentSrc)) return;
-      frameIndex   = 0;
-      markedFrames = [];
-      loadUrl(latestUrl, 0);
+      if (latestValue !== undefined) {
+        const latestUrl = extractUrl(latestValue);
+        if (latestUrl === null && currentSrc !== null) { clearVideo(); return; }
+        if (latestUrl && urlBase(latestUrl) !== urlBase(currentSrc)) { frameIndex = 0; loadUrl(latestUrl, 0); }
+      } else {
+        const siblingVal = readSiblingParamValue('input_video');
+        if (siblingVal !== undefined) {
+          const sibUrl = extractUrl(siblingVal);
+          if (sibUrl === null && currentSrc !== null) clearVideo();
+          else if (sibUrl && urlBase(sibUrl) !== urlBase(currentSrc)) { frameIndex = 0; loadUrl(sibUrl, 0); }
+        }
+      }
+
+      let needsSync = false;
+
+      const latestFrames = readSiblingParamValue('input_frame_numbers');
+      if (latestFrames !== undefined) {
+        const str = String(latestFrames || '');
+        updateErrorState(str);
+        if (str !== selectedFramesStr) {
+          selectedFramesStr = str;
+          markers = parseFrameString(str);
+          needsSync = true;
+        }
+      }
+
+      const latestMode = readSiblingParamValue('frame_selection_mode');
+      if (latestMode !== undefined && latestMode !== selectionMode) { selectionMode = latestMode; needsSync = true; }
+
+      const latestEveryN = readSiblingParamValue('every_n');
+      if (latestEveryN !== undefined) {
+        const n = Number(latestEveryN);
+        if (Number.isFinite(n) && n !== everyN) { everyN = n; needsSync = true; }
+      }
+
+      if (needsSync) { syncTimeline(); saveSession(); }
     }, 500);
   }
 
-  /* ── Timeline interaction ───────────────────────────────────────────────── */
+  /* ── Marker commit ─────────────────────────────────────────────────────── */
 
+  /** Serialize markers to string, write to the input_frame_numbers param, and re-render. */
+  function commitMarkers() {
+    selectedFramesStr = markersToFrameString(markers);
+    setSiblingParamValue('input_frame_numbers', selectedFramesStr);
+    syncTimeline();
+    saveSession();
+  }
+
+  /* ── Seek zone interaction (track area) ────────────────────────────────── */
+
+  /** Convert a pointer event's X position to a 0-based frame index. */
   function frameFromEvent(e, el) {
     const r = el.getBoundingClientRect();
     return Math.round(clamp((e.clientX - r.left) / r.width, 0, 1) * Math.max(0, totalFrames - 1));
   }
 
-  function attachTimeline(tlEl) {
+  /** Attach pointer handlers to the track bar for click/drag seeking. */
+  function attachSeekZone(trackEl) {
     let dragging = false;
-    tlEl.addEventListener('pointerdown', (e) => {
-      tlEl.setPointerCapture(e.pointerId);
+    trackEl.addEventListener('pointerdown', (e) => {
+      trackEl.setPointerCapture(e.pointerId);
       dragging = true;
-      const f = frameFromEvent(e, tlEl);
-      if (e.shiftKey) {
-        const i = markedFrames.indexOf(f);
-        if (i >= 0) markedFrames.splice(i, 1);
-        else { markedFrames.push(f); markedFrames.sort((a, b) => a - b); }
-        syncTimeline();
-      } else {
-        seekToFrame(f);
-      }
+      seekToFrame(frameFromEvent(e, trackEl));
     });
-    tlEl.addEventListener('pointermove', (e) => {
-      if (!dragging || e.shiftKey) return;
-      seekToFrame(frameFromEvent(e, tlEl));
-    });
-    tlEl.addEventListener('pointerup',     () => { dragging = false; });
-    tlEl.addEventListener('pointercancel', () => { dragging = false; });
+    trackEl.addEventListener('pointermove', (e) => { if (dragging) seekToFrame(frameFromEvent(e, trackEl)); });
+    trackEl.addEventListener('pointerup',     () => { dragging = false; });
+    trackEl.addEventListener('pointercancel', () => { dragging = false; });
   }
 
-  attachTimeline(tl);
-  attachTimeline(dtl);
+  /* ── Marker zone interaction (above track) ─────────────────────────────── */
+
+  const DBLCLICK_MS = 350;
+  const HIT_TOLERANCE_PX = 8;
+
+  /** Hit-test a pointer event against all markers. Returns {markerIndex, edge} or null. */
+  function hitTestMarker(e, mzoneEl) {
+    const r = mzoneEl.getBoundingClientRect();
+    const clickX = e.clientX - r.left;
+    const maxFrame = Math.max(0, totalFrames - 1);
+    if (maxFrame === 0) return null;
+
+    for (let i = 0; i < markers.length; i++) {
+      const m = markers[i];
+      if (m.type === 'single') {
+        const markerX = ((m.frame - 1) / maxFrame) * r.width;
+        if (Math.abs(clickX - markerX) <= HIT_TOLERANCE_PX) return { markerIndex: i, edge: 'single' };
+      } else {
+        const startX = ((m.start - 1) / maxFrame) * r.width;
+        const endX   = ((m.end - 1)   / maxFrame) * r.width;
+        if (Math.abs(clickX - startX) <= HIT_TOLERANCE_PX) return { markerIndex: i, edge: 'start' };
+        if (Math.abs(clickX - endX) <= HIT_TOLERANCE_PX) return { markerIndex: i, edge: 'end' };
+        if (clickX > startX + HIT_TOLERANCE_PX && clickX < endX - HIT_TOLERANCE_PX) return { markerIndex: i, edge: 'fill' };
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Attach pointer handlers to the marker zone above the track.
+   * Double-click: add marker. Drag existing: move. Alt+click: remove.
+   * Drag from double-click: create range.
+   */
+  function attachMarkerZone(mzoneEl) {
+    let isDragging = false;
+    let dragInfo = null;
+    let isCreatingRange = false;
+    let rangeAnchorFrame = null;
+    let rangeAnchorIndex = null;
+    let lastClickTime = 0;
+    let lastClickFrame = -1;
+
+    function frameFromMzone(e) {
+      const r = mzoneEl.getBoundingClientRect();
+      return Math.round(clamp((e.clientX - r.left) / r.width, 0, 1) * Math.max(0, totalFrames - 1));
+    }
+
+    mzoneEl.addEventListener('pointerdown', (e) => {
+      if (selectionMode !== 'list') return;
+      const f = frameFromMzone(e);
+      const now = Date.now();
+      const hit = hitTestMarker(e, mzoneEl);
+
+      // Alt+click: remove marker
+      if (e.altKey) {
+        if (hit) { markers.splice(hit.markerIndex, 1); commitMarkers(); }
+        return;
+      }
+
+      // Click on existing marker: start drag
+      if (hit) {
+        mzoneEl.setPointerCapture(e.pointerId);
+        isDragging = true;
+        dragInfo = { ...hit, dragStartFrame: f + 1 };
+        return;
+      }
+
+      // Double-click detection
+      const isDblClick = (now - lastClickTime < DBLCLICK_MS) && (Math.abs(f - lastClickFrame) <= 2);
+
+      if (isDblClick) {
+        lastClickTime = 0; lastClickFrame = -1;
+        mzoneEl.setPointerCapture(e.pointerId);
+        isDragging = true;
+        isCreatingRange = true;
+        rangeAnchorFrame = f + 1;
+        markers.push({ type: 'single', frame: rangeAnchorFrame });
+        rangeAnchorIndex = markers.length - 1;
+        syncTimeline();
+        return;
+      }
+
+      lastClickTime = now;
+      lastClickFrame = f;
+    });
+
+    mzoneEl.addEventListener('pointermove', (e) => {
+      if (!isDragging) return;
+      const f = frameFromMzone(e);
+
+      if (dragInfo) {
+        const m = markers[dragInfo.markerIndex];
+        if (!m) return;
+        const newFrame = clamp(f + 1, 1, totalFrames);
+
+        if (dragInfo.edge === 'fill' && m.type === 'range') {
+          const delta = newFrame - dragInfo.dragStartFrame;
+          const rangeLen = m.end - m.start;
+          let newStart = m.start + delta, newEnd = m.end + delta;
+          if (newStart < 1) { newStart = 1; newEnd = 1 + rangeLen; }
+          if (newEnd > totalFrames) { newEnd = totalFrames; newStart = totalFrames - rangeLen; }
+          m.start = newStart; m.end = newEnd;
+          dragInfo.dragStartFrame = newFrame;
+        } else if (m.type === 'single') {
+          m.frame = newFrame;
+        } else if (dragInfo.edge === 'start') {
+          m.start = Math.min(newFrame, m.end);
+        } else if (dragInfo.edge === 'end') {
+          m.end = Math.max(newFrame, m.start);
+        }
+        if (m.type === 'range' && m.start === m.end) markers[dragInfo.markerIndex] = { type: 'single', frame: m.start };
+        syncTimeline();
+        return;
+      }
+
+      if (isCreatingRange && rangeAnchorIndex !== null) {
+        const currentFrame = clamp(f + 1, 1, totalFrames);
+        const s = Math.min(rangeAnchorFrame, currentFrame);
+        const en = Math.max(rangeAnchorFrame, currentFrame);
+        markers[rangeAnchorIndex] = s === en ? { type: 'single', frame: s } : { type: 'range', start: s, end: en };
+        syncTimeline();
+      }
+    });
+
+    function endInteraction() {
+      if (isDragging && (dragInfo || isCreatingRange)) {
+        markers = mergeOverlapping(markers);
+        commitMarkers();
+      }
+      isDragging = false; dragInfo = null;
+      isCreatingRange = false; rangeAnchorFrame = null; rangeAnchorIndex = null;
+    }
+
+    mzoneEl.addEventListener('pointerup',     endInteraction);
+    mzoneEl.addEventListener('pointercancel', endInteraction);
+  }
+
+  attachSeekZone(tlTrack);
+  attachSeekZone(dtlTrack);
+  attachMarkerZone(tlMzone);
+  attachMarkerZone(dtlMzone);
 
   /* ── Video events ───────────────────────────────────────────────────────── */
 
   video.addEventListener('loadedmetadata', () => {
     const d = video.duration;
     if (!Number.isFinite(d) || d <= 0) return;
-    duration    = d;
-    totalFrames = computeTotal();
-    isLoaded    = true;
-    overlay.style.display = 'none';
-    updateUi();
+    duration = d; totalFrames = computeTotal(); isLoaded = true;
+    overlay.style.display = 'none'; updateUi();
   });
 
   video.addEventListener('durationchange', () => {
@@ -591,26 +1152,15 @@ export default function VideoPlayerWidget(container, props) {
     if (Number.isFinite(d) && d > 0) { duration = d; totalFrames = computeTotal(); updateUi(); }
   });
 
-  video.addEventListener('canplay', () => {
-    isLoaded = true;
-    overlay.style.display = 'none';
-    updateUi();
-  });
+  video.addEventListener('canplay', () => { isLoaded = true; overlay.style.display = 'none'; updateUi(); });
 
   video.addEventListener('timeupdate', () => {
     if (!nativeFps || totalFrames === 0) return;
     const max = Math.max(0, totalFrames - 1);
     frameIndex = clamp(Math.round(video.currentTime * nativeFps), 0, max);
-    // Fast path: skip full updateUi during playback
-    const pct = totalFrames > 1 ? (frameIndex / max) * 100 : 0;
-    tlFill.style.width    = `${pct}%`;
-    tlSeeker.style.left   = `${pct}%`;
-    dtlFill.style.width   = `${pct}%`;
-    dtlSeeker.style.left  = `${pct}%`;
-    mFrameInput.value     = String(frameIndex);
-    dFrameInput.value     = String(frameIndex);
+    mFrameInput.value = String(frameIndex); dFrameInput.value = String(frameIndex);
     setTimecode(video.currentTime, duration);
-    saveSession();
+    syncSeeker(); saveSession();
   });
 
   video.addEventListener('seeked', () => updateUi());
@@ -619,26 +1169,18 @@ export default function VideoPlayerWidget(container, props) {
   video.addEventListener('error', () => {
     isLoaded = false;
     const code = video.error?.code;
-    // MediaError codes: 1=aborted 2=network 3=decode 4=src_not_supported
     const codeMsg = code ? ` (MediaError ${code})` : '';
-    console.warn('[VideoPlayerWidget] video error', code, video.error?.message, 'src:', video.src);
-    overlay.textContent = `Video could not be loaded${codeMsg}. Check console for URL details.`;
-    overlay.style.display = 'flex';
-    updateUi();
+    overlay.textContent = `Video could not be loaded${codeMsg}.`;
+    overlay.style.display = 'flex'; updateUi();
   });
 
   /* ── FPS input ──────────────────────────────────────────────────────────── */
 
   function commitFps(inputEl, mirrorEl) {
     const v = Number(inputEl.value);
-    if (Number.isFinite(v) && v >= MIN_FPS && v <= MAX_FPS) {
-      fps = v;
-      mirrorEl.value = String(fps);
-    } else {
-      inputEl.value = String(fps);
-    }
+    if (Number.isFinite(v) && v >= MIN_FPS && v <= MAX_FPS) { fps = v; mirrorEl.value = String(fps); }
+    else inputEl.value = String(fps);
   }
-
   mFpsInput.addEventListener('change', () => commitFps(mFpsInput, dFpsInput));
   mFpsInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFps(mFpsInput, dFpsInput));
   dFpsInput.addEventListener('change', () => commitFps(dFpsInput, mFpsInput));
@@ -648,10 +1190,8 @@ export default function VideoPlayerWidget(container, props) {
 
   function commitFrame(inputEl) {
     const n = parseInt(inputEl.value, 10);
-    if (Number.isFinite(n)) seekToFrame(n);
-    else inputEl.value = String(frameIndex);
+    if (Number.isFinite(n)) seekToFrame(n); else inputEl.value = String(frameIndex);
   }
-
   mFrameInput.addEventListener('input',   () => commitFrame(mFrameInput));
   mFrameInput.addEventListener('keydown', (e) => e.key === 'Enter' && commitFrame(mFrameInput));
   dFrameInput.addEventListener('input',   () => commitFrame(dFrameInput));
@@ -673,19 +1213,32 @@ export default function VideoPlayerWidget(container, props) {
   dPauseFwd.addEventListener('click',  pause);
   dStepFwd.addEventListener('click',  () => stepFrame(1));
 
-  /* ── Dialog open/close ──────────────────────────────────────────────────── */
+  /* ── Clear markers ─────────────────────────────────────────────────────── */
+
+  function clearAllMarkers() {
+    if (markers.length === 0) return;
+    markers = []; commitMarkers();
+  }
+  mClearBtn.addEventListener('click', clearAllMarkers);
+  dClearBtn.addEventListener('click', clearAllMarkers);
+
+  /* ── Dialog open/close ─────────────────────────────────────────────────── */
 
   enlargeBtn.addEventListener('click', openDialog);
   dialogClose.addEventListener('click', closeDialog);
   backdrop.addEventListener('click', (e) => { if (e.target === backdrop) closeDialog(); });
 
-  /* ── Prevent node drag while using widget ───────────────────────────────── */
+  /* ── Prevent node drag ─────────────────────────────────────────────────── */
 
   const root = container.firstElementChild;
   root.addEventListener('pointerdown', (e) => e.stopPropagation());
   root.addEventListener('mousedown',   (e) => e.stopPropagation());
-
   if (disabled) root.style.opacity = '0.8';
+
+  /* ── Resize observer (re-snap px positions when width changes) ─────────── */
+
+  const resizeObs = new ResizeObserver(() => syncTimeline());
+  resizeObs.observe(tl);
 
   /* ── Init ───────────────────────────────────────────────────────────────── */
 
@@ -696,10 +1249,8 @@ export default function VideoPlayerWidget(container, props) {
   /* ── Cleanup ────────────────────────────────────────────────────────────── */
 
   return () => {
-    stopBackward();
-    stopMirror();
-    closeDialog();
-    backdrop.remove();
+    stopPlayback(); stopMirror(); closeDialog(); backdrop.remove();
+    resizeObs.disconnect();
     if (pollId) clearInterval(pollId);
     saveSession();
   };

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -101,13 +101,13 @@ const CSS = `
   /* ── Played fill (medium gray) ───────────────────────────────────────── */
   .vpw-tl-fill {
     position:absolute; bottom:0; left:0; height:10px;
-    background:#666; border-radius:3px;
+    background:#666; border-radius:3px 0 0 3px;
     pointer-events:none; z-index:2;
   }
 
-  /* ── Seeker (thin red vertical line, no triangles, no transform) ──────── */
+  /* ── Seeker (thin red vertical line confined to the track bar) ───────── */
   .vpw-tl-seeker {
-    position:absolute; bottom:0; width:1px; height:100%;
+    position:absolute; bottom:0; width:1px; height:10px;
     background:#cc3333;
     pointer-events:none; z-index:5;
   }
@@ -171,10 +171,11 @@ const CSS = `
   }
   .vpw-marker-range-bar:hover { background:rgba(212,160,48,0.15); }
 
-  /* JS-applied class when hovering the range bar — highlights both markers */
+  /* JS-applied class when hovering the range bar — highlights markers and track fill */
   .vpw-marker.vpw-range-hover .vpw-marker-line { background:#d4a030; }
   .vpw-marker.vpw-range-hover .vpw-marker-tri-start { border-right-color:#d4a030; }
   .vpw-marker.vpw-range-hover .vpw-marker-tri-end { border-left-color:#d4a030; }
+  .vpw-range-fill.vpw-range-hover { background:rgba(212,160,48,0.25); }
 
   /* Range fill on track (purely visual, non-interactive — track handles seeking) */
   .vpw-range-fill {
@@ -348,7 +349,8 @@ function controlsHtml(pfx) {
 function timelineHtml(id) {
   return `
     <div class="vpw-timeline nowheel" data-tl="${id}">
-      <div class="vpw-tl-marker-zone" data-tl-mzone="${id}"></div>
+      <div class="vpw-tl-marker-zone" data-tl-mzone="${id}"
+        title="Double-click to add a marker&#10;Double-click &amp; drag to create a range&#10;Drag a triangle to move it&#10;Alt+click to remove"></div>
       <div class="vpw-tl-track" data-tl-track="${id}"></div>
       <div class="vpw-tl-fill" data-tl-fill="${id}"></div>
       <div class="vpw-tl-seeker" data-tl-seeker="${id}"></div>
@@ -713,8 +715,8 @@ export default function VideoPlayerWidget(container, props) {
         bar.className = 'vpw-marker-range-bar';
         bar.style.left = snap(startPct);
         bar.style.width = w > 0 ? `${snapNum(endPct) - snapNum(startPct)}px` : `${endPct - startPct}%`;
-        bar.addEventListener('mouseenter', () => { startEl.classList.add('vpw-range-hover'); endEl.classList.add('vpw-range-hover'); });
-        bar.addEventListener('mouseleave', () => { startEl.classList.remove('vpw-range-hover'); endEl.classList.remove('vpw-range-hover'); });
+        bar.addEventListener('mouseenter', () => { startEl.classList.add('vpw-range-hover'); endEl.classList.add('vpw-range-hover'); fill.classList.add('vpw-range-hover'); });
+        bar.addEventListener('mouseleave', () => { startEl.classList.remove('vpw-range-hover'); endEl.classList.remove('vpw-range-hover'); fill.classList.remove('vpw-range-hover'); });
         if (mzone) mzone.appendChild(bar); else tlEl.appendChild(bar);
       }
     }
@@ -739,10 +741,13 @@ export default function VideoPlayerWidget(container, props) {
   /** Update only the seeker position and fill width — cheap, called on every frame. */
   function syncSeeker() {
     const pct = totalFrames > 1 ? (frameIndex / (totalFrames - 1)) * 100 : 0;
-    tlFill.style.width   = `${pct}%`;
-    tlSeeker.style.left  = `${pct}%`;
-    dtlFill.style.width  = `${pct}%`;
-    dtlSeeker.style.left = `${pct}%`;
+    const fillRadius = pct >= 99.9 ? '3px' : '3px 0 0 3px';
+    tlFill.style.width        = `${pct}%`;
+    tlFill.style.borderRadius = fillRadius;
+    tlSeeker.style.left       = `${pct}%`;
+    dtlFill.style.width        = `${pct}%`;
+    dtlFill.style.borderRadius = fillRadius;
+    dtlSeeker.style.left       = `${pct}%`;
     updateFrameHighlight();
   }
 

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -2,16 +2,17 @@
  * VideoPlayerFrameSelector — vanilla JS widget for frame-accurate video scrubbing.
  *
  * Layout:
- *   - Marker zone (upper 7px): click to add marker, drag to move, alt+click to remove
- *   - Track bar  (lower 10px): click/drag to seek
+ *   - Add zone (top 16px): hover to show "+", click to add marker, drag to create range
+ *   - Marker zone (7px): drag to move existing markers; trash icon on hover to delete
+ *   - Track bar (bottom 10px): click/drag to seek
  *
  * Visual:
  *   - Seeker: thin 1px red vertical line, no decorations
  *   - Markers: equilateral/right-triangle caps above track, gray dashes through track
  *   - Playback buttons: borderless; text buttons (Enlarge, Clear): outlined
  *
- * Reads sibling parameters (input_frame_numbers, frame_selection_mode, every_n)
- * via React fiber tree traversal. Writes back via handleParamChange.
+ * Reads sibling parameters (input_frame_numbers, frame_selection_mode, every_n,
+ * _video_fps) via React fiber tree traversal. Writes back via handleParamChange.
  */
 
 const SESSIONS = new Map();
@@ -791,7 +792,7 @@ export default function VideoPlayerWidget(container, props) {
 
     if (totalFrames <= 1) return;
     const max = totalFrames - 1;
-    const mzone = tlEl.querySelector('[class*="vpw-tl-marker-zone"]');
+    const mzone = tlEl.querySelector('.vpw-tl-marker-zone');
     const w = tlEl.offsetWidth || 0;
     const dpr = window.devicePixelRatio || 1;
     const snap = (pct) => w > 0 ? `${Math.round(pct / 100 * w * dpr) / dpr}px` : `${pct}%`;
@@ -1041,6 +1042,13 @@ export default function VideoPlayerWidget(container, props) {
     selectionMode     = session.selectionMode || 'list';
     everyN            = session.everyN || 1;
 
+    // Pick up native FPS detected by the node (via ffprobe) if available
+    const detectedFps = Number(readSiblingParamValue('_video_fps'));
+    if (Number.isFinite(detectedFps) && detectedFps > 0) {
+      nativeFps = detectedFps;
+      fps = detectedFps;
+    }
+
     let url = extractUrl(value);
     // The prop value may not have propagated yet when the widget first mounts
     // (e.g. after_value_set resolves the URL and sets the parameter, but React
@@ -1069,6 +1077,9 @@ export default function VideoPlayerWidget(container, props) {
     currentSrc = null; session.videoSrc = null; session.videoWidth = null; session.videoHeight = null; isLoaded = false;
     videoName = ''; duration = 0; totalFrames = 0; frameIndex = 0;
     markers = []; selectedFramesStr = '';
+    setSiblingParamValue('input_frame_numbers', '');
+    ignoreFrameUpdateUntil = Date.now() + 600;
+    nativeFps = DEFAULT_FPS; fps = DEFAULT_FPS;
     overlay.textContent = 'No video loaded'; overlay.style.display = 'flex';
     resetAspectRatio();
     updateUi();
@@ -1116,6 +1127,17 @@ export default function VideoPlayerWidget(container, props) {
       if (latestEveryN !== undefined) {
         const n = Number(latestEveryN);
         if (Number.isFinite(n) && n !== everyN) { everyN = n; needsSync = true; }
+      }
+
+      const latestFps = readSiblingParamValue('_video_fps');
+      if (latestFps !== undefined) {
+        const detectedFps = Number(latestFps);
+        if (Number.isFinite(detectedFps) && detectedFps > 0 && detectedFps !== nativeFps) {
+          nativeFps = detectedFps;
+          fps = detectedFps;
+          mFpsInput.value = dFpsInput.value = String(fps);
+          needsSync = true;
+        }
       }
 
       if (needsSync) { syncTimeline(); saveSession(); }

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -88,38 +88,37 @@ const CSS = `
     user-select:none; touch-action:none;
   }
 
-  /* ── Add / delete icon strip (top 16px) ─────────────────────────────────── */
+  /* ── Add zone (top 16px): pointer-events:none so markers underneath receive hover ── */
   .vpw-tl-add-zone {
     position:absolute; top:0; left:0; right:0; height:16px;
-    cursor:pointer; z-index:6;
+    pointer-events:none; z-index:6;
   }
 
-  /* "+" button — floats at cursor X, shown by JS */
+  /* "+" button — floats at cursor X, shown by JS on timeline mousemove */
   .vpw-add-btn {
     position:absolute; top:1px; width:14px; height:14px;
     background:#222; border:1px solid #888; border-radius:3px;
     color:#aaa; display:none; align-items:center; justify-content:center;
-    cursor:pointer; pointer-events:auto;
+    cursor:crosshair; pointer-events:auto;
     transform:translateX(-50%); z-index:7;
     transition:background .1s, border-color .1s, color .1s;
   }
   .vpw-add-btn:hover { background:#2d2d2d; border-color:#aaa; color:#ccc; }
 
-  /* Per-marker trash button — shown on marker hover.
-     ::after pseudo-element extends the hoverable area down to bridge the gap
-     to the marker triangle without blocking marker drag interactions. */
+  /* Trash button — lives inside .vpw-marker or .vpw-marker-range-bar;
+     shown via CSS :hover on the parent, no JS required */
   .vpw-trash-btn {
-    position:absolute; top:1px; width:20px; height:14px;
+    position:absolute; top:1px; left:50%; width:14px; height:14px;
     background:#222; border:1px solid #888; border-radius:3px;
     color:#aaa; display:flex; align-items:center; justify-content:center;
     cursor:pointer; pointer-events:none;
     transform:translateX(-50%); z-index:7;
     opacity:0; transition:opacity .1s, background .1s, border-color .1s, color .1s;
   }
-  .vpw-trash-btn::after {
-    content:''; position:absolute; top:100%; left:-4px; right:-4px; height:10px;
-  }
   .vpw-trash-btn:hover { background:#2d1a1a; border-color:#aa4444; color:#cc6666; }
+
+  /* Trash visibility is driven by JS (coordinate-based) not CSS :hover,
+     because :hover doesn't cross the marker-zone / add-zone stacking-context boundary. */
 
   /* ── Marker interaction zone (7px, sits below add-zone) ─────────────────── */
   .vpw-tl-marker-zone {
@@ -149,21 +148,24 @@ const CSS = `
   }
 
   /* ── Frame selection markers ─────────────────────────────────────────── */
+  /* top:-16px extends the marker up into the add-zone, placing the trash btn there.
+     bottom:-10px extends down through the track bar. */
   .vpw-marker {
-    position:absolute; top:0; bottom:-10px; z-index:3; /* bottom:-10px = track height, extends marker to timeline bottom */
+    position:absolute; top:-16px; bottom:-10px; z-index:5;
     pointer-events:auto; cursor:grab;
   }
   .vpw-marker:active { cursor:grabbing; }
 
-  /* Vertical dash: starts at triangle bottom, extends to timeline bottom */
+  /* Vertical dash: starts at triangle bottom (16px add-zone + 7px marker-zone = 23px),
+     extends to bottom of marker element */
   .vpw-marker-line {
-    position:absolute; top:7px; bottom:0; left:0; width:1px;
+    position:absolute; top:23px; bottom:0; left:0; width:1px;
     background:#aaa; pointer-events:none;
   }
 
-  /* Triangle base (shared): sits in marker zone, receives hover for highlight */
+  /* Triangle base (shared): at top:16px (just below add-zone within marker) */
   .vpw-marker-tri {
-    position:absolute; top:0; pointer-events:auto; cursor:grab;
+    position:absolute; top:16px; pointer-events:auto; cursor:grab;
     width:0; height:0;
   }
 
@@ -199,13 +201,15 @@ const CSS = `
   .vpw-marker:active .vpw-marker-tri-start { border-right-color:#e0a830; }
   .vpw-marker:active .vpw-marker-tri-end { border-left-color:#e0a830; }
 
-  /* Range bar in marker zone (visual fill + hover target between start/end triangles) */
+  /* Range bar — extends from add-zone top through marker zone (16px + 7px = 23px).
+     The upper 16px is the hover area for the trash button; lower 7px is the drag strip. */
   .vpw-marker-range-bar {
-    position:absolute; top:0; height:7px;
-    background:rgba(170,170,170,0.08);
-    pointer-events:auto; cursor:grab; z-index:2;
+    position:absolute; top:-16px; height:23px;
+    background:transparent;
+    pointer-events:auto; cursor:grab; z-index:5;
   }
-  .vpw-marker-range-bar:hover { background:rgba(212,160,48,0.15); }
+  /* Only color the lower (marker zone) portion on hover */
+  .vpw-marker-range-bar:hover { background:linear-gradient(to bottom, transparent 16px, rgba(212,160,48,0.15) 16px); }
 
   /* JS-applied class when hovering the range bar — highlights markers and track fill */
   .vpw-marker.vpw-range-hover .vpw-marker-line { background:#d4a030; }
@@ -699,53 +703,32 @@ export default function VideoPlayerWidget(container, props) {
 
   /* ── Marker rendering ──────────────────────────────────────────────────── */
 
-  /** Create a trash button in the add zone for marker at index idx. */
-  function createTrashBtn(leftPx, idx, addZoneEl) {
-    const btn = document.createElement('button');
-    btn.className = 'vpw-trash-btn';
-    btn.style.left = leftPx;
-    btn.dataset.markerIndex = String(idx);
-    btn.title = 'Remove marker';
-    btn.innerHTML = ICONS.trash;
-    addZoneEl.appendChild(btn);
-
-    btn.addEventListener('pointerdown', (e) => e.stopPropagation());
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      markers.splice(idx, 1);
-      commitMarkers();
-    });
-    return btn;
-  }
-
-  /** Wire mutual hover between a trash button and marker elements (show/hide with debounce). */
-  function wireTrashHover(trashBtn, markerEls) {
-    let timeout = null;
-    const show = () => {
-      clearTimeout(timeout);
-      trashBtn.style.opacity = '1';
-      trashBtn.style.pointerEvents = 'auto';
-    };
-    const hide = () => {
-      timeout = setTimeout(() => {
-        trashBtn.style.opacity = '0';
-        trashBtn.style.pointerEvents = 'none';
-      }, 200);
-    };
-    for (const el of markerEls) {
-      el.addEventListener('mouseenter', show);
-      el.addEventListener('mouseleave', hide);
-    }
-    trashBtn.addEventListener('mouseenter', show);
-    trashBtn.addEventListener('mouseleave', hide);
-  }
-
-  /** Create a marker DOM element with a triangle cap and vertical dash line. */
-  function createMarkerEl(leftPx, idx, triClass) {
+  /**
+   * Create a marker DOM element.
+   * Top 16px (add-zone area): optional trash button, shown via CSS :hover.
+   * Next 7px (marker-zone area): triangle cap.
+   * Bottom (track area): vertical dash line.
+   * withTrash=false for range start/end endpoints (range bar holds the shared trash).
+   */
+  function createMarkerEl(leftPx, idx, triClass, withTrash = false) {
     const el = document.createElement('div');
     el.className = 'vpw-marker';
     el.style.left = leftPx;
     el.dataset.markerIndex = String(idx);
+
+    if (withTrash) {
+      const trash = document.createElement('button');
+      trash.className = 'vpw-trash-btn';
+      trash.title = 'Remove marker';
+      trash.innerHTML = ICONS.trash;
+      trash.addEventListener('pointerdown', (e) => e.stopPropagation());
+      trash.addEventListener('click', (e) => {
+        e.stopPropagation();
+        markers.splice(idx, 1);
+        commitMarkers();
+      });
+      el.appendChild(trash);
+    }
 
     const line = document.createElement('div');
     line.className = 'vpw-marker-line';
@@ -764,9 +747,6 @@ export default function VideoPlayerWidget(container, props) {
    */
   function renderMarkers(tlEl) {
     tlEl.querySelectorAll('.vpw-marker, .vpw-range-fill, .vpw-marker-range-bar, .vpw-nth-tick').forEach(m => m.remove());
-
-    const addZone = tlEl.querySelector('[data-tl-addzone]');
-    if (addZone) addZone.querySelectorAll('.vpw-trash-btn').forEach(t => t.remove());
 
     if (totalFrames <= 1) return;
     const max = totalFrames - 1;
@@ -792,14 +772,9 @@ export default function VideoPlayerWidget(container, props) {
       const m = markers[i];
       if (m.type === 'single') {
         const pct = ((m.frame - 1) / max) * 100;
-        const el = createMarkerEl(snap(pct), i, 'vpw-marker-tri-full');
+        const el = createMarkerEl(snap(pct), i, 'vpw-marker-tri-full', true);
         el.dataset.markerEdge = 'single';
         if (mzone) mzone.appendChild(el); else tlEl.appendChild(el);
-
-        if (addZone) {
-          const trash = createTrashBtn(snap(pct), i, addZone);
-          wireTrashHover(trash, [el]);
-        }
       } else {
         const startPct = ((m.start - 1) / max) * 100;
         const endPct   = ((m.end - 1) / max) * 100;
@@ -812,27 +787,32 @@ export default function VideoPlayerWidget(container, props) {
         fill.dataset.markerEdge = 'fill';
         tlEl.appendChild(fill);
 
-        const startEl = createMarkerEl(snap(startPct), i, 'vpw-marker-tri-start');
+        const startEl = createMarkerEl(snap(startPct), i, 'vpw-marker-tri-start', false);
         startEl.dataset.markerEdge = 'start';
         if (mzone) mzone.appendChild(startEl); else tlEl.appendChild(startEl);
 
-        const endEl = createMarkerEl(snap(endPct), i, 'vpw-marker-tri-end');
+        const endEl = createMarkerEl(snap(endPct), i, 'vpw-marker-tri-end', false);
         endEl.dataset.markerEdge = 'end';
         if (mzone) mzone.appendChild(endEl); else tlEl.appendChild(endEl);
 
+        // Range bar: extends into add-zone (top:-16px) for hover area + trash button.
         const bar = document.createElement('div');
         bar.className = 'vpw-marker-range-bar';
+        bar.dataset.markerIndex = String(i);
         bar.style.left = snap(startPct);
         bar.style.width = w > 0 ? `${snapNum(endPct) - snapNum(startPct)}px` : `${endPct - startPct}%`;
         bar.addEventListener('mouseenter', () => { startEl.classList.add('vpw-range-hover'); endEl.classList.add('vpw-range-hover'); fill.classList.add('vpw-range-hover'); });
         bar.addEventListener('mouseleave', () => { startEl.classList.remove('vpw-range-hover'); endEl.classList.remove('vpw-range-hover'); fill.classList.remove('vpw-range-hover'); });
-        if (mzone) mzone.appendChild(bar); else tlEl.appendChild(bar);
 
-        if (addZone) {
-          const centerPct = (startPct + endPct) / 2;
-          const trash = createTrashBtn(snap(centerPct), i, addZone);
-          wireTrashHover(trash, [startEl, endEl, bar]);
-        }
+        const rangeTrash = document.createElement('button');
+        rangeTrash.className = 'vpw-trash-btn';
+        rangeTrash.title = 'Remove range';
+        rangeTrash.innerHTML = ICONS.trash;
+        rangeTrash.addEventListener('pointerdown', (e) => e.stopPropagation());
+        rangeTrash.addEventListener('click', (e) => { e.stopPropagation(); markers.splice(i, 1); commitMarkers(); });
+        bar.appendChild(rangeTrash);
+
+        if (mzone) mzone.appendChild(bar); else tlEl.appendChild(bar);
       }
     }
   }
@@ -1193,6 +1173,10 @@ export default function VideoPlayerWidget(container, props) {
 
     mzoneEl.addEventListener('pointerdown', (e) => {
       if (selectionMode !== 'list') return;
+      // Reject clicks in the add-zone area (top 16px of the extended marker)
+      const mzoneRect = mzoneEl.getBoundingClientRect();
+      if (e.clientY < mzoneRect.top) return;
+
       const hit = hitTestMarker(e, mzoneEl);
       if (!hit) return;
 
@@ -1243,47 +1227,98 @@ export default function VideoPlayerWidget(container, props) {
    */
   function attachAddZone(addZoneEl) {
     const addBtn = addZoneEl.querySelector('.vpw-add-btn');
+    // Use the timeline parent so mousemove fires even when cursor is over extended markers
+    // and so positioning uses the same offsetWidth that renderMarkers uses for snap().
+    const tlEl = addZoneEl.parentElement;
+    const ADD_ZONE_H = 16; // px — height of the add zone strip
+
     let isCreating = false;
     let rangeAnchorFrame = null;
     let rangeAnchorIndex = null;
 
-    function frameFromX(clientX) {
-      const r = addZoneEl.getBoundingClientRect();
+    function frameFromClientX(clientX) {
+      const r = tlEl.getBoundingClientRect();
       return Math.round(clamp((clientX - r.left) / r.width, 0, 1) * Math.max(0, totalFrames - 1));
     }
 
-    function isNearMarker(clientX) {
-      const r = addZoneEl.getBoundingClientRect();
+    // Returns the index of the first marker whose position is within HIT_TOLERANCE_PX
+    // of clientX (viewport px), or -1 if none. All arithmetic in viewport space.
+    function nearMarkerIndex(clientX) {
+      const r = tlEl.getBoundingClientRect();
       const curX = clientX - r.left;
       const maxFrame = Math.max(0, totalFrames - 1);
-      if (maxFrame === 0) return false;
-      for (const m of markers) {
+      if (maxFrame === 0) return -1;
+      for (let i = 0; i < markers.length; i++) {
+        const m = markers[i];
         if (m.type === 'single') {
-          const mx = ((m.frame - 1) / maxFrame) * r.width;
-          if (Math.abs(curX - mx) <= HIT_TOLERANCE_PX) return true;
+          if (Math.abs(curX - ((m.frame - 1) / maxFrame) * r.width) <= HIT_TOLERANCE_PX) return i;
         } else {
           const sx = ((m.start - 1) / maxFrame) * r.width;
-          const ex = ((m.end - 1) / maxFrame) * r.width;
-          if (curX >= sx - HIT_TOLERANCE_PX && curX <= ex + HIT_TOLERANCE_PX) return true;
+          const ex = ((m.end   - 1) / maxFrame) * r.width;
+          if (curX >= sx - HIT_TOLERANCE_PX && curX <= ex + HIT_TOLERANCE_PX) return i;
         }
       }
-      return false;
+      return -1;
     }
 
-    addZoneEl.addEventListener('mousemove', (e) => {
-      if (selectionMode !== 'list' || !isLoaded || isCreating) return;
-      const r = addZoneEl.getBoundingClientRect();
-      if (isNearMarker(e.clientX)) {
-        addBtn.style.display = 'none';
-      } else {
+    // JS-driven trash visibility — CSS :hover can't cross the marker-zone / add-zone
+    // stacking-context boundary, so we drive it from tlEl.mousemove instead.
+    let activeTrash = null;
+    let hideTimer   = null;
+
+    function trashBtnEl(idx) {
+      return (
+        tlEl.querySelector(`.vpw-marker[data-marker-index="${idx}"] .vpw-trash-btn`) ||
+        tlEl.querySelector(`.vpw-marker-range-bar[data-marker-index="${idx}"] .vpw-trash-btn`)
+      );
+    }
+
+    function showTrashAt(idx) {
+      clearTimeout(hideTimer);
+      const btn = trashBtnEl(idx);
+      if (btn === activeTrash) return;
+      if (activeTrash) { activeTrash.style.opacity = '0'; activeTrash.style.pointerEvents = 'none'; }
+      activeTrash = btn;
+      if (btn) { btn.style.opacity = '1'; btn.style.pointerEvents = 'auto'; }
+    }
+
+    function scheduleHide() {
+      clearTimeout(hideTimer);
+      hideTimer = setTimeout(() => {
+        if (activeTrash) { activeTrash.style.opacity = '0'; activeTrash.style.pointerEvents = 'none'; activeTrash = null; }
+      }, 150);
+    }
+
+    // Single mousemove on the whole timeline drives both "+" and trash.
+    tlEl.addEventListener('mousemove', (e) => {
+      if (selectionMode !== 'list' || !isLoaded) return;
+      const r = tlEl.getBoundingClientRect();
+      const localY = e.clientY - r.top;
+
+      // Show trash when cursor is in the add-zone+marker-zone strip and near a marker.
+      if (localY >= 0 && localY < ADD_ZONE_H + 7) {
+        const idx = nearMarkerIndex(e.clientX);
+        if (idx >= 0) {
+          showTrashAt(idx);
+          addBtn.style.display = 'none';
+          return;
+        }
+      }
+
+      scheduleHide();
+
+      if (!isCreating && localY >= 0 && localY < ADD_ZONE_H) {
         const fraction = clamp((e.clientX - r.left) / r.width, 0, 1);
         addBtn.style.display = 'flex';
-        addBtn.style.left = `${fraction * (addZoneEl.offsetWidth || r.width)}px`;
+        addBtn.style.left = `${fraction * tlEl.offsetWidth}px`;
+      } else {
+        addBtn.style.display = 'none';
       }
     });
 
-    addZoneEl.addEventListener('mouseleave', () => {
+    tlEl.addEventListener('mouseleave', () => {
       if (!isCreating) addBtn.style.display = 'none';
+      scheduleHide();
     });
 
     addBtn.addEventListener('pointerdown', (e) => {
@@ -1291,7 +1326,7 @@ export default function VideoPlayerWidget(container, props) {
       e.stopPropagation();
       addBtn.setPointerCapture(e.pointerId);
       isCreating = true;
-      rangeAnchorFrame = clamp(frameFromX(e.clientX) + 1, 1, totalFrames);
+      rangeAnchorFrame = clamp(frameFromClientX(e.clientX) + 1, 1, totalFrames);
       markers.push({ type: 'single', frame: rangeAnchorFrame });
       rangeAnchorIndex = markers.length - 1;
       syncTimeline();
@@ -1299,7 +1334,7 @@ export default function VideoPlayerWidget(container, props) {
 
     addBtn.addEventListener('pointermove', (e) => {
       if (!isCreating || rangeAnchorIndex === null) return;
-      const currentFrame = clamp(frameFromX(e.clientX) + 1, 1, totalFrames);
+      const currentFrame = clamp(frameFromClientX(e.clientX) + 1, 1, totalFrames);
       const s = Math.min(rangeAnchorFrame, currentFrame);
       const en = Math.max(rangeAnchorFrame, currentFrame);
       markers[rangeAnchorIndex] = s === en

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -410,7 +410,7 @@ function bottomHtml(pfx, initFps) {
         Frame <input class="${pfx}frame vpw-num" type="number" min="0" value="0" style="width:72px;">
       </label>
       <span class="${pfx}total vpw-total">/ 0</span>
-      <button class="${pfx}clear-markers vpw-btn-text" title="Clear all markers">&#x2715; Markers</button>
+      <button class="${pfx}clear-markers vpw-btn-text" title="Clear all markers">${ICONS.trash} Markers</button>
     </div>`;
 }
 

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -2,7 +2,7 @@
  * VideoPlayerFrameSelector — vanilla JS widget for frame-accurate video scrubbing.
  *
  * Layout:
- *   - Marker zone (upper 7px): double-click to add marker, drag to move, alt+click to remove
+ *   - Marker zone (upper 7px): click to add marker, drag to move, alt+click to remove
  *   - Track bar  (lower 10px): click/drag to seek
  *
  * Visual:
@@ -28,6 +28,8 @@ const ICONS = {
   playFwd:   _svg('M8 5v14l11-7z'),
   stepFwd:   _svg('M4 5v14 M9 5l12 7-12 7z'),
   enlarge:   `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>`,
+  plus:      `<svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>`,
+  trash:     `<svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/><path d="M9 6V4h6v2"/></svg>`,
 };
 
 /* ─── CSS ────────────────────────────────────────────────────────────────── */
@@ -79,16 +81,52 @@ const CSS = `
     font-family:'SF Mono','Monaco','Menlo',monospace;
   }
 
-  /* ── Timeline container (17px: 7px marker zone + 10px track) ──────── */
+  /* ── Timeline container (33px: 16px add-zone + 7px marker zone + 10px track) */
   .vpw-timeline {
-    position:relative; height:17px;
+    position:relative; height:33px;
     user-select:none; touch-action:none;
   }
 
-  /* ── Marker interaction zone (top 7px, same height as triangles) ─────── */
+  /* ── Add / delete icon strip (top 16px) ─────────────────────────────────── */
+  .vpw-tl-add-zone {
+    position:absolute; top:0; left:0; right:0; height:16px;
+    cursor:pointer; z-index:6;
+  }
+
+  /* "+" button — floats at cursor X, shown by JS */
+  .vpw-add-btn {
+    position:absolute; top:1px; width:14px; height:14px;
+    background:#222; border:1px solid #888; border-radius:3px;
+    color:#aaa; display:none; align-items:center; justify-content:center;
+    cursor:pointer; pointer-events:auto;
+    transform:translateX(-50%); z-index:7;
+    transition:background .1s, border-color .1s, color .1s;
+  }
+  .vpw-add-btn:hover { background:#2d2d2d; border-color:#aaa; color:#ccc; }
+
+  /* Per-marker trash button — shown on marker hover */
+  .vpw-trash-btn {
+    position:absolute; top:1px; width:20px; height:14px;
+    background:#222; border:1px solid #888; border-radius:3px;
+    color:#aaa; display:flex; align-items:center; justify-content:center;
+    cursor:pointer; pointer-events:none;
+    transform:translateX(-50%); z-index:7;
+    opacity:0; transition:opacity .1s, background .1s, border-color .1s, color .1s;
+  }
+  .vpw-trash-btn:hover { background:#2d1a1a; border-color:#aa4444; color:#cc6666; }
+
+  /* Transparent bridge that extends from the add-zone into the marker zone,
+     creating a continuous hover column between the trash button and the marker
+     triangle. pointer-events toggled by JS — none by default so drags work. */
+  .vpw-marker-hover-bridge {
+    position:absolute; top:13px; height:16px; width:22px;
+    transform:translateX(-50%); pointer-events:none; z-index:7; cursor:pointer;
+  }
+
+  /* ── Marker interaction zone (7px, sits below add-zone) ─────────────────── */
   .vpw-tl-marker-zone {
-    position:absolute; top:0; left:0; right:0; bottom:10px;
-    cursor:crosshair; z-index:4;
+    position:absolute; top:16px; left:0; right:0; bottom:10px;
+    cursor:pointer; z-index:4;
   }
 
   /* ── Track bar (dark gray, 10px) ─────────────────────────────────────── */
@@ -349,8 +387,11 @@ function controlsHtml(pfx) {
 function timelineHtml(id) {
   return `
     <div class="vpw-timeline nowheel" data-tl="${id}">
+      <div class="vpw-tl-add-zone" data-tl-addzone="${id}">
+        <div class="vpw-add-btn" data-tl-addbtn="${id}" title="Click to add marker&#10;Drag to create range">${ICONS.plus}</div>
+      </div>
       <div class="vpw-tl-marker-zone" data-tl-mzone="${id}"
-        title="Double-click to add a marker&#10;Double-click &amp; drag to create a range&#10;Drag a triangle to move it&#10;Alt+click to remove"></div>
+        title="Drag to move marker"></div>
       <div class="vpw-tl-track" data-tl-track="${id}"></div>
       <div class="vpw-tl-fill" data-tl-fill="${id}"></div>
       <div class="vpw-tl-seeker" data-tl-seeker="${id}"></div>
@@ -385,7 +426,7 @@ export default function VideoPlayerWidget(container, props) {
   const session = SESSIONS.get(sessionKey) || {
     fps: null, nativeFps: null, frameIndex: 0, currentTime: 0,
     markers: [], selectedFramesStr: '', selectionMode: 'list', everyN: 1,
-    videoSrc: null,
+    videoSrc: null, videoWidth: null, videoHeight: null,
   };
   SESSIONS.set(sessionKey, session);
 
@@ -413,7 +454,7 @@ export default function VideoPlayerWidget(container, props) {
         </button>
       </div>
 
-      <div style="position:relative;background:#000;border-radius:8px;overflow:hidden;height:${vpH}px;">
+      <div class="vpw-video-container" style="position:relative;background:#000;border-radius:8px;overflow:hidden;height:${vpH}px;">
         <video class="vpw-video" style="width:100%;height:100%;object-fit:contain;" playsinline preload="metadata"></video>
         <div class="vpw-overlay" style="position:absolute;inset:0;display:${session.videoSrc ? 'none' : 'flex'};align-items:center;justify-content:center;color:#3a3a3a;font-size:13px;pointer-events:none;">
           No video loaded
@@ -449,16 +490,18 @@ export default function VideoPlayerWidget(container, props) {
   const q  = (sel) => container.querySelector(sel);
   const qd = (sel) => backdrop.querySelector(sel);
 
-  const widgetRoot = q('.vpw-root');
-  const enlargeBtn = q('.vpw-enlarge');
-  const video      = q('.vpw-video');
-  const overlay    = q('.vpw-overlay');
+  const widgetRoot      = q('.vpw-root');
+  const enlargeBtn      = q('.vpw-enlarge');
+  const video           = q('.vpw-video');
+  const overlay         = q('.vpw-overlay');
+  const videoContainerEl = q('.vpw-video-container');
 
-  if (session.videoSrc) video.src = session.videoSrc;
+  // Video src is restored conditionally in initFromProps (requires prop value to match)
 
   const tl         = q('[data-tl="main"]');
   const tlTrack    = q('[data-tl-track="main"]');
   const tlMzone    = q('[data-tl-mzone="main"]');
+  const tlAddZone  = q('[data-tl-addzone="main"]');
   const tlFill     = q('[data-tl-fill="main"]');
   const tlSeeker   = q('[data-tl-seeker="main"]');
 
@@ -481,6 +524,7 @@ export default function VideoPlayerWidget(container, props) {
   const dtl        = qd('[data-tl="dialog"]');
   const dtlTrack   = qd('[data-tl-track="dialog"]');
   const dtlMzone   = qd('[data-tl-mzone="dialog"]');
+  const dtlAddZone = qd('[data-tl-addzone="dialog"]');
   const dtlFill    = qd('[data-tl-fill="dialog"]');
   const dtlSeeker  = qd('[data-tl-seeker="dialog"]');
 
@@ -517,6 +561,10 @@ export default function VideoPlayerWidget(container, props) {
   let currentSrc   = null;
   let pollId       = null;
   let hasError     = false;
+  // Timestamp until which the poll should ignore incoming input_frame_numbers updates.
+  // Set after commitMarkers() to prevent the poll from reverting local marker state
+  // before React has propagated the write back through the fiber tree.
+  let ignoreFrameUpdateUntil = 0;
 
   /* ── React fiber helpers ────────────────────────────────────────────────── */
   // These walk up the React component tree from this container's fiber node
@@ -623,6 +671,20 @@ export default function VideoPlayerWidget(container, props) {
     session.selectedFramesStr = selectedFramesStr;
     session.selectionMode   = selectionMode;
     session.everyN          = everyN;
+    if (video.videoWidth)  session.videoWidth  = video.videoWidth;
+    if (video.videoHeight) session.videoHeight = video.videoHeight;
+  }
+
+  /** Apply the video's natural aspect ratio to the container so height scales with width. */
+  function applyAspectRatio(w, h) {
+    if (!w || !h) return;
+    videoContainerEl.style.aspectRatio = `${w} / ${h}`;
+    videoContainerEl.style.height = '';
+  }
+
+  function resetAspectRatio() {
+    videoContainerEl.style.aspectRatio = '';
+    videoContainerEl.style.height = `${vpH}px`;
   }
 
   /* ── Error state ───────────────────────────────────────────────────────── */
@@ -638,6 +700,66 @@ export default function VideoPlayerWidget(container, props) {
   }
 
   /* ── Marker rendering ──────────────────────────────────────────────────── */
+
+  /** Create a trash button in the add zone for marker at index idx. */
+  function createTrashBtn(leftPx, idx, addZoneEl) {
+    const btn = document.createElement('button');
+    btn.className = 'vpw-trash-btn';
+    btn.style.left = leftPx;
+    btn.dataset.markerIndex = String(idx);
+    btn.title = 'Remove marker';
+    btn.innerHTML = ICONS.trash;
+    addZoneEl.appendChild(btn);
+
+    btn.addEventListener('pointerdown', (e) => e.stopPropagation());
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      markers.splice(idx, 1);
+      commitMarkers();
+    });
+    return btn;
+  }
+
+  /** Transparent div that bridges the gap between the trash button (add-zone) and
+   *  the marker triangle (marker-zone), giving the mouse a continuous hover path. */
+  function createMarkerHoverBridge(leftPx, addZoneEl) {
+    const bridge = document.createElement('div');
+    bridge.className = 'vpw-marker-hover-bridge';
+    bridge.style.left = leftPx;
+    addZoneEl.appendChild(bridge);
+    return bridge;
+  }
+
+  /** Wire mutual hover between a trash button, marker elements, and an optional bridge element. */
+  function wireTrashHover(trashBtn, markerEls, bridgeEl) {
+    let timeout = null;
+    const show = () => {
+      clearTimeout(timeout);
+      trashBtn.style.opacity = '1';
+      trashBtn.style.pointerEvents = 'auto';
+      // Enable the bridge so it can relay hover while the mouse travels
+      // from the marker triangle up to the trash button.
+      if (bridgeEl) bridgeEl.style.pointerEvents = 'auto';
+    };
+    const hide = () => {
+      timeout = setTimeout(() => {
+        trashBtn.style.opacity = '0';
+        trashBtn.style.pointerEvents = 'none';
+        // Disable the bridge again so it doesn't block marker drag interactions.
+        if (bridgeEl) bridgeEl.style.pointerEvents = 'none';
+      }, 200);
+    };
+    for (const el of markerEls) {
+      el.addEventListener('mouseenter', show);
+      el.addEventListener('mouseleave', hide);
+    }
+    trashBtn.addEventListener('mouseenter', show);
+    trashBtn.addEventListener('mouseleave', hide);
+    if (bridgeEl) {
+      bridgeEl.addEventListener('mouseenter', show);
+      bridgeEl.addEventListener('mouseleave', hide);
+    }
+  }
 
   /** Create a marker DOM element with a triangle cap and vertical dash line. */
   function createMarkerEl(leftPx, idx, triClass) {
@@ -663,6 +785,9 @@ export default function VideoPlayerWidget(container, props) {
    */
   function renderMarkers(tlEl) {
     tlEl.querySelectorAll('.vpw-marker, .vpw-range-fill, .vpw-marker-range-bar, .vpw-nth-tick').forEach(m => m.remove());
+
+    const addZone = tlEl.querySelector('[data-tl-addzone]');
+    if (addZone) addZone.querySelectorAll('.vpw-trash-btn, .vpw-marker-hover-bridge').forEach(t => t.remove());
 
     if (totalFrames <= 1) return;
     const max = totalFrames - 1;
@@ -691,6 +816,12 @@ export default function VideoPlayerWidget(container, props) {
         const el = createMarkerEl(snap(pct), i, 'vpw-marker-tri-full');
         el.dataset.markerEdge = 'single';
         if (mzone) mzone.appendChild(el); else tlEl.appendChild(el);
+
+        if (addZone) {
+          const trash = createTrashBtn(snap(pct), i, addZone);
+          const bridge = createMarkerHoverBridge(snap(pct), addZone);
+          wireTrashHover(trash, [el], bridge);
+        }
       } else {
         const startPct = ((m.start - 1) / max) * 100;
         const endPct   = ((m.end - 1) / max) * 100;
@@ -718,6 +849,13 @@ export default function VideoPlayerWidget(container, props) {
         bar.addEventListener('mouseenter', () => { startEl.classList.add('vpw-range-hover'); endEl.classList.add('vpw-range-hover'); fill.classList.add('vpw-range-hover'); });
         bar.addEventListener('mouseleave', () => { startEl.classList.remove('vpw-range-hover'); endEl.classList.remove('vpw-range-hover'); fill.classList.remove('vpw-range-hover'); });
         if (mzone) mzone.appendChild(bar); else tlEl.appendChild(bar);
+
+        if (addZone) {
+          const centerPct = (startPct + endPct) / 2;
+          const trash = createTrashBtn(snap(centerPct), i, addZone);
+          const bridge = createMarkerHoverBridge(snap(centerPct), addZone);
+          wireTrashHover(trash, [startEl, endEl, bar], bridge);
+        }
       }
     }
   }
@@ -903,22 +1041,36 @@ export default function VideoPlayerWidget(container, props) {
     selectionMode     = session.selectionMode || 'list';
     everyN            = session.everyN || 1;
 
-    if (session.videoSrc && urlBase(session.videoSrc) === urlBase(video.src)) {
+    let url = extractUrl(value);
+    // The prop value may not have propagated yet when the widget first mounts
+    // (e.g. after_value_set resolves the URL and sets the parameter, but React
+    // hasn't re-rendered with the new value). Read directly from the fiber tree
+    // so the video loads immediately rather than waiting for the 500ms poll.
+    if (!url) url = extractUrl(readSiblingParamValue('input_video'));
+
+    // Only restore session video if the prop value has a matching URL.
+    // Without this check, nodes that share a session key (e.g. 'vpw-default') would
+    // inherit another node's loaded video when created with an empty input_video.
+    if (url && session.videoSrc && urlBase(session.videoSrc) === urlBase(url)) {
       currentSrc = session.videoSrc;
+      video.src  = session.videoSrc;
+      video.load(); // ensure loadedmetadata fires on this new element so isLoaded is set
       videoName  = session.videoSrc.split('/').pop()?.split('?')[0] || 'video';
+      // Apply saved aspect ratio immediately so the container doesn't flash to default height
+      applyAspectRatio(session.videoWidth, session.videoHeight);
       if (session.currentTime > 0) video.addEventListener('loadedmetadata', () => { video.currentTime = session.currentTime; }, { once: true });
       return;
     }
-    const url = extractUrl(value);
     if (url) loadUrl(url, session.currentTime || 0);
   }
 
   function clearVideo() {
     pause(); video.removeAttribute('src'); video.load();
-    currentSrc = null; session.videoSrc = null; isLoaded = false;
+    currentSrc = null; session.videoSrc = null; session.videoWidth = null; session.videoHeight = null; isLoaded = false;
     videoName = ''; duration = 0; totalFrames = 0; frameIndex = 0;
     markers = []; selectedFramesStr = '';
     overlay.textContent = 'No video loaded'; overlay.style.display = 'flex';
+    resetAspectRatio();
     updateUi();
   }
 
@@ -947,7 +1099,7 @@ export default function VideoPlayerWidget(container, props) {
       let needsSync = false;
 
       const latestFrames = readSiblingParamValue('input_frame_numbers');
-      if (latestFrames !== undefined) {
+      if (latestFrames !== undefined && Date.now() > ignoreFrameUpdateUntil) {
         const str = String(latestFrames || '');
         updateErrorState(str);
         if (str !== selectedFramesStr) {
@@ -976,6 +1128,9 @@ export default function VideoPlayerWidget(container, props) {
   function commitMarkers() {
     selectedFramesStr = markersToFrameString(markers);
     setSiblingParamValue('input_frame_numbers', selectedFramesStr);
+    // Suppress poll reads for slightly longer than one poll cycle so the stale fiber
+    // value (pre-React-update) doesn't overwrite local marker state mid-flight.
+    ignoreFrameUpdateUntil = Date.now() + 600;
     syncTimeline();
     saveSession();
   }
@@ -1003,7 +1158,6 @@ export default function VideoPlayerWidget(container, props) {
 
   /* ── Marker zone interaction (above track) ─────────────────────────────── */
 
-  const DBLCLICK_MS = 350;
   const HIT_TOLERANCE_PX = 8;
 
   /** Hit-test a pointer event against all markers. Returns {markerIndex, edge} or null. */
@@ -1029,19 +1183,10 @@ export default function VideoPlayerWidget(container, props) {
     return null;
   }
 
-  /**
-   * Attach pointer handlers to the marker zone above the track.
-   * Double-click: add marker. Drag existing: move. Alt+click: remove.
-   * Drag from double-click: create range.
-   */
+  /** Attach drag handlers to the marker zone — move existing markers only. */
   function attachMarkerZone(mzoneEl) {
     let isDragging = false;
     let dragInfo = null;
-    let isCreatingRange = false;
-    let rangeAnchorFrame = null;
-    let rangeAnchorIndex = null;
-    let lastClickTime = 0;
-    let lastClickFrame = -1;
 
     function frameFromMzone(e) {
       const r = mzoneEl.getBoundingClientRect();
@@ -1050,98 +1195,137 @@ export default function VideoPlayerWidget(container, props) {
 
     mzoneEl.addEventListener('pointerdown', (e) => {
       if (selectionMode !== 'list') return;
-      const f = frameFromMzone(e);
-      const now = Date.now();
       const hit = hitTestMarker(e, mzoneEl);
+      if (!hit) return;
 
-      // Alt+click: remove marker
-      if (e.altKey) {
-        if (hit) { markers.splice(hit.markerIndex, 1); commitMarkers(); }
-        return;
-      }
-
-      // Click on existing marker: start drag
-      if (hit) {
-        mzoneEl.setPointerCapture(e.pointerId);
-        isDragging = true;
-        dragInfo = { ...hit, dragStartFrame: f + 1 };
-        return;
-      }
-
-      // Double-click detection
-      const isDblClick = (now - lastClickTime < DBLCLICK_MS) && (Math.abs(f - lastClickFrame) <= 2);
-
-      if (isDblClick) {
-        lastClickTime = 0; lastClickFrame = -1;
-        mzoneEl.setPointerCapture(e.pointerId);
-        isDragging = true;
-        isCreatingRange = true;
-        rangeAnchorFrame = f + 1;
-        markers.push({ type: 'single', frame: rangeAnchorFrame });
-        rangeAnchorIndex = markers.length - 1;
-        syncTimeline();
-        return;
-      }
-
-      lastClickTime = now;
-      lastClickFrame = f;
+      mzoneEl.setPointerCapture(e.pointerId);
+      isDragging = true;
+      dragInfo = { ...hit, dragStartFrame: frameFromMzone(e) + 1 };
     });
 
     mzoneEl.addEventListener('pointermove', (e) => {
-      if (!isDragging) return;
+      if (!isDragging || !dragInfo) return;
       const f = frameFromMzone(e);
+      const m = markers[dragInfo.markerIndex];
+      if (!m) return;
+      const newFrame = clamp(f + 1, 1, totalFrames);
 
-      if (dragInfo) {
-        const m = markers[dragInfo.markerIndex];
-        if (!m) return;
-        const newFrame = clamp(f + 1, 1, totalFrames);
-
-        if (dragInfo.edge === 'fill' && m.type === 'range') {
-          const delta = newFrame - dragInfo.dragStartFrame;
-          const rangeLen = m.end - m.start;
-          let newStart = m.start + delta, newEnd = m.end + delta;
-          if (newStart < 1) { newStart = 1; newEnd = 1 + rangeLen; }
-          if (newEnd > totalFrames) { newEnd = totalFrames; newStart = totalFrames - rangeLen; }
-          m.start = newStart; m.end = newEnd;
-          dragInfo.dragStartFrame = newFrame;
-        } else if (m.type === 'single') {
-          m.frame = newFrame;
-        } else if (dragInfo.edge === 'start') {
-          m.start = Math.min(newFrame, m.end);
-        } else if (dragInfo.edge === 'end') {
-          m.end = Math.max(newFrame, m.start);
-        }
-        if (m.type === 'range' && m.start === m.end) markers[dragInfo.markerIndex] = { type: 'single', frame: m.start };
-        syncTimeline();
-        return;
+      if (dragInfo.edge === 'fill' && m.type === 'range') {
+        const delta = newFrame - dragInfo.dragStartFrame;
+        const rangeLen = m.end - m.start;
+        let newStart = m.start + delta, newEnd = m.end + delta;
+        if (newStart < 1) { newStart = 1; newEnd = 1 + rangeLen; }
+        if (newEnd > totalFrames) { newEnd = totalFrames; newStart = totalFrames - rangeLen; }
+        m.start = newStart; m.end = newEnd;
+        dragInfo.dragStartFrame = newFrame;
+      } else if (m.type === 'single') {
+        m.frame = newFrame;
+      } else if (dragInfo.edge === 'start') {
+        m.start = Math.min(newFrame, m.end);
+      } else if (dragInfo.edge === 'end') {
+        m.end = Math.max(newFrame, m.start);
       }
+      if (m.type === 'range' && m.start === m.end) markers[dragInfo.markerIndex] = { type: 'single', frame: m.start };
+      syncTimeline();
+    });
 
-      if (isCreatingRange && rangeAnchorIndex !== null) {
-        const currentFrame = clamp(f + 1, 1, totalFrames);
-        const s = Math.min(rangeAnchorFrame, currentFrame);
-        const en = Math.max(rangeAnchorFrame, currentFrame);
-        markers[rangeAnchorIndex] = s === en ? { type: 'single', frame: s } : { type: 'range', start: s, end: en };
-        syncTimeline();
+    function endDrag() {
+      if (isDragging && dragInfo) { markers = mergeOverlapping(markers); commitMarkers(); }
+      isDragging = false; dragInfo = null;
+    }
+
+    mzoneEl.addEventListener('pointerup',     endDrag);
+    mzoneEl.addEventListener('pointercancel', endDrag);
+  }
+
+  /**
+   * Attach handlers to the add zone strip above the marker area.
+   * Mousemove: show "+" button at cursor, hide near existing markers.
+   * Click/drag on "+": add single marker or create range.
+   */
+  function attachAddZone(addZoneEl) {
+    const addBtn = addZoneEl.querySelector('.vpw-add-btn');
+    let isCreating = false;
+    let rangeAnchorFrame = null;
+    let rangeAnchorIndex = null;
+
+    function frameFromX(clientX) {
+      const r = addZoneEl.getBoundingClientRect();
+      return Math.round(clamp((clientX - r.left) / r.width, 0, 1) * Math.max(0, totalFrames - 1));
+    }
+
+    function isNearMarker(clientX) {
+      const r = addZoneEl.getBoundingClientRect();
+      const curX = clientX - r.left;
+      const maxFrame = Math.max(0, totalFrames - 1);
+      if (maxFrame === 0) return false;
+      for (const m of markers) {
+        if (m.type === 'single') {
+          const mx = ((m.frame - 1) / maxFrame) * r.width;
+          if (Math.abs(curX - mx) <= HIT_TOLERANCE_PX) return true;
+        } else {
+          const sx = ((m.start - 1) / maxFrame) * r.width;
+          const ex = ((m.end - 1) / maxFrame) * r.width;
+          if (curX >= sx - HIT_TOLERANCE_PX && curX <= ex + HIT_TOLERANCE_PX) return true;
+        }
+      }
+      return false;
+    }
+
+    addZoneEl.addEventListener('mousemove', (e) => {
+      if (selectionMode !== 'list' || !isLoaded || isCreating) return;
+      const r = addZoneEl.getBoundingClientRect();
+      if (isNearMarker(e.clientX)) {
+        addBtn.style.display = 'none';
+      } else {
+        const fraction = clamp((e.clientX - r.left) / r.width, 0, 1);
+        addBtn.style.display = 'flex';
+        addBtn.style.left = `${fraction * (addZoneEl.offsetWidth || r.width)}px`;
       }
     });
 
-    function endInteraction() {
-      if (isDragging && (dragInfo || isCreatingRange)) {
-        markers = mergeOverlapping(markers);
-        commitMarkers();
-      }
-      isDragging = false; dragInfo = null;
-      isCreatingRange = false; rangeAnchorFrame = null; rangeAnchorIndex = null;
+    addZoneEl.addEventListener('mouseleave', () => {
+      if (!isCreating) addBtn.style.display = 'none';
+    });
+
+    addBtn.addEventListener('pointerdown', (e) => {
+      if (selectionMode !== 'list') return;
+      e.stopPropagation();
+      addBtn.setPointerCapture(e.pointerId);
+      isCreating = true;
+      rangeAnchorFrame = clamp(frameFromX(e.clientX) + 1, 1, totalFrames);
+      markers.push({ type: 'single', frame: rangeAnchorFrame });
+      rangeAnchorIndex = markers.length - 1;
+      syncTimeline();
+    });
+
+    addBtn.addEventListener('pointermove', (e) => {
+      if (!isCreating || rangeAnchorIndex === null) return;
+      const currentFrame = clamp(frameFromX(e.clientX) + 1, 1, totalFrames);
+      const s = Math.min(rangeAnchorFrame, currentFrame);
+      const en = Math.max(rangeAnchorFrame, currentFrame);
+      markers[rangeAnchorIndex] = s === en
+        ? { type: 'single', frame: s }
+        : { type: 'range', start: s, end: en };
+      syncTimeline();
+    });
+
+    function endCreate() {
+      if (isCreating) { markers = mergeOverlapping(markers); commitMarkers(); }
+      isCreating = false; rangeAnchorFrame = null; rangeAnchorIndex = null;
+      addBtn.style.display = 'none';
     }
 
-    mzoneEl.addEventListener('pointerup',     endInteraction);
-    mzoneEl.addEventListener('pointercancel', endInteraction);
+    addBtn.addEventListener('pointerup',     endCreate);
+    addBtn.addEventListener('pointercancel', endCreate);
   }
 
   attachSeekZone(tlTrack);
   attachSeekZone(dtlTrack);
   attachMarkerZone(tlMzone);
   attachMarkerZone(dtlMzone);
+  attachAddZone(tlAddZone);
+  attachAddZone(dtlAddZone);
 
   /* ── Video events ───────────────────────────────────────────────────────── */
 
@@ -1149,7 +1333,9 @@ export default function VideoPlayerWidget(container, props) {
     const d = video.duration;
     if (!Number.isFinite(d) || d <= 0) return;
     duration = d; totalFrames = computeTotal(); isLoaded = true;
-    overlay.style.display = 'none'; updateUi();
+    overlay.style.display = 'none';
+    applyAspectRatio(video.videoWidth, video.videoHeight);
+    updateUi();
   });
 
   video.addEventListener('durationchange', () => {

--- a/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
+++ b/griptape_nodes_library/video/widgets/VideoPlayerFrameSelector.js
@@ -105,7 +105,9 @@ const CSS = `
   }
   .vpw-add-btn:hover { background:#2d2d2d; border-color:#aaa; color:#ccc; }
 
-  /* Per-marker trash button — shown on marker hover */
+  /* Per-marker trash button — shown on marker hover.
+     ::after pseudo-element extends the hoverable area down to bridge the gap
+     to the marker triangle without blocking marker drag interactions. */
   .vpw-trash-btn {
     position:absolute; top:1px; width:20px; height:14px;
     background:#222; border:1px solid #888; border-radius:3px;
@@ -114,15 +116,10 @@ const CSS = `
     transform:translateX(-50%); z-index:7;
     opacity:0; transition:opacity .1s, background .1s, border-color .1s, color .1s;
   }
-  .vpw-trash-btn:hover { background:#2d1a1a; border-color:#aa4444; color:#cc6666; }
-
-  /* Transparent bridge that extends from the add-zone into the marker zone,
-     creating a continuous hover column between the trash button and the marker
-     triangle. pointer-events toggled by JS — none by default so drags work. */
-  .vpw-marker-hover-bridge {
-    position:absolute; top:13px; height:16px; width:22px;
-    transform:translateX(-50%); pointer-events:none; z-index:7; cursor:pointer;
+  .vpw-trash-btn::after {
+    content:''; position:absolute; top:100%; left:-4px; right:-4px; height:10px;
   }
+  .vpw-trash-btn:hover { background:#2d1a1a; border-color:#aa4444; color:#cc6666; }
 
   /* ── Marker interaction zone (7px, sits below add-zone) ─────────────────── */
   .vpw-tl-marker-zone {
@@ -721,33 +718,18 @@ export default function VideoPlayerWidget(container, props) {
     return btn;
   }
 
-  /** Transparent div that bridges the gap between the trash button (add-zone) and
-   *  the marker triangle (marker-zone), giving the mouse a continuous hover path. */
-  function createMarkerHoverBridge(leftPx, addZoneEl) {
-    const bridge = document.createElement('div');
-    bridge.className = 'vpw-marker-hover-bridge';
-    bridge.style.left = leftPx;
-    addZoneEl.appendChild(bridge);
-    return bridge;
-  }
-
-  /** Wire mutual hover between a trash button, marker elements, and an optional bridge element. */
-  function wireTrashHover(trashBtn, markerEls, bridgeEl) {
+  /** Wire mutual hover between a trash button and marker elements (show/hide with debounce). */
+  function wireTrashHover(trashBtn, markerEls) {
     let timeout = null;
     const show = () => {
       clearTimeout(timeout);
       trashBtn.style.opacity = '1';
       trashBtn.style.pointerEvents = 'auto';
-      // Enable the bridge so it can relay hover while the mouse travels
-      // from the marker triangle up to the trash button.
-      if (bridgeEl) bridgeEl.style.pointerEvents = 'auto';
     };
     const hide = () => {
       timeout = setTimeout(() => {
         trashBtn.style.opacity = '0';
         trashBtn.style.pointerEvents = 'none';
-        // Disable the bridge again so it doesn't block marker drag interactions.
-        if (bridgeEl) bridgeEl.style.pointerEvents = 'none';
       }, 200);
     };
     for (const el of markerEls) {
@@ -756,10 +738,6 @@ export default function VideoPlayerWidget(container, props) {
     }
     trashBtn.addEventListener('mouseenter', show);
     trashBtn.addEventListener('mouseleave', hide);
-    if (bridgeEl) {
-      bridgeEl.addEventListener('mouseenter', show);
-      bridgeEl.addEventListener('mouseleave', hide);
-    }
   }
 
   /** Create a marker DOM element with a triangle cap and vertical dash line. */
@@ -788,7 +766,7 @@ export default function VideoPlayerWidget(container, props) {
     tlEl.querySelectorAll('.vpw-marker, .vpw-range-fill, .vpw-marker-range-bar, .vpw-nth-tick').forEach(m => m.remove());
 
     const addZone = tlEl.querySelector('[data-tl-addzone]');
-    if (addZone) addZone.querySelectorAll('.vpw-trash-btn, .vpw-marker-hover-bridge').forEach(t => t.remove());
+    if (addZone) addZone.querySelectorAll('.vpw-trash-btn').forEach(t => t.remove());
 
     if (totalFrames <= 1) return;
     const max = totalFrames - 1;
@@ -820,8 +798,7 @@ export default function VideoPlayerWidget(container, props) {
 
         if (addZone) {
           const trash = createTrashBtn(snap(pct), i, addZone);
-          const bridge = createMarkerHoverBridge(snap(pct), addZone);
-          wireTrashHover(trash, [el], bridge);
+          wireTrashHover(trash, [el]);
         }
       } else {
         const startPct = ((m.start - 1) / max) * 100;
@@ -854,8 +831,7 @@ export default function VideoPlayerWidget(container, props) {
         if (addZone) {
           const centerPct = (startPct + endPct) / 2;
           const trash = createTrashBtn(snap(centerPct), i, addZone);
-          const bridge = createMarkerHoverBridge(snap(centerPct), addZone);
-          wireTrashHover(trash, [startEl, endEl, bar], bridge);
+          wireTrashHover(trash, [startEl, endEl, bar]);
         }
       }
     }


### PR DESCRIPTION
# Summary
<img width="350" height="auto" alt="Screenshot 2026-04-30 at 12 55 32" src="https://github.com/user-attachments/assets/7f0642be-c0c6-40e8-8275-cc12a44af2a8" />

- Introduces BaseVideoInputNode, a format-agnostic abstract base for nodes that consume video but produce non-video output (images, audio, metadata). BaseVideoProcessor now inherits from it, so all existing nodes are unaffected.
- Adds ExtractFrames, a node that accepts a list of 1-based frame numbers and extracts each as an image file using ffmpeg.
- Adds VideoPlayerFrameSelector, a custom JS widget for frame-by-frame scrubbing and selection inside the node editor.


# Test plan
- Instantiate an existing BaseVideoProcessor subclass (e.g. CropVideo) and confirm parameter order and behaviour are unchanged
- Connect a video to ExtractFrames, provide a frame list (e.g. [1, 10, 50]), run the node, and verify output paths point to valid image files
- Verify ExtractFrames does not show output_frame_rate or processing_speed parameters
 Open the VideoPlayerFrameSelector widget and confirm frame scrubbing works end-to-end
