### PR TITLE
fix(tests): set metadata input in test_write_image_metadata workflow

### DIFF
--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -23,7 +23,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(
@@ -96,6 +96,16 @@ with GriptapeNodes.ContextManager().flow(flow_name):
                 ui_options={},
                 parent_container_name="",
                 initial_setup=True,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="metadata",
+                node_name=gen_node,
+                value={"author": "griptape-nodes-tests", "description": "integration test"},
+                initial_setup=True,
+                is_output=False,
             )
         )
     GriptapeNodes.handle_request(


### PR DESCRIPTION
Closes #250.

The integration workflow had `CreateColorBars` feeding `WriteImageMetadataNode.input_image` but never set the `metadata` parameter, so it stayed as the default empty dict and the node aborted with "No metadata provided". Followed the same pattern other integration tests use (e.g. `test_extract_last_frame.py`, `test_ltx_image_to_video_generation.py`) and added a `SetParameterValueRequest` for `metadata` inside a `ContextManager().node(gen_node)` block with a small sample dict.

Left `WriteImageMetadataNode` itself unchanged. Empty-metadata-as-error is reasonable behavior for a 'write metadata' operation, and changing it would silently mask bad workflow wiring rather than surface it.