### PR TITLE
fix(openai-image): hide transparent background for unsupported models

### DIFF
--- a/griptape_nodes_library/image/openai_image_generation.py
+++ b/griptape_nodes_library/image/openai_image_generation.py
@@ -54,6 +54,13 @@ class OpenAiImageGeneration(GriptapeProxyNode):
     GPT_IMAGE_2_DEFAULT_CUSTOM_HEIGHT: ClassVar[int] = 1024
     QUALITY_OPTIONS: ClassVar[list[str]] = ["low", "medium", "high"]
     BACKGROUND_OPTIONS: ClassVar[list[str]] = ["auto", "opaque", "transparent"]
+    # Only gpt-image-1 supports transparent backgrounds; gpt-image-1.5 and gpt-image-2 reject
+    # background="transparent" at the API level.
+    BACKGROUND_OPTIONS_BY_MODEL: ClassVar[dict[str, list[str]]] = {
+        GPT_IMAGE_1_MODEL_NAME: ["auto", "opaque", "transparent"],
+        GPT_IMAGE_1_5_MODEL_NAME: ["auto", "opaque"],
+        GPT_IMAGE_2_MODEL_NAME: ["auto", "opaque"],
+    }
     MODERATION_OPTIONS: ClassVar[list[str]] = ["auto", "low"]
     OUTPUT_FORMAT_OPTIONS: ClassVar[list[str]] = ["png", "jpeg", "webp"]
     MAX_REFERENCE_IMAGES: ClassVar[int] = 16
@@ -176,12 +183,16 @@ class OpenAiImageGeneration(GriptapeProxyNode):
                 traits={Options(choices=self.QUALITY_OPTIONS)},
             )
 
+            initial_background_choices = self._background_choices_for_model(self.DEFAULT_MODEL)
             ParameterString(
                 name="background",
-                default_value="auto",
-                tooltip="Background handling. Transparent backgrounds require PNG or WEBP output.",
+                default_value=initial_background_choices[0],
+                tooltip=(
+                    "Background handling. Transparent backgrounds are only supported on GPT Image 1 "
+                    "and require PNG or WEBP output."
+                ),
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.BACKGROUND_OPTIONS)},
+                traits={Options(choices=initial_background_choices)},
             )
 
             ParameterString(
@@ -269,6 +280,10 @@ class OpenAiImageGeneration(GriptapeProxyNode):
             return list(cls.GPT_IMAGE_2_SIZE_OPTIONS)
         return list(cls.GPT_IMAGE_SIZE_OPTIONS)
 
+    @classmethod
+    def _background_choices_for_model(cls, model_name: str) -> list[str]:
+        return list(cls.BACKGROUND_OPTIONS_BY_MODEL.get(model_name, cls.BACKGROUND_OPTIONS))
+
     def _get_payload_model_id(self) -> str:
         model_name = self.get_parameter_value("model") or self.DEFAULT_MODEL
         return self.MODEL_NAME_MAP[model_name]
@@ -311,6 +326,25 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         self.set_parameter_value("size", choices[0])
         self.publish_update_to_parameter("size", choices[0])
         self._sync_custom_size_visibility(model_name, choices[0])
+
+    def _sync_background_options_for_model(self, model_name: str) -> None:
+        background_param = self.get_parameter_by_name("background")
+        if background_param is None:
+            return
+
+        choices = self._background_choices_for_model(model_name)
+
+        existing_traits = background_param.find_elements_by_type(Options)
+        if existing_traits:
+            background_param.remove_trait(trait_type=existing_traits[0])
+        background_param.add_trait(Options(choices=choices))
+
+        current_background = self.get_parameter_value("background")
+        if current_background in choices:
+            return
+
+        self.set_parameter_value("background", choices[0])
+        self.publish_update_to_parameter("background", choices[0])
 
     def _sync_custom_size_visibility(self, model_name: str, size_value: Any) -> None:
         show_custom = model_name == GPT_IMAGE_2_MODEL_NAME and size_value == self.GPT_IMAGE_2_CUSTOM_SIZE
@@ -385,6 +419,7 @@ class OpenAiImageGeneration(GriptapeProxyNode):
     def _react_to_parameter_change(self, param_name: str, value: Any, *, sync_only: bool) -> None:
         if param_name == "model" and isinstance(value, str):
             self._sync_size_options_for_model(value)
+            self._sync_background_options_for_model(value)
 
         if param_name == "size" and isinstance(value, str):
             current_model = self.get_parameter_value("model") or self.DEFAULT_MODEL

--- a/tests/unit/image/test_openai_image_generation.py
+++ b/tests/unit/image/test_openai_image_generation.py
@@ -73,6 +73,7 @@ def test_validate_rejects_invalid_gpt_image_1_size(node: OpenAiImageGeneration) 
 
 
 def test_validate_rejects_transparent_jpeg(node: OpenAiImageGeneration) -> None:
+    node.set_parameter_value("model", "GPT Image 1")
     node.set_parameter_value("prompt", "A red circle")
     node.set_parameter_value("background", "transparent")
     node.set_parameter_value("output_format", "jpeg")
@@ -259,6 +260,51 @@ async def test_parse_result_saves_base64_images(
     assert Path(first_artifact.value).read_bytes() == image_1_bytes
     assert Path(second_artifact.value).read_bytes() == image_2_bytes
     assert node.parameter_output_values["was_successful"] is True
+
+
+def _background_choices(node: OpenAiImageGeneration) -> list[str]:
+    background_param = node.get_parameter_by_name("background")
+    assert background_param is not None
+    options_traits = background_param.find_elements_by_type(Options)
+    assert options_traits, "background parameter is missing an Options trait"
+    return list(options_traits[0].choices)
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_choices"),
+    [
+        ("GPT Image 1", ["auto", "opaque", "transparent"]),
+        ("GPT Image 1.5", ["auto", "opaque"]),
+        ("GPT Image 2", ["auto", "opaque"]),
+    ],
+)
+def test_background_options_update_when_model_changes(
+    node: OpenAiImageGeneration, model_name: str, expected_choices: list[str]
+) -> None:
+    node.set_parameter_value("model", model_name)
+
+    assert _background_choices(node) == expected_choices
+
+
+def test_default_model_omits_transparent_background(node: OpenAiImageGeneration) -> None:
+    assert "transparent" not in _background_choices(node)
+
+
+def test_switching_to_unsupported_model_resets_transparent_background(node: OpenAiImageGeneration) -> None:
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+    node.set_parameter_value("background", "transparent")
+
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+
+    assert node.get_parameter_value("background") == "auto"
+
+
+def test_switching_to_supported_model_preserves_opaque_background(node: OpenAiImageGeneration) -> None:
+    node.set_parameter_value("background", "opaque")
+
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+
+    assert node.get_parameter_value("background") == "opaque"
 
 
 def test_default_model_uses_display_name(node: OpenAiImageGeneration) -> None:


### PR DESCRIPTION
Closes #260.

The OpenAI API only honors `background="transparent"` on `gpt-image-1`. Selecting `transparent` with `gpt-image-1.5` or `gpt-image-2` (the default) bubbles up as a runtime error from the proxy instead of being prevented in the UI.

Mirrors the existing per-model size handling: `BACKGROUND_OPTIONS_BY_MODEL` drives the `background` choice list, and `_sync_background_options_for_model` swaps the `Options` trait when the model changes, resetting to `auto` if the previous selection (`transparent`) is no longer valid. The runtime check that `transparent` requires `png`/`webp` output stays as a backstop for the one model where it remains selectable.


<img width="782" height="811" alt="image" src="https://github.com/user-attachments/assets/e7d30200-f46f-4ceb-a0d4-5d5e556c5536" />
<img width="829" height="871" alt="image" src="https://github.com/user-attachments/assets/5644af93-797a-4366-aa78-3db26cb322d1" />
