### PR TITLE
Make Adjust Mask Size dramatically faster

### DIFF
--- a/griptape_nodes_library/video/adjust_mask_size.py
+++ b/griptape_nodes_library/video/adjust_mask_size.py
@@ -245,13 +245,20 @@ class AdjustMaskSize(DataNode):
 
             cmd = [
                 ffmpeg_path,
-                "-i", video_url,
-                "-vf", vf,
-                "-c:v", "libx264",
-                "-pix_fmt", "yuv420p",
-                "-preset", "medium",
-                "-crf", "18",
-                "-y", str(output_video),
+                "-i",
+                video_url,
+                "-vf",
+                vf,
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-preset",
+                "medium",
+                "-crf",
+                "18",
+                "-y",
+                str(output_video),
             ]
 
             try:
@@ -294,4 +301,3 @@ class AdjustMaskSize(DataNode):
         if not validate_url(url):
             msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
             raise ValueError(msg)
-

--- a/griptape_nodes_library/video/adjust_mask_size.py
+++ b/griptape_nodes_library/video/adjust_mask_size.py
@@ -1,10 +1,8 @@
-import json
 import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 import static_ffmpeg.run  # type: ignore[import-untyped]
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
@@ -15,7 +13,6 @@ from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.widget import Widget
-from PIL import Image, ImageFilter
 
 
 class AdjustMaskSize(DataNode):
@@ -224,55 +221,62 @@ class AdjustMaskSize(DataNode):
             raise ValueError(msg) from e
 
     def _process_mask_video(self, mask_video: Any, adjustment: int) -> None:
-        """Process mask video by adjusting each frame."""
-        temp_dirs: list[Path] = []
-        temp_files: list[Path] = []
+        """Process mask video using FFmpeg's native morphological filters.
 
+        Chains dilation or erosion N times (once per pixel of adjustment),
+        replacing the Python frame-extract → process → reassemble pipeline
+        with a single FFmpeg invocation.
+        """
+        output_video: Path | None = None
         try:
-            # Get FFmpeg paths
-            ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
-
-            # Get video URL
+            ffmpeg_path, _ = self._get_ffmpeg_paths()
             video_url = File(mask_video.value).resolve()
             self._validate_url_safety(video_url)
 
-            # Get video properties
-            props = self._get_video_properties(video_url, ffprobe_path)
+            # Chain dilation or erosion N times for N-pixel radius effect
+            steps = abs(adjustment)
+            filter_name = "dilation" if adjustment > 0 else "erosion"
+            vf = "format=gray," + ",".join([filter_name] * steps)
 
-            # Extract frames
-            frames_dir = Path(tempfile.mkdtemp())
-            temp_dirs.append(frames_dir)
-            self._extract_frames(video_url, frames_dir, ffmpeg_path)
+            with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+                output_video = Path(tmp.name)
 
-            # Adjust frames
-            adjusted_frames_dir = Path(tempfile.mkdtemp())
-            temp_dirs.append(adjusted_frames_dir)
-            last_progress = self._adjust_frames(frames_dir, adjusted_frames_dir, props["frame_count"], adjustment)
+            self.progress_component.initialize(2)
 
-            # Reassemble video
-            output_video = self._reassemble_video(adjusted_frames_dir, props, ffmpeg_path, last_progress)
-            temp_files.append(output_video)
+            cmd = [
+                ffmpeg_path,
+                "-i", video_url,
+                "-vf", vf,
+                "-c:v", "libx264",
+                "-pix_fmt", "yuv420p",
+                "-preset", "medium",
+                "-crf", "18",
+                "-y", str(output_video),
+            ]
 
-            # Read video bytes
+            try:
+                subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)  # noqa: S603
+            except subprocess.CalledProcessError as e:
+                msg = f"{self.name}: FFmpeg morphological filter failed: {e.stderr}"
+                raise ValueError(msg) from e
+            except subprocess.TimeoutExpired as e:
+                msg = f"{self.name}: FFmpeg morphological filter timed out"
+                raise ValueError(msg) from e
+
+            self.progress_component.increment()
+
             with output_video.open("rb") as f:
                 video_bytes = f.read()
 
-            # Save output
             dest = self._output_file.build_file()
             saved = dest.write_bytes(video_bytes)
-            output_artifact = VideoUrlArtifact(saved.location)
+            self.parameter_output_values["output_mask"] = VideoUrlArtifact(saved.location)
 
-            self.parameter_output_values["output_mask"] = output_artifact
+            self.progress_component.increment()
 
         finally:
-            # Cleanup temp directories and files
-            for temp_dir in temp_dirs:
-                import shutil
-
-                shutil.rmtree(temp_dir, ignore_errors=True)
-
-            for temp_file in temp_files:
-                temp_file.unlink(missing_ok=True)
+            if output_video and output_video.exists():
+                output_video.unlink(missing_ok=True)
 
     def _get_ffmpeg_paths(self) -> tuple[str, str]:
         """Get FFmpeg and FFprobe executable paths."""
@@ -291,233 +295,3 @@ class AdjustMaskSize(DataNode):
             msg = f"{self.name}: Invalid or unsafe URL provided: {url}"
             raise ValueError(msg)
 
-    def _get_video_properties(self, video_url: str, ffprobe_path: str) -> dict[str, Any]:
-        """Get video properties (resolution, fps, frame count)."""
-        try:
-            cmd = [
-                ffprobe_path,
-                "-v",
-                "quiet",
-                "-print_format",
-                "json",
-                "-show_streams",
-                "-select_streams",
-                "v:0",
-                video_url,
-            ]
-
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
-            streams_data = json.loads(result.stdout)
-
-            if not streams_data.get("streams") or len(streams_data["streams"]) == 0:
-                msg = f"{self.name}: No video stream found in {video_url}"
-                raise ValueError(msg)
-
-            video_stream = streams_data["streams"][0]
-
-            # Get frame rate
-            fps_str = video_stream.get("r_frame_rate", "30/1")
-            if "/" in fps_str:
-                num, den = map(int, fps_str.split("/"))
-                fps = num / den
-            else:
-                fps = float(fps_str)
-
-            # Get resolution
-            width = int(video_stream.get("width", 0))
-            height = int(video_stream.get("height", 0))
-
-            # Get frame count
-            nb_frames = video_stream.get("nb_frames")
-            if nb_frames:
-                frame_count = int(nb_frames)
-            else:
-                # Calculate from duration and fps
-                duration = float(video_stream.get("duration", 0))
-                frame_count = int(duration * fps)
-
-            return {"width": width, "height": height, "fps": fps, "frame_count": frame_count}
-
-        except Exception as e:
-            msg = f"{self.name}: Failed to get video properties: {e}"
-            raise ValueError(msg) from e
-
-    def _extract_frames(self, video_url: str, output_dir: Path, ffmpeg_path: str) -> None:
-        """Extract all frames from video to directory."""
-        output_pattern = str(output_dir / "frame_%06d.png")
-
-        cmd = [
-            ffmpeg_path,
-            "-i",
-            video_url,
-            "-vf",
-            "format=gray",  # Convert to grayscale
-            "-y",
-            output_pattern,
-        ]
-
-        try:
-            subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=300)  # noqa: S603
-        except subprocess.CalledProcessError as e:
-            msg = f"{self.name}: FFmpeg frame extraction failed: {e.stderr}"
-            raise ValueError(msg) from e
-        except subprocess.TimeoutExpired as e:
-            msg = f"{self.name}: FFmpeg frame extraction timed out"
-            raise ValueError(msg) from e
-
-    def _adjust_frames(self, input_dir: Path, output_dir: Path, frame_count: int, adjustment: int) -> int:
-        """Adjust mask size in each frame using dilation or erosion.
-
-        Args:
-            input_dir: Directory containing input frames
-            output_dir: Directory to save adjusted frames
-            frame_count: Number of frames to process
-            adjustment: Adjustment amount (positive for dilation, negative for erosion)
-
-        Returns:
-            The last progress step (should be 9 after frame processing)
-        """
-        # 10 steps for frame processing + 1 step for reassembly = 11 total
-        self.progress_component.initialize(11)
-        last_step = 0
-
-        # Create structuring element for morphological operations
-        # Use a circular/elliptical kernel for more natural-looking results
-        kernel_size = abs(adjustment)
-        y, x = np.ogrid[-kernel_size : kernel_size + 1, -kernel_size : kernel_size + 1]
-        kernel = x**2 + y**2 <= kernel_size**2
-        kernel = kernel.astype(np.uint8)
-
-        for frame_idx in range(1, frame_count + 1):
-            frame_filename = f"frame_{frame_idx:06d}.png"
-            input_path = input_dir / frame_filename
-            output_path = output_dir / frame_filename
-
-            if not input_path.exists():
-                msg = f"{self.name}: Missing frame {frame_filename}"
-                raise ValueError(msg)
-
-            # Load frame
-            frame_img = Image.open(input_path).convert("L")  # Ensure grayscale
-            frame_array = np.array(frame_img)
-
-            # Apply morphological operation
-            if adjustment > 0:
-                # Dilation (expand mask)
-                adjusted_array = self._dilate_binary(frame_array > 127, kernel).astype(np.uint8) * 255
-            else:
-                # Erosion (shrink mask)
-                adjusted_array = self._erode_binary(frame_array > 127, kernel).astype(np.uint8) * 255
-
-            # Save adjusted frame
-            adjusted_img = Image.fromarray(adjusted_array, mode="L")
-            adjusted_img.save(output_path, "PNG")
-
-            # Step progress at each 10% boundary (10 steps total for frame processing)
-            current_step = int((frame_idx / frame_count) * 10)
-            if current_step > last_step:
-                for _ in range(current_step - last_step):
-                    self.progress_component.increment()
-                last_step = current_step
-
-        return last_step
-
-    def _dilate_binary(self, binary_mask: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-        """Perform binary dilation on a mask using a structuring element.
-
-        Uses PIL's MaxFilter to expand the mask. Dilation sets a pixel to True if any
-        pixel in the kernel neighborhood is True.
-
-        Args:
-            binary_mask: Boolean array representing the binary mask
-            kernel: Boolean or uint8 array representing the structuring element
-
-        Returns:
-            Boolean array with dilated mask
-        """
-        # Convert binary mask to uint8 image (0 or 255)
-        mask_img = Image.fromarray((binary_mask * 255).astype(np.uint8), mode="L")
-
-        # Apply MaxFilter with kernel size
-        dilated_img = mask_img.filter(ImageFilter.MaxFilter(size=kernel.shape[0]))
-
-        # Convert back to boolean array
-        dilated_array = np.array(dilated_img) > 127
-        return dilated_array
-
-    def _erode_binary(self, binary_mask: np.ndarray, kernel: np.ndarray) -> np.ndarray:
-        """Perform binary erosion on a mask using a structuring element.
-
-        Uses PIL's MinFilter to shrink the mask. Erosion sets a pixel to False if any
-        pixel in the kernel neighborhood is False.
-
-        Args:
-            binary_mask: Boolean array representing the binary mask
-            kernel: Boolean or uint8 array representing the structuring element
-
-        Returns:
-            Boolean array with eroded mask
-        """
-        # Convert binary mask to uint8 image (0 or 255)
-        mask_img = Image.fromarray((binary_mask * 255).astype(np.uint8), mode="L")
-
-        # Apply MinFilter with kernel size
-        eroded_img = mask_img.filter(ImageFilter.MinFilter(size=kernel.shape[0]))
-
-        # Convert back to boolean array
-        eroded_array = np.array(eroded_img) > 127
-        return eroded_array
-
-    def _reassemble_video(self, frames_dir: Path, props: dict[str, Any], ffmpeg_path: str, last_progress: int) -> Path:
-        """Reassemble video from adjusted frames.
-
-        Args:
-            frames_dir: Directory containing adjusted frames
-            props: Video properties (fps, width, height)
-            ffmpeg_path: Path to FFmpeg executable
-            last_progress: Current progress value from frame processing
-
-        Returns:
-            Path to reassembled video file
-        """
-        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as temp_file:
-            output_video = Path(temp_file.name)
-        input_pattern = str(frames_dir / "frame_%06d.png")
-
-        # Ensure frame processing steps are complete before reassembly
-        while last_progress < 10:
-            self.progress_component.increment()
-            last_progress += 1
-
-        cmd = [
-            ffmpeg_path,
-            "-framerate",
-            str(props["fps"]),
-            "-i",
-            input_pattern,
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-preset",
-            "medium",
-            "-crf",
-            "18",
-            "-y",
-            str(output_video),
-        ]
-
-        try:
-            subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=600)  # noqa: S603
-
-            # Final step for reassembly complete
-            self.progress_component.increment()
-
-        except subprocess.CalledProcessError as e:
-            msg = f"{self.name}: FFmpeg video reassembly failed: {e.stderr}"
-            raise ValueError(msg) from e
-        except subprocess.TimeoutExpired as e:
-            msg = f"{self.name}: FFmpeg video reassembly timed out"
-            raise ValueError(msg) from e
-
-        return output_video


### PR DESCRIPTION
## Summary

- Replaced the Python frame-extract → PIL/numpy process → reassemble pipeline in `AdjustMaskSize` with a single FFmpeg invocation using the built-in `dilation`/`erosion` video filters
- Removed `json`, `numpy`, and `PIL` imports — no longer needed
- Deleted five methods that are now dead code: `_get_video_properties`, `_extract_frames`, `_adjust_frames`, `_dilate_binary`, `_erode_binary`, `_reassemble_video`
- File reduced from ~520 lines to ~298 lines

## How it works

For a given adjustment value N, the new code builds a chained FFmpeg filter string:

```
format=gray,dilation,dilation,...   # N times for expansion
format=gray,erosion,erosion,...     # N times for shrinkage
```

FFmpeg applies all filters in a single streaming decode→filter→encode pass, running entirely in C with no per-frame disk I/O or Python overhead.

## Performance

Previously: extract every frame as a PNG → read each PNG → numpy → PIL MaxFilter/MinFilter → write PNG → re-encode video (N+2 disk round-trips per frame).

Now: one FFmpeg subprocess call.

## Trade-off

FFmpeg's `dilation`/`erosion` filters use a 3×3 neighborhood per step, so chaining N times produces a diamond-shaped structuring element rather than the circular kernel used previously. The difference is imperceptible for typical mask adjustment values (1–10px).

## Test plan

- [x] Run `AdjustMaskSize` node with a mask video and positive adjustment — output mask should be dilated
- [x] Run with negative adjustment — output mask should be eroded
- [x] Verify adjustment = 0 passes the input through unchanged (short-circuits before FFmpeg)
- [x] Verify cleanup: no temp files left behind after processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)