### PR TITLE
fix: show_snapshot_button visibility

### DIFF
--- a/griptape_nodes_library/three_d/load_gltf.py
+++ b/griptape_nodes_library/three_d/load_gltf.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
@@ -17,19 +17,15 @@ class LoadGLTF(DataNode):
         gltf_parameter = Parameter3D(
             name="gltf",
             default_value=None,
-            ui_options={"clickable_file_browser": True, "expander": True},
+            ui_options={
+                "clickable_file_browser": True,
+                "expander": True,
+                "show_snapshot_button": True,
+            },
             tooltip="The GLTF file that has been loaded.",
         )
         self.add_parameter(gltf_parameter)
 
-        self.add_node_element(
-            ParameterMessage(
-                variant="none",
-                name="help_message",
-                value='To output an image of the model, click "Save Snapshot".',
-                ui_options={"text_align": "text-center"},
-            )
-        )
         image_parameter = ParameterImage(
             name="image",
             default_value=None,
@@ -49,9 +45,6 @@ class LoadGLTF(DataNode):
                 image_artifact = ImageUrlArtifact(value=image_url)
                 self.set_parameter_value("image", image_artifact)
                 self.parameter_output_values["image"] = image_artifact
-                self.hide_message_by_name("help_message")
-            else:
-                self.show_message_by_name("help_message")
 
         return super().after_value_set(parameter, value)
 

--- a/griptape_nodes_library/three_d/load_three_d.py
+++ b/griptape_nodes_library/three_d/load_three_d.py
@@ -1,7 +1,7 @@
 from typing import Any, ClassVar
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_three_d import Parameter3D
@@ -42,6 +42,7 @@ class LoadThreeD(ControlNode):
                 "clickable_file_browser": True,
                 "expander": True,
                 "display_name": "3D File or path to 3D file",
+                "show_snapshot_button": True,
             },
             tooltip="The 3D file that has been loaded.",
         )
@@ -64,14 +65,6 @@ class LoadThreeD(ControlNode):
             config=self._tethering_config,
         )
 
-        self.add_node_element(
-            ParameterMessage(
-                variant="none",
-                name="help_message",
-                value='To output an image of the model, click "Save Snapshot".',
-                ui_options={"text_align": "text-center"},
-            )
-        )
         image_parameter = ParameterImage(
             name="image",
             default_value=None,
@@ -127,9 +120,6 @@ class LoadThreeD(ControlNode):
                 image_artifact = ImageUrlArtifact(value=image_url)
                 self.set_parameter_value("image", image_artifact)
                 self.parameter_output_values["image"] = image_artifact
-                self.hide_message_by_name("help_message")
-            else:
-                self.show_message_by_name("help_message")
 
         return super().after_value_set(parameter, value)
 


### PR DESCRIPTION
fixes: https://github.com/griptape-ai/griptape-nodes-library-standard/issues/36

Previously the snapshot button in the 3d viewer was hidden. 

This now works with a frontend change to change the snapshot button to be an actual button instead of a hidden hover element.

It also removes the annoying message parameter.

<img width="535" height="642" alt="image" src="https://github.com/user-attachments/assets/c128b122-809a-4783-b83a-5597ec856114" />



## IMPORTANT: 
requires frontend pr: https://github.com/griptape-ai/griptape-vsl-gui/pull/2240
These releases need to be in sync