### PR TITLE
fix(wan-animate): upload inputs as public URLs and read DashScope's nested results shape

### DIFF
--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -18,7 +18,6 @@ from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.media import prepare_media_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.utils.video_utils import get_video_duration
 
@@ -206,19 +205,20 @@ class WanAnimateGeneration(GriptapeProxyNode):
             self._public_video_url_parameter.delete_uploaded_artifact()
 
     async def _get_parameters(self) -> dict[str, Any]:
-        # Get the original video URL before uploading to calculate duration
+        # The DashScope Animate endpoint requires a real video URL, so the
+        # public-URL upload happens in ``_build_payload``. Duration is probed
+        # from the original local input here so that ffprobe works against a
+        # resolvable filesystem path (macro paths included) rather than an
+        # uploaded asset URL we'd otherwise have to download again.
         video_param = self.get_parameter_value("video_url")
         original_video_url = video_param.value if hasattr(video_param, "value") else str(video_param)
 
-        # Calculate duration from the original video (ceiling to int)
         duration = math.ceil(await get_video_duration(original_video_url))
         logger.debug("Detected video duration: %ss", duration)
 
         return {
             "model": self.get_parameter_value("model"),
             "mode": self.get_parameter_value("mode"),
-            "image_input": self.get_parameter_value("image_url"),
-            "video_input": self.get_parameter_value("video_url"),
             "duration": duration,
         }
 
@@ -236,18 +236,23 @@ class WanAnimateGeneration(GriptapeProxyNode):
     async def _build_payload(self) -> dict[str, Any]:
         params = await self._get_parameters()
 
-        image_url = await self._prepare_image_data_url_async(params["image_input"])
+        # The DashScope Animate endpoint (``services/aigc/image2video/video-synthesis``)
+        # is called via raw POST in the cloud proxy and forwards ``image_url``
+        # and ``video_url`` straight through. DashScope only accepts public
+        # HTTP URLs there; ``data:`` URIs come back as ``InvalidVideo.FileFormat``.
+        # Upload via ``PublicArtifactUrlParameter`` so the request carries a
+        # short-lived public URL the provider can fetch.
+        image_url = self._public_image_url_parameter.get_public_url_for_parameter()
         if not image_url:
-            msg = "Failed to process input image"
+            msg = "Failed to upload input image"
             raise ValueError(msg)
 
-        video_url = await self._prepare_video_data_url_async(params["video_input"])
+        video_url = self._public_video_url_parameter.get_public_url_for_parameter()
         if not video_url:
-            msg = "Failed to process input video"
+            msg = "Failed to upload input video"
             raise ValueError(msg)
 
-        # Build payload matching proxy expected format
-        payload = {
+        return {
             "input": {
                 "image_url": image_url,
                 "video_url": video_url,
@@ -258,8 +263,6 @@ class WanAnimateGeneration(GriptapeProxyNode):
             },
         }
 
-        return payload
-
     async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
         status = self._extract_status(result_json) or STATUS_UNKNOWN
         if status in {STATUS_FAILED, STATUS_CANCELED}:
@@ -269,12 +272,6 @@ class WanAnimateGeneration(GriptapeProxyNode):
             return
 
         await self._handle_completion(result_json, generation_id)
-
-    async def _prepare_image_data_url_async(self, image_input: Any) -> str | None:
-        return await prepare_media_data_uri(image_input, kind="image", node_name=self.name, fallback_mime="image/jpeg")
-
-    async def _prepare_video_data_url_async(self, video_input: Any) -> str | None:
-        return await prepare_media_data_uri(video_input, kind="video", node_name=self.name)
 
     async def _handle_completion(self, last_json: dict[str, Any] | None, generation_id: str | None = None) -> None:
         extracted_url = self._extract_video_url(last_json)
@@ -390,6 +387,13 @@ class WanAnimateGeneration(GriptapeProxyNode):
     def _extract_status(response_json: dict[str, Any] | None) -> str | None:
         if not response_json:
             return None
+        # DashScope wraps the live status under ``output.task_status``; older
+        # / pre-v2 responses surfaced it at the top level.
+        output = response_json.get("output")
+        if isinstance(output, dict):
+            task_status = output.get("task_status")
+            if isinstance(task_status, str):
+                return task_status
         task_status = response_json.get("task_status")
         if isinstance(task_status, str):
             return task_status
@@ -397,26 +401,43 @@ class WanAnimateGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _extract_video_url(obj: dict[str, Any] | None) -> str | None:
-        """Extract video URL from response.
+        """Extract the generated video URL from a WAN Animate response.
 
-        The WAN proxy nests the result under ``output.video_url``; some
-        responses use ``results.video_url`` or expose ``video_url`` at the
-        top level. Check the nested locations first and fall back to the
-        top-level key.
+        DashScope's documented shape (``wan2.2-animate-mix`` / ``-move``) is::
+
+            {
+              "request_id": "...",
+              "output": {
+                "task_status": "SUCCEEDED",
+                "results": {"video_url": "https://..."}
+              },
+              "usage": {...}
+            }
+
+        Older / sibling WAN endpoints have used ``output.video_url`` directly,
+        a top-level ``results.video_url`` (shape kept for backwards compat),
+        and a top-level ``video_url``. We probe each location in turn so a
+        documented response shift across model versions keeps working.
         """
         if not obj:
             return None
+
+        def _is_http_url(value: Any) -> bool:
+            return isinstance(value, str) and value.startswith("http")
+
         output = obj.get("output")
         if isinstance(output, dict):
-            nested = output.get("video_url")
-            if isinstance(nested, str) and nested.startswith("http"):
-                return nested
+            results = output.get("results")
+            if isinstance(results, dict) and _is_http_url(results.get("video_url")):
+                return results["video_url"]
+            if _is_http_url(output.get("video_url")):
+                return output["video_url"]
+
         results = obj.get("results")
-        if isinstance(results, dict):
-            video_url = results.get("video_url")
-            if isinstance(video_url, str) and video_url.startswith("http"):
-                return video_url
-        video_url = obj.get("video_url")
-        if isinstance(video_url, str) and video_url.startswith("http"):
-            return video_url
+        if isinstance(results, dict) and _is_http_url(results.get("video_url")):
+            return results["video_url"]
+
+        if _is_http_url(obj.get("video_url")):
+            return obj["video_url"]
+
         return None

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -18,6 +18,7 @@ from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes_library.media import coerce_media_url_or_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.utils.video_utils import get_video_duration
 
@@ -210,10 +211,20 @@ class WanAnimateGeneration(GriptapeProxyNode):
         # from the original local input here so that ffprobe works against a
         # resolvable filesystem path (macro paths included) rather than an
         # uploaded asset URL we'd otherwise have to download again.
-        video_param = self.get_parameter_value("video_url")
-        original_video_url = video_param.value if hasattr(video_param, "value") else str(video_param)
+        #
+        # Direct uploads via the node's media badge land as serialized
+        # ``VideoUrlArtifact`` dicts (``{"value": "<path>", "type": "VideoUrlArtifact", ...}``)
+        # rather than artifact instances. ``PublicArtifactUrlParameter`` and
+        # ``File()`` both expect strings/artifacts, so we normalize the
+        # parameter value first; the same call also covers ``image_url`` so
+        # the upload step in ``_build_payload`` doesn't trip on dict inputs.
+        self._normalize_artifact_url_parameter("image_url", "image")
+        video_url = self._normalize_artifact_url_parameter("video_url", "video")
+        if not video_url:
+            msg = "Video URL must be provided"
+            raise ValueError(msg)
 
-        duration = math.ceil(await get_video_duration(original_video_url))
+        duration = math.ceil(await get_video_duration(video_url))
         logger.debug("Detected video duration: %ss", duration)
 
         return {
@@ -221,6 +232,37 @@ class WanAnimateGeneration(GriptapeProxyNode):
             "mode": self.get_parameter_value("mode"),
             "duration": duration,
         }
+
+    def _normalize_artifact_url_parameter(self, parameter_name: str, kind: str) -> str | None:
+        """Coerce a media-input parameter into a string URL/path.
+
+        Direct uploads through the media-upload badge serialize the artifact
+        as a dict (``{"value": "<path>", "type": "<Kind>UrlArtifact", ...}``).
+        Both ``PublicArtifactUrlParameter.get_public_url_for_parameter`` and
+        ``File(...)`` only accept strings or artifact instances, so a dict in
+        the parameter slot crashes the upload path and produces a misleading
+        "missing required variables" macro error from ``File`` when the
+        repr-string is parsed as a macro.
+
+        Coerce the dict to its inner string via the shared media helpers and
+        write that back to the parameter so downstream callers see a value
+        they can consume. String / artifact inputs are returned as-is.
+        """
+        raw = self.get_parameter_value(parameter_name)
+        if not raw:
+            return None
+        if isinstance(raw, dict):
+            coerced = coerce_media_url_or_data_uri(raw, kind=kind)  # type: ignore[arg-type]
+            if not coerced:
+                return None
+            self.set_parameter_value(parameter_name, coerced)
+            return coerced
+        value = getattr(raw, "value", None)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(raw, str):
+            return raw
+        return None
 
     def _validate_api_key(self) -> str:
         api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)

--- a/tests/unit/video/test_wan_animate_generation.py
+++ b/tests/unit/video/test_wan_animate_generation.py
@@ -158,6 +158,88 @@ async def test_build_payload_passes_through_existing_public_urls(monkeypatch: py
     assert payload["parameters"]["duration"] == 10
 
 
+@pytest.mark.asyncio
+async def test_build_payload_normalizes_serialized_artifact_dicts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Direct uploads through the media-upload badge land as serialized
+    ``VideoUrlArtifact`` dicts rather than artifact instances. The node must
+    coerce the dict to its inner ``value`` so ``File()`` and the upload
+    helper can consume it; otherwise ``File`` parses the dict's repr as a
+    macro path and reports "missing required variables".
+    """
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value(
+        "image_url",
+        {
+            "value": "/abs/path/source.png",
+            "name": "source.png",
+            "type": "ImageUrlArtifact",
+        },
+    )
+    node.set_parameter_value(
+        "video_url",
+        {
+            "value": "/abs/path/reference.mp4",
+            "width": 1280,
+            "height": 720,
+            "duration": 6.041992,
+            "name": "reference.mp4",
+            "type": "VideoUrlArtifact",
+        },
+    )
+
+    seen_duration_url: list[str] = []
+
+    async def fake_get_video_duration(url: str) -> float:
+        seen_duration_url.append(url)
+        return 6.041992
+
+    monkeypatch.setattr(wan_animate_module, "get_video_duration", fake_get_video_duration)
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/source.png",
+    )
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/reference.mp4",
+    )
+
+    payload = await node._build_payload()
+
+    # The dict was unwrapped to its inner string before duration probing.
+    assert seen_duration_url == ["/abs/path/reference.mp4"]
+    # Both parameters are now plain strings the upload helpers can consume.
+    assert node.get_parameter_value("image_url") == "/abs/path/source.png"
+    assert node.get_parameter_value("video_url") == "/abs/path/reference.mp4"
+    assert payload["input"] == {
+        "image_url": "https://public.example/source.png",
+        "video_url": "https://public.example/reference.mp4",
+    }
+    assert payload["parameters"]["duration"] == 7  # math.ceil(6.041992)
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_when_video_dict_has_no_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A serialized-dict shape with no usable inner string should fail with
+    a clear "Video URL must be provided" error rather than a misleading
+    macro-resolution error from ``File()``.
+    """
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "https://public.example/source.png")
+    node.set_parameter_value("video_url", {"type": "VideoUrlArtifact"})
+    _stub_video_duration(monkeypatch)
+
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/source.png",
+    )
+
+    with pytest.raises(ValueError, match="Video URL must be provided"):
+        await node._build_payload()
+
+
 class TestExtractVideoUrl:
     """DashScope's documented WAN Animate response nests the result URL under
     ``output.results.video_url``. Older/sibling response shapes expose it at

--- a/tests/unit/video/test_wan_animate_generation.py
+++ b/tests/unit/video/test_wan_animate_generation.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import pytest
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+
+import griptape_nodes_library.video.wan_animate_generation as wan_animate_module
+from griptape_nodes_library.video.wan_animate_generation import WanAnimateGeneration
+
+
+@pytest.fixture(autouse=True)
+def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
+    )
+
+
+def _stub_video_duration(monkeypatch: pytest.MonkeyPatch, seconds: float = 4.0) -> None:
+    async def fake_get_video_duration(_url: str) -> float:
+        return seconds
+
+    monkeypatch.setattr(wan_animate_module, "get_video_duration", fake_get_video_duration)
+
+
+@pytest.mark.asyncio
+async def test_build_payload_uploads_inputs_to_public_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The DashScope Animate endpoint forwards ``image_url`` / ``video_url``
+    straight through; sending ``data:`` URIs trips
+    ``InvalidVideo.FileFormat``. ``_build_payload`` must hand the provider
+    public HTTP URLs produced by the ``PublicArtifactUrlParameter`` helpers.
+    """
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "{inputs}/source.jpg")
+    node.set_parameter_value("video_url", "{inputs}/reference.mp4")
+    _stub_video_duration(monkeypatch, seconds=4.2)
+
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/source.jpg",
+    )
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/reference.mp4",
+    )
+
+    payload = await node._build_payload()
+
+    assert payload == {
+        "input": {
+            "image_url": "https://public.example/source.jpg",
+            "video_url": "https://public.example/reference.mp4",
+        },
+        "parameters": {
+            # 4.2s is rounded up to 5 by ``math.ceil``.
+            "mode": "wan-std",
+            "duration": 5,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_payload_does_not_send_data_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression guard against re-introducing the ``prepare_media_data_uri``
+    flow: the payload must contain HTTP(S) URLs, never ``data:`` URIs.
+    """
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "{inputs}/source.jpg")
+    node.set_parameter_value("video_url", "{inputs}/reference.mp4")
+    _stub_video_duration(monkeypatch)
+
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/source.jpg",
+    )
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/reference.mp4",
+    )
+
+    payload = await node._build_payload()
+
+    for key in ("image_url", "video_url"):
+        assert payload["input"][key].startswith(("http://", "https://"))
+        assert not payload["input"][key].startswith("data:")
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_when_image_upload_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "{inputs}/source.jpg")
+    node.set_parameter_value("video_url", "{inputs}/reference.mp4")
+    _stub_video_duration(monkeypatch)
+
+    monkeypatch.setattr(node._public_image_url_parameter, "get_public_url_for_parameter", lambda: "")
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/reference.mp4",
+    )
+
+    with pytest.raises(ValueError, match="Failed to upload input image"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_when_video_upload_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "{inputs}/source.jpg")
+    node.set_parameter_value("video_url", "{inputs}/reference.mp4")
+    _stub_video_duration(monkeypatch)
+
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://public.example/source.jpg",
+    )
+    monkeypatch.setattr(node._public_video_url_parameter, "get_public_url_for_parameter", lambda: "")
+
+    with pytest.raises(ValueError, match="Failed to upload input video"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_passes_through_existing_public_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``PublicArtifactUrlParameter`` short-circuits when the parameter is
+    already a public HTTP URL (no upload, no cleanup). Verify the payload still
+    carries those URLs verbatim.
+    """
+    node = WanAnimateGeneration(name="WanAnimate")
+    node.set_parameter_value("image_url", "https://cdn.example/already-public.jpg")
+    node.set_parameter_value("video_url", "https://cdn.example/already-public.mp4")
+    node.set_parameter_value("mode", "wan-pro")
+    _stub_video_duration(monkeypatch, seconds=10.0)
+
+    monkeypatch.setattr(
+        node._public_image_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://cdn.example/already-public.jpg",
+    )
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: "https://cdn.example/already-public.mp4",
+    )
+
+    payload = await node._build_payload()
+
+    assert payload["input"] == {
+        "image_url": "https://cdn.example/already-public.jpg",
+        "video_url": "https://cdn.example/already-public.mp4",
+    }
+    assert payload["parameters"]["mode"] == "wan-pro"
+    assert payload["parameters"]["duration"] == 10
+
+
+class TestExtractVideoUrl:
+    """DashScope's documented WAN Animate response nests the result URL under
+    ``output.results.video_url``. Older/sibling response shapes expose it at
+    other locations; the extractor must keep working across all of them so
+    successful generations don't silently produce "no video URL was found".
+    """
+
+    helper = staticmethod(WanAnimateGeneration._extract_video_url)
+
+    def test_dashscope_documented_shape(self) -> None:
+        # https://help.aliyun.com/zh/model-studio/wan2-2-animate-mix-api
+        response = {
+            "request_id": "a67f8716-18ef-447c-a286-xxxxxx",
+            "output": {
+                "task_id": "0385dc79-5ff8-4d82-bcb6-xxxxxx",
+                "task_status": "SUCCEEDED",
+                "submit_time": "2025-09-18 15:32:00.105",
+                "scheduled_time": "2025-09-18 15:32:15.066",
+                "end_time": "2025-09-18 15:34:41.898",
+                "results": {"video_url": "https://dashscope.example/result.mp4"},
+            },
+            "usage": {"video_duration": 5.2, "video_ratio": "standard"},
+        }
+        assert self.helper(response) == "https://dashscope.example/result.mp4"
+
+    def test_falls_back_to_output_video_url(self) -> None:
+        # Earlier WAN Animate response variants put video_url directly on output.
+        assert self.helper({"output": {"video_url": "https://example.com/foo.mp4"}}) == "https://example.com/foo.mp4"
+
+    def test_falls_back_to_top_level_results_video_url(self) -> None:
+        assert self.helper({"results": {"video_url": "https://example.com/foo.mp4"}}) == "https://example.com/foo.mp4"
+
+    def test_falls_back_to_top_level_video_url(self) -> None:
+        assert self.helper({"video_url": "https://example.com/foo.mp4"}) == "https://example.com/foo.mp4"
+
+    def test_nested_results_takes_precedence(self) -> None:
+        # When DashScope returns the documented shape ``output.results.video_url``
+        # we must use that and not any stale value at older locations.
+        response = {
+            "output": {
+                "results": {"video_url": "https://example.com/nested.mp4"},
+                "video_url": "https://example.com/old.mp4",
+            },
+            "video_url": "https://example.com/top.mp4",
+        }
+        assert self.helper(response) == "https://example.com/nested.mp4"
+
+    def test_returns_none_for_none(self) -> None:
+        assert self.helper(None) is None
+
+    def test_returns_none_for_empty_dict(self) -> None:
+        assert self.helper({}) is None
+
+    def test_returns_none_for_non_http_url(self) -> None:
+        assert self.helper({"output": {"results": {"video_url": "ftp://example.com/foo.mp4"}}}) is None
+
+    def test_returns_none_when_results_is_not_dict(self) -> None:
+        # The Wan I2V endpoint puts results at the top level as a dict; if a
+        # caller hands us a list shape we must not crash.
+        assert self.helper({"output": {"results": ["not-a-dict"]}}) is None
+
+
+class TestExtractStatus:
+    """DashScope nests ``task_status`` under ``output``. ``_extract_status``
+    must look there first; otherwise FAILED tasks fall through to the
+    "no video URL was found" branch instead of surfacing the provider error.
+    """
+
+    helper = staticmethod(WanAnimateGeneration._extract_status)
+
+    def test_extracts_nested_output_task_status(self) -> None:
+        assert self.helper({"output": {"task_status": "SUCCEEDED"}}) == "SUCCEEDED"
+
+    def test_extracts_failed_status(self) -> None:
+        assert self.helper({"output": {"task_status": "FAILED"}}) == "FAILED"
+
+    def test_falls_back_to_top_level(self) -> None:
+        assert self.helper({"task_status": "SUCCEEDED"}) == "SUCCEEDED"
+
+    def test_returns_none_for_missing(self) -> None:
+        assert self.helper({"output": {"foo": "bar"}}) is None
+        assert self.helper(None) is None


### PR DESCRIPTION
WAN Animate has been failing for two unrelated reasons since the Feb 4 sync from `griptape-nodes@23e7ef1` (`528f139`, first shipped in v0.63.9):

1. `_build_payload` switched from `get_public_url_for_parameter()` to `prepare_media_data_uri`, so `input.image_url` and `input.video_url` started going out as `data:` URIs. The Animate endpoint (`services/aigc/image2video/video-synthesis`) is one of the few DashScope endpoints the cloud proxy hits via raw `requests.post` rather than the DashScope SDK, so the field is forwarded verbatim and the provider rejects the data URI with `code InvalidVideo.FileFormat: Invalid video type. Only mp4/mov/avi is supported.` Restoring the `PublicArtifactUrlParameter` upload path matches what `Seedance20VideoGeneration`, `KlingMotionControl`, and `SeedVRVideoUpscale` already do for the same reason; cleanup of the short-lived asset still runs in the existing `finally` block via `delete_uploaded_artifact()`.

2. `_extract_status` and `_extract_video_url` were probing flat shapes that don't match what DashScope actually returns. The documented response is `output.task_status` and `output.results.video_url` (see <https://help.aliyun.com/zh/model-studio/wan2-2-animate-mix-api>); without those lookups, a successful generation surfaced as "Generation completed but no video URL was found" and a FAILED task fell through to the same misleading branch instead of producing the provider error. The legacy `output.video_url`, top-level `results.video_url`, and top-level `video_url` shapes are kept as fallbacks so older / sibling response variants still resolve.


<img width="785" height="1165" alt="image" src="https://github.com/user-attachments/assets/0ed0f3e4-4642-4d37-8a1c-fdd03e6c2ae6" />
