### PR TITLE
Enable retrieval of a generation after client timeout

### DIFF
--- a/griptape_nodes_library/audio/eleven_labs_music_generation.py
+++ b/griptape_nodes_library/audio/eleven_labs_music_generation.py
@@ -118,16 +118,6 @@ class ElevenLabsMusicGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterAudio(
                 name="audio_url",
                 tooltip="Generated music audio as URL artifact",

--- a/griptape_nodes_library/audio/eleven_labs_sound_effect.py
+++ b/griptape_nodes_library/audio/eleven_labs_sound_effect.py
@@ -88,16 +88,6 @@ class ElevenLabsSoundEffectGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterAudio(
                 name="audio_url",
                 tooltip="Generated sound effect audio as URL artifact",

--- a/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
+++ b/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
@@ -207,16 +207,6 @@ class ElevenLabsTextToSpeechGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/flux_2_image_generation.py
+++ b/griptape_nodes_library/image/flux_2_image_generation.py
@@ -213,16 +213,6 @@ class Flux2ImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/flux_image_generation.py
+++ b/griptape_nodes_library/image/flux_image_generation.py
@@ -162,18 +162,6 @@ class FluxImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allow_input=False,
-                allow_property=False,
-                allow_output=True,
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from the API",

--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -225,15 +225,6 @@ class GoogleImageGeneration(GriptapeProxyNode):
         self.add_node_element(generation_settings_group)
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation ID",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (final result)",

--- a/griptape_nodes_library/image/grok_image_edit.py
+++ b/griptape_nodes_library/image/grok_image_edit.py
@@ -118,16 +118,6 @@ class GrokImageEdit(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/grok_image_generation.py
+++ b/griptape_nodes_library/image/grok_image_generation.py
@@ -136,16 +136,6 @@ class GrokImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/openai_image_generation.py
+++ b/griptape_nodes_library/image/openai_image_generation.py
@@ -224,16 +224,6 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         self.add_node_element(generation_settings_group)
 
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/qwen_image_edit.py
+++ b/griptape_nodes_library/image/qwen_image_edit.py
@@ -153,16 +153,6 @@ class QwenImageEdit(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/qwen_image_generation.py
+++ b/griptape_nodes_library/image/qwen_image_generation.py
@@ -132,16 +132,6 @@ class QwenImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/seedream_image_generation.py
+++ b/griptape_nodes_library/image/seedream_image_generation.py
@@ -281,16 +281,6 @@ class SeedreamImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/seedvr_image_upscale.py
+++ b/griptape_nodes_library/image/seedvr_image_upscale.py
@@ -133,15 +133,6 @@ class SeedVRImageUpscale(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (initial POST)",

--- a/griptape_nodes_library/image/topaz_image_enhance.py
+++ b/griptape_nodes_library/image/topaz_image_enhance.py
@@ -754,16 +754,6 @@ class TopazImageEnhance(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -137,16 +137,6 @@ class WanImageGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import threading
 from abc import ABC, abstractmethod
 from contextlib import suppress
 from typing import Any
@@ -13,7 +14,9 @@ from urllib.parse import urljoin
 import httpx
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
@@ -29,6 +32,7 @@ STATUS_RUNNING = "RUNNING"
 STATUS_ERRORED = "ERRORED"
 STATUS_FAILED = "FAILED"
 STATUS_COMPLETED = "COMPLETED"
+STATUS_TIMED_OUT = "TIMED_OUT"
 
 
 class GriptapeProxyNode(SuccessFailureNode, ABC):
@@ -87,6 +91,54 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
 
         self._api_key_provider = ProxyAuthProviderParameter(node=self, provider_config=provider_config)
         self._api_key_provider.add_parameters()
+
+    def _create_status_parameters(
+        self,
+        *,
+        result_details_tooltip: str = "Details about the operation result",
+        result_details_placeholder: str = "Details on the operation will be presented here.",
+        parameter_group_initially_collapsed: bool = True,
+    ) -> None:
+        super()._create_status_parameters(
+            result_details_tooltip=result_details_tooltip,
+            result_details_placeholder=result_details_placeholder,
+            parameter_group_initially_collapsed=parameter_group_initially_collapsed,
+        )
+        # Inject generation_id, generation_status, and a Refresh button into the Status group.
+        # The button is the affordance that lets users recover a result after timeout
+        # without re-running the workflow.
+        status_group = self.status_component.get_parameter_group()
+        status_group.add_child(
+            ParameterString(
+                name="generation_id",
+                default_value="",
+                tooltip="Griptape Cloud generation ID. Preserved across timeouts and failures so the result can be recovered via the Refresh button.",
+                allowed_modes={ParameterMode.OUTPUT},
+                settable=False,
+                hide=True,
+                hide_property=True,
+            )
+        )
+        status_group.add_child(
+            ParameterString(
+                name="generation_status",
+                default_value="",
+                tooltip="Latest known status of the generation (e.g., RUNNING, COMPLETED, TIMED_OUT).",
+                allowed_modes={ParameterMode.OUTPUT},
+                settable=False,
+            )
+        )
+        status_group.add_child(
+            ParameterButton(
+                name="generation_refresh",
+                label="Refresh / Retrieve Result",
+                icon="refresh-cw",
+                variant="secondary",
+                full_width=True,
+                tooltip="Re-check the generation status and pull the result onto the node if completed.",
+                on_click=self._on_refresh_clicked,
+            )
+        )
 
     def register_user_auth_info(self, user_auth_info: str | None) -> None:
         """Register optional user auth info to send with generation submissions."""
@@ -339,10 +391,14 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         if status == STATUS_COMPLETED:
             return True, result_json
 
+        generation_id = self.parameter_output_values.get("generation_id", "") or ""
+
         if status in [STATUS_FAILED, STATUS_ERRORED]:
             logger.error("%s: Generation failed with status: %s", self.name, status)
             logger.error("%s: Error response: %s", self.name, result_json)
             self._set_safe_defaults()
+            self.parameter_output_values["generation_id"] = generation_id
+            self.parameter_output_values["generation_status"] = status
             error_message = self._extract_error_message(result_json)
             logger.error("%s: Extracted error message: %s", self.name, error_message)
             if not error_message:
@@ -355,6 +411,8 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         if status == STATUS_CANCELLED:
             logger.info("%s: Generation cancelled.", self.name)
             self._set_safe_defaults()
+            self.parameter_output_values["generation_id"] = generation_id
+            self.parameter_output_values["generation_status"] = status
             status_detail = result_json.get("status_detail", {})
             details = ""
             if isinstance(status_detail, dict):
@@ -406,6 +464,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
 
                     status = result_json.get("status", "unknown")
                     self._log(f"Status: {status}")
+                    self.parameter_output_values["generation_status"] = status
 
                     is_terminal, terminal_result = self._handle_terminal_status(status, result_json)
                     if is_terminal:
@@ -439,12 +498,18 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
                         return None
                     await asyncio.sleep(poll_interval)
 
-        # Timeout reached
+        # Timeout reached — preserve generation_id so the user can recover via Refresh
         self._log("Polling timed out waiting for result")
         self._set_safe_defaults()
+        self.parameter_output_values["generation_id"] = generation_id
+        self.parameter_output_values["generation_status"] = STATUS_TIMED_OUT
         self._set_status_results(
             was_successful=False,
-            result_details=f"Generation timed out after {timeout_s} seconds waiting for result.",
+            result_details=(
+                f"Generation `{generation_id}` did not finish within {timeout_s} seconds. "
+                f"It may still be running on Griptape Cloud — click the refresh icon on the "
+                f"`generation_status` parameter to re-check and pull the result onto this node."
+            ),
         )
         return None
 
@@ -566,9 +631,9 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             self._handle_submission_error(e)
             return None
 
-        # Store generation_id if output parameter exists
-        if "generation_id" in self.parameter_output_values:
-            self.parameter_output_values["generation_id"] = generation_id
+        # Store generation_id so the Refresh affordance can recover the result on timeout/failure.
+        # Subclasses declare a `generation_id` output parameter; writing here surfaces the value to the UI.
+        self.parameter_output_values["generation_id"] = generation_id
 
         # Poll for completion
         status_response = await self._poll_generation_status(generation_id, headers)
@@ -589,6 +654,8 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         """
         # Clear execution status at the start
         self._clear_execution_status()
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["generation_status"] = ""
 
         try:
             self._prepare_user_auth_info()
@@ -620,6 +687,139 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             await self._parse_result(result_json, generation_id)
         except Exception as e:
             self._handle_result_parsing_error(e)
+
+    def _on_refresh_clicked(self, _button: Any, _details: Any) -> None:
+        """Sync entry point for the Refresh button — bridges into the async refresh flow.
+
+        Button.on_click_callback is invoked synchronously from a thread that may already
+        have a running event loop, so we run the coroutine on a dedicated worker thread
+        with its own fresh loop to avoid `RuntimeError: This event loop is already running`.
+        """
+
+        def _runner() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(self._refresh_async())
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=_runner, name=f"{self.name}-refresh", daemon=True)
+        thread.start()
+        thread.join()
+
+    async def _fetch_status_for_refresh(self, generation_id: str, headers: dict[str, str]) -> dict[str, Any] | None:
+        """Single GET against the generations status endpoint for the Refresh flow.
+
+        Sets failure status and returns None on HTTP/transport errors.
+        """
+        get_url = urljoin(self._proxy_base, f"generations/{generation_id}")
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(get_url, headers=headers, timeout=60)
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPStatusError as e:
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Failed to fetch status for `{generation_id}`: HTTP {e.response.status_code}",
+            )
+        except Exception as e:
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Failed to fetch status for `{generation_id}`: {e}",
+            )
+        return None
+
+    async def _refresh_completed(self, generation_id: str) -> None:
+        """Fetch and parse the result onto the node."""
+        result_json = await self._fetch_generation_result(generation_id)
+        if not result_json:
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Generation `{generation_id}` is COMPLETED, but fetching the result failed. See node logs.",
+            )
+            return
+        if "provider_response" in self.parameter_output_values:
+            self.parameter_output_values["provider_response"] = result_json
+        try:
+            await self._parse_result(result_json, generation_id)
+        except Exception as e:
+            self._handle_result_parsing_error(e)
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Generation `{generation_id}` completed, but parsing the result failed: {e}",
+            )
+            return
+        self._set_status_results(
+            was_successful=True,
+            result_details=f"Refreshed: generation `{generation_id}` completed and result was retrieved.",
+        )
+
+    def _refresh_render_status(self, generation_id: str, status: str, status_json: dict[str, Any]) -> None:
+        """Update result_details for non-completed states."""
+        if status in (STATUS_FAILED, STATUS_ERRORED):
+            error_message = self._extract_error_message(status_json)
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"Generation `{generation_id}` ended with status {status}.\n\n{error_message}",
+            )
+            return
+
+        if status == STATUS_CANCELLED:
+            status_detail = status_json.get("status_detail", {})
+            details = ""
+            if isinstance(status_detail, dict):
+                details = status_detail.get("details") or ""
+            body = (
+                f"Generation `{generation_id}` was cancelled.\n\n{details}"
+                if details
+                else f"Generation `{generation_id}` was cancelled."
+            )
+            self._set_status_results(was_successful=False, result_details=body)
+            return
+
+        # QUEUED / RUNNING / unknown — still in flight
+        self._set_status_results(
+            was_successful=False,
+            result_details=(
+                f"Generation `{generation_id}` is still in progress (status: {status}). "
+                f"Click the refresh icon again to re-check."
+            ),
+        )
+
+    async def _refresh_async(self) -> None:
+        """Re-check the generation status and pull the result if it has completed.
+
+        A single GET to /generations/{id}; never re-enters the polling loop.
+        """
+        generation_id = (self.parameter_output_values.get("generation_id") or "").strip()
+        if not generation_id:
+            self._set_status_results(
+                was_successful=False,
+                result_details="No generation ID is available on this node yet. Run the node first to submit a generation.",
+            )
+            return
+
+        try:
+            api_key = self._validate_api_key()
+        except ValueError as e:
+            self._set_status_results(was_successful=False, result_details=f"Cannot refresh: {e}")
+            return
+
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        status_json = await self._fetch_status_for_refresh(generation_id, headers)
+        if status_json is None:
+            return
+
+        status = status_json.get("status", "unknown")
+        self.parameter_output_values["generation_status"] = status
+
+        if status == STATUS_COMPLETED:
+            await self._refresh_completed(generation_id)
+            return
+
+        self._refresh_render_status(generation_id, status, status_json)
 
     async def aprocess(self) -> None:
         """Async processing entry point."""

--- a/griptape_nodes_library/splat/world_labs_world_generation.py
+++ b/griptape_nodes_library/splat/world_labs_world_generation.py
@@ -239,16 +239,6 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Complete World object from World Labs",

--- a/griptape_nodes_library/three_d/rodin_2_3d_generation.py
+++ b/griptape_nodes_library/three_d/rodin_2_3d_generation.py
@@ -277,16 +277,6 @@ class Rodin23DGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/three_d/tripo_image_to_3d_generation.py
+++ b/griptape_nodes_library/three_d/tripo_image_to_3d_generation.py
@@ -161,16 +161,6 @@ class TripoImageTo3DGeneration(GriptapeProxyNode):
         )
 
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the proxy",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/three_d/tripo_text_to_3d_generation.py
+++ b/griptape_nodes_library/three_d/tripo_text_to_3d_generation.py
@@ -143,16 +143,6 @@ class TripoTextTo3DGeneration(GriptapeProxyNode):
         )
 
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the proxy",
-                allow_input=False,
-                allow_property=False,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/grok_video_edit.py
+++ b/griptape_nodes_library/video/grok_video_edit.py
@@ -78,16 +78,6 @@ class GrokVideoEdit(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/grok_video_generation.py
+++ b/griptape_nodes_library/video/grok_video_generation.py
@@ -129,16 +129,6 @@ class GrokVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -319,15 +319,6 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/kling_motion_control.py
+++ b/griptape_nodes_library/video/kling_motion_control.py
@@ -120,15 +120,6 @@ class KlingMotionControl(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -256,15 +256,6 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -266,15 +266,6 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/kling_video_extension.py
+++ b/griptape_nodes_library/video/kling_video_extension.py
@@ -85,15 +85,6 @@ class KlingVideoExtension(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -128,15 +128,6 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             Parameter(
                 name="provider_response",
                 output_type="dict",

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -181,15 +181,6 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -168,15 +168,6 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -137,15 +137,6 @@ class LTXVideoExtend(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Response from API (latest polling response)",

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -147,15 +147,6 @@ class LTXVideoRetake(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Response from API (latest polling response)",

--- a/griptape_nodes_library/video/ltx_video_to_video_hdr.py
+++ b/griptape_nodes_library/video/ltx_video_to_video_hdr.py
@@ -81,15 +81,6 @@ class LTXVideoToVideoHDR(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Response from API (latest polling response)",

--- a/griptape_nodes_library/video/minimax_hailuo_video_generation.py
+++ b/griptape_nodes_library/video/minimax_hailuo_video_generation.py
@@ -194,15 +194,6 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (latest polling response)",

--- a/griptape_nodes_library/video/omnihuman_subject_recognition.py
+++ b/griptape_nodes_library/video/omnihuman_subject_recognition.py
@@ -80,15 +80,6 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation identifier",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterBool(
                 name="contains_subject",
                 tooltip="Whether the image contains human or human-like subjects",

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -167,15 +167,6 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation identifier",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterVideo(
                 name="video_url",
                 tooltip="Generated video URL artifact",

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -257,15 +257,6 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
         # Outputs
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API",

--- a/griptape_nodes_library/video/seedance_video_generation.py
+++ b/griptape_nodes_library/video/seedance_video_generation.py
@@ -191,15 +191,6 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (initial POST)",

--- a/griptape_nodes_library/video/seedvr_video_upscale.py
+++ b/griptape_nodes_library/video/seedvr_video_upscale.py
@@ -144,16 +144,6 @@ class SeedVRVideoUpscale(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                output_type="str",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (final result)",

--- a/griptape_nodes_library/video/sora_video_generation.py
+++ b/griptape_nodes_library/video/sora_video_generation.py
@@ -128,16 +128,6 @@ class SoraVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (final result)",

--- a/griptape_nodes_library/video/veo3_video_generation.py
+++ b/griptape_nodes_library/video/veo3_video_generation.py
@@ -252,15 +252,6 @@ class Veo3VideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Griptape Cloud generation id",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from API (initial POST)",

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -142,16 +142,6 @@ class WanAnimateGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/wan_image_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_image_to_video_generation.py
@@ -268,16 +268,6 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -284,16 +284,6 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/griptape_nodes_library/video/wan_text_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_text_to_video_generation.py
@@ -240,16 +240,6 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
 
         # OUTPUTS
         self.add_parameter(
-            ParameterString(
-                name="generation_id",
-                tooltip="Generation ID from the API",
-                allowed_modes={ParameterMode.OUTPUT},
-                hide_property=True,
-                hide=True,
-            )
-        )
-
-        self.add_parameter(
             ParameterDict(
                 name="provider_response",
                 tooltip="Verbatim response from Griptape model proxy",

--- a/tests/unit/test_griptape_proxy_node_refresh.py
+++ b/tests/unit/test_griptape_proxy_node_refresh.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from griptape_nodes.exe_types.core_types import ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+
+from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
+from griptape_nodes_library.proxy.griptape_proxy_node import (
+    STATUS_COMPLETED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
+    STATUS_TIMED_OUT,
+)
+
+
+@pytest.fixture(autouse=True)
+def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
+    )
+
+
+def _find_status_group_children(node: Any) -> dict[str, Any]:
+    status_group = node.status_component.get_parameter_group()
+    return {child.name: child for child in status_group.children}
+
+
+def test_status_group_contains_generation_id_status_and_refresh_button() -> None:
+    node = Flux2ImageGeneration(name="Flux2")
+    children = _find_status_group_children(node)
+
+    assert "generation_id" in children
+    assert isinstance(children["generation_id"], ParameterString)
+    assert ParameterMode.OUTPUT in children["generation_id"].get_mode()
+
+    assert "generation_status" in children
+    assert isinstance(children["generation_status"], ParameterString)
+    assert ParameterMode.OUTPUT in children["generation_status"].get_mode()
+
+    assert "generation_refresh" in children
+    assert isinstance(children["generation_refresh"], ParameterButton)
+
+
+@pytest.mark.asyncio
+async def test_polling_timeout_preserves_generation_id_and_sets_timed_out_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timeout must not wipe generation_id — that's how the Refresh button recovers the result."""
+
+    class RunningResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"status": STATUS_RUNNING}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str], timeout: int) -> RunningResponse:
+            return RunningResponse()
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+
+    async def noop_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.asyncio.sleep", noop_sleep)
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.set_parameter_value("timeout", 5)
+    # Simulate that submission already wrote the generation_id (as _submit_and_poll does).
+    node.parameter_output_values["generation_id"] = "gen-preserved"
+    node._set_safe_defaults = lambda: None  # type: ignore[method-assign]
+
+    result = await node._poll_generation_status("gen-preserved", {"Authorization": "Bearer key"})
+
+    assert result is None
+    assert node.parameter_output_values["generation_id"] == "gen-preserved"
+    assert node.parameter_output_values["generation_status"] == STATUS_TIMED_OUT
+
+
+def test_handle_terminal_status_preserves_generation_id_on_failure() -> None:
+    node = Flux2ImageGeneration(name="Flux2")
+    node.parameter_output_values["generation_id"] = "gen-failed"
+    node._set_safe_defaults = lambda: None  # type: ignore[method-assign]
+
+    is_terminal, terminal_result = node._handle_terminal_status(
+        STATUS_FAILED,
+        {"status": STATUS_FAILED, "status_detail": {"error": "boom", "details": "bad"}},
+    )
+
+    assert is_terminal is True
+    assert terminal_result is None
+    assert node.parameter_output_values["generation_id"] == "gen-failed"
+    assert node.parameter_output_values["generation_status"] == STATUS_FAILED
+
+
+@pytest.mark.asyncio
+async def test_refresh_async_without_generation_id_reports_unavailable() -> None:
+    node = Flux2ImageGeneration(name="Flux2")
+    # Explicitly empty
+    node.parameter_output_values["generation_id"] = ""
+
+    captured: list[dict[str, Any]] = []
+    node._set_status_results = lambda **kwargs: captured.append(kwargs)  # type: ignore[method-assign]
+
+    await node._refresh_async()
+
+    assert len(captured) == 1
+    assert captured[0]["was_successful"] is False
+    assert "No generation ID" in captured[0]["result_details"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_async_running_updates_status_without_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    class RunningResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"status": STATUS_RUNNING}
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str], timeout: int) -> RunningResponse:
+            return RunningResponse()
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(
+        "griptape_nodes_library.proxy.griptape_proxy_node.GriptapeNodes.SecretsManager",
+        lambda: type("S", (), {"get_secret": lambda self, _name: "fake-key"})(),
+    )
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.parameter_output_values["generation_id"] = "gen-running"
+
+    parse_called = False
+
+    async def _parse_result(_result_json: dict[str, Any], _generation_id: str) -> None:
+        nonlocal parse_called
+        parse_called = True
+
+    node._parse_result = _parse_result  # type: ignore[method-assign]
+
+    captured: list[dict[str, Any]] = []
+    node._set_status_results = lambda **kwargs: captured.append(kwargs)  # type: ignore[method-assign]
+
+    await node._refresh_async()
+
+    assert node.parameter_output_values["generation_status"] == STATUS_RUNNING
+    assert parse_called is False
+    # _refresh_render_status emits one set_status_results call for non-completed states.
+    assert any("still in progress" in c.get("result_details", "") for c in captured)
+
+
+@pytest.mark.asyncio
+async def test_refresh_async_completed_invokes_parse_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the cloud reports COMPLETED, refresh must fetch the result and call _parse_result."""
+
+    class StatusResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"status": STATUS_COMPLETED}
+
+    class ResultResponse:
+        headers = {"content-type": "application/json"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"images": [{"url": "https://example.com/x.png"}]}
+
+    call_log: list[str] = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, headers: dict[str, str], timeout: int) -> Any:
+            call_log.append(url)
+            if url.endswith("/result"):
+                return ResultResponse()
+            return StatusResponse()
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(
+        "griptape_nodes_library.proxy.griptape_proxy_node.GriptapeNodes.SecretsManager",
+        lambda: type("S", (), {"get_secret": lambda self, _name: "fake-key"})(),
+    )
+
+    node = Flux2ImageGeneration(name="Flux2")
+    node.parameter_output_values["generation_id"] = "gen-done"
+
+    parsed: dict[str, Any] = {}
+
+    async def _parse_result(result_json: dict[str, Any], generation_id: str) -> None:
+        parsed["result_json"] = result_json
+        parsed["generation_id"] = generation_id
+
+    node._parse_result = _parse_result  # type: ignore[method-assign]
+    node._set_status_results = lambda **_kwargs: None  # type: ignore[method-assign]
+
+    await node._refresh_async()
+
+    assert node.parameter_output_values["generation_status"] == STATUS_COMPLETED
+    assert parsed["generation_id"] == "gen-done"
+    assert parsed["result_json"] == {"images": [{"url": "https://example.com/x.png"}]}
+    # Both endpoints were hit: status, then /result
+    assert any(u.endswith("/generations/gen-done") for u in call_log)
+    assert any(u.endswith("/generations/gen-done/result") for u in call_log)


### PR DESCRIPTION
Closes #192

## Summary

Adds a recovery affordance for `GriptapeProxyNode` when a long-running Griptape Cloud generation outlives the client-side polling window. Today a timeout calls `_set_safe_defaults()` and the cloud-side artifact is unrecoverable from the node — the user has to re-run the workflow. After this change, `generation_id` and `generation_status` are preserved across timeout/failure paths and a Refresh button on the node fetches the result on demand.

<img width="582" height="1022" alt="Screenshot 2026-05-27 at 11 46 05 AM" src="https://github.com/user-attachments/assets/89244573-a1ff-4397-90e0-0eb886c67fe2" />

## Changes

**Base class (`griptape_nodes_library/proxy/griptape_proxy_node.py`)**
- Adds three elements to the existing collapsible **Status** group via an override of `_create_status_parameters`, so subclasses pick them up automatically:
  - `generation_id` (output, hidden by default — surfaces as a port for connections without taking node real estate).
  - `generation_status` (output) — values: `QUEUED`, `RUNNING`, `COMPLETED`, `FAILED`, `ERRORED`, `CANCELLED`, `TIMED_OUT`. Updated on every poll iteration so it's fresh mid-flight.
  - `generation_refresh` (`ParameterButton`) — re-checks status and pulls the result onto the node if completed.
- Polling timeout now preserves `generation_id`, sets `generation_status="TIMED_OUT"`, and writes a `result_details` message pointing the user at the Refresh button (instead of `_set_safe_defaults` blowing away the ID).
- `_handle_terminal_status` for `FAILED`/`ERRORED`/`CANCELLED` similarly preserves `generation_id` and writes the terminal status.
- Refresh flow: `_on_refresh_clicked` runs the async refresh on a worker thread (avoids `RuntimeError: This event loop is already running` when the click handler fires inside an existing loop). Single `GET /generations/{id}`; never re-enters the polling loop. Branches on status and only fetches/parses the `/result` endpoint when status is `COMPLETED`.
- `_submit_and_poll` writes `parameter_output_values["generation_id"]` unconditionally (it was previously gated on the key already existing in the dict, which meant the ID wasn't surfaced on first runs).

**Subclasses (44 files)**
Removed the per-subclass `generation_id` `ParameterString` declaration since it now lives on the base. No other subclass code changes.

**Tests (`tests/unit/test_griptape_proxy_node_refresh.py`)** — 6 new tests:
- Status group structure (`generation_id`, `generation_status`, `generation_refresh` all present).
- Polling timeout preserves `generation_id` and writes `TIMED_OUT`.
- `_handle_terminal_status` preserves `generation_id` on `FAILED`.
- `_refresh_async` with no `generation_id` reports gracefully without making HTTP calls.
- `_refresh_async` while `RUNNING` updates status and does not invoke `_parse_result`.
- `_refresh_async` on `COMPLETED` hits both the status and `/result` endpoints and forwards the payload to `_parse_result`.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run ruff format` clean
- [x] `uv run pytest tests/unit/test_griptape_proxy_node_*.py` — 138 passed (was 132 before this PR's tests), 9 pre-existing failures unchanged
- [x] Manual: run a proxy node with `timeout=2` so it times out before completion. Confirm node fails with timeout message, `generation_id` is populated on the output port, `generation_status="TIMED_OUT"`, and the Refresh button is visible inside the Status group.
- [x] Manual: wait for the cloud generation to finish, click Refresh. Confirm `generation_status` flips to `COMPLETED`, the result outputs populate, and `result_details` reflects success.
- [x] Manual: click Refresh while still `RUNNING`. Confirm status updates and no result is fetched.
- [ ] Manual: trigger a failure (invalid model id). Confirm `generation_id` is preserved and error details are surfaced via `result_details`.