### PR TITLE
fix: resolve macro-path media inputs across video, audio, image, and splat nodes

### DIFF
--- a/griptape_nodes_library/audio/audio_details.py
+++ b/griptape_nodes_library/audio/audio_details.py
@@ -12,6 +12,7 @@ from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
 
@@ -171,7 +172,15 @@ class AudioDetails(DataNode):
             return None
 
         if isinstance(audio, AudioUrlArtifact):
-            return audio.value
+            # ``audio.value`` may be an HTTP URL, a project macro path
+            # (``{outputs}/clip.mp3``), or a plain filesystem path. ffprobe
+            # cannot resolve macro paths, so route through ``File`` first;
+            # for HTTP URLs ``File.resolve()`` is a no-op pass-through.
+            try:
+                return File(audio.value).resolve()
+            except FileLoadError as e:
+                logger.error(f"{self.name}: Failed to resolve audio path {audio.value}: {e}")
+                return None
 
         if isinstance(audio, AudioArtifact):
             # For AudioArtifact with bytes, save to temp file and return path

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -8,6 +8,7 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, Par
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
@@ -175,7 +176,15 @@ class TranscribeAudio(ControlNode):
             audio_artifact = audio
 
         if isinstance(audio_artifact, AudioUrlArtifact):
-            audio_artifact = AudioLoader().parse(audio_artifact.to_bytes())
+            # ``AudioUrlArtifact.to_bytes()`` issues an HTTP GET against ``self.value``,
+            # which fails when the value is a project macro path (e.g. ``{outputs}/clip.mp3``)
+            # emitted by upstream nodes that write through ``ProjectFileParameter``.
+            try:
+                audio_bytes = File(audio_artifact.value).read_bytes()
+            except FileLoadError as e:
+                msg = f"{self.name}: Failed to read audio from {audio_artifact.value}: {e}"
+                raise ValueError(msg) from e
+            audio_artifact = AudioLoader().parse(audio_bytes)
         task = AudioTranscriptionTask(audio_artifact, audio_transcription_driver=driver)
 
         # Set the new audio transcription task

--- a/griptape_nodes_library/image/extract_key_colors.py
+++ b/griptape_nodes_library/image/extract_key_colors.py
@@ -9,6 +9,7 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import File
 from griptape_nodes.traits.color_picker import ColorPicker
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
@@ -181,15 +182,19 @@ class ExtractKeyColors(SuccessFailureNode):
             raise ValueError(msg)
 
         try:
-            # Handle dictionary format (serialized artifacts)
+            # Handle dictionary format (serialized artifacts).
             if isinstance(image_artifact, dict):
-                # Convert dict to ImageUrlArtifact first
-                image_url_artifact = dict_to_image_url_artifact(image_artifact)
-                return image_url_artifact.to_bytes()
-            # Handle artifact objects directly
-            if isinstance(image_artifact, (ImageArtifact, ImageUrlArtifact)):
+                image_artifact = dict_to_image_url_artifact(image_artifact)
+
+            # ``ImageUrlArtifact.to_bytes()`` issues an HTTP GET against ``self.value``,
+            # which fails when the value is a project macro path emitted by upstream
+            # nodes that wrote through ``ProjectFileParameter``. Read via ``File`` instead
+            # so macro paths and plain filesystem paths resolve correctly.
+            if isinstance(image_artifact, ImageUrlArtifact):
+                return File(image_artifact.value).read_bytes()
+            if isinstance(image_artifact, ImageArtifact):
                 return image_artifact.to_bytes()
-            # Try to convert to bytes if it's a different artifact type
+            # Other artifact types: best-effort fall through.
             return image_artifact.to_bytes()
 
         except Exception as e:

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -10,6 +10,7 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from PIL import Image
 
@@ -153,7 +154,13 @@ class SaveImage(SuccessFailureNode):
 
         # Re-encode image bytes to the target format and write to disk
         try:
-            image_bytes = image_artifact.to_bytes()
+            if isinstance(image_artifact, ImageUrlArtifact):
+                # ``ImageUrlArtifact.to_bytes()`` issues an HTTP GET against ``self.value``,
+                # which fails when the value is a project macro path emitted by an upstream
+                # node that wrote through ``ProjectFileParameter`` (e.g. ``CreateColorBars``).
+                image_bytes = File(image_artifact.value).read_bytes()
+            else:
+                image_bytes = image_artifact.to_bytes()
             pil_image = Image.open(BytesIO(image_bytes))
             if target_format == "JPEG" and pil_image.mode in ("RGBA", "LA", "P"):
                 pil_image = pil_image.convert("RGB")

--- a/griptape_nodes_library/splat/world_labs_world_generation.py
+++ b/griptape_nodes_library/splat/world_labs_world_generation.py
@@ -620,21 +620,27 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
         }
 
     async def _get_media_bytes(self, media_input: Any) -> bytes | None:
-        """Get raw bytes from a media input (image or video)."""
+        """Get raw bytes from a media input (image or video).
+
+        URL-bearing artifacts (``ImageUrlArtifact``, ``VideoUrlArtifact``) hold a
+        URL/path string in ``.value`` and their ``to_bytes()`` issues an HTTP GET
+        against that string — which fails for project macro paths. Resolve string
+        ``.value`` payloads via ``File`` first; only fall back to ``to_bytes()``
+        for raw-bytes artifacts (``ImageArtifact``, ``VideoArtifact``).
+        """
         if not media_input:
             return None
 
-        # Prefer string-value path: File() resolves project macros like "{inputs}/...",
-        # local paths, URLs, and data URIs uniformly. UrlArtifact.to_bytes() calls
-        # requests.get() directly and would fail on unresolved macro paths.
+        # Plain string input: treat as URL / macro path / file path.
         if isinstance(media_input, str):
             return await self._string_to_bytes(media_input)
 
+        # Artifact-like with a string ``.value`` (URL / macro path / file path).
         value = getattr(media_input, "value", None)
         if isinstance(value, str) and value:
             return await self._string_to_bytes(value)
 
-        # Fall back to to_bytes() for artifacts whose value is binary (e.g. ImageArtifact).
+        # Raw-bytes artifacts: ``to_bytes()`` returns the in-memory payload.
         if hasattr(media_input, "to_bytes"):
             try:
                 return media_input.to_bytes()

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -1026,23 +1026,27 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
-        """Convert various image input types to a URL or data URI string."""
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
             # ImageUrlArtifact: .value holds URL string or file path
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v:
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
 
             # ImageArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -791,23 +791,27 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
-        """Convert various image input types to a URL or data URI string."""
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # ImageUrlArtifact: .value holds URL string
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             # ImageArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -410,23 +410,25 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_audio_url_or_data_uri(val: Any) -> str | None:
-        """Convert various audio input types to a URL or data URI string."""
+        """Extract a usable string from various audio input types.
+
+        Returns an HTTP(S) URL, a ``data:audio/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:audio/")) else f"data:audio/mpeg;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # AudioUrlArtifact: .value holds URL string
+            # AudioUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:audio/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             # AudioArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
@@ -438,23 +440,27 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
-        """Convert various image input types to a URL or data URI string."""
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # ImageUrlArtifact: .value holds URL string
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             # ImageArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -354,24 +354,28 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
-        """Convert various image input types to a URL or data URI string."""
+        """Extract a usable string from various image input types.
+
+        Returns one of: an HTTP(S) URL, a ``data:image/...;base64,`` URI, a project
+        macro path like ``{inputs}/foo.png``, or a plain filesystem path. All of
+        these are resolvable by ``File`` downstream; this helper does **not** try
+        to classify non-URI strings as base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # ImageUrlArtifact: .value holds URL string
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
-            # ImageArtifact: .base64 holds raw or data-URI
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+            # ImageArtifact: .base64 holds raw base64 or a data URI; wrap raw base64 as a data URI.
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -242,10 +242,38 @@ class LTXVideoRetake(GriptapeProxyNode):
             retake_segment_param.max_val = float(MAX_VIDEO_DURATION)
 
     def _extract_video_url(self, video_input: Any) -> str | None:
-        """Extract video URL from video input."""
-        if isinstance(video_input, VideoUrlArtifact):
-            return video_input.value
-        return str(video_input) if video_input else None
+        """Extract a usable video URL/path string from various input types."""
+        return self._coerce_video_url_or_data_uri(video_input)
+
+    @staticmethod
+    def _coerce_video_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various video input types.
+
+        Returns an HTTP(S) URL, a ``data:video/...`` URI, a project macro path
+        like ``{inputs}/foo.mp4``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
+        if val is None:
+            return None
+
+        if isinstance(val, str):
+            v = val.strip()
+            return v or None
+
+        try:
+            # VideoUrlArtifact / any artifact with .value holding a URL/path string.
+            v = getattr(val, "value", None)
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+            # VideoArtifact: .base64 holds raw or data-URI video bytes.
+            b64 = getattr(val, "base64", None)
+            if isinstance(b64, str) and b64:
+                return b64 if b64.startswith("data:video/") else f"data:video/mp4;base64,{b64}"
+        except AttributeError:
+            pass
+
+        return None
 
     def _update_segment_range_max(self, max_duration: float, actual_duration: float) -> None:
         """Update retake_segment max value and adjust current segment if needed."""
@@ -429,8 +457,7 @@ class LTXVideoRetake(GriptapeProxyNode):
         if not video_input:
             return None
 
-        # Get the video URL from VideoUrlArtifact
-        video_url = video_input.value if isinstance(video_input, VideoUrlArtifact) else str(video_input)
+        video_url = self._coerce_video_url_or_data_uri(video_input)
         if not video_url:
             return None
 

--- a/griptape_nodes_library/video/minimax_hailuo_video_generation.py
+++ b/griptape_nodes_library/video/minimax_hailuo_video_generation.py
@@ -507,23 +507,27 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
-        """Convert various image input types to a URL or data URI string."""
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # ImageUrlArtifact: .value holds URL string
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             # ImageArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:

--- a/griptape_nodes_library/video/omnihuman_subject_detection.py
+++ b/griptape_nodes_library/video/omnihuman_subject_detection.py
@@ -170,19 +170,26 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         try:
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"

--- a/griptape_nodes_library/video/omnihuman_subject_recognition.py
+++ b/griptape_nodes_library/video/omnihuman_subject_recognition.py
@@ -192,19 +192,26 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         try:
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -515,19 +515,26 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         try:
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
@@ -538,19 +545,22 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_audio_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various audio input types.
+
+        Returns an HTTP(S) URL, a ``data:audio/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:audio/")) else f"data:audio/mpeg;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:audio/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:audio/") else f"data:audio/mpeg;base64,{b64}"

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -803,6 +803,13 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
@@ -810,20 +817,24 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             value = val.get("value")
             artifact_type = val.get("type")
             if isinstance(value, str):
+                stripped = value.strip()
+                if not stripped:
+                    return None
                 if artifact_type == "ImageUrlArtifact":
-                    return value
-                if value.startswith(("http://", "https://", "data:image/")):
-                    return value
+                    return stripped
+                if stripped.startswith(("http://", "https://", "data:image/")):
+                    return stripped
                 if artifact_type == "ImageArtifact":
                     image_format = str(val.get("format") or "png").lower()
-                    return f"data:image/{image_format};base64,{value}"
+                    return f"data:image/{image_format};base64,{stripped}"
+                # Unknown artifact shape — return raw string and let File() resolve it.
+                return stripped
             return None
 
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         try:
             to_dict = getattr(val, "to_dict", None)
@@ -834,12 +845,11 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                     if coerced:
                         return coerced
 
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
             if isinstance(v, str):
                 stripped = v.strip()
                 if stripped:
-                    if stripped.startswith(("http://", "https://", "data:image/")):
-                        return stripped
                     return stripped
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:

--- a/griptape_nodes_library/video/seedance_video_generation.py
+++ b/griptape_nodes_library/video/seedance_video_generation.py
@@ -631,22 +631,27 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
-        # String handling
+        # Plain string: return stripped value; File() handles URLs, macro paths, and file paths.
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         # Artifact-like objects
         try:
-            # ImageUrlArtifact: .value holds URL string
+            # ImageUrlArtifact: .value holds URL/path string — return as-is for File() to resolve.
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             # ImageArtifact: .base64 holds raw or data-URI
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -308,19 +308,24 @@ class WanAnimateGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_image_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various image input types.
+
+        Returns an HTTP(S) URL, a ``data:image/...`` URI, a project macro path
+        like ``{inputs}/foo.png``, or a plain filesystem path. All of these are
+        resolvable by ``File`` downstream; non-URI strings are NOT wrapped as
+        base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:image/")) else f"data:image/png;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:image/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:image/") else f"data:image/png;base64,{b64}"
@@ -331,19 +336,22 @@ class WanAnimateGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_video_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various video input types.
+
+        Returns an HTTP(S) URL, a ``data:video/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:video/")) else f"data:video/mp4;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:video/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:video/") else f"data:video/mp4;base64,{b64}"

--- a/griptape_nodes_library/video/wan_image_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_image_to_video_generation.py
@@ -641,19 +641,22 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_audio_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various audio input types.
+
+        Returns an HTTP(S) URL, a ``data:audio/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:audio/")) else f"data:audio/mpeg;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:audio/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:audio/") else f"data:audio/mpeg;base64,{b64}"

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -538,19 +538,22 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_video_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various video input types.
+
+        Returns an HTTP(S) URL, a ``data:video/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:video/")) else f"data:video/mp4;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:video/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:video/") else f"data:video/mp4;base64,{b64}"
@@ -561,19 +564,22 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_audio_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various audio input types.
+
+        Returns an HTTP(S) URL, a ``data:audio/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:audio/")) else f"data:audio/mpeg;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:audio/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:audio/") else f"data:audio/mpeg;base64,{b64}"

--- a/griptape_nodes_library/video/wan_text_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_text_to_video_generation.py
@@ -545,19 +545,22 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _coerce_audio_url_or_data_uri(val: Any) -> str | None:
+        """Extract a usable string from various audio input types.
+
+        Returns an HTTP(S) URL, a ``data:audio/...`` URI, a project macro path,
+        or a plain filesystem path. Non-URI strings are NOT wrapped as base64.
+        """
         if val is None:
             return None
 
         if isinstance(val, str):
             v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "data:audio/")) else f"data:audio/mpeg;base64,{v}"
+            return v or None
 
         try:
             v = getattr(val, "value", None)
-            if isinstance(v, str) and v.startswith(("http://", "https://", "data:audio/")):
-                return v
+            if isinstance(v, str) and v.strip():
+                return v.strip()
             b64 = getattr(val, "base64", None)
             if isinstance(b64, str) and b64:
                 return b64 if b64.startswith("data:audio/") else f"data:audio/mpeg;base64,{b64}"

--- a/tests/unit/audio/test_audio_details.py
+++ b/tests/unit/audio/test_audio_details.py
@@ -1,0 +1,90 @@
+"""Tests that ``AudioDetails._get_audio_url`` resolves macro paths via ``File``.
+
+The ffprobe subprocess used by ``AudioDetails`` cannot understand project macro
+paths like ``{outputs}/clip.mp3`` that upstream nodes emit when they write
+through ``ProjectFileParameter``. The fix routes ``AudioUrlArtifact`` values
+through ``File(value).resolve()`` so macro paths become absolute paths and
+HTTP URLs pass through unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
+from griptape_nodes.files import file as file_module
+
+from griptape_nodes_library.audio.audio_details import AudioDetails
+
+
+@pytest.fixture
+def captured_paths(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    def fake_resolve(self: file_module.File) -> str:
+        return f"/resolved{paths[-1]}"
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "resolve", fake_resolve)
+    return paths
+
+
+def test_audio_url_artifact_macro_path_is_resolved_via_file(captured_paths: list[str]) -> None:
+    node = AudioDetails.__new__(AudioDetails)
+    node.name = "audio_details"
+    artifact = AudioUrlArtifact("{outputs}/clip.mp3")
+
+    result = node._get_audio_url(artifact)
+
+    assert result == "/resolved{outputs}/clip.mp3"
+    assert "{outputs}/clip.mp3" in captured_paths
+
+
+def test_audio_url_artifact_filesystem_path_is_resolved_via_file(captured_paths: list[str]) -> None:
+    node = AudioDetails.__new__(AudioDetails)
+    node.name = "audio_details"
+    artifact = AudioUrlArtifact("/abs/path/clip.mp3")
+
+    result = node._get_audio_url(artifact)
+
+    assert result == "/resolved/abs/path/clip.mp3"
+    assert "/abs/path/clip.mp3" in captured_paths
+
+
+def test_audio_url_artifact_http_url_is_resolved_via_file(captured_paths: list[str]) -> None:
+    """ffprobe handles HTTP URLs natively; ``File.resolve`` is a pass-through."""
+    node = AudioDetails.__new__(AudioDetails)
+    node.name = "audio_details"
+    artifact = AudioUrlArtifact("https://example.com/clip.mp3")
+
+    result = node._get_audio_url(artifact)
+
+    assert result == "/resolvedhttps://example.com/clip.mp3"
+    assert "https://example.com/clip.mp3" in captured_paths
+
+
+def test_falsy_audio_returns_none() -> None:
+    node = AudioDetails.__new__(AudioDetails)
+    node.name = "audio_details"
+    assert node._get_audio_url(None) is None  # pyright: ignore[reportArgumentType]
+
+
+def test_file_load_error_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+
+    def fail_resolve(self: file_module.File) -> str:
+        raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "boom")
+
+    monkeypatch.setattr(file_module.File, "resolve", fail_resolve)
+
+    node = AudioDetails.__new__(AudioDetails)
+    node.name = "audio_details"
+    artifact = AudioUrlArtifact("{outputs}/missing.mp3")
+
+    assert node._get_audio_url(artifact) is None

--- a/tests/unit/audio/test_transcribe_audio.py
+++ b/tests/unit/audio/test_transcribe_audio.py
@@ -1,0 +1,212 @@
+"""Tests that ``TranscribeAudio.process`` reads bytes via ``File`` for
+``AudioUrlArtifact`` inputs (issue #215).
+
+``AudioUrlArtifact.to_bytes()`` issues an HTTP GET against ``self.value`` and
+fails when the value is a project macro path (``{outputs}/Extract Audio.mp4``)
+emitted by upstream nodes that write through ``ProjectFileParameter`` (e.g.
+``ExtractAudio``). The fix routes ``AudioUrlArtifact`` inputs through
+``File(value).read_bytes()`` so macro paths and plain filesystem paths
+resolve correctly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
+from griptape_nodes.files import file as file_module
+
+import griptape_nodes_library.audio.transcribe_audio as transcribe_audio_module
+from griptape_nodes_library.audio.transcribe_audio import TranscribeAudio
+
+
+@pytest.fixture(autouse=True)
+def _stub_external_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace external dependencies (driver, agent, loader, task) with no-ops
+    so the test can drive ``process()`` up to the ``File`` call without
+    requiring API keys, real audio bytes, or actual transcription.
+    """
+
+    class FakeDriver:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    monkeypatch.setattr(transcribe_audio_module, "OpenAiAudioTranscriptionDriver", FakeDriver)
+
+    class FakeAgent:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.output = type("Out", (), {"value": "transcribed-text"})()
+
+        def from_dict(self, _data: dict) -> FakeAgent:
+            return self
+
+        def swap_task(self, _task: Any) -> None:
+            pass
+
+        def run(self, _tasks: list) -> None:
+            pass
+
+        def insert_false_memory(self, **_kwargs: Any) -> None:
+            pass
+
+        def restore_task(self) -> None:
+            pass
+
+        def to_dict(self) -> dict:
+            return {}
+
+    monkeypatch.setattr(transcribe_audio_module, "GtAgent", FakeAgent)
+
+    class FakeLoader:
+        def parse(self, _bytes: bytes) -> Any:
+            return type("AudioArtifact", (), {})()
+
+    monkeypatch.setattr(transcribe_audio_module, "AudioLoader", FakeLoader)
+
+    monkeypatch.setattr(
+        transcribe_audio_module,
+        "AudioTranscriptionTask",
+        lambda *_args, **_kwargs: object(),
+    )
+
+
+def _drive_process(node: TranscribeAudio) -> None:
+    """Drive ``process()`` past its single yield (the agent runner)."""
+    result = node.process()
+    if result is None:
+        return
+    try:
+        runner = next(result)
+    except StopIteration:
+        # Early return path (e.g. ``audio is None``) yields nothing.
+        return
+    runner()
+    try:
+        next(result)
+    except StopIteration:
+        pass
+
+
+def _make_node() -> TranscribeAudio:
+    node = TranscribeAudio(name="transcribe")
+    node.set_parameter_value("model", "whisper-1")
+    return node
+
+
+def test_audio_url_artifact_with_macro_path_reads_via_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {"paths": []}
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        captured["paths"].append(path)
+        real_init(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+
+    node = _make_node()
+    node.set_parameter_value("audio", AudioUrlArtifact("{outputs}/Extract Audio_output.mp4"))
+
+    _drive_process(node)
+
+    assert "{outputs}/Extract Audio_output.mp4" in captured["paths"]
+
+
+def test_audio_url_artifact_with_filesystem_path_reads_via_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+
+    node = _make_node()
+    node.set_parameter_value("audio", AudioUrlArtifact("/abs/path/clip.mp3"))
+
+    _drive_process(node)
+
+    assert "/abs/path/clip.mp3" in paths
+
+
+def test_audio_url_artifact_with_http_url_reads_via_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+
+    node = _make_node()
+    node.set_parameter_value("audio", AudioUrlArtifact("https://example.com/clip.mp3"))
+
+    _drive_process(node)
+
+    assert "https://example.com/clip.mp3" in paths
+
+
+def test_dict_serialized_audio_url_artifact_with_macro_path_reads_via_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+
+    node = _make_node()
+    node.set_parameter_value("audio", {"type": "AudioUrlArtifact", "value": "{outputs}/clip.mp3"})
+
+    _drive_process(node)
+
+    assert "{outputs}/clip.mp3" in paths
+
+
+def test_file_load_error_is_wrapped_as_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+
+    def fail_read(self: file_module.File) -> bytes:
+        raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "missing")
+
+    monkeypatch.setattr(file_module.File, "read_bytes", fail_read)
+
+    node = _make_node()
+    node.set_parameter_value("audio", AudioUrlArtifact("{outputs}/missing.mp3"))
+
+    with pytest.raises(ValueError, match="Failed to read audio from"):
+        _drive_process(node)
+
+
+def test_none_audio_returns_early_without_calling_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+
+    node = _make_node()
+    node.set_parameter_value("audio", None)
+
+    _drive_process(node)
+
+    assert paths == []
+    assert node.parameter_output_values.get("output") == "No audio provided"

--- a/tests/unit/image/test_extract_key_colors.py
+++ b/tests/unit/image/test_extract_key_colors.py
@@ -1,0 +1,129 @@
+"""Tests that ``ExtractKeyColors`` reads bytes via ``File`` for URL artifacts.
+
+``ImageUrlArtifact.to_bytes()`` does ``requests.get(self.value)``, which fails
+when ``.value`` is a project macro path like ``{outputs}/foo.png`` emitted by
+upstream nodes that wrote through ``ProjectFileParameter``. The fix routes
+URL artifacts through ``File(value).read_bytes()`` so macro paths and plain
+filesystem paths resolve correctly, while raw-bytes ``ImageArtifact`` inputs
+continue to use ``to_bytes()``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape.artifacts import ImageUrlArtifact
+from griptape_nodes.files import file as file_module
+
+import griptape_nodes_library.image.extract_key_colors as extract_key_colors_module
+from griptape_nodes_library.image.extract_key_colors import ExtractKeyColors
+
+CANNED_BYTES = b"\x89PNG\r\n\x1a\n-CANNED-IMAGE"
+
+
+@pytest.fixture
+def captured_paths(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Capture every path passed to ``File(...)`` and return canned bytes."""
+    paths: list[str] = []
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        paths.append(path)
+        real_init(self, path, *args, **kwargs)
+
+    def fake_read_bytes(self: file_module.File) -> bytes:
+        return CANNED_BYTES
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", fake_read_bytes)
+    return paths
+
+
+def test_image_url_artifact_with_macro_path_reads_via_file(captured_paths: list[str]) -> None:
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    artifact = ImageUrlArtifact("{outputs}/color_bars.png")
+
+    result = node._image_to_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert "{outputs}/color_bars.png" in captured_paths
+
+
+def test_image_url_artifact_with_filesystem_path_reads_via_file(captured_paths: list[str]) -> None:
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    artifact = ImageUrlArtifact("/abs/path/foo.png")
+
+    result = node._image_to_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert "/abs/path/foo.png" in captured_paths
+
+
+def test_image_url_artifact_with_http_url_reads_via_file(captured_paths: list[str]) -> None:
+    """File handles HTTP URLs via the engine's read pipeline, not requests.get
+    bypassing macro resolution.
+    """
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    artifact = ImageUrlArtifact("https://example.com/foo.png")
+
+    result = node._image_to_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert "https://example.com/foo.png" in captured_paths
+
+
+def test_dict_serialized_image_url_artifact_with_macro_path_reads_via_file(
+    captured_paths: list[str],
+) -> None:
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    serialized = {"type": "ImageUrlArtifact", "value": "{outputs}/foo.png"}
+
+    result = node._image_to_bytes(serialized)
+
+    assert result == CANNED_BYTES
+    assert "{outputs}/foo.png" in captured_paths
+
+
+def test_image_artifact_uses_to_bytes_directly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Raw-bytes ``ImageArtifact`` inputs must NOT route through ``File`` because
+    their ``.value`` is bytes, not a path/URL.
+    """
+
+    class FakeImageArtifact:
+        # Mimic griptape ImageArtifact's payload location well enough for isinstance.
+        pass
+
+    # Patch the type check so isinstance(fake, ImageArtifact) is True.
+    monkeypatch.setattr(extract_key_colors_module, "ImageArtifact", FakeImageArtifact)
+
+    file_calls: list[Any] = []
+
+    def fail_file_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        file_calls.append(path)
+
+    monkeypatch.setattr(file_module.File, "__init__", fail_file_init)
+
+    instance = FakeImageArtifact()
+    instance.to_bytes = lambda: b"RAW-BYTES"  # type: ignore[attr-defined]
+
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    result = node._image_to_bytes(instance)  # pyright: ignore[reportArgumentType]
+
+    assert result == b"RAW-BYTES"
+    assert file_calls == []  # File never constructed for raw-bytes artifacts
+
+
+def test_file_load_error_is_wrapped_as_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
+
+    def fail_read(self: file_module.File) -> bytes:
+        raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "missing")
+
+    monkeypatch.setattr(file_module.File, "read_bytes", fail_read)
+
+    node = ExtractKeyColors.__new__(ExtractKeyColors)
+    artifact = ImageUrlArtifact("{outputs}/missing.png")
+
+    with pytest.raises(ValueError, match="Failed to extract image data"):
+        node._image_to_bytes(artifact)

--- a/tests/unit/image/test_save_image.py
+++ b/tests/unit/image/test_save_image.py
@@ -1,0 +1,113 @@
+"""Tests that ``SaveImage`` reads bytes via ``File`` for URL artifacts.
+
+When an upstream node emits an ``ImageUrlArtifact`` whose ``.value`` is a
+project macro path (``{outputs}/foo.png``), calling
+``ImageUrlArtifact.to_bytes()`` does ``requests.get(self.value)`` and fails
+with "No scheme supplied". The fix routes ``ImageUrlArtifact`` inputs through
+``File(value).read_bytes()`` so macro paths and plain filesystem paths
+resolve correctly. Raw-bytes ``ImageArtifact`` inputs continue to use
+``to_bytes()``.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Any
+
+import pytest
+from griptape.artifacts import ImageArtifact
+from griptape_nodes.files import file as file_module
+from PIL import Image
+
+from griptape_nodes_library.image.save_image import SaveImage
+
+
+def _make_png_bytes() -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (1, 1), color="red").save(buf, "PNG")
+    return buf.getvalue()
+
+
+CANNED_BYTES = _make_png_bytes()
+SAVED_LOCATION = "{outputs}/saved.png"
+
+
+@pytest.fixture
+def file_capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {"paths": []}
+    real_init = file_module.File.__init__
+
+    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
+        captured["paths"].append(path)
+        real_init(self, path, *args, **kwargs)
+
+    def fake_read_bytes(self: file_module.File) -> bytes:
+        return CANNED_BYTES
+
+    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+    monkeypatch.setattr(file_module.File, "read_bytes", fake_read_bytes)
+    return captured
+
+
+@pytest.fixture
+def stub_output_file(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {"written": None}
+
+    class FakeSaved:
+        location = SAVED_LOCATION
+
+    class FakeDest:
+        def write_bytes(self, content: bytes) -> FakeSaved:
+            captured["written"] = content
+            return FakeSaved()
+
+    class FakeOutputFile:
+        _default_filename = "griptape_nodes.png"
+
+        def add_parameter(self) -> None:
+            pass
+
+        def build_file(self) -> FakeDest:
+            return FakeDest()
+
+    monkeypatch.setattr(
+        "griptape_nodes_library.image.save_image.ProjectFileParameter",
+        lambda **_kwargs: FakeOutputFile(),
+    )
+    return captured
+
+
+def test_dict_serialized_image_url_artifact_with_macro_path_reads_via_file(
+    file_capture: dict[str, Any], stub_output_file: dict[str, Any]
+) -> None:
+    """A dict-shaped ``ImageUrlArtifact`` with a macro-path value flows through
+    ``to_image_artifact`` (which returns an ``ImageUrlArtifact``) and previously
+    crashed at ``image_artifact.to_bytes()``. The fix detects the URL-artifact
+    case and uses ``File`` instead.
+    """
+    node = SaveImage(name="save")
+    serialized = {"type": "ImageUrlArtifact", "value": "{outputs}/color_bars.png"}
+    node.set_parameter_value("image", serialized)
+    node.process()
+
+    assert "{outputs}/color_bars.png" in file_capture["paths"]
+    # SaveImage re-encodes bytes to the target output format before writing,
+    # so we don't compare to the canned source bytes; just assert the write
+    # happened with non-empty bytes.
+    assert isinstance(stub_output_file["written"], bytes)
+    assert len(stub_output_file["written"]) > 0
+
+
+def test_image_artifact_uses_to_bytes_directly(file_capture: dict[str, Any], stub_output_file: dict[str, Any]) -> None:
+    """Raw-bytes ``ImageArtifact`` inputs must NOT route through ``File``."""
+    artifact = ImageArtifact(value=CANNED_BYTES, format="png", width=1, height=1)
+
+    node = SaveImage(name="save")
+    node.set_parameter_value("image", artifact)
+    node.process()
+
+    # ``ImageArtifact.to_bytes()`` returns the raw value; ``File`` should never
+    # have been constructed for this input.
+    assert file_capture["paths"] == []
+    assert isinstance(stub_output_file["written"], bytes)
+    assert len(stub_output_file["written"]) > 0

--- a/tests/unit/splat/test_world_labs_world_generation.py
+++ b/tests/unit/splat/test_world_labs_world_generation.py
@@ -1,0 +1,135 @@
+"""Tests that ``WorldLabsWorldGeneration._get_media_bytes`` resolves URL-bearing
+artifacts via ``File`` instead of attempting ``UrlArtifact.to_bytes()`` (which
+issues an HTTP GET against ``self.value`` and fails for project macro paths
+like ``{outputs}/foo.png``).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from griptape.artifacts import ImageUrlArtifact
+
+from griptape_nodes_library.splat.world_labs_world_generation import WorldLabsWorldGeneration
+
+CANNED_BYTES = b"BYTES-FROM-FILE"
+
+
+@pytest.fixture
+def node(monkeypatch: pytest.MonkeyPatch) -> WorldLabsWorldGeneration:
+    instance = WorldLabsWorldGeneration.__new__(WorldLabsWorldGeneration)
+    monkeypatch.setattr(instance, "_log", lambda *_args, **_kwargs: None, raising=False)
+    return instance
+
+
+@pytest.fixture
+def captured_paths(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    paths: list[str] = []
+
+    async def fake_string_to_bytes(self: WorldLabsWorldGeneration, value: str) -> bytes:
+        paths.append(value)
+        return CANNED_BYTES
+
+    monkeypatch.setattr(WorldLabsWorldGeneration, "_string_to_bytes", fake_string_to_bytes)
+    return paths
+
+
+@pytest.mark.asyncio
+async def test_image_url_artifact_with_macro_path_routes_through_file(
+    node: WorldLabsWorldGeneration, captured_paths: list[str]
+) -> None:
+    artifact = ImageUrlArtifact("{outputs}/foo.png")
+
+    result = await node._get_media_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert captured_paths == ["{outputs}/foo.png"]
+
+
+@pytest.mark.asyncio
+async def test_image_url_artifact_with_filesystem_path_routes_through_file(
+    node: WorldLabsWorldGeneration, captured_paths: list[str]
+) -> None:
+    artifact = ImageUrlArtifact("/abs/path/foo.png")
+
+    result = await node._get_media_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert captured_paths == ["/abs/path/foo.png"]
+
+
+@pytest.mark.asyncio
+async def test_image_url_artifact_with_http_url_routes_through_file(
+    node: WorldLabsWorldGeneration, captured_paths: list[str]
+) -> None:
+    artifact = ImageUrlArtifact("https://example.com/foo.png")
+
+    result = await node._get_media_bytes(artifact)
+
+    assert result == CANNED_BYTES
+    assert captured_paths == ["https://example.com/foo.png"]
+
+
+@pytest.mark.asyncio
+async def test_plain_string_input_routes_through_file(
+    node: WorldLabsWorldGeneration, captured_paths: list[str]
+) -> None:
+    result = await node._get_media_bytes("{outputs}/foo.png")
+    assert result == CANNED_BYTES
+    assert captured_paths == ["{outputs}/foo.png"]
+
+
+@pytest.mark.asyncio
+async def test_raw_bytes_artifact_uses_to_bytes_directly(
+    node: WorldLabsWorldGeneration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Raw-bytes artifacts (no string ``.value``) must use ``to_bytes()``; we
+    must NOT route them through ``File`` because their value is bytes, not a
+    path/URL.
+    """
+
+    async def should_not_be_called(self: WorldLabsWorldGeneration, value: str) -> bytes:
+        raise AssertionError("_string_to_bytes should not be called for raw-bytes artifacts")
+
+    monkeypatch.setattr(WorldLabsWorldGeneration, "_string_to_bytes", should_not_be_called)
+
+    artifact = SimpleNamespace(value=b"\x89PNG", to_bytes=lambda: b"RAW-BYTES")
+
+    result = await node._get_media_bytes(artifact)
+    assert result == b"RAW-BYTES"
+
+
+@pytest.mark.asyncio
+async def test_falsy_input_returns_none(node: WorldLabsWorldGeneration) -> None:
+    assert await node._get_media_bytes(None) is None
+    assert await node._get_media_bytes("") is None
+
+
+@pytest.mark.asyncio
+async def test_empty_string_value_artifact_returns_none(
+    node: WorldLabsWorldGeneration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An artifact whose ``.value`` is an empty string and which lacks
+    ``to_bytes`` should return None rather than asking File to resolve nothing.
+    """
+
+    async def should_not_be_called(self: WorldLabsWorldGeneration, value: str) -> bytes:
+        raise AssertionError("_string_to_bytes should not be called for empty values")
+
+    monkeypatch.setattr(WorldLabsWorldGeneration, "_string_to_bytes", should_not_be_called)
+
+    artifact = SimpleNamespace(value="")
+    assert await node._get_media_bytes(artifact) is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_input_type_returns_none(node: WorldLabsWorldGeneration) -> None:
+    """An object with neither a string ``.value`` nor ``to_bytes`` should not
+    crash; it should just return None.
+    """
+
+    class _Bare:
+        pass
+
+    assert await node._get_media_bytes(_Bare()) is None

--- a/tests/unit/video/test_input_coercion.py
+++ b/tests/unit/video/test_input_coercion.py
@@ -1,0 +1,576 @@
+"""Tests for ``_coerce_*_url_or_data_uri`` helpers across video nodes.
+
+These helpers normalize various image/video/audio inputs (plain strings,
+artifact objects, serialized artifact dicts) into a single string that is
+safe to hand to ``File(...).aread_data_uri()``. The helpers MUST pass through
+HTTP(S) URLs, ``data:`` URIs, project macro paths like ``{inputs}/foo.png``,
+and plain filesystem paths without wrapping them as raw base64. Wrapping is
+only applied to artifact ``.base64`` payloads (which are genuinely raw bytes).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from griptape.artifacts import ImageUrlArtifact
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+
+from griptape_nodes_library.video.kling_image_to_video_generation import KlingImageToVideoGeneration
+from griptape_nodes_library.video.kling_omni_video_generation import KlingOmniVideoGeneration
+from griptape_nodes_library.video.ltx_audio_to_video_generation import LTXAudioToVideoGeneration
+from griptape_nodes_library.video.ltx_image_to_video_generation import LTXImageToVideoGeneration
+from griptape_nodes_library.video.ltx_video_retake import LTXVideoRetake
+from griptape_nodes_library.video.minimax_hailuo_video_generation import MinimaxHailuoVideoGeneration
+from griptape_nodes_library.video.omnihuman_subject_detection import OmnihumanSubjectDetection
+from griptape_nodes_library.video.omnihuman_subject_recognition import OmnihumanSubjectRecognition
+from griptape_nodes_library.video.omnihuman_video_generation import OmnihumanVideoGeneration
+from griptape_nodes_library.video.seedance_2_0_video_generation import Seedance20VideoGeneration
+from griptape_nodes_library.video.seedance_video_generation import SeedanceVideoGeneration
+from griptape_nodes_library.video.wan_animate_generation import WanAnimateGeneration
+from griptape_nodes_library.video.wan_image_to_video_generation import WanImageToVideoGeneration
+from griptape_nodes_library.video.wan_reference_to_video_generation import WanReferenceToVideoGeneration
+from griptape_nodes_library.video.wan_text_to_video_generation import WanTextToVideoGeneration
+
+# ---------------------------------------------------------------------------
+# Helper registries
+# ---------------------------------------------------------------------------
+
+# Every node class whose ``_coerce_image_url_or_data_uri`` was modified in this
+# branch. Seedance 2.0 has dict-handling behavior that differs from the others
+# and is covered separately.
+IMAGE_HELPERS_GENERIC: list[tuple[str, Callable[[Any], str | None]]] = [
+    ("KlingImageToVideoGeneration", KlingImageToVideoGeneration._coerce_image_url_or_data_uri),
+    ("KlingOmniVideoGeneration", KlingOmniVideoGeneration._coerce_image_url_or_data_uri),
+    ("LTXAudioToVideoGeneration", LTXAudioToVideoGeneration._coerce_image_url_or_data_uri),
+    ("LTXImageToVideoGeneration", LTXImageToVideoGeneration._coerce_image_url_or_data_uri),
+    ("MinimaxHailuoVideoGeneration", MinimaxHailuoVideoGeneration._coerce_image_url_or_data_uri),
+    ("OmnihumanSubjectDetection", OmnihumanSubjectDetection._coerce_image_url_or_data_uri),
+    ("OmnihumanSubjectRecognition", OmnihumanSubjectRecognition._coerce_image_url_or_data_uri),
+    ("OmnihumanVideoGeneration", OmnihumanVideoGeneration._coerce_image_url_or_data_uri),
+    ("SeedanceVideoGeneration", SeedanceVideoGeneration._coerce_image_url_or_data_uri),
+    ("WanAnimateGeneration", WanAnimateGeneration._coerce_image_url_or_data_uri),
+]
+
+VIDEO_HELPERS: list[tuple[str, Callable[[Any], str | None]]] = [
+    ("LTXVideoRetake", LTXVideoRetake._coerce_video_url_or_data_uri),
+    ("WanAnimateGeneration", WanAnimateGeneration._coerce_video_url_or_data_uri),
+    ("WanReferenceToVideoGeneration", WanReferenceToVideoGeneration._coerce_video_url_or_data_uri),
+]
+
+AUDIO_HELPERS: list[tuple[str, Callable[[Any], str | None]]] = [
+    ("LTXAudioToVideoGeneration", LTXAudioToVideoGeneration._coerce_audio_url_or_data_uri),
+    ("OmnihumanVideoGeneration", OmnihumanVideoGeneration._coerce_audio_url_or_data_uri),
+    ("WanImageToVideoGeneration", WanImageToVideoGeneration._coerce_audio_url_or_data_uri),
+    ("WanReferenceToVideoGeneration", WanReferenceToVideoGeneration._coerce_audio_url_or_data_uri),
+    ("WanTextToVideoGeneration", WanTextToVideoGeneration._coerce_audio_url_or_data_uri),
+]
+
+
+def _ids(helpers: list[tuple[str, Callable[[Any], str | None]]]) -> list[str]:
+    return [name for name, _ in helpers]
+
+
+# ---------------------------------------------------------------------------
+# IMAGE helpers (excluding Seedance 2.0 which has special dict handling)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("_name", "helper"), IMAGE_HELPERS_GENERIC, ids=_ids(IMAGE_HELPERS_GENERIC))
+class TestImageHelpers:
+    def test_none_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper(None) is None
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t\n"])
+    def test_empty_string_returns_none(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://example.com/foo.png",
+            "https://example.com/foo.png",
+            "data:image/png;base64,QUJD",
+            "data:image/jpeg;base64,QUJD",
+        ],
+    )
+    def test_known_uri_strings_pass_through(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) == value
+
+    def test_strings_are_stripped(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper("  https://example.com/foo.png  ") == "https://example.com/foo.png"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "{inputs}/foo.png",
+            "{outputs}/color_bars.png",
+            "{workspace}/scene/frame.jpeg",
+        ],
+    )
+    def test_macro_paths_pass_through_unwrapped(
+        self, _name: str, helper: Callable[[Any], str | None], value: str
+    ) -> None:
+        # Critical fix: macro paths must NOT be wrapped as raw base64 since
+        # File() can resolve them downstream.
+        assert helper(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/tmp/foo.png",
+            "/abs/path/to/image.jpg",
+            "relative/path/foo.webp",
+            "image.png",
+        ],
+    )
+    def test_filesystem_paths_pass_through_unwrapped(
+        self, _name: str, helper: Callable[[Any], str | None], value: str
+    ) -> None:
+        assert helper(value) == value
+
+    def test_raw_string_is_not_wrapped_as_base64(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        # Even a string that "looks like" base64 is no longer auto-wrapped:
+        # if the caller wanted base64 data it would be on .base64 of an artifact.
+        assert helper("QUJDREVG") == "QUJDREVG"
+
+    def test_image_url_artifact_with_http_url(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = ImageUrlArtifact("https://example.com/foo.png")
+        assert helper(artifact) == "https://example.com/foo.png"
+
+    def test_image_url_artifact_with_macro_path(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        # The artifact .value branch previously gated on URL/data-URI prefix,
+        # which caused macro-path artifacts to fall through to None.
+        artifact = ImageUrlArtifact("{inputs}/foo.png")
+        assert helper(artifact) == "{inputs}/foo.png"
+
+    def test_image_url_artifact_with_filesystem_path(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = ImageUrlArtifact("/abs/path/foo.png")
+        assert helper(artifact) == "/abs/path/foo.png"
+
+    def test_artifact_value_is_stripped(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = SimpleNamespace(value="  {inputs}/foo.png  ", base64=None)
+        assert helper(artifact) == "{inputs}/foo.png"
+
+    def test_artifact_base64_raw_is_wrapped_as_data_uri(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = SimpleNamespace(value=None, base64="RAW_IMAGE_B64")
+        assert helper(artifact) == "data:image/png;base64,RAW_IMAGE_B64"
+
+    def test_artifact_base64_already_data_uri_passes_through(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=None, base64="data:image/jpeg;base64,RAW")
+        assert helper(artifact) == "data:image/jpeg;base64,RAW"
+
+    def test_artifact_value_takes_precedence_over_base64(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = SimpleNamespace(value="https://example.com/foo.png", base64="UNUSED")
+        assert helper(artifact) == "https://example.com/foo.png"
+
+    def test_empty_artifact_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = SimpleNamespace(value="", base64="")
+        assert helper(artifact) is None
+
+    def test_artifact_with_no_known_attrs_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        # Plain object that exposes neither .value nor .base64.
+        assert helper(SimpleNamespace()) is None
+
+    def test_artifact_with_non_string_value_falls_back_to_base64(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=123, base64="RAW")
+        assert helper(artifact) == "data:image/png;base64,RAW"
+
+
+# ---------------------------------------------------------------------------
+# VIDEO helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("_name", "helper"), VIDEO_HELPERS, ids=_ids(VIDEO_HELPERS))
+class TestVideoHelpers:
+    def test_none_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper(None) is None
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_string_returns_none(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://example.com/foo.mp4",
+            "https://example.com/foo.mp4",
+            "data:video/mp4;base64,QUJD",
+            "data:video/webm;base64,QUJD",
+        ],
+    )
+    def test_known_uri_strings_pass_through(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ["{inputs}/foo.mp4", "{outputs}/render.mp4", "/tmp/clip.mov", "relative/clip.mp4"],
+    )
+    def test_macro_paths_and_filesystem_paths_pass_through_unwrapped(
+        self, _name: str, helper: Callable[[Any], str | None], value: str
+    ) -> None:
+        assert helper(value) == value
+
+    def test_video_url_artifact_with_http_url(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = VideoUrlArtifact("https://example.com/foo.mp4")
+        assert helper(artifact) == "https://example.com/foo.mp4"
+
+    def test_video_url_artifact_with_macro_path(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = VideoUrlArtifact("{inputs}/foo.mp4")
+        assert helper(artifact) == "{inputs}/foo.mp4"
+
+    def test_artifact_base64_raw_is_wrapped_as_video_data_uri(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=None, base64="RAW_VIDEO_B64")
+        assert helper(artifact) == "data:video/mp4;base64,RAW_VIDEO_B64"
+
+    def test_artifact_base64_already_data_uri_passes_through(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=None, base64="data:video/webm;base64,RAW")
+        assert helper(artifact) == "data:video/webm;base64,RAW"
+
+    def test_strings_are_stripped(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper("  https://example.com/foo.mp4  ") == "https://example.com/foo.mp4"
+
+    def test_artifact_with_no_known_attrs_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper(SimpleNamespace()) is None
+
+
+# ---------------------------------------------------------------------------
+# AUDIO helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("_name", "helper"), AUDIO_HELPERS, ids=_ids(AUDIO_HELPERS))
+class TestAudioHelpers:
+    def test_none_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper(None) is None
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_empty_string_returns_none(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) is None
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://example.com/foo.mp3",
+            "https://example.com/foo.wav",
+            "data:audio/mpeg;base64,QUJD",
+            "data:audio/wav;base64,QUJD",
+        ],
+    )
+    def test_known_uri_strings_pass_through(self, _name: str, helper: Callable[[Any], str | None], value: str) -> None:
+        assert helper(value) == value
+
+    @pytest.mark.parametrize(
+        "value",
+        ["{inputs}/foo.mp3", "{outputs}/voice.wav", "/tmp/clip.mp3", "relative/clip.wav"],
+    )
+    def test_macro_paths_and_filesystem_paths_pass_through_unwrapped(
+        self, _name: str, helper: Callable[[Any], str | None], value: str
+    ) -> None:
+        assert helper(value) == value
+
+    def test_audio_url_artifact_with_macro_path(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        artifact = SimpleNamespace(value="{inputs}/voice.mp3", base64=None)
+        assert helper(artifact) == "{inputs}/voice.mp3"
+
+    def test_artifact_base64_raw_is_wrapped_as_audio_data_uri(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=None, base64="RAW_AUDIO_B64")
+        assert helper(artifact) == "data:audio/mpeg;base64,RAW_AUDIO_B64"
+
+    def test_artifact_base64_already_data_uri_passes_through(
+        self, _name: str, helper: Callable[[Any], str | None]
+    ) -> None:
+        artifact = SimpleNamespace(value=None, base64="data:audio/wav;base64,RAW")
+        assert helper(artifact) == "data:audio/wav;base64,RAW"
+
+    def test_strings_are_stripped(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper("  https://example.com/foo.mp3  ") == "https://example.com/foo.mp3"
+
+    def test_artifact_value_with_path_passes_through(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        # Plain filesystem path on .value (as Load Audio emits) must survive.
+        artifact = SimpleNamespace(value="/abs/path/voice.wav", base64=None)
+        assert helper(artifact) == "/abs/path/voice.wav"
+
+
+# ---------------------------------------------------------------------------
+# Seedance 2.0 image helper: dict path
+# ---------------------------------------------------------------------------
+
+
+class TestSeedance20ImageHelperDictPath:
+    """Seedance 2.0 also accepts serialized artifact dicts as inputs."""
+
+    helper = staticmethod(Seedance20VideoGeneration._coerce_image_url_or_data_uri)
+
+    def test_dict_with_image_url_artifact_type_passes_value_through(self) -> None:
+        result = self.helper({"type": "ImageUrlArtifact", "value": "https://example.com/foo.png"})
+        assert result == "https://example.com/foo.png"
+
+    def test_dict_with_image_url_artifact_type_passes_macro_path_through(self) -> None:
+        result = self.helper({"type": "ImageUrlArtifact", "value": "{inputs}/foo.png"})
+        assert result == "{inputs}/foo.png"
+
+    def test_dict_with_image_url_artifact_type_strips_whitespace(self) -> None:
+        result = self.helper({"type": "ImageUrlArtifact", "value": "  {inputs}/foo.png  "})
+        assert result == "{inputs}/foo.png"
+
+    def test_dict_with_url_value_passes_through_regardless_of_type(self) -> None:
+        result = self.helper({"type": "SomethingElse", "value": "https://example.com/foo.png"})
+        assert result == "https://example.com/foo.png"
+
+    def test_dict_with_data_uri_value_passes_through(self) -> None:
+        result = self.helper({"type": "ImageArtifact", "value": "data:image/png;base64,RAW"})
+        assert result == "data:image/png;base64,RAW"
+
+    def test_dict_with_image_artifact_wraps_with_format(self) -> None:
+        result = self.helper({"type": "ImageArtifact", "value": "RAW", "format": "jpeg"})
+        assert result == "data:image/jpeg;base64,RAW"
+
+    def test_dict_with_image_artifact_defaults_to_png_format(self) -> None:
+        result = self.helper({"type": "ImageArtifact", "value": "RAW"})
+        assert result == "data:image/png;base64,RAW"
+
+    def test_dict_with_image_artifact_lowercases_format(self) -> None:
+        result = self.helper({"type": "ImageArtifact", "value": "RAW", "format": "JPEG"})
+        assert result == "data:image/jpeg;base64,RAW"
+
+    def test_dict_with_unknown_type_and_macro_path_passes_through(self) -> None:
+        # This is the key fix for serialized artifacts with macro-path values.
+        # Previously the dict branch only handled ImageUrlArtifact / known
+        # data-URI prefixes / ImageArtifact, so an unknown type with a macro
+        # path returned None.
+        result = self.helper({"type": "RandomShape", "value": "{inputs}/foo.png"})
+        assert result == "{inputs}/foo.png"
+
+    def test_dict_with_unknown_type_and_filesystem_path_passes_through(self) -> None:
+        result = self.helper({"type": "RandomShape", "value": "/tmp/foo.png"})
+        assert result == "/tmp/foo.png"
+
+    def test_dict_with_no_type_and_macro_path_passes_through(self) -> None:
+        result = self.helper({"value": "{inputs}/foo.png"})
+        assert result == "{inputs}/foo.png"
+
+    def test_dict_with_empty_value_returns_none(self) -> None:
+        assert self.helper({"type": "ImageArtifact", "value": ""}) is None
+        assert self.helper({"type": "ImageArtifact", "value": "   "}) is None
+
+    def test_dict_with_non_string_value_returns_none(self) -> None:
+        assert self.helper({"type": "ImageArtifact", "value": 123}) is None
+        assert self.helper({"type": "ImageArtifact", "value": None}) is None
+
+    def test_dict_with_no_value_key_returns_none(self) -> None:
+        assert self.helper({"type": "ImageArtifact"}) is None
+
+    def test_object_with_to_dict_routes_through_dict_path(self) -> None:
+        class Fake:
+            def to_dict(self) -> dict:
+                return {"type": "ImageUrlArtifact", "value": "{inputs}/foo.png"}
+
+        assert self.helper(Fake()) == "{inputs}/foo.png"
+
+    def test_object_to_dict_returning_non_dict_falls_back_to_attrs(self) -> None:
+        class Fake:
+            def to_dict(self) -> str:
+                return "not-a-dict"
+
+            value = "{inputs}/fallback.png"
+            base64 = None
+
+        assert self.helper(Fake()) == "{inputs}/fallback.png"
+
+    def test_object_with_failing_to_dict_returns_none_safely(self) -> None:
+        # The outer try/except swallows the exception; we just need to assert
+        # the helper does not propagate it. (The .value fallback only runs when
+        # to_dict either is missing or returns a dict that does not coerce.)
+        class Fake:
+            def to_dict(self) -> dict:
+                raise RuntimeError("boom")
+
+        assert self.helper(Fake()) is None
+
+    def test_plain_string_macro_path_passes_through(self) -> None:
+        # Confirms the non-dict, non-artifact string branch matches the
+        # generic helper behavior.
+        assert self.helper("{inputs}/foo.png") == "{inputs}/foo.png"
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoRetake: _extract_video_url delegates to _coerce_video_url_or_data_uri
+# ---------------------------------------------------------------------------
+
+
+class TestLTXVideoRetakeExtractVideoUrl:
+    """``_extract_video_url`` is a thin wrapper that previously str()'d unknown
+    inputs (which would mangle artifact objects). It now delegates to the new
+    ``_coerce_video_url_or_data_uri`` helper.
+    """
+
+    def test_extracts_url_from_video_url_artifact(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)  # bypass __init__
+        artifact = VideoUrlArtifact("https://example.com/foo.mp4")
+        assert node._extract_video_url(artifact) == "https://example.com/foo.mp4"
+
+    def test_extracts_macro_path_from_video_url_artifact(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        artifact = VideoUrlArtifact("{inputs}/foo.mp4")
+        assert node._extract_video_url(artifact) == "{inputs}/foo.mp4"
+
+    def test_extracts_plain_string_macro_path(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert node._extract_video_url("{inputs}/foo.mp4") == "{inputs}/foo.mp4"
+
+    def test_extracts_plain_string_url(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert node._extract_video_url("https://example.com/foo.mp4") == "https://example.com/foo.mp4"
+
+    def test_returns_none_for_none(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert node._extract_video_url(None) is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert node._extract_video_url("") is None
+
+    def test_returns_none_for_whitespace_string(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert node._extract_video_url("   ") is None
+
+    def test_extracts_value_from_generic_artifact_with_value_attr(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        artifact = SimpleNamespace(value="{inputs}/foo.mp4", base64=None)
+        assert node._extract_video_url(artifact) == "{inputs}/foo.mp4"
+
+    def test_wraps_raw_base64_from_video_artifact(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        artifact = SimpleNamespace(value=None, base64="RAW_VIDEO_B64")
+        assert node._extract_video_url(artifact) == "data:video/mp4;base64,RAW_VIDEO_B64"
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoRetake: _prepare_video_data_uri_async passes macro paths to File()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLTXVideoRetakePrepareDataUriAsync:
+    """Verifies that the helper output threads correctly into ``File()`` so
+    macro paths and filesystem paths are resolved by File rather than wrapped
+    as raw base64 (the original bug).
+    """
+
+    async def test_macro_path_string_is_handed_to_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        captured: dict[str, str] = {}
+
+        from griptape_nodes.files import file as file_module
+
+        original_init = file_module.File.__init__
+
+        def capture_init(self: file_module.File, path: str, *args: Any, **kwargs: Any) -> None:
+            captured["path"] = path
+            original_init(self, path, *args, **kwargs)
+
+        async def fake_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
+            return "data:video/mp4;base64,RESOLVED"
+
+        monkeypatch.setattr(file_module.File, "__init__", capture_init)
+        monkeypatch.setattr(file_module.File, "aread_data_uri", fake_aread)
+
+        result = await node._prepare_video_data_uri_async("{inputs}/clip.mp4")
+        assert result == "data:video/mp4;base64,RESOLVED"
+        assert captured["path"] == "{inputs}/clip.mp4"
+
+    async def test_filesystem_path_string_is_handed_to_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        captured: dict[str, str] = {}
+
+        from griptape_nodes.files import file as file_module
+
+        original_init = file_module.File.__init__
+
+        def capture_init(self: file_module.File, path: str, *args: Any, **kwargs: Any) -> None:
+            captured["path"] = path
+            original_init(self, path, *args, **kwargs)
+
+        async def fake_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
+            return "data:video/mp4;base64,RESOLVED"
+
+        monkeypatch.setattr(file_module.File, "__init__", capture_init)
+        monkeypatch.setattr(file_module.File, "aread_data_uri", fake_aread)
+
+        result = await node._prepare_video_data_uri_async("/tmp/clip.mp4")
+        assert result == "data:video/mp4;base64,RESOLVED"
+        assert captured["path"] == "/tmp/clip.mp4"
+
+    async def test_video_url_artifact_with_macro_path_is_handed_to_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        captured: dict[str, str] = {}
+
+        from griptape_nodes.files import file as file_module
+
+        original_init = file_module.File.__init__
+
+        def capture_init(self: file_module.File, path: str, *args: Any, **kwargs: Any) -> None:
+            captured["path"] = path
+            original_init(self, path, *args, **kwargs)
+
+        async def fake_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
+            return "data:video/mp4;base64,RESOLVED"
+
+        monkeypatch.setattr(file_module.File, "__init__", capture_init)
+        monkeypatch.setattr(file_module.File, "aread_data_uri", fake_aread)
+
+        result = await node._prepare_video_data_uri_async(VideoUrlArtifact("{inputs}/clip.mp4"))
+        assert result == "data:video/mp4;base64,RESOLVED"
+        assert captured["path"] == "{inputs}/clip.mp4"
+
+    async def test_data_uri_input_is_returned_without_calling_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+
+        from griptape_nodes.files import file as file_module
+
+        async def fail_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
+            raise AssertionError("File.aread_data_uri must not be called for data: URIs")
+
+        monkeypatch.setattr(file_module.File, "aread_data_uri", fail_aread)
+
+        result = await node._prepare_video_data_uri_async("data:video/mp4;base64,ALREADY_BASE64")
+        assert result == "data:video/mp4;base64,ALREADY_BASE64"
+
+    async def test_returns_none_for_falsy_input(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        assert await node._prepare_video_data_uri_async(None) is None
+        assert await node._prepare_video_data_uri_async("") is None
+        assert await node._prepare_video_data_uri_async(0) is None
+
+    async def test_returns_none_when_helper_resolves_to_none(self) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        # A non-falsy input that the coercer cannot resolve to a string.
+        assert await node._prepare_video_data_uri_async(SimpleNamespace()) is None
+
+    async def test_file_load_error_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = LTXVideoRetake.__new__(LTXVideoRetake)
+        node.name = "LTXVideoRetake"
+
+        from griptape_nodes.files import file as file_module
+        from griptape_nodes.files.file import FileIOFailureReason
+
+        async def fail_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
+            raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "nope")
+
+        monkeypatch.setattr(file_module.File, "aread_data_uri", fail_aread)
+
+        assert await node._prepare_video_data_uri_async("{inputs}/missing.mp4") is None

--- a/tests/unit/video/test_input_coercion.py
+++ b/tests/unit/video/test_input_coercion.py
@@ -566,7 +566,7 @@ class TestLTXVideoRetakePrepareDataUriAsync:
         node.name = "LTXVideoRetake"
 
         from griptape_nodes.files import file as file_module
-        from griptape_nodes.files.file import FileIOFailureReason
+        from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
 
         async def fail_aread(self: file_module.File, fallback_mime: str = "application/octet-stream") -> str:
             raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "nope")


### PR DESCRIPTION
When upstream nodes that write through `ProjectFileParameter` (like `CreateColorBars`, `ExtractAudio`, `LoadImage`) emit a `*UrlArtifact` whose `.value` is a project macro path such as `{outputs}/foo.png`, downstream nodes that try to consume that value fail in node-specific ways. The video-generation/processing nodes raised "requires an input image"; `TranscribeAudio` raised `Invalid URL '{outputs}/Extract Audio_output.mp4': No scheme supplied`. Same root cause, different symptoms.

The internal `_coerce_*_url_or_data_uri` helpers across the video library did two broken things: plain strings that didn't start with `http://`, `https://`, or `data:image/` were eagerly wrapped as `data:image/png;base64,<string>` (so `{inputs}/foo.png` became `data:image/png;base64,{inputs}/foo.png` — garbage); and the artifact `.value` branch gated on the same prefix check and fell through to look for `.base64` (which doesn't exist on `*UrlArtifact`), returning `None`. The downstream node interpreted `None` as "no input provided."

A separate set of nodes outside the video module had the same family of bug at a different layer: they called `*UrlArtifact.to_bytes()` directly (which does `requests.get(self.value)`) or passed `.value` straight to subprocess/ffprobe/PIL. Macro paths went through to those external libraries unchanged and got rejected.

The fix in both cases is to defer string classification to `File`, which already understands HTTP(S) URLs, data URIs, project macro paths, and plain filesystem paths uniformly. The helpers now just extract the raw string from plain input or artifact `.value`, strip it, and return it for `File(...).aread_data_uri()` / `File(...).read_bytes()` / `File(...).resolve()` to resolve. Raw base64 on `ImageArtifact.base64` / `AudioArtifact.base64` / `VideoArtifact.base64` is still wrapped as a data URI because that path is genuinely raw bytes.

Affected sites:

- 15 video-generation/processing helpers (`_coerce_*_url_or_data_uri`) across `ltx_image_to_video_generation`, `ltx_audio_to_video_generation`, `ltx_video_retake`, `kling_image_to_video_generation`, `kling_omni_video_generation`, `minimax_hailuo_video_generation`, `omnihuman_subject_detection`, `omnihuman_subject_recognition`, `omnihuman_video_generation`, `seedance_video_generation`, `seedance_2_0_video_generation`, `wan_animate_generation`, `wan_reference_to_video_generation`, `wan_image_to_video_generation`, `wan_text_to_video_generation`. `ltx_video_retake` also gets a dedicated `_coerce_video_url_or_data_uri` where the node previously used an ad-hoc extractor with the same gap.
- `audio/transcribe_audio.py`: `AudioUrlArtifact` audio bytes now read via `File(value).read_bytes()` instead of `to_bytes()`.
- `audio/audio_details.py`: `_get_audio_url` resolves `AudioUrlArtifact.value` via `File(value).resolve()` before ffprobe.
- `image/save_image.py`: when `to_image_artifact()` returns an `ImageUrlArtifact` (from a dict-shaped input), bytes are read via `File(value).read_bytes()` instead of `to_bytes()`.
- `image/extract_key_colors.py`: `_image_to_bytes` reads URL-bearing artifacts via `File(value).read_bytes()` and reserves `to_bytes()` for raw `ImageArtifact` only.
- `splat/world_labs_world_generation.py`: `_get_media_bytes` checks for string `.value` first and routes through `File`, only falling back to `to_bytes()` for raw-bytes artifacts.

I also did a comprehensive sweep of every site that consumes `*UrlArtifact` inputs (`rg .to_bytes\(\)`, `rg requests\.|httpx\.|urlopen`, `rg <T>UrlArtifact\.value`) and audited each hit. The list above is the complete set of currently-broken sites I could find. Sites that already route through `File()` (`combine_audio`, `concatenate_videos`, `crop_video`, `resize_video`, `base_video_processor`, `apply_mask`, `image_bash`, `paint_mask`, `flux_image_generation`, `flux_2_image_generation`, `qwen_image_generation`, `qwen_image_edit`, `grok_image_generation`, `grok_image_edit`, `wan_image_generation`, `kling_omni_video_generation`, `omnihuman_video_generation`, etc.) and sites that type-check before calling `to_bytes()` (`combine_masks`, `image_grid_splitter`, `merge_images`, `add_text_to_existing_image`) are unaffected.

Tests live in `tests/unit/video/test_input_coercion.py` (435 cases parametrized across all 15 video helpers, plus a dedicated suite for `LTXVideoRetake._extract_video_url` and `_prepare_video_data_uri_async` that monkeypatches `File.__init__` to verify macro paths reach `File()` unwrapped) and in five new files for the non-video fixes (`tests/unit/audio/test_transcribe_audio.py`, `tests/unit/audio/test_audio_details.py`, `tests/unit/image/test_save_image.py`, `tests/unit/image/test_extract_key_colors.py`, `tests/unit/splat/test_world_labs_world_generation.py`). I verified each fix catches its bug by stashing the production change and observing the corresponding new tests fail loudly, then restoring and observing them pass. 462 new tests pass; the 9 pre-existing unit failures on `main` (unrelated BYOK + Seedance 2.0 tests) are unchanged.

A note about CI: the existing `tests/workflows/test_integration_workflows.py` runs only on push to `main` and `merge_group`, not on PRs, so this PR doesn't get integration coverage at PR time. And separately, the advanced workflow integration files (image-to-video, video-input, video-and-prompt, etc., generated by `scripts/generate_test_workflows.py`) don't include a `StartFlow` control node, so the engine resolves only `EndFlow` and never executes the gen node under test. I confirmed this experimentally by injecting `raise ValueError("FORCED_TEST_ERROR_MARKER_xyz123")` at the top of `LTXImageToVideoGeneration._build_payload` and observing the integration test still pass in 4.4 seconds. Fixing both gaps (running unit tests on PRs, plus making the generator's advanced templates wire up a real control flow) would close the test-coverage hole that let this regression land in the first place. I'm leaving those for follow-up PRs.

Closes #178
Closes #43
Closes #215