### PR TITLE
feat(proxy): expose generation timeout as user-configurable parameter

### DIFF
--- a/griptape_nodes_library/image/seedvr_image_upscale.py
+++ b/griptape_nodes_library/image/seedvr_image_upscale.py
@@ -16,7 +16,6 @@ from griptape_nodes.exe_types.param_components.seed_parameter import SeedParamet
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
-from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -130,15 +129,6 @@ class SeedVRImageUpscale(GriptapeProxyNode):
                 traits={Options(choices=["png", "jpg", "webp"])},
             )
 
-            ParameterInt(
-                name="timeout",
-                default_value=600,
-                tooltip="Polling timeout in seconds. Set to 0 for no timeout.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                min_val=0,
-                max_val=86400,
-            )
-
         self.add_node_element(generation_settings_group)
 
         # OUTPUTS
@@ -219,11 +209,6 @@ class SeedVRImageUpscale(GriptapeProxyNode):
 
     async def _process_generation(self) -> None:
         self.preprocess()
-        timeout_s = float(self.get_parameter_value("timeout") or 0)
-        if timeout_s > 0:
-            poll_interval = self.DEFAULT_POLL_INTERVAL
-            self.DEFAULT_MAX_ATTEMPTS = max(1, int((timeout_s + poll_interval - 1) // poll_interval))
-
         try:
             await super()._process_generation()
         finally:

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -11,8 +11,9 @@ from typing import Any
 from urllib.parse import urljoin
 
 import httpx
-from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
@@ -66,6 +67,18 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._user_auth_info: str | None = None
         self._api_key_provider: ProxyAuthProviderParameter | None = None
         self._initialize_api_key_provider()
+
+        default_timeout = self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
+        with ParameterGroup(name="Generation Settings", ui_options={"collapsed": True}) as _timeout_group:
+            ParameterInt(
+                name="timeout",
+                default_value=default_timeout,
+                tooltip="Polling timeout in seconds. Set to 0 for no timeout.",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                min_val=0,
+                max_val=86400,
+            )
+        self.add_node_element(_timeout_group)
 
     def _initialize_api_key_provider(self) -> None:
         provider_config = get_proxy_api_key_provider_config(type(self).__name__)
@@ -356,6 +369,15 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
 
         return False, None
 
+    def _resolve_timeout_seconds(self) -> int:
+        try:
+            value = self.get_parameter_value("timeout")
+        except Exception:
+            value = None
+        if value is None:
+            return self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
+        return max(0, int(value))
+
     async def _poll_generation_status(self, generation_id: str, headers: dict[str, str]) -> dict[str, Any] | None:
         """Poll generation status until terminal state is reached.
 
@@ -367,11 +389,18 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             dict | None: The final status response, or None if polling failed
         """
         get_url = urljoin(self._proxy_base, f"generations/{generation_id}")
-        max_attempts = self.DEFAULT_MAX_ATTEMPTS
         poll_interval = self.DEFAULT_POLL_INTERVAL
+        timeout_s = self._resolve_timeout_seconds()
+        # None means unbounded (timeout=0 set by user)
+        max_attempts = (
+            max(1, (timeout_s + poll_interval - 1) // poll_interval)
+            if timeout_s > 0
+            else None
+        )
 
+        attempt = 0
         async with httpx.AsyncClient() as client:
-            for attempt in range(max_attempts):
+            while True:
                 try:
                     self._log(f"Polling attempt #{attempt + 1} for generation {generation_id}")
 
@@ -386,31 +415,40 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
                     if is_terminal:
                         return terminal_result
 
+                    attempt += 1
+
+                    # Timeout reached (only when max_attempts is set)
+                    if max_attempts is not None and attempt >= max_attempts:
+                        break
+
                     # Still processing (QUEUED or RUNNING), wait before next poll
-                    if attempt < max_attempts - 1:
-                        await asyncio.sleep(poll_interval)
+                    await asyncio.sleep(poll_interval)
 
                 except httpx.HTTPStatusError as e:
                     self._log(f"HTTP error while polling: {e.response.status_code} - {e.response.text}")
-                    if attempt == max_attempts - 1:
+                    attempt += 1
+                    if max_attempts is not None and attempt >= max_attempts:
                         self._set_safe_defaults()
                         error_msg = f"Failed to poll generation status: HTTP {e.response.status_code}"
                         self._set_status_results(was_successful=False, result_details=error_msg)
                         return None
+                    await asyncio.sleep(poll_interval)
                 except Exception as e:
                     self._log(f"Error while polling: {e}")
-                    if attempt == max_attempts - 1:
+                    attempt += 1
+                    if max_attempts is not None and attempt >= max_attempts:
                         self._set_safe_defaults()
                         error_msg = f"Failed to poll generation status: {e}"
                         self._set_status_results(was_successful=False, result_details=error_msg)
                         return None
+                    await asyncio.sleep(poll_interval)
 
         # Timeout reached
         self._log("Polling timed out waiting for result")
         self._set_safe_defaults()
         self._set_status_results(
             was_successful=False,
-            result_details=f"Generation timed out after {max_attempts * poll_interval} seconds waiting for result.",
+            result_details=f"Generation timed out after {timeout_s} seconds waiting for result.",
         )
         return None
 

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 import httpx
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -69,7 +69,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._initialize_api_key_provider()
 
         default_timeout = self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
-        with ParameterGroup(name="Generation Settings", ui_options={"collapsed": True}) as _timeout_group:
+        self.add_parameter(
             ParameterInt(
                 name="timeout",
                 default_value=default_timeout,
@@ -78,7 +78,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
                 min_val=0,
                 max_val=86400,
             )
-        self.add_node_element(_timeout_group)
+        )
 
     def _initialize_api_key_provider(self) -> None:
         provider_config = get_proxy_api_key_provider_config(type(self).__name__)
@@ -392,11 +392,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         poll_interval = self.DEFAULT_POLL_INTERVAL
         timeout_s = self._resolve_timeout_seconds()
         # None means unbounded (timeout=0 set by user)
-        max_attempts = (
-            max(1, (timeout_s + poll_interval - 1) // poll_interval)
-            if timeout_s > 0
-            else None
-        )
+        max_attempts = max(1, (timeout_s + poll_interval - 1) // poll_interval) if timeout_s > 0 else None
 
         attempt = 0
         async with httpx.AsyncClient() as client:

--- a/griptape_nodes_library/video/seedvr_video_upscale.py
+++ b/griptape_nodes_library/video/seedvr_video_upscale.py
@@ -13,7 +13,6 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_components.seed_parameter import SeedParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
-from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -141,16 +140,6 @@ class SeedVRVideoUpscale(GriptapeProxyNode):
             self._seed_parameter = SeedParameter(self)
             self._seed_parameter.add_input_parameters(inside_param_group=True)
 
-            # Polling timeout (0 = no timeout)
-            ParameterInt(
-                name="timeout",
-                default_value=1000,
-                tooltip="Polling timeout in seconds. Set to 0 for no timeout.",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                min_val=0,
-                max_val=86400,
-            )
-
         self.add_node_element(generation_settings_group)
 
         # OUTPUTS
@@ -226,11 +215,6 @@ class SeedVRVideoUpscale(GriptapeProxyNode):
 
     async def _process_generation(self) -> None:
         self.preprocess()
-        timeout_s = float(self.get_parameter_value("timeout") or 0)
-        if timeout_s > 0:
-            poll_interval = self.DEFAULT_POLL_INTERVAL
-            self.DEFAULT_MAX_ATTEMPTS = max(1, int((timeout_s + poll_interval - 1) // poll_interval))
-
         try:
             await super()._process_generation()
         finally:

--- a/tests/unit/test_griptape_proxy_node_polling.py
+++ b/tests/unit/test_griptape_proxy_node_polling.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+import ast
+
+import pytest
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+
+from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
+from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
+
+
+def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
+    library_root = Path(__file__).parents[2] / "griptape_nodes_library"
+    for path in sorted(library_root.rglob("*.py")):
+        module_rel_path = path.relative_to(library_root.parent)
+        module_name = ".".join(module_rel_path.with_suffix("").parts)
+        tree = ast.parse(path.read_text())
+        for node in tree.body:
+            if not isinstance(node, ast.ClassDef):
+                continue
+            if not any(isinstance(base, ast.Name) and base.id == "GriptapeProxyNode" for base in node.bases):
+                continue
+            yield node.name, module_name
+
+
+PROXY_NODE_CLASSES = tuple(_iter_proxy_node_classes())
+
+
+@pytest.fixture(autouse=True)
+def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
+    )
+
+
+@pytest.mark.parametrize(("class_name", "module_name"), PROXY_NODE_CLASSES)
+def test_every_proxy_node_has_timeout_parameter(class_name: str, module_name: str) -> None:
+    module = importlib.import_module(module_name)
+    node_class = getattr(module, class_name)
+    node = node_class(name=class_name)
+
+    timeout_param = next((p for p in node.parameters if p.name == "timeout"), None)
+    assert timeout_param is not None, f"{class_name} is missing a 'timeout' parameter"
+
+    cls = type(node)
+    expected_default = cls.DEFAULT_MAX_ATTEMPTS * cls.DEFAULT_POLL_INTERVAL
+    assert timeout_param.default_value == expected_default, (
+        f"{class_name}: expected timeout default {expected_default}, got {timeout_param.default_value}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeout_parameter_limits_poll_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    poll_count = 0
+
+    class AlwaysRunningResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"status": "RUNNING"}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str], timeout: int) -> AlwaysRunningResponse:
+            nonlocal poll_count
+            poll_count += 1
+            return AlwaysRunningResponse()
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+    async def noop_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.asyncio.sleep", noop_sleep)
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.set_parameter_value("timeout", 10)
+
+    status_calls: list[dict[str, Any]] = []
+
+    def capture_status_results(**kwargs: Any) -> None:
+        status_calls.append(kwargs)
+
+    node._set_status_results = capture_status_results  # type: ignore[method-assign]
+    node._set_safe_defaults = lambda: None  # type: ignore[method-assign]
+
+    headers = {"Authorization": "Bearer key"}
+    result = await node._poll_generation_status("gen-abc", headers)
+
+    assert result is None
+    # poll_interval=5, timeout=10 → max_attempts=2
+    assert poll_count == 2
+    assert len(status_calls) == 1
+    assert status_calls[0]["was_successful"] is False
+    assert "10 seconds" in status_calls[0]["result_details"]
+
+
+@pytest.mark.asyncio
+async def test_zero_timeout_polls_until_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    poll_count = 0
+    complete_after = 15
+
+    class EventuallyCompletedResponse:
+        def __init__(self, count: int) -> None:
+            self._count = count
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            if self._count >= complete_after:
+                return {"status": "COMPLETED"}
+            return {"status": "RUNNING"}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str], timeout: int) -> EventuallyCompletedResponse:
+            nonlocal poll_count
+            poll_count += 1
+            return EventuallyCompletedResponse(poll_count)
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+    async def noop_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.asyncio.sleep", noop_sleep)
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.set_parameter_value("timeout", 0)
+
+    timeout_fired = False
+
+    def capture_status_results(**kwargs: Any) -> None:
+        nonlocal timeout_fired
+        if not kwargs.get("was_successful") and "timed out" in kwargs.get("result_details", ""):
+            timeout_fired = True
+
+    node._set_status_results = capture_status_results  # type: ignore[method-assign]
+
+    headers = {"Authorization": "Bearer key"}
+    # Wrap in asyncio.wait_for to guard against infinite-loop regression
+    result = await asyncio.wait_for(node._poll_generation_status("gen-xyz", headers), timeout=5.0)
+
+    assert result is not None
+    assert result["status"] == "COMPLETED"
+    assert poll_count == complete_after
+    assert not timeout_fired
+
+
+def test_timeout_parameter_does_not_mutate_class_attribute() -> None:
+    original_max_attempts = Flux2ImageGeneration.DEFAULT_MAX_ATTEMPTS
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.set_parameter_value("timeout", 30)
+
+    # _resolve_timeout_seconds reads the parameter
+    resolved = node._resolve_timeout_seconds()
+    assert resolved == 30
+
+    # Class attribute must be untouched
+    assert Flux2ImageGeneration.DEFAULT_MAX_ATTEMPTS == original_max_attempts
+    assert node.DEFAULT_MAX_ATTEMPTS == original_max_attempts

--- a/tests/unit/test_griptape_proxy_node_polling.py
+++ b/tests/unit/test_griptape_proxy_node_polling.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import ast
 import asyncio
 import importlib
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
-import ast
 
 import pytest
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
@@ -13,7 +13,6 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 )
 
 from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
-from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 
 
 def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
@@ -80,6 +79,7 @@ async def test_timeout_parameter_limits_poll_attempts(monkeypatch: pytest.Monkey
             return AlwaysRunningResponse()
 
     monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+
     async def noop_sleep(_: float) -> None:
         pass
 
@@ -137,6 +137,7 @@ async def test_zero_timeout_polls_until_completion(monkeypatch: pytest.MonkeyPat
             return EventuallyCompletedResponse(poll_count)
 
     monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+
     async def noop_sleep(_: float) -> None:
         pass
 


### PR DESCRIPTION
## Summary

closes #235 
- Adds a `timeout` parameter (seconds) to every proxy node via the `GriptapeProxyNode` base class — no per-subclass changes needed
- Default is seeded from each class's `DEFAULT_MAX_ATTEMPTS * DEFAULT_POLL_INTERVAL`, preserving existing behaviour (600s for most nodes, 1200s for LTX/Minimax)
- Setting `timeout=0` disables the cap entirely — the node will poll until the job completes or fails
- Removes the now-redundant local `timeout` overrides from `SeedVRImageUpscale` and `SeedVRVideoUpscale`
- Polling loop refactored to avoid mutating class attributes on the instance

## Test plan

- [x] All 48 new unit tests in `tests/unit/test_griptape_proxy_node_polling.py` pass
  - Parametrized check that every proxy node has a `timeout` param with the correct default
  - `timeout=10` stops polling after 2 attempts (10s / 5s interval) with a clear timeout message
  - `timeout=0` polls until completion without firing the timeout branch
  - Class attribute `DEFAULT_MAX_ATTEMPTS` is never mutated after a run
- [x] Open a proxy node in the UI — `timeout` field visible as a top-level parameter, default 600
- [x] `LTXTextToVideoGeneration` shows default 1200
- [x] `SeedVRImageUpscale` shows default 600 with no duplicate field
- [x] Set `timeout=30` on a slow model and confirm it times out with `Generation timed out after 30 seconds waiting for result.`

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)