### PR TITLE
fix: save_image conversion to inferred file format from output file name (#190)

### DIFF
--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -1,5 +1,6 @@
 from enum import StrEnum, auto
 from io import BytesIO
+from pathlib import Path
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
@@ -14,7 +15,9 @@ from PIL import Image
 
 from griptape_nodes_library.utils.image_utils import (
     dict_to_image_url_artifact,
+    image_to_bytes,
     load_image_from_url_artifact,
+    validate_pil_format,
 )
 
 PREVIEW_LENGTH = 50
@@ -29,7 +32,7 @@ class SaveImageStatus(StrEnum):
 
 
 def to_image_artifact(image: ImageArtifact | dict) -> ImageArtifact | ImageUrlArtifact:
-    """Convert an image or a dictionary to an ImageArtifact."""
+    """Normalise a raw dict wire-value into an artifact; pass ImageArtifact through unchanged."""
     if isinstance(image, dict):
         return dict_to_image_url_artifact(image)
     return image
@@ -63,19 +66,18 @@ class SaveImage(SuccessFailureNode):
         )
         self._output_file.add_parameter()
 
+    def _get_target_pil_format(self) -> str:
+        """Determine the target PIL format string from the output_file parameter."""
+        param_value = self.get_parameter_value("output_file")
+        filename = param_value if isinstance(param_value, str) and param_value else self._output_file._default_filename
+        ext = Path(filename).suffix.lstrip(".").upper()
+        return "JPEG" if ext == "JPG" else ext
+
     def _extract_format_from_artifact(self, image_artifact: Any) -> str | None:
-        """Extract format from image artifact.
-
-        Args:
-            image_artifact: ImageArtifact or similar object
-
-        Returns:
-            Format string (e.g., 'png', 'jpeg') or None if not detected
-        """
+        """Detect the format of an image artifact (e.g. 'png', 'jpeg'), or None if unknown."""
         # Try to get format from PIL Image
         if hasattr(image_artifact, "value"):
             try:
-                # If it's bytes, load as PIL image
                 if isinstance(image_artifact.value, bytes):
                     pil_image = Image.open(BytesIO(image_artifact.value))
                     if pil_image.format:
@@ -115,7 +117,7 @@ class SaveImage(SuccessFailureNode):
             )
             return
 
-        # Capture input source details for forensics
+        # Captured here so all downstream error paths can include source details
         input_info = self._get_input_info(image)
 
         # Convert ImageUrlArtifact to ImageArtifact if needed
@@ -136,11 +138,28 @@ class SaveImage(SuccessFailureNode):
             self._handle_error_with_graceful_exit(error_details, e, input_info)
             return
 
-        # Convert image to bytes and save
+        # Detect incoming format for logging
+        source_format = self._extract_format_from_artifact(image_artifact)
+        logger.debug("Source image format detected: %s", source_format)
+
+        # Determine and validate target format from output filename
+        target_format = self._get_target_pil_format()
+        try:
+            validate_pil_format(target_format)
+        except ValueError as e:
+            error_details = f"Unsupported output file extension: {e!s}"
+            self._handle_error_with_graceful_exit(error_details, e, input_info)
+            return
+
+        # Re-encode image bytes to the target format and write to disk
         try:
             image_bytes = image_artifact.to_bytes()
+            pil_image = Image.open(BytesIO(image_bytes))
+            if target_format == "JPEG" and pil_image.mode in ("RGBA", "LA", "P"):
+                pil_image = pil_image.convert("RGB")
+            converted_bytes = image_to_bytes(pil_image, target_format)
             dest = self._output_file.build_file()
-            saved = dest.write_bytes(image_bytes)
+            saved = dest.write_bytes(converted_bytes)
             saved_path = saved.location
         except Exception as e:
             error_details = f"Failed to save image: {e!s}"
@@ -155,10 +174,10 @@ class SaveImage(SuccessFailureNode):
             input_info=input_info,
             details=success_details,
         )
-        logger.info(f"Saved image: {saved_path}")
+        logger.info("Saved image: %s", saved_path)
 
     def _get_input_info(self, image: Any) -> str:
-        """Get input information for forensics logging."""
+        """Return a short human-readable description of the image source."""
         input_type = type(image).__name__
         if isinstance(image, dict):
             return f"Dictionary input with type: {image.get('type', 'unknown')}"
@@ -167,7 +186,7 @@ class SaveImage(SuccessFailureNode):
         return f"ImageArtifact of type: {input_type}"
 
     def _get_input_info_for_failure(self, image: Any) -> str:
-        """Get detailed input information for failure forensics logging."""
+        """Return a detailed description of the image source, including a value preview for dicts."""
         input_type = type(image).__name__
         if isinstance(image, dict):
             input_info = f"Dictionary input with type: {image.get('type', 'unknown')}"
@@ -188,10 +207,10 @@ class SaveImage(SuccessFailureNode):
         details: str,
         exception: Exception | None = None,
     ) -> None:
-        """Handle execution result for all cases."""
+        """Set status outputs and log based on the outcome of a save attempt."""
         match status:
             case SaveImageStatus.FAILURE:
-                # Get detailed input info for failures (including dictionary preview)
+                # Use the richer variant here — it includes a value preview for dict inputs
                 detailed_input_info = self._get_input_info_for_failure(self.get_parameter_value("image"))
 
                 failure_details = f"Image save failed\nInput: {detailed_input_info}\nError: {details}"
@@ -202,7 +221,7 @@ class SaveImage(SuccessFailureNode):
                         failure_details += f"\nCause: {exception.__cause__}"
 
                 self._set_status_results(was_successful=False, result_details=f"{status}: {failure_details}")
-                logger.error(f"Error saving image: {details}")
+                logger.error("Error saving image: %s", details)
 
             case SaveImageStatus.WARNING:
                 result_details = f"No image to save (warning)\nInput: {input_info}\nResult: No file created"
@@ -215,7 +234,7 @@ class SaveImage(SuccessFailureNode):
                 self._set_status_results(was_successful=True, result_details=f"{status}: {result_details}")
 
     def _handle_error_with_graceful_exit(self, error_details: str, exception: Exception, input_info: str) -> None:
-        """Handle error with graceful exit if failure output is connected."""
+        """Record failure status and re-raise only when no failure output is connected."""
         self._handle_execution_result(
             status=SaveImageStatus.FAILURE,
             saved_path="",


### PR DESCRIPTION
## Fix `SaveImage` writing raw bytes without format conversion

Fixes #190 

### Problem

`SaveImage` was occasionally saving JPEG payloads with a `.png` extension (and vice-versa), producing files that image viewers and downstream nodes would misidentify or reject.

The root cause: `process()` called `image_artifact.to_bytes()` — which returns the raw internal bytes with no format conversion — and wrote those bytes directly to disk, completely ignoring the extension of the configured output file. The `_extract_format_from_artifact` helper existed to detect the incoming format but was dead code; it was never called during execution.

### Fix

- Added `_get_target_pil_format()` which resolves the intended output format from the `output_file` parameter (e.g. `griptape_nodes.png` → `PNG`, `output.jpg` → `JPEG`).
- Before writing, the target format is validated against PIL's supported formats via `validate_pil_format()`. If the extension is unsupported (e.g. `.tga`), the node now fails with a descriptive error instead of silently writing garbage bytes.
- Image bytes are opened with PIL and re-encoded to the target format using the existing `image_to_bytes()` utility. RGBA/LA/P images are converted to RGB before JPEG encoding, since JPEG has no alpha channel support.
- `_extract_format_from_artifact` is now wired in to log the detected source format at debug level, making format-mismatch issues easier to diagnose.

