### PR TITLE
fix(wan): handle dict inputs and nested output.video_url

### DIFF
--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -261,6 +261,16 @@ class LTXVideoRetake(GriptapeProxyNode):
             v = val.strip()
             return v or None
 
+        if isinstance(val, dict):
+            # Serialized VideoUrlArtifact: {"value": "...", "url": "..."}.
+            v = val.get("value")
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+            url = val.get("url")
+            if isinstance(url, str) and url.strip():
+                return url.strip()
+            return None
+
         try:
             # VideoUrlArtifact / any artifact with .value holding a URL/path string.
             v = getattr(val, "value", None)

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -348,6 +348,15 @@ class WanAnimateGeneration(GriptapeProxyNode):
             v = val.strip()
             return v or None
 
+        if isinstance(val, dict):
+            v = val.get("value")
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+            url = val.get("url")
+            if isinstance(url, str) and url.strip():
+                return url.strip()
+            return None
+
         try:
             v = getattr(val, "value", None)
             if isinstance(v, str) and v.strip():
@@ -481,11 +490,26 @@ class WanAnimateGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _extract_video_url(obj: dict[str, Any] | None) -> str | None:
+        """Extract video URL from response.
+
+        The WAN proxy nests the result under ``output.video_url``; some
+        responses use ``results.video_url`` or expose ``video_url`` at the
+        top level. Check the nested locations first and fall back to the
+        top-level key.
+        """
         if not obj:
             return None
+        output = obj.get("output")
+        if isinstance(output, dict):
+            nested = output.get("video_url")
+            if isinstance(nested, str) and nested.startswith("http"):
+                return nested
         results = obj.get("results")
         if isinstance(results, dict):
             video_url = results.get("video_url")
             if isinstance(video_url, str) and video_url.startswith("http"):
                 return video_url
+        video_url = obj.get("video_url")
+        if isinstance(video_url, str) and video_url.startswith("http"):
+            return video_url
         return None

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -550,6 +550,15 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
             v = val.strip()
             return v or None
 
+        if isinstance(val, dict):
+            v = val.get("value")
+            if isinstance(v, str) and v.strip():
+                return v.strip()
+            url = val.get("url")
+            if isinstance(url, str) and url.strip():
+                return url.strip()
+            return None
+
         try:
             v = getattr(val, "value", None)
             if isinstance(v, str) and v.strip():
@@ -711,9 +720,19 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _extract_result_video_url(obj: dict[str, Any] | None) -> str | None:
-        """Extract video URL from response."""
+        """Extract video URL from response.
+
+        The WAN proxy nests the result under ``output.video_url``; older or
+        flatter responses may put it at the top level. Check the nested
+        location first and fall back to the top-level key.
+        """
         if not obj:
             return None
+        output = obj.get("output")
+        if isinstance(output, dict):
+            nested = output.get("video_url")
+            if isinstance(nested, str) and nested.startswith("http"):
+                return nested
         video_url = obj.get("video_url")
         if isinstance(video_url, str) and video_url.startswith("http"):
             return video_url

--- a/tests/unit/video/test_input_coercion.py
+++ b/tests/unit/video/test_input_coercion.py
@@ -246,6 +246,27 @@ class TestVideoHelpers:
     def test_artifact_with_no_known_attrs_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
         assert helper(SimpleNamespace()) is None
 
+    def test_dict_with_value_key(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        # Serialized VideoUrlArtifact (dict form) arrives when a video is
+        # uploaded directly to the node rather than fed via Load Video.
+        assert helper({"value": "https://example.com/foo.mp4"}) == "https://example.com/foo.mp4"
+
+    def test_dict_with_value_key_is_stripped(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper({"value": "  https://example.com/foo.mp4  "}) == "https://example.com/foo.mp4"
+
+    def test_dict_with_url_key_only(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper({"url": "https://example.com/foo.mp4"}) == "https://example.com/foo.mp4"
+
+    def test_dict_value_takes_precedence_over_url(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        result = helper({"value": "https://example.com/value.mp4", "url": "https://example.com/url.mp4"})
+        assert result == "https://example.com/value.mp4"
+
+    def test_dict_with_neither_key_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper({"type": "VideoUrlArtifact"}) is None
+
+    def test_dict_with_empty_value_and_url_returns_none(self, _name: str, helper: Callable[[Any], str | None]) -> None:
+        assert helper({"value": "", "url": "   "}) is None
+
 
 # ---------------------------------------------------------------------------
 # AUDIO helpers
@@ -576,3 +597,105 @@ class TestLTXVideoRetakePrepareDataUriAsync:
         monkeypatch.setattr(file_module.File, "aread_data_uri", fail_aread)
 
         assert await node._prepare_video_data_uri_async("{inputs}/missing.mp4") is None
+
+
+# ---------------------------------------------------------------------------
+# WAN response: _extract_result_video_url / _extract_video_url
+# ---------------------------------------------------------------------------
+
+
+class TestWanReferenceExtractResultVideoUrl:
+    """The WAN proxy nests successful generations under ``output.video_url``;
+    older or flatter responses may put the URL at the top level. The helper
+    must check the nested location first and fall back to the top-level key,
+    or successful generations silently produce no output (charging credits
+    for videos the user cannot see).
+    """
+
+    helper = staticmethod(WanReferenceToVideoGeneration._extract_result_video_url)
+
+    def test_extracts_nested_output_video_url(self) -> None:
+        result = self.helper({"output": {"video_url": "https://example.com/foo.mp4"}})
+        assert result == "https://example.com/foo.mp4"
+
+    def test_extracts_top_level_video_url(self) -> None:
+        result = self.helper({"video_url": "https://example.com/foo.mp4"})
+        assert result == "https://example.com/foo.mp4"
+
+    def test_nested_takes_precedence_over_top_level(self) -> None:
+        result = self.helper(
+            {
+                "output": {"video_url": "https://example.com/nested.mp4"},
+                "video_url": "https://example.com/top.mp4",
+            }
+        )
+        assert result == "https://example.com/nested.mp4"
+
+    def test_falls_back_to_top_level_when_nested_missing(self) -> None:
+        result = self.helper({"output": {}, "video_url": "https://example.com/top.mp4"})
+        assert result == "https://example.com/top.mp4"
+
+    def test_falls_back_to_top_level_when_nested_value_invalid(self) -> None:
+        # Non-http nested value should not be returned; the helper should keep
+        # looking and use the valid top-level URL instead.
+        result = self.helper(
+            {
+                "output": {"video_url": "not-a-url"},
+                "video_url": "https://example.com/top.mp4",
+            }
+        )
+        assert result == "https://example.com/top.mp4"
+
+    def test_returns_none_for_none(self) -> None:
+        assert self.helper(None) is None
+
+    def test_returns_none_for_empty_dict(self) -> None:
+        assert self.helper({}) is None
+
+    def test_returns_none_when_neither_present(self) -> None:
+        assert self.helper({"task_status": "SUCCEEDED"}) is None
+
+    def test_returns_none_when_output_is_not_dict(self) -> None:
+        assert self.helper({"output": "https://example.com/foo.mp4"}) is None
+
+    def test_returns_none_when_url_is_non_http(self) -> None:
+        assert self.helper({"output": {"video_url": "ftp://example.com/foo.mp4"}}) is None
+        assert self.helper({"video_url": "ftp://example.com/foo.mp4"}) is None
+
+
+class TestWanAnimateExtractVideoUrl:
+    """``WanAnimateGeneration`` calls the same WAN proxy as the reference node,
+    so it must also handle ``output.video_url``. The historical
+    ``results.video_url`` shape and a plain top-level ``video_url`` are kept
+    as fallbacks so existing responses continue to work.
+    """
+
+    helper = staticmethod(WanAnimateGeneration._extract_video_url)
+
+    def test_extracts_nested_output_video_url(self) -> None:
+        result = self.helper({"output": {"video_url": "https://example.com/foo.mp4"}})
+        assert result == "https://example.com/foo.mp4"
+
+    def test_extracts_results_video_url(self) -> None:
+        result = self.helper({"results": {"video_url": "https://example.com/foo.mp4"}})
+        assert result == "https://example.com/foo.mp4"
+
+    def test_extracts_top_level_video_url(self) -> None:
+        result = self.helper({"video_url": "https://example.com/foo.mp4"})
+        assert result == "https://example.com/foo.mp4"
+
+    def test_output_takes_precedence_over_results_and_top_level(self) -> None:
+        result = self.helper(
+            {
+                "output": {"video_url": "https://example.com/output.mp4"},
+                "results": {"video_url": "https://example.com/results.mp4"},
+                "video_url": "https://example.com/top.mp4",
+            }
+        )
+        assert result == "https://example.com/output.mp4"
+
+    def test_returns_none_for_none(self) -> None:
+        assert self.helper(None) is None
+
+    def test_returns_none_when_nothing_present(self) -> None:
+        assert self.helper({"task_status": "SUCCEEDED"}) is None


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/234
Resolves the two issues reported against the WAN Reference to Video Generation node in https://github.com/orgs/griptape-ai/discussions/2178.

When a video is uploaded directly to the node (rather than fed through a Load Video node), the artifact arrives at `_coerce_video_url_or_data_uri` as a serialized dict like `{"value": "...", "url": "..."}`. The helper only handled `str` and objects exposing `.value`/`.base64`, so dict inputs fell through to `None` and the node errored with "no url provided". A dict branch now pulls from `value` first, then `url`, returning a stripped non-empty string or `None`. The same vulnerable helper is duplicated across `wan_reference_to_video_generation.py`, `wan_animate_generation.py`, and `ltx_video_retake.py`, so the fix is applied to all three.

The WAN proxy nests successful generations under `output.video_url`, but `_extract_result_video_url` in `wan_reference_to_video_generation.py` only inspected the top-level `video_url` key, so completed generations silently returned no URL and users were charged for videos they could not see. The helper now checks `output.video_url` first and falls back to top-level `video_url`. `wan_animate_generation.py` calls the same proxy and was reading `results.video_url`; rather than swap one shape for another, `_extract_video_url` there now checks `output.video_url`, then `results.video_url`, then top-level `video_url`, so any of the observed shapes resolve. `ltx_video_retake.py` consumes `result_json["raw_bytes"]` directly and has no JSON URL extraction, so Bug 2 does not apply there.

New cases in `tests/unit/video/test_input_coercion.py` cover the dict input paths across all three video helpers and the nested/top-level/missing variants of `_extract_result_video_url` and `_extract_video_url`.