### PR TITLE
Support all Rodin file types

### DIFF
--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMessage, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_components.seed_parameter import SeedParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
@@ -144,6 +144,21 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 ui_options={"display_name": "File Format"},
             )
         )
+
+        # Only GLB renders in the built-in 3D viewer; warn users when they pick anything else.
+        self.add_node_element(
+            ParameterMessage(
+                name="non_glb_viewer_warning",
+                title="Preview not supported",
+                variant="warning",
+                value=(
+                    "The 3D viewer only renders GLB. Files in the selected format will still "
+                    "be saved to disk, but no in-app preview will appear. Use GLB if you need "
+                    "an in-app preview."
+                ),
+            )
+        )
+        self.hide_message_by_name("non_glb_viewer_warning")
 
         # Material parameter
         self.add_parameter(
@@ -329,6 +344,11 @@ class Rodin23DGeneration(GriptapeProxyNode):
             if new_output_file != current:
                 self.set_parameter_value("output_file", new_output_file)
                 self.publish_update_to_parameter("output_file", new_output_file)
+
+            if value.lower() == "usdz":
+                self.show_message_by_name("usdz_viewer_warning")
+            else:
+                self.hide_message_by_name("usdz_viewer_warning")
 
         # Convert string paths to ImageUrlArtifact by uploading to static storage
         # Handle both the list parameter itself and individual child parameters

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -35,7 +35,7 @@ MAX_INPUT_IMAGES = 5
 # Output format options
 GLB_FORMAT = "glb"
 GEOMETRY_FORMAT_OPTIONS = [GLB_FORMAT, "usdz", "fbx", "obj", "stl"]
-DEFAULT_GEOMETRY_FORMAT = "GLB_FORMAT"
+DEFAULT_GEOMETRY_FORMAT = GLB_FORMAT
 
 # Material options
 MATERIAL_OPTIONS = ["PBR", "Shaded", "All"]
@@ -656,11 +656,20 @@ class Rodin23DGeneration(GriptapeProxyNode):
         primary_name, _ = max(primary_candidates, key=lambda item: len(item[1]))
         self._log(f"Selected primary .{requested_format}: {primary_name} (largest by size)")
 
-        # Derive the shared sub-directory from the user's output_file so every
-        # companion file lands next to the preview.
+        # Derive the preview's target path from the user's output_file, but always
+        # force the .webp extension since Rodin's preview is always a webp regardless
+        # of the selected geometry_file_format. Companion files land in the same
+        # directory, keeping their Rodin-assigned names and extensions.
         output_file_value = self.get_parameter_value("output_file") or "preview.webp"
-        sub_dir = str(Path(output_file_value).parent)
+        output_path = Path(output_file_value)
+        preview_filename = str(output_path.with_suffix(".webp"))
+        sub_dir = str(output_path.parent)
         sub_dir_prefix = "" if sub_dir in ("", ".") else sub_dir
+
+        # Clear prior run state so repeated executions don't accumulate outputs.
+        self.parameter_output_values["all_files"] = []
+        self.parameter_output_values["preview_image"] = None
+        self.parameter_output_values["model_url"] = None
 
         all_file_urls: list[str] = []
         primary_url: str | None = None
@@ -672,8 +681,11 @@ class Rodin23DGeneration(GriptapeProxyNode):
             try:
                 is_preview = file_name == preview_name
                 if is_preview:
-                    # Preview honors the user-configured output_file parameter.
-                    dest = self._output_file.build_file()
+                    # Preview follows the user's output_file directory + stem but is
+                    # always saved as .webp.
+                    dest = ProjectFileDestination.from_situation(
+                        filename=preview_filename, situation="save_node_output"
+                    )
                 else:
                     # All other files keep their Rodin-assigned names but share
                     # the preview's parent directory.

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -15,6 +15,7 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
 from griptape_nodes.files.file import File, FileLoadError
+from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
@@ -320,6 +321,15 @@ class Rodin23DGeneration(GriptapeProxyNode):
         super().after_value_set(parameter, value)
         self._seed_parameter.after_value_set(parameter, value)
 
+        # Keep output_file's extension in sync with the selected geometry_file_format
+        if parameter.name == "geometry_file_format" and isinstance(value, str) and value:
+            current = self.get_parameter_value("output_file") or "model"
+            base = current.rsplit(".", 1)[0] if "." in current else current
+            new_output_file = f"{base}.{value}"
+            if new_output_file != current:
+                self.set_parameter_value("output_file", new_output_file)
+                self.publish_update_to_parameter("output_file", new_output_file)
+
         # Convert string paths to ImageUrlArtifact by uploading to static storage
         # Handle both the list parameter itself and individual child parameters
         is_input_images = parameter.name == "input_images"
@@ -577,12 +587,21 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 file_bytes = await self._download_bytes_from_url(file_url)
 
                 if file_bytes:
-                    dest = self._output_file.build_file()
+                    is_primary = file_name == primary_name
+                    if is_primary:
+                        # Primary honors the user-configured output_file parameter.
+                        dest = self._output_file.build_file()
+                    else:
+                        # Companion files (textures/materials/preview) keep their
+                        # original filename so their extension is preserved.
+                        dest = ProjectFileDestination.from_situation(
+                            filename=file_name, situation="save_node_output"
+                        )
                     saved = await dest.awrite_bytes(file_bytes)
                     all_file_urls.append(saved.location)
                     self._log(f"Saved file: {saved.name}")
 
-                    if file_name == primary_name:
+                    if is_primary:
                         primary_url = saved.location
                         primary_filename = saved.name
 

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -31,8 +31,9 @@ __all__ = ["Rodin23DGeneration"]
 MAX_INPUT_IMAGES = 5
 
 # Output format options
-GEOMETRY_FORMAT_OPTIONS = ["glb", "usdz", "fbx", "obj", "stl"]
-DEFAULT_GEOMETRY_FORMAT = "glb"
+GLB_FORMAT = "glb"
+GEOMETRY_FORMAT_OPTIONS = [GLB_FORMAT, "usdz", "fbx", "obj", "stl"]
+DEFAULT_GEOMETRY_FORMAT = "GLB_FORMAT"
 
 # Material options
 MATERIAL_OPTIONS = ["PBR", "Shaded", "All"]
@@ -345,10 +346,10 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 self.set_parameter_value("output_file", new_output_file)
                 self.publish_update_to_parameter("output_file", new_output_file)
 
-            if value.lower() == "usdz":
-                self.show_message_by_name("usdz_viewer_warning")
+            if value.lower() != GLB_FORMAT:
+                self.show_message_by_name("non_glb_viewer_warning")
             else:
-                self.hide_message_by_name("usdz_viewer_warning")
+                self.hide_message_by_name("non_glb_viewer_warning")
 
         # Convert string paths to ImageUrlArtifact by uploading to static storage
         # Handle both the list parameter itself and individual child parameters

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -538,6 +538,29 @@ class Rodin23DGeneration(GriptapeProxyNode):
         """Download and save the generated 3D model files."""
         requested_format = params["geometry_file_format"]
 
+        # Identify the primary file by requested format before downloading anything,
+        # so a non-matching file returned first doesn't win by default.
+        received_names = [f.get("name", "") for f in files]
+        primary_name = next(
+            (name for name in received_names if name.lower().endswith(f".{requested_format}")),
+            None,
+        )
+        if primary_name is None:
+            logger.warning(
+                "Rodin did not return a .%s file in the response; received: %s",
+                requested_format,
+                received_names,
+            )
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"Rodin did not return a .{requested_format} file in the response; "
+                    f"received: {received_names}"
+                ),
+            )
+            return
+
         all_file_urls: list[str] = []
         primary_url: str | None = None
         primary_filename: str | None = None
@@ -559,12 +582,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
                     all_file_urls.append(saved.location)
                     self._log(f"Saved file: {saved.name}")
 
-                    # Track primary model file
-                    if file_name.lower().endswith(f".{requested_format}") and primary_url is None:
-                        primary_url = saved.location
-                        primary_filename = saved.name
-                    elif primary_url is None:
-                        # Use first file as fallback
+                    if file_name == primary_name:
                         primary_url = saved.location
                         primary_filename = saved.name
 

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from contextlib import suppress
+from pathlib import Path
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
@@ -11,6 +12,7 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_components.seed_parameter import SeedParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
@@ -304,6 +306,19 @@ class Rodin23DGeneration(GriptapeProxyNode):
             )
         )
 
+        # Preview image is shown in place of the 3D viewer for formats the viewer
+        # cannot render (anything other than GLB). Hidden by default; toggled in
+        # after_value_set whenever geometry_file_format changes.
+        self.add_parameter(
+            ParameterImage(
+                name="preview_image",
+                tooltip="Preview image of the generated 3D model (shown when the selected format is not renderable in the 3D viewer).",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True, "display_name": "Preview", "hide": True},
+            )
+        )
+
         self.add_parameter(
             Parameter(
                 name="all_files",
@@ -318,7 +333,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
-            default_filename="model.glb",
+            default_filename="preview.webp",
         )
         self._output_file.add_parameter()
 
@@ -337,19 +352,19 @@ class Rodin23DGeneration(GriptapeProxyNode):
         super().after_value_set(parameter, value)
         self._seed_parameter.after_value_set(parameter, value)
 
-        # Keep output_file's extension in sync with the selected geometry_file_format
+        # The 3D viewer only renders GLB. For other formats, swap the model_url
+        # display for the preview_image so the user still sees the generated result.
+        # output_file is the preview (.webp) and stays constant across format changes;
+        # all model files are saved next to it.
         if parameter.name == "geometry_file_format" and isinstance(value, str) and value:
-            current = self.get_parameter_value("output_file") or "model"
-            base = current.rsplit(".", 1)[0] if "." in current else current
-            new_output_file = f"{base}.{value}"
-            if new_output_file != current:
-                self.set_parameter_value("output_file", new_output_file)
-                self.publish_update_to_parameter("output_file", new_output_file)
-
             if value.lower() != GLB_FORMAT:
                 self.show_message_by_name("non_glb_viewer_warning")
+                self.hide_parameter_by_name("model_url")
+                self.show_parameter_by_name("preview_image")
             else:
                 self.hide_message_by_name("non_glb_viewer_warning")
+                self.show_parameter_by_name("model_url")
+                self.hide_parameter_by_name("preview_image")
 
         # Convert string paths to ImageUrlArtifact by uploading to static storage
         # Handle both the list parameter itself and individual child parameters
@@ -566,11 +581,14 @@ class Rodin23DGeneration(GriptapeProxyNode):
         await self._save_model_files(files, params)
 
     async def _save_model_files(self, files: list[dict[str, Any]], params: dict[str, Any]) -> None:
-        """Download and save the generated 3D model files."""
+        """Download and save the generated 3D model files.
+
+        The preview (.webp) is saved to the user-configured `output_file` path; all
+        other files (mesh, textures, materials) are saved alongside it in the same
+        directory, preserving their original Rodin-assigned filenames and extensions.
+        """
         requested_format = params["geometry_file_format"]
 
-        # Identify the primary file by requested format before downloading anything,
-        # so a non-matching file returned first doesn't win by default.
         received_names = [f.get("name", "") for f in files]
         primary_name = next(
             (name for name in received_names if name.lower().endswith(f".{requested_format}")),
@@ -592,9 +610,22 @@ class Rodin23DGeneration(GriptapeProxyNode):
             )
             return
 
+        preview_name = next(
+            (name for name in received_names if name.lower().endswith(".webp")),
+            None,
+        )
+
+        # Derive the shared sub-directory from the user's output_file so every
+        # companion file lands next to the preview.
+        output_file_value = self.get_parameter_value("output_file") or "preview.webp"
+        sub_dir = str(Path(output_file_value).parent)
+        sub_dir_prefix = "" if sub_dir in ("", ".") else sub_dir
+
         all_file_urls: list[str] = []
         primary_url: str | None = None
         primary_filename: str | None = None
+        preview_url: str | None = None
+        preview_saved_name: str | None = None
 
         for idx, file_info in enumerate(files):
             file_url = file_info.get("url")
@@ -608,29 +639,40 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 file_bytes = await self._download_bytes_from_url(file_url)
 
                 if file_bytes:
-                    is_primary = file_name == primary_name
-                    if is_primary:
-                        # Primary honors the user-configured output_file parameter.
+                    is_preview = file_name == preview_name
+                    if is_preview:
+                        # Preview honors the user-configured output_file parameter.
                         dest = self._output_file.build_file()
                     else:
-                        # Companion files (textures/materials/preview) keep their
-                        # original filename so their extension is preserved.
+                        # All other files keep their Rodin-assigned names but share
+                        # the preview's parent directory.
+                        companion_filename = (
+                            str(Path(sub_dir_prefix) / file_name) if sub_dir_prefix else file_name
+                        )
                         dest = ProjectFileDestination.from_situation(
-                            filename=file_name, situation="save_node_output"
+                            filename=companion_filename, situation="save_node_output"
                         )
                     saved = await dest.awrite_bytes(file_bytes)
                     all_file_urls.append(saved.location)
                     self._log(f"Saved file: {saved.name}")
 
-                    if is_primary:
+                    if file_name == primary_name:
                         primary_url = saved.location
                         primary_filename = saved.name
+                    if is_preview:
+                        preview_url = saved.location
+                        preview_saved_name = saved.name
 
             except Exception as e:
                 self._log(f"Failed to save file {file_name}: {e}")
 
-        # Set outputs
         self.parameter_output_values["all_files"] = all_file_urls
+
+        if preview_url:
+            self.parameter_output_values["preview_image"] = ImageUrlArtifact(
+                value=preview_url,
+                meta={"filename": preview_saved_name},
+            )
 
         if primary_url:
             self.parameter_output_values["model_url"] = ThreeDUrlArtifact(
@@ -715,6 +757,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
         self.parameter_output_values["generation_id"] = ""
         self.parameter_output_values["provider_response"] = None
         self.parameter_output_values["model_url"] = None
+        self.parameter_output_values["preview_image"] = None
         self.parameter_output_values["all_files"] = []
 
     def _handle_payload_build_error(self, e: Exception) -> None:

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -586,15 +586,17 @@ class Rodin23DGeneration(GriptapeProxyNode):
         The preview (.webp) is saved to the user-configured `output_file` path; all
         other files (mesh, textures, materials) are saved alongside it in the same
         directory, preserving their original Rodin-assigned filenames and extensions.
+
+        When Rodin returns multiple files with the requested extension (common for
+        PBR + glb, where you get a base mesh plus a texture-baked variant), the
+        largest by byte size is treated as the primary. Rodin's API does not
+        document a canonical primary field, so size is the most reliable heuristic
+        -- the "full" file with embedded textures is always biggest.
         """
         requested_format = params["geometry_file_format"]
 
         received_names = [f.get("name", "") for f in files]
-        primary_name = next(
-            (name for name in received_names if name.lower().endswith(f".{requested_format}")),
-            None,
-        )
-        if primary_name is None:
+        if not any(name.lower().endswith(f".{requested_format}") for name in received_names):
             logger.warning(
                 "Rodin did not return a .%s file in the response; received: %s",
                 requested_format,
@@ -615,6 +617,45 @@ class Rodin23DGeneration(GriptapeProxyNode):
             None,
         )
 
+        # Download everything up front so we can pick the primary by byte size
+        # before saving (largest file matching the requested extension wins).
+        downloaded: list[tuple[str, bytes]] = []
+        for idx, file_info in enumerate(files):
+            file_url = file_info.get("url")
+            file_name = file_info.get("name", f"model_{idx}.{requested_format}")
+            if not file_url:
+                continue
+            try:
+                self._log(f"Downloading file: {file_name}")
+                file_bytes = await self._download_bytes_from_url(file_url)
+                if file_bytes:
+                    downloaded.append((file_name, file_bytes))
+            except Exception as e:
+                self._log(f"Failed to download file {file_name}: {e}")
+
+        primary_candidates = [
+            (name, data)
+            for name, data in downloaded
+            if name.lower().endswith(f".{requested_format}")
+        ]
+        if not primary_candidates:
+            logger.warning(
+                "Rodin response listed a .%s file but none downloaded successfully; received: %s",
+                requested_format,
+                received_names,
+            )
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"Rodin response listed a .{requested_format} file but none downloaded successfully."
+                ),
+            )
+            return
+
+        primary_name, _ = max(primary_candidates, key=lambda item: len(item[1]))
+        self._log(f"Selected primary .{requested_format}: {primary_name} (largest by size)")
+
         # Derive the shared sub-directory from the user's output_file so every
         # companion file lands next to the preview.
         output_file_value = self.get_parameter_value("output_file") or "preview.webp"
@@ -627,41 +668,31 @@ class Rodin23DGeneration(GriptapeProxyNode):
         preview_url: str | None = None
         preview_saved_name: str | None = None
 
-        for idx, file_info in enumerate(files):
-            file_url = file_info.get("url")
-            file_name = file_info.get("name", f"model_{idx}.{requested_format}")
-
-            if not file_url:
-                continue
-
+        for file_name, file_bytes in downloaded:
             try:
-                self._log(f"Downloading file: {file_name}")
-                file_bytes = await self._download_bytes_from_url(file_url)
+                is_preview = file_name == preview_name
+                if is_preview:
+                    # Preview honors the user-configured output_file parameter.
+                    dest = self._output_file.build_file()
+                else:
+                    # All other files keep their Rodin-assigned names but share
+                    # the preview's parent directory.
+                    companion_filename = (
+                        str(Path(sub_dir_prefix) / file_name) if sub_dir_prefix else file_name
+                    )
+                    dest = ProjectFileDestination.from_situation(
+                        filename=companion_filename, situation="save_node_output"
+                    )
+                saved = await dest.awrite_bytes(file_bytes)
+                all_file_urls.append(saved.location)
+                self._log(f"Saved file: {saved.name}")
 
-                if file_bytes:
-                    is_preview = file_name == preview_name
-                    if is_preview:
-                        # Preview honors the user-configured output_file parameter.
-                        dest = self._output_file.build_file()
-                    else:
-                        # All other files keep their Rodin-assigned names but share
-                        # the preview's parent directory.
-                        companion_filename = (
-                            str(Path(sub_dir_prefix) / file_name) if sub_dir_prefix else file_name
-                        )
-                        dest = ProjectFileDestination.from_situation(
-                            filename=companion_filename, situation="save_node_output"
-                        )
-                    saved = await dest.awrite_bytes(file_bytes)
-                    all_file_urls.append(saved.location)
-                    self._log(f"Saved file: {saved.name}")
-
-                    if file_name == primary_name:
-                        primary_url = saved.location
-                        primary_filename = saved.name
-                    if is_preview:
-                        preview_url = saved.location
-                        preview_saved_name = saved.name
+                if file_name == primary_name:
+                    primary_url = saved.location
+                    primary_filename = saved.name
+                if is_preview:
+                    preview_url = saved.location
+                    preview_saved_name = saved.name
 
             except Exception as e:
                 self._log(f"Failed to save file {file_name}: {e}")

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -606,8 +606,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
             self._set_status_results(
                 was_successful=False,
                 result_details=(
-                    f"Rodin did not return a .{requested_format} file in the response; "
-                    f"received: {received_names}"
+                    f"Rodin did not return a .{requested_format} file in the response; received: {received_names}"
                 ),
             )
             return
@@ -634,9 +633,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 self._log(f"Failed to download file {file_name}: {e}")
 
         primary_candidates = [
-            (name, data)
-            for name, data in downloaded
-            if name.lower().endswith(f".{requested_format}")
+            (name, data) for name, data in downloaded if name.lower().endswith(f".{requested_format}")
         ]
         if not primary_candidates:
             logger.warning(
@@ -647,9 +644,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
             self._set_safe_defaults()
             self._set_status_results(
                 was_successful=False,
-                result_details=(
-                    f"Rodin response listed a .{requested_format} file but none downloaded successfully."
-                ),
+                result_details=(f"Rodin response listed a .{requested_format} file but none downloaded successfully."),
             )
             return
 
@@ -689,9 +684,7 @@ class Rodin23DGeneration(GriptapeProxyNode):
                 else:
                     # All other files keep their Rodin-assigned names but share
                     # the preview's parent directory.
-                    companion_filename = (
-                        str(Path(sub_dir_prefix) / file_name) if sub_dir_prefix else file_name
-                    )
+                    companion_filename = str(Path(sub_dir_prefix) / file_name) if sub_dir_prefix else file_name
                     dest = ProjectFileDestination.from_situation(
                         filename=companion_filename, situation="save_node_output"
                     )


### PR DESCRIPTION
Rodin generates multiple filetypes and the logic just grabbed the first generated file, not the requested filetype. And it didn't save to the right directory for all generated files. And only GLBs render in editor GUI. It was very broken and this makes it somewhat better.

output_file is now just for the preview image but the rest of the files will get saved to the same parent of output_file

https://thefoundrygroup.slack.com/archives/C0ALEB6EAQ6/p1777754149712049
https://thefoundrygroup.slack.com/archives/C0AG2LUL24B/p1777743914840859