### PR TITLE
Update: Crop Image node - replace modal editor with inline crop editor widget

### DIFF
--- a/.claude/skills/griptape-nodes-widget-dev/SKILL.md
+++ b/.claude/skills/griptape-nodes-widget-dev/SKILL.md
@@ -106,6 +106,112 @@ Do **not** call `set_parameter_value` on the widget param from `__init__` — un
 
 ---
 
+## Preventing sync loops between Python and the widget
+
+When the widget emits a change and Python writes individual parameters back, `after_value_set` fires for each one. Without guards these trigger another widget push, which triggers another emit, and so on.
+
+Use two flags — one for each direction — to break the loop:
+
+```python
+self._syncing_to_widget = False  # Python → widget in progress
+self._syncing_to_params = False  # widget → params in progress
+
+def after_value_set(self, parameter, value):
+    if parameter.name == "my_widget_param" and not self._syncing_to_widget:
+        # widget changed → sync to individual params
+        self._syncing_to_params = True
+        try:
+            self.set_parameter_value("x", value.get("x", 0))
+            self.publish_update_to_parameter("x", value.get("x", 0))
+        finally:
+            self._syncing_to_params = False
+
+    elif not self._syncing_to_params and parameter.name == "x":
+        # individual param changed → push to widget
+        self._syncing_to_widget = True
+        try:
+            self._push_widget({...})
+        finally:
+            self._syncing_to_widget = False
+```
+
+---
+
+## Pre-publish the widget dict before individual param publishes
+
+**Problem (snap-then-jump):** When the widget emits and Python calls `publish_update_to_parameter("x", 300)` for each individual param, FlowEditor re-renders *all* widgets using the currently-stored widget dict value. If the stored dict still has the old value (`x: 100`), the widget snaps back to `x: 100` on every individual param publish.
+
+**Fix:** publish the full widget dict first, before any individual param publishes. This ensures the stored value is authoritative before the re-render fires.
+
+```python
+def _sync_params_from_widget(self, widget_dict: dict) -> None:
+    # ✅ pre-publish the widget dict FIRST
+    self.publish_update_to_parameter("my_widget_param", widget_dict)
+
+    self._syncing_to_params = True
+    try:
+        for key, val in widget_dict.items():
+            self.set_parameter_value(key, val)
+            self.publish_update_to_parameter(key, val)
+    finally:
+        self._syncing_to_params = False
+```
+
+---
+
+## Detecting wire connections to lock widget controls
+
+When an upstream node wires into a parameter, the widget should show that parameter as read-only (don't let the user drag a handle that would override a connected value).
+
+```python
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+
+def _get_locked_params(self) -> list[str]:
+    watched = {"x", "y", "width", "height"}
+    try:
+        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
+        if isinstance(result, ListConnectionsForNodeResultSuccess):
+            return [c.target_parameter_name for c in result.incoming_connections
+                    if c.target_parameter_name in watched]
+    except Exception:
+        pass
+    return []
+
+def after_incoming_connection(self, source_node, source_parameter, target_parameter):
+    if target_parameter.name in self._watched_params:
+        self._push_widget({**self._current_widget_dict(), "locked": self._get_locked_params()})
+    return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter):
+    if target_parameter.name in self._watched_params:
+        self._push_widget({**self._current_widget_dict(), "locked": self._get_locked_params()})
+    return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
+```
+
+In the widget JS, read `value.locked` and use it to disable the relevant interactive elements.
+
+---
+
+## Hiding a parameter's property row (keep socket only)
+
+Use `hide_property=True` on the parameter to hide it from the property panel while keeping the input socket visible for wiring:
+
+```python
+self.add_parameter(
+    ParameterImage(
+        name="input_image",
+        default_value=None,
+        tooltip="...",
+        hide_property=True,   # hides the row; input socket still visible
+    )
+)
+```
+
+---
+
 ## Resolving file paths to browser-accessible URLs
 
 ```python
@@ -119,6 +225,160 @@ result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest
 if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
     return result.url
 ```
+
+---
+
+## Canvas sizing: fill the node, letterbox the image
+
+To make a canvas widget that scales with the node and never pushes controls off-screen:
+
+```js
+// wrapper fills the node container
+wrapper.style.cssText = "display:flex;flex-direction:column;height:100%;gap:6px;";
+
+// canvasWrap takes all remaining vertical space
+canvasWrap.style.cssText = [
+  "flex:1 1 0", "min-height:180px",
+  "display:flex", "align-items:center", "justify-content:center",
+  "background:#111", "border-radius:6px", "overflow:hidden",
+].join(";");
+
+// size the canvas to letterbox within the available area
+function resizeCanvas() {
+  if (!imageLoaded || !imgNatW || !imgNatH) return;
+  const areaW = canvasWrap.clientWidth  || 480;
+  const areaH = canvasWrap.clientHeight || 360;
+  scale = Math.min(areaW / imgNatW, areaH / imgNatH);
+  canvas.width  = Math.round(imgNatW * scale);
+  canvas.height = Math.round(imgNatH * scale);
+  render();
+}
+
+// fire on resize
+const ro = new ResizeObserver(() => { if (imageLoaded) resizeCanvas(); });
+ro.observe(canvasWrap);
+```
+
+- `flex:1 1 0; min-height:0` lets `canvasWrap` shrink; `min-height:180px` gives a sensible floor.
+- `Math.min(areaW/imgNatW, areaH/imgNatH)` letterboxes — the canvas never exceeds either dimension.
+- Canvas element has no CSS `width:100%`; its pixel dimensions are set directly.
+- The flex-centering (`align-items/justify-content: center`) keeps the canvas centered when it doesn't fill the full area (e.g., portrait image in wide node).
+
+---
+
+## Multi-file widget organization (subdirectory pattern)
+
+For complex widgets, split into a subdirectory so the main file stays readable:
+
+```
+widgets/MyWidget/
+  MyWidget.js     ← main entry point (registered in library JSON)
+  _styles.js      ← visual constants (colors, sizes)
+  _sidebar.js     ← preset controls, toolbars
+  _footer.js      ← sliders, status bar
+```
+
+Update the library JSON path:
+```json
+{ "name": "MyWidget", "path": "widgets/MyWidget/MyWidget.js" }
+```
+
+Import from siblings with relative paths — these are standard ES module imports:
+```js
+import { HANDLE_R, HANDLE_FILL } from './_styles.js';
+import { createSidebar } from './_sidebar.js';
+import { createFooter }  from './_footer.js';
+```
+
+Each sub-module exports a factory function that returns DOM elements and a `sync` method:
+```js
+// _sidebar.js
+export function createSidebar({ getState, onAction }) {
+  const el = document.createElement("div");
+  // ... build DOM ...
+  function syncDisabled(locked, disabled) { /* update button states */ }
+  return { el, syncDisabled };
+}
+```
+
+---
+
+## Icons: use Lucide SVGs via a `_icons.js` file
+
+Widgets use Lucide icons (MIT licensed). Store only the inner SVG path markup in a shared `_icons.js` — not the full `<svg>` tag — and wrap it with a `mkIcon` factory that applies the standard Lucide attributes.
+
+**`_icons.js`**
+```js
+// Lucide SVG icon paths (MIT licensed)
+
+export const ICON_PATHS = {
+  "rotate-ccw": `<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>`,
+  trash:        `<polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>`,
+  // add more as needed...
+};
+
+export function mkIcon(name, size = 15) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", size);
+  svg.setAttribute("height", size);
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.style.cssText = "display:block;flex-shrink:0;pointer-events:none;";
+  svg.innerHTML = ICON_PATHS[name] || "";
+  return svg;
+}
+```
+
+**Usage:**
+```js
+import { mkIcon } from './_icons.js';
+
+const btn = document.createElement("button");
+btn.appendChild(mkIcon("rotate-ccw", 14));
+btn.title = "Reset rotation";
+```
+
+**How to get path data for a new icon:**
+1. Find the icon on [lucide.dev](https://lucide.dev)
+2. Copy the SVG source
+3. Strip the outer `<svg ...>` tag — keep only the inner `<path>`, `<circle>`, `<line>`, etc. elements as a single string
+4. Add it to `ICON_PATHS`
+
+`mkIcon` sets `stroke="currentColor"` so icons inherit the button/label text color automatically, and they adapt to both light and dark themes. Set `pointer-events:none` so icon clicks don't block the parent button's handler.
+
+---
+
+## Theming: use Tailwind CSS variables, not hardcoded colors
+
+The app uses Tailwind CSS / shadcn UI. Always use CSS variables so widgets render correctly in both light and dark modes. Never use hardcoded hex colors like `#1a1a1a` or `#888` for UI chrome.
+
+| Variable | Purpose |
+|---|---|
+| `var(--background)` | Page/node background |
+| `var(--card)` | Card/panel surface |
+| `var(--muted)` | Subtle panel background (for toolbars, status bars, etc.) |
+| `var(--muted-foreground)` | De-emphasised text and icons |
+| `var(--foreground)` | Primary text |
+| `var(--border)` | Borders and dividers |
+| `var(--accent)` | Hover highlight background |
+| `var(--accent-foreground)` | Text on accent |
+| `var(--destructive)` | Error / destructive action color |
+
+```js
+// WRONG — breaks in light mode
+panel.style.background = "#1a1a1a";
+label.style.color = "#888";
+
+// CORRECT — adapts automatically
+panel.style.background = "var(--muted)";
+label.style.color = "var(--muted-foreground)";
+```
+
+The canvas/image area can keep a hardcoded dark background (`#111`) since it's always showing media content.
 
 ---
 

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -68,6 +68,11 @@
       "name": "SplatViewer",
       "path": "griptape_nodes_library/splat/widgets/SplatViewer.js",
       "description": "Inline Gaussian splat viewer — auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
+    },
+    {
+      "name": "CropImageEditor",
+      "path": "widgets/CropImageEditor/CropImageEditor.js",
+      "description": "Interactive crop editor — drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
     }
   ],
   "categories": [

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -51,7 +51,7 @@ ROTATION_MAX = 180.0
 # Parameter defaults
 DEFAULT_LEFT = 0
 DEFAULT_TOP = 0
-DEFAULT_WIDTH = 0   # 0 = use full image width
+DEFAULT_WIDTH = 0  # 0 = use full image width
 DEFAULT_HEIGHT = 0  # 0 = use full image height
 DEFAULT_ZOOM = NO_ZOOM
 DEFAULT_ROTATE = 0.0

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -30,7 +30,6 @@ from PIL import Image
 from griptape_nodes_library.utils.color_utils import NAMED_COLORS, parse_color_to_rgba
 from griptape_nodes_library.utils.file_utils import generate_filename
 from griptape_nodes_library.utils.image_utils import (
-    dict_to_image_url_artifact,
     load_pil_from_url,
     validate_pil_format,
 )
@@ -222,7 +221,7 @@ class CropImage(ControlNode):
             CreateStaticFileDownloadUrlFromPathResultSuccess,
         )
 
-        raw = getattr(artifact, "value", "") or ""
+        raw = artifact if isinstance(artifact, str) else (getattr(artifact, "value", "") or "")
         if not raw:
             return ""
         if isinstance(raw, str) and raw.startswith(("http://", "https://", "data:")):
@@ -284,20 +283,6 @@ class CropImage(ControlNode):
         if target_parameter.name in self._CROP_PARAMS:
             self._refresh_locked_in_widget()
         return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
-
-    def _update_widget_from_image(self, artifact: Any) -> None:
-        """Resolve image URL + dimensions and push them into the crop_editor widget."""
-        try:
-            img = load_pil_from_url(artifact.value)
-        except Exception:
-            return
-        url = self._resolve_image_url(artifact)
-        new_dict = self._build_widget_dict(image_url=url, img_width=img.width, img_height=img.height)
-        self._syncing_to_widget = True
-        try:
-            self._push_widget(new_dict)
-        finally:
-            self._syncing_to_widget = False
 
     def _update_widget_coords(self) -> None:
         """Refresh the crop_editor widget with current coordinate parameter values.
@@ -376,15 +361,35 @@ class CropImage(ControlNode):
         finally:
             self._syncing_to_params = False
 
+    # ── Input normalization ────────────────────────────────────────────────────
+
+    def _extract_image_path(self, value: Any) -> str | None:
+        """Extract string path/URL from str, ImageUrlArtifact, or similar inputs."""
+        if isinstance(value, str):
+            return value
+        try:
+            if hasattr(value, "value"):
+                v = getattr(value, "value", None)
+                if isinstance(v, str):
+                    return v
+        except Exception:
+            pass
+        return None
+
     # ── Crop logic ─────────────────────────────────────────────────────────────
 
     def _crop(self) -> None:
         # Get parameters
         params = self._get_crop_parameters()
 
+        path = self._extract_image_path(params["input_artifact"])
+        if not path:
+            logger.error("%s: No valid input image to crop", self.name)
+            return
+
         # Load image
         try:
-            img = load_pil_from_url(params["input_artifact"].value)
+            img = load_pil_from_url(path)
         except Exception as e:
             msg = f"{self.name}: Error loading image: {e}"
             logger.error(msg)
@@ -641,11 +646,13 @@ class CropImage(ControlNode):
         if parameter.name == "input_image":
             if not value:
                 return super().after_value_set(parameter, value)
+            path = self._extract_image_path(value)
+            if not path:
+                return super().after_value_set(parameter, value)
             try:
-                img = load_pil_from_url(value.value)
+                img = load_pil_from_url(path)
             except Exception as e:
-                msg = f"{self.name}: Error loading image: {e}"
-                logger.error(msg)
+                logger.error("%s: Error loading image: %s", self.name, e)
                 return super().after_value_set(parameter, value)
 
             if img.width and img.height:
@@ -662,7 +669,7 @@ class CropImage(ControlNode):
                 if height_param:
                     height_param.update_ui_options({"slider": {"max_val": img.height, "min_val": 0}})
 
-                url = self._resolve_image_url(value)
+                url = self._resolve_image_url(path)
                 new_dict = self._build_widget_dict(image_url=url, img_width=img.width, img_height=img.height)
                 self._syncing_to_widget = True
                 try:
@@ -691,18 +698,8 @@ class CropImage(ControlNode):
             exceptions.append(Exception(msg))
             return exceptions
 
-        # Validate input artifact type
-        if isinstance(input_artifact, dict):
-            # Convert dict to ImageUrlArtifact for validation
-            try:
-                input_artifact = dict_to_image_url_artifact(input_artifact)
-            except Exception as e:
-                msg = f"{self.name} - Invalid image dictionary: {e}"
-                exceptions.append(Exception(msg))
-                return exceptions
-
-        if not isinstance(input_artifact, ImageUrlArtifact):
-            msg = f"{self.name} - Input must be an ImageUrlArtifact, got {type(input_artifact).__name__}"
+        if not self._extract_image_path(input_artifact):
+            msg = f"{self.name} - Input image could not be resolved to a valid path"
             exceptions.append(Exception(msg))
 
         return exceptions

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -77,7 +77,6 @@ class CropImage(ControlNode):
 
         self.MAX_WIDTH = MAX_WIDTH
         self.MAX_HEIGHT = MAX_HEIGHT
-        self._processing = False  # Lock to prevent live cropping during process()
         self._syncing_to_widget = False  # Prevent loop: param → widget → param
         self._syncing_to_params = False  # Prevent loop: widget → param → widget
 
@@ -626,12 +625,7 @@ class CropImage(ControlNode):
         return img
 
     def process(self) -> None:
-        # Set processing lock to prevent live cropping during actual processing
-        self._processing = True
-        try:
-            self._crop()
-        finally:
-            self._processing = False
+        self._crop()
 
     def _parse_color(self, color_str: str) -> tuple[int, int, int, int]:
         """Parse color string to RGBA tuple."""

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -207,8 +207,8 @@ class CropImage(ControlNode):
                     for conn in result.incoming_connections
                     if conn.target_parameter_name in crop_params
                 ]
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("%s: could not fetch connections: %s", self.name, e)
         return []
 
     # ── Image URL resolution ───────────────────────────────────────────────────
@@ -233,8 +233,8 @@ class CropImage(ControlNode):
             result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
             if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
                 return result.url
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("%s: could not resolve static file URL for %r: %s", self.name, resolved, e)
         return raw
 
     # ── Widget ↔ parameter sync ────────────────────────────────────────────────

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -48,6 +48,14 @@ MAX_HEIGHT = MAX_IMAGE_DIMENSION
 ROTATION_MIN = -180.0
 ROTATION_MAX = 180.0
 
+# Parameter defaults
+DEFAULT_LEFT = 0
+DEFAULT_TOP = 0
+DEFAULT_WIDTH = 0   # 0 = use full image width
+DEFAULT_HEIGHT = 0  # 0 = use full image height
+DEFAULT_ZOOM = NO_ZOOM
+DEFAULT_ROTATE = 0.0
+
 
 @dataclass
 class CropArea:
@@ -113,28 +121,28 @@ class CropImage(ControlNode):
         with ParameterGroup(name="crop_coordinates", ui_options={"collapsed": True}) as crop_coordinates:
             ParameterInt(
                 name="left",
-                default_value=0,
+                default_value=DEFAULT_LEFT,
                 tooltip="Left edge of crop area in pixels",
                 traits={Slider(min_val=0, max_val=self.MAX_WIDTH)},
             )
 
             ParameterInt(
                 name="top",
-                default_value=0,
+                default_value=DEFAULT_TOP,
                 tooltip="Top edge of crop area in pixels",
                 traits={Slider(min_val=0, max_val=self.MAX_HEIGHT)},
             )
 
             ParameterInt(
                 name="width",
-                default_value=0,
+                default_value=DEFAULT_WIDTH,
                 tooltip="Width of crop area in pixels (0 = use full width)",
                 traits={Slider(min_val=0, max_val=self.MAX_WIDTH)},
             )
 
             ParameterInt(
                 name="height",
-                default_value=0,
+                default_value=DEFAULT_HEIGHT,
                 tooltip="Height of crop area in pixels (0 = use full height)",
                 traits={Slider(min_val=0, max_val=self.MAX_HEIGHT)},
             )
@@ -143,13 +151,13 @@ class CropImage(ControlNode):
         with ParameterGroup(name="transform_options", ui_options={"collapsed": True}) as transform_options:
             ParameterFloat(
                 name="zoom",
-                default_value=NO_ZOOM,
+                default_value=DEFAULT_ZOOM,
                 tooltip="Zoom percentage (100 = no zoom, 200 = 2x zoom in, 50 = 0.5x zoom out)",
                 traits={Slider(min_val=0.0, max_val=MAX_ZOOM)},
             )
             ParameterFloat(
                 name="rotate",
-                default_value=0.0,
+                default_value=DEFAULT_ROTATE,
                 tooltip="Rotation in degrees (-180 to 180)",
                 traits={Slider(min_val=ROTATION_MIN, max_val=ROTATION_MAX)},
             )
@@ -245,12 +253,12 @@ class CropImage(ControlNode):
             "image_url": image_url,
             "img_width": img_width,
             "img_height": img_height,
-            "left": self.get_parameter_value("left") or 0,
-            "top": self.get_parameter_value("top") or 0,
-            "width": self.get_parameter_value("width") or 0,
-            "height": self.get_parameter_value("height") or 0,
-            "zoom": self.get_parameter_value("zoom") or NO_ZOOM,
-            "rotate": self.get_parameter_value("rotate") or 0.0,
+            "left": self.get_parameter_value("left") or DEFAULT_LEFT,
+            "top": self.get_parameter_value("top") or DEFAULT_TOP,
+            "width": self.get_parameter_value("width") or DEFAULT_WIDTH,
+            "height": self.get_parameter_value("height") or DEFAULT_HEIGHT,
+            "zoom": self.get_parameter_value("zoom") or DEFAULT_ZOOM,
+            "rotate": self.get_parameter_value("rotate") or DEFAULT_ROTATE,
             "locked": self._get_locked_params(),
         }
 

--- a/griptape_nodes_library/image/crop_image.py
+++ b/griptape_nodes_library/image/crop_image.py
@@ -4,24 +4,27 @@ from typing import Any
 
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import (
-    NodeMessagePayload,
-    NodeMessageResult,
     Parameter,
     ParameterGroup,
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.retained_mode.griptape_nodes import logger
-from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.files.file import File
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.color_picker import ColorPicker
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
+from griptape_nodes.traits.widget import Widget
 from PIL import Image
 
 from griptape_nodes_library.utils.color_utils import NAMED_COLORS, parse_color_to_rgba
@@ -76,25 +79,40 @@ class CropImage(ControlNode):
         self.MAX_WIDTH = MAX_WIDTH
         self.MAX_HEIGHT = MAX_HEIGHT
         self._processing = False  # Lock to prevent live cropping during process()
+        self._syncing_to_widget = False  # Prevent loop: param → widget → param
+        self._syncing_to_params = False  # Prevent loop: widget → param → widget
 
         self.add_parameter(
             ParameterImage(
                 name="input_image",
                 default_value=None,
                 tooltip="Input image to crop",
-                ui_options={"crop_image": True},
+                hide_property=True,
             )
         )
+
+        # Interactive crop editor widget — the primary UI for setting crop coordinates
         self.add_parameter(
-            ParameterButton(
-                name="crop_button",
-                label="Open Crop Editor",
-                variant="secondary",
-                icon="crop",
-                on_click=self._open_crop_modal,
+            ParameterDict(
+                name="crop_editor",
+                default_value={
+                    "image_url": "",
+                    "img_width": 0,
+                    "img_height": 0,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0,
+                    "height": 0,
+                    "zoom": NO_ZOOM,
+                    "rotate": 0.0,
+                },
+                tooltip="Interactive crop editor — drag to set crop area",
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={Widget(name="CropImageEditor", library="Griptape Nodes Library")},
             )
         )
-        with ParameterGroup(name="crop_coordinates", ui_options={"collapsed": False}) as crop_coordinates:
+
+        with ParameterGroup(name="crop_coordinates", ui_options={"collapsed": True}) as crop_coordinates:
             ParameterInt(
                 name="left",
                 default_value=0,
@@ -124,7 +142,7 @@ class CropImage(ControlNode):
             )
         self.add_node_element(crop_coordinates)
 
-        with ParameterGroup(name="transform_options", ui_options={"collapsed": False}) as transform_options:
+        with ParameterGroup(name="transform_options", ui_options={"collapsed": True}) as transform_options:
             ParameterFloat(
                 name="zoom",
                 default_value=NO_ZOOM,
@@ -178,25 +196,187 @@ class CropImage(ControlNode):
         )
         self._output_file.add_parameter()
 
-    def _open_crop_modal(self, _button: Button, _details: ButtonDetailsMessagePayload) -> NodeMessageResult:
-        """Open the crop modal in the frontend."""
-        # Create the open_modal payload structure
-        open_modal_data = {
-            "modal_type": "crop",
-            "node_name": self.name,
-            "parameter_name": "input_image",
+    # ── Connection detection ───────────────────────────────────────────────────
+
+    def _get_locked_params(self) -> list[str]:
+        """Return crop param names that have an incoming wire connection."""
+        crop_params = {"left", "top", "width", "height", "zoom", "rotate"}
+        try:
+            result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
+            if isinstance(result, ListConnectionsForNodeResultSuccess):
+                return [
+                    conn.target_parameter_name
+                    for conn in result.incoming_connections
+                    if conn.target_parameter_name in crop_params
+                ]
+        except Exception:
+            pass
+        return []
+
+    # ── Image URL resolution ───────────────────────────────────────────────────
+
+    def _resolve_image_url(self, artifact: Any) -> str:
+        """Return a browser-accessible URL for an image artifact."""
+        from griptape_nodes.retained_mode.events.static_file_events import (
+            CreateStaticFileDownloadUrlFromPathRequest,
+            CreateStaticFileDownloadUrlFromPathResultSuccess,
+        )
+
+        raw = getattr(artifact, "value", "") or ""
+        if not raw:
+            return ""
+        if isinstance(raw, str) and raw.startswith(("http://", "https://", "data:")):
+            return raw
+        try:
+            resolved = File(raw).resolve()
+        except Exception:
+            resolved = str(raw)
+        try:
+            result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                return result.url
+        except Exception:
+            pass
+        return raw
+
+    # ── Widget ↔ parameter sync ────────────────────────────────────────────────
+
+    def _build_widget_dict(self, image_url: str = "", img_width: int = 0, img_height: int = 0) -> dict:
+        """Build the crop_editor dict from current parameter values."""
+        return {
+            "image_url": image_url,
+            "img_width": img_width,
+            "img_height": img_height,
+            "left": self.get_parameter_value("left") or 0,
+            "top": self.get_parameter_value("top") or 0,
+            "width": self.get_parameter_value("width") or 0,
+            "height": self.get_parameter_value("height") or 0,
+            "zoom": self.get_parameter_value("zoom") or NO_ZOOM,
+            "rotate": self.get_parameter_value("rotate") or 0.0,
+            "locked": self._get_locked_params(),
         }
 
-        # Create payload with open_modal structure
-        payload = NodeMessagePayload(data={"open_modal": open_modal_data})
+    def _push_widget(self, new_dict: dict) -> None:
+        """Push an updated crop_editor dict to the widget."""
+        self.set_parameter_value("crop_editor", new_dict)
+        self.publish_update_to_parameter("crop_editor", new_dict)
 
-        # Return NodeMessageResult with the payload
-        return NodeMessageResult(
-            success=True,
-            details="Opening crop modal",
-            response=payload,
-            altered_workflow_state=False,
-        )
+    _CROP_PARAMS = frozenset({"left", "top", "width", "height", "zoom", "rotate"})
+
+    def _refresh_locked_in_widget(self) -> None:
+        """Re-compute locked params and push only if the list changed."""
+        existing = self.get_parameter_value("crop_editor") or {}
+        new_locked = self._get_locked_params()
+        if set(existing.get("locked") or []) == set(new_locked):
+            return
+        self._syncing_to_widget = True
+        try:
+            self._push_widget({**existing, "locked": new_locked})
+        finally:
+            self._syncing_to_widget = False
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        if target_parameter.name in self._CROP_PARAMS:
+            self._refresh_locked_in_widget()
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        if target_parameter.name in self._CROP_PARAMS:
+            self._refresh_locked_in_widget()
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
+
+    def _update_widget_from_image(self, artifact: Any) -> None:
+        """Resolve image URL + dimensions and push them into the crop_editor widget."""
+        try:
+            img = load_pil_from_url(artifact.value)
+        except Exception:
+            return
+        url = self._resolve_image_url(artifact)
+        new_dict = self._build_widget_dict(image_url=url, img_width=img.width, img_height=img.height)
+        self._syncing_to_widget = True
+        try:
+            self._push_widget(new_dict)
+        finally:
+            self._syncing_to_widget = False
+
+    def _update_widget_coords(self) -> None:
+        """Refresh the crop_editor widget with current coordinate parameter values.
+
+        Skips the push if nothing changed — prevents spurious widget resets that
+        happen when ParameterGroups are expanded (which re-fires after_value_set
+        for child params with their existing stored values).
+
+        locked is intentionally excluded from the early-return check: comparing
+        None (absent key) to [] would always trigger a push, defeating the guard.
+        locked is computed only when we are already going to push.
+        """
+        existing = self.get_parameter_value("crop_editor") or {}
+        new_left = self.get_parameter_value("left") or 0
+        new_top = self.get_parameter_value("top") or 0
+        new_width = self.get_parameter_value("width") or 0
+        new_height = self.get_parameter_value("height") or 0
+        new_zoom = self.get_parameter_value("zoom") or NO_ZOOM
+        new_rotate = self.get_parameter_value("rotate") or 0.0
+
+        if (
+            existing.get("left") == new_left
+            and existing.get("top") == new_top
+            and existing.get("width") == new_width
+            and existing.get("height") == new_height
+            and existing.get("zoom") == new_zoom
+            and existing.get("rotate") == new_rotate
+        ):
+            return
+
+        new_dict = {
+            **existing,
+            "left": new_left,
+            "top": new_top,
+            "width": new_width,
+            "height": new_height,
+            "zoom": new_zoom,
+            "rotate": new_rotate,
+            "locked": self._get_locked_params(),
+        }
+        self._syncing_to_widget = True
+        try:
+            self._push_widget(new_dict)
+        finally:
+            self._syncing_to_widget = False
+
+    def _sync_params_from_widget(self, widget_dict: dict) -> None:
+        """Push values from the widget dict into unlocked individual parameters.
+
+        publish_update_to_parameter("crop_editor", ...) is called FIRST so the
+        frontend's stored crop_editor value is authoritative before the individual
+        param publishes arrive.  When any individual param update (e.g. "left")
+        triggers a FlowEditor re-render, all widgets are called with current stored
+        props; without the pre-publish the stored crop_editor still has the old
+        value and the widget snaps back.
+        """
+        locked = set(widget_dict.get("locked", []))
+        mapping = {
+            "left": "left",
+            "top": "top",
+            "width": "width",
+            "height": "height",
+            "zoom": "zoom",
+            "rotate": "rotate",
+        }
+        # Pre-publish the full crop_editor dict so stored frontend value is correct
+        # before individual param publishes trigger a node re-render.
+        self.publish_update_to_parameter("crop_editor", widget_dict)
+        self._syncing_to_params = True
+        try:
+            for wkey, pkey in mapping.items():
+                if wkey in widget_dict and pkey not in locked:
+                    val = widget_dict[wkey]
+                    self.set_parameter_value(pkey, val)
+                    self.publish_update_to_parameter(pkey, val)
+        finally:
+            self._syncing_to_params = False
+
+    # ── Crop logic ─────────────────────────────────────────────────────────────
 
     def _crop(self) -> None:
         # Get parameters
@@ -456,16 +636,18 @@ class CropImage(ControlNode):
             # Fallback to transparent if color parsing fails
             return NAMED_COLORS["transparent"]
 
-    def after_value_set(self, parameter: Parameter, value: Any) -> None:  # noqa: C901
-        # Set the max_value for sliders based on the image size
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        # ── Input image changed: update sliders + push image URL to widget ───
         if parameter.name == "input_image":
-            # Load image
+            if not value:
+                return super().after_value_set(parameter, value)
             try:
                 img = load_pil_from_url(value.value)
             except Exception as e:
                 msg = f"{self.name}: Error loading image: {e}"
                 logger.error(msg)
-                return None
+                return super().after_value_set(parameter, value)
+
             if img.width and img.height:
                 top_param = self.get_parameter_by_name("top")
                 left_param = self.get_parameter_by_name("left")
@@ -480,37 +662,22 @@ class CropImage(ControlNode):
                 if height_param:
                     height_param.update_ui_options({"slider": {"max_val": img.height, "min_val": 0}})
 
-        # Do live cropping for crop parameters (only when not processing)
-        if not self._processing and parameter.name in [
-            "left",
-            "top",
-            "width",
-            "height",
-            "zoom",
-            "rotate",
-            "background_color",
-            "output_format",
-            "output_quality",
-        ]:
-            # Check if image is valid
-            image_exceptions = self._validate_image()
-            if image_exceptions:
-                # Image is not valid, don't run crop
-                return None
+                url = self._resolve_image_url(value)
+                new_dict = self._build_widget_dict(image_url=url, img_width=img.width, img_height=img.height)
+                self._syncing_to_widget = True
+                try:
+                    self._push_widget(new_dict)
+                finally:
+                    self._syncing_to_widget = False
 
-            # Check if parameters are valid
-            parameter_exceptions = self._validate_parameters()
-            if parameter_exceptions:
-                # Parameters are not valid, don't run crop
-                return None
+        # ── Widget changed: sync coords to individual params only (no live crop) ─
+        elif parameter.name == "crop_editor" and not self._syncing_to_widget:
+            if isinstance(value, dict):
+                self._sync_params_from_widget(value)
 
-            # Both image and parameters are valid, run crop
-            try:
-                self._crop()
-            except Exception as e:
-                # Log error but don't crash the UI
-                msg = f"{self.name}: Error during live crop: {e}"
-                logger.warning(msg)
+        # ── Individual param changed: update widget overlay if value changed ───
+        elif not self._syncing_to_params and parameter.name in ["left", "top", "width", "height", "zoom", "rotate"]:
+            self._update_widget_coords()
 
         return super().after_value_set(parameter, value)
 

--- a/widgets/CropImageEditor/CropImageEditor.js
+++ b/widgets/CropImageEditor/CropImageEditor.js
@@ -1,7 +1,7 @@
 import {
   WIDGET_VERSION,
   HANDLE_R,
-  OVERLAY, CROP_BORDER, GUIDE, TRANSFORM_PREVIEW,
+  OVERLAY, CROP_BORDER, GUIDE, TRANSFORM_PREVIEW, TRANSFORM_OVERLAY,
   HANDLE_FILL, HANDLE_STROKE, HANDLE_STROKE_HOVER, HANDLE_LOCKED,
 } from './_styles.js';
 import { createSidebar } from './_sidebar.js';
@@ -89,7 +89,10 @@ export default function CropImageEditor(container, props) {
       if (isDisabled || !imageLoaded || !imgNatW || !imgNatH) return;
       mode = "idle"; activeHandle = null; dragStart = null; hoveredHandle = null;
       cropL = crop.left; cropT = crop.top; cropW = crop.width; cropH = crop.height;
+      if ("zoom"   in crop) cropZoom   = crop.zoom;
+      if ("rotate" in crop) cropRotate = crop.rotate;
       commit();
+      syncUI();
     },
   });
 
@@ -211,7 +214,7 @@ export default function CropImageEditor(container, props) {
     ctx.stroke();
     ctx.restore();
 
-    // Zoom/rotate preview: dashed blue rect = actual pixel-capture area
+    // Zoom/rotate preview: dashed rect = actual pixel-capture area
     const hasTransform = (cropZoom !== 100 && cropZoom > 0) || cropRotate !== 0;
     if (hasTransform) {
       const zoomFactor = Math.max(0.01, cropZoom / 100);
@@ -219,6 +222,19 @@ export default function CropImageEditor(container, props) {
       const cy_px = (ecT() + ecH() / 2) * scale;
       const pw = (ecW() / zoomFactor) * scale;
       const ph = (ecH() / zoomFactor) * scale;
+
+      // Darken everything outside the capture zone using even-odd hole punch
+      ctx.save();
+      ctx.fillStyle = TRANSFORM_OVERLAY;
+      ctx.beginPath();
+      ctx.rect(0, 0, cw, ch);           // outer: full canvas
+      ctx.translate(cx_px, cy_px);
+      ctx.rotate(cropRotate * Math.PI / 180);
+      ctx.rect(-pw / 2, -ph / 2, pw, ph); // inner hole: the capture rect
+      ctx.restore();                     // restore transform; path coords are already baked
+      ctx.fill("evenodd");
+
+      // Dashed preview border + up-arrow indicator
       ctx.save();
       ctx.translate(cx_px, cy_px);
       ctx.rotate(cropRotate * Math.PI / 180);

--- a/widgets/CropImageEditor/CropImageEditor.js
+++ b/widgets/CropImageEditor/CropImageEditor.js
@@ -1,0 +1,483 @@
+import {
+  WIDGET_VERSION,
+  HANDLE_R,
+  OVERLAY, CROP_BORDER, GUIDE, TRANSFORM_PREVIEW,
+  HANDLE_FILL, HANDLE_STROKE, HANDLE_STROKE_HOVER, HANDLE_LOCKED,
+} from './_styles.js';
+import { createSidebar } from './_sidebar.js';
+import { createFooter }  from './_footer.js';
+
+export default function CropImageEditor(container, props) {
+  if (container._cropEditor?.wrapper?.isConnected) {
+    container._cropEditor.handleUpdate(props);
+    return { cleanup: container._cropEditor.cleanup, update: container._cropEditor.handleUpdate };
+  }
+  if (container._cropEditor) delete container._cropEditor;
+
+  // ── State ──────────────────────────────────────────────────────────────────
+  let latestValue = props.value || {};
+  let onChangeRef = props.onChange;
+  let isDisabled = props.disabled || false;
+
+  let imageUrl     = latestValue.image_url || "";
+  let imgNatW      = latestValue.img_width  || 0;
+  let imgNatH      = latestValue.img_height || 0;
+  let cropL        = latestValue.left   ?? 0;
+  let cropT        = latestValue.top    ?? 0;
+  let cropW        = latestValue.width  ?? 0;
+  let cropH        = latestValue.height ?? 0;
+  let cropZoom     = latestValue.zoom   ?? 100;
+  let cropRotate   = latestValue.rotate ?? 0;
+  let lockedParams = latestValue.locked || [];
+
+  function ecL() { return Math.max(0, cropL); }
+  function ecT() { return Math.max(0, cropT); }
+  function ecW() { return cropW > 0 ? cropW : (imgNatW || 1); }
+  function ecH() { return cropH > 0 ? cropH : (imgNatH || 1); }
+
+  // ── Per-handle locking ─────────────────────────────────────────────────────
+  function handleAffects(id) {
+    const fields = [];
+    if (id.includes("n")) { fields.push("top"); fields.push("height"); }
+    if (id.includes("s")) { fields.push("height"); }
+    if (id.includes("w")) { fields.push("left"); fields.push("width"); }
+    if (id.includes("e")) { fields.push("width"); }
+    return fields;
+  }
+  function isHandleLocked(id) { return handleAffects(id).some(f => lockedParams.includes(f)); }
+  function isMoveLocked()  { return lockedParams.includes("left") || lockedParams.includes("top"); }
+  function isDrawLocked()  { return ["left", "top", "width", "height"].some(f => lockedParams.includes(f)); }
+
+  let scale = 1;
+  let mode = "idle";
+  let activeHandle = null;
+  let dragStart = null;
+  let hoveredHandle = null;
+
+  // ── DOM ────────────────────────────────────────────────────────────────────
+  const wrapper = document.createElement("div");
+  wrapper.className = "crop-image-editor nodrag nowheel";
+  wrapper.style.cssText = [
+    "display:flex", "flex-direction:column", "gap:6px",
+    "height:100%",
+    "user-select:none", "-webkit-user-select:none",
+  ].join(";");
+
+  // Canvas row: canvas on left, sidebar on right
+  const canvasRow = document.createElement("div");
+  canvasRow.style.cssText = [
+    "display:flex", "flex-direction:row", "gap:6px",
+    "flex:1 1 0", "min-height:180px",
+  ].join(";");
+
+  const canvasWrap = document.createElement("div");
+  canvasWrap.style.cssText = [
+    "position:relative", "background:#111", "border-radius:6px",
+    "overflow:hidden", "flex:1 1 0", "min-height:0",
+    "display:flex", "align-items:center", "justify-content:center",
+  ].join(";");
+
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "display:block;cursor:crosshair;";
+  const ctx = canvas.getContext("2d");
+
+  // ── Sidebar ────────────────────────────────────────────────────────────────
+  const sidebarInst = createSidebar({
+    getImgSize:  () => ({ imgNatW, imgNatH }),
+    getCropRect: () => ({ l: ecL(), t: ecT(), w: ecW(), h: ecH() }),
+    onApply(crop) {
+      if (isDisabled || !imageLoaded || !imgNatW || !imgNatH) return;
+      mode = "idle"; activeHandle = null; dragStart = null; hoveredHandle = null;
+      cropL = crop.left; cropT = crop.top; cropW = crop.width; cropH = crop.height;
+      commit();
+    },
+  });
+
+  // ── Footer (sliders + status) ──────────────────────────────────────────────
+  const footerInst = createFooter({
+    getZoom:    () => cropZoom,
+    setZoom:    (v) => { cropZoom = v; },
+    getRotate:  () => cropRotate,
+    setRotate:  (v) => { cropRotate = v; },
+    isLocked:   (key) => lockedParams.includes(key),
+    isDisabled: () => isDisabled,
+    onRender:   () => render(),
+    onEmit:     () => emitAll(),
+    version:    WIDGET_VERSION,
+  });
+
+  canvasWrap.appendChild(canvas);
+  canvasRow.appendChild(canvasWrap);
+  canvasRow.appendChild(sidebarInst.el);
+  wrapper.appendChild(canvasRow);
+  wrapper.appendChild(footerInst.controls);
+  wrapper.appendChild(footerInst.statusBar);
+  container.appendChild(wrapper);
+
+  function syncUI() {
+    footerInst.sync(lockedParams, isDisabled);
+    sidebarInst.syncDisabled(lockedParams, isDisabled);
+  }
+
+  // ── Image ──────────────────────────────────────────────────────────────────
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  let imageLoaded = false;
+
+  function initCrop() {
+    if (imgNatW > 0 && imgNatH > 0) {
+      if (cropW === 0) cropW = imgNatW;
+      if (cropH === 0) cropH = imgNatH;
+    }
+  }
+
+  function resizeCanvas() {
+    if (!imageLoaded || !imgNatW || !imgNatH) return;
+    const areaW = canvasWrap.clientWidth  || 480;
+    const areaH = canvasWrap.clientHeight || 360;
+    scale = Math.min(areaW / imgNatW, areaH / imgNatH);
+    canvas.width  = Math.round(imgNatW * scale);
+    canvas.height = Math.round(imgNatH * scale);
+    render();
+  }
+
+  img.onload = () => {
+    imageLoaded = true;
+    if (!imgNatW) imgNatW = img.naturalWidth;
+    if (!imgNatH) imgNatH = img.naturalHeight;
+    initCrop();
+    resizeCanvas();
+  };
+  img.onerror = () => { imageLoaded = false; render(); };
+
+  function loadImage(url) {
+    if (!url) { imageLoaded = false; render(); return; }
+    const base = (u) => u ? u.split("?")[0] : "";
+    if (base(url) === base(img.src)) return;
+    img.src = url;
+  }
+
+  // ── Emit ───────────────────────────────────────────────────────────────────
+  function emitAll() {
+    if (typeof onChangeRef === "function") {
+      onChangeRef({
+        ...latestValue,
+        left: cropL, top: cropT, width: cropW, height: cropH,
+        zoom: cropZoom, rotate: cropRotate,
+      });
+    }
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  function render() {
+    const cw = canvas.width  || 400;
+    const ch = canvas.height || 300;
+    ctx.clearRect(0, 0, cw, ch);
+
+    if (!imageLoaded) {
+      ctx.fillStyle = "#1a1a1a";
+      ctx.fillRect(0, 0, cw, ch);
+      ctx.fillStyle = "#555";
+      ctx.font = "13px sans-serif";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText("Connect an image to begin", cw / 2, ch / 2);
+      footerInst.updateStatus({ imageLoaded, lockedParams, ecL: 0, ecT: 0, ecW: 0, ecH: 0 });
+      return;
+    }
+
+    ctx.drawImage(img, 0, 0, cw, ch);
+
+    const x  = ecL() * scale, y  = ecT() * scale;
+    const x2 = (ecL() + ecW()) * scale, y2 = (ecT() + ecH()) * scale;
+    const rw = x2 - x, rh = y2 - y;
+
+    // Dark overlay outside crop (4 rects)
+    ctx.fillStyle = OVERLAY;
+    if (y  > 0)  ctx.fillRect(0, 0, cw, y);
+    if (y2 < ch) ctx.fillRect(0, y2, cw, ch - y2);
+    if (x  > 0)  ctx.fillRect(0, y, x, rh);
+    if (x2 < cw) ctx.fillRect(x2, y, cw - x2, rh);
+
+    // Rule-of-thirds guides
+    ctx.save();
+    ctx.strokeStyle = GUIDE;
+    ctx.lineWidth = 0.8;
+    ctx.beginPath();
+    for (let i = 1; i < 3; i++) {
+      ctx.moveTo(x + rw * i / 3, y);  ctx.lineTo(x + rw * i / 3, y2);
+      ctx.moveTo(x, y + rh * i / 3);  ctx.lineTo(x2, y + rh * i / 3);
+    }
+    ctx.stroke();
+    ctx.restore();
+
+    // Zoom/rotate preview: dashed blue rect = actual pixel-capture area
+    const hasTransform = (cropZoom !== 100 && cropZoom > 0) || cropRotate !== 0;
+    if (hasTransform) {
+      const zoomFactor = Math.max(0.01, cropZoom / 100);
+      const cx_px = (ecL() + ecW() / 2) * scale;
+      const cy_px = (ecT() + ecH() / 2) * scale;
+      const pw = (ecW() / zoomFactor) * scale;
+      const ph = (ecH() / zoomFactor) * scale;
+      ctx.save();
+      ctx.translate(cx_px, cy_px);
+      ctx.rotate(cropRotate * Math.PI / 180);
+      ctx.setLineDash([5, 3]);
+      ctx.strokeStyle = TRANSFORM_PREVIEW;
+      ctx.lineWidth = 1.5;
+      ctx.strokeRect(-pw / 2, -ph / 2, pw, ph);
+      ctx.setLineDash([]);
+      ctx.fillStyle = TRANSFORM_PREVIEW;
+      ctx.beginPath();
+      ctx.moveTo(0, -ph / 2 - 8);
+      ctx.lineTo(-5, -ph / 2);
+      ctx.lineTo(5, -ph / 2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.restore();
+    }
+
+    // Crop border
+    ctx.strokeStyle = CROP_BORDER;
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(x, y, rw, rh);
+
+    // Resize handles
+    if (!isDisabled) {
+      for (const h of getHandles()) {
+        const locked = isHandleLocked(h.id);
+        ctx.beginPath();
+        ctx.arc(h.cx, h.cy, HANDLE_R, 0, Math.PI * 2);
+        ctx.fillStyle = locked ? HANDLE_LOCKED : HANDLE_FILL;
+        ctx.fill();
+        ctx.strokeStyle = locked ? "rgba(100,100,100,0.6)" : (hoveredHandle === h.id ? HANDLE_STROKE_HOVER : HANDLE_STROKE);
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+    }
+
+    footerInst.updateStatus({ imageLoaded, lockedParams, ecL: ecL(), ecT: ecT(), ecW: ecW(), ecH: ecH() });
+  }
+
+  // ── Handles ────────────────────────────────────────────────────────────────
+  function getHandles() {
+    const x  = ecL() * scale, y  = ecT() * scale;
+    const x2 = (ecL() + ecW()) * scale, y2 = (ecT() + ecH()) * scale;
+    const mx = (x + x2) / 2, my = (y + y2) / 2;
+    return [
+      { id: "nw", cx: x,  cy: y  }, { id: "n",  cx: mx, cy: y  },
+      { id: "ne", cx: x2, cy: y  }, { id: "e",  cx: x2, cy: my },
+      { id: "se", cx: x2, cy: y2 }, { id: "s",  cx: mx, cy: y2 },
+      { id: "sw", cx: x,  cy: y2 }, { id: "w",  cx: x,  cy: my },
+    ];
+  }
+
+  function hitHandle(px, py) {
+    const hitR = HANDLE_R + 5;
+    for (const h of getHandles()) {
+      if (isHandleLocked(h.id)) continue;
+      if (Math.hypot(px - h.cx, py - h.cy) <= hitR) return h.id;
+    }
+    return null;
+  }
+
+  function hitCrop(px, py) {
+    return px >= ecL() * scale && px <= (ecL() + ecW()) * scale
+        && py >= ecT() * scale && py <= (ecT() + ecH()) * scale;
+  }
+
+  const CURSORS = { nw:"nw-resize", n:"n-resize", ne:"ne-resize", e:"e-resize", se:"se-resize", s:"s-resize", sw:"sw-resize", w:"w-resize" };
+
+  function canvasPos(e) {
+    const r = canvas.getBoundingClientRect();
+    return [(e.clientX - r.left) * (canvas.width / r.width), (e.clientY - r.top) * (canvas.height / r.height)];
+  }
+
+  function toImg(cx, cy) { return [cx / scale, cy / scale]; }
+
+  function clampRect(l, t, w, h) {
+    w = Math.max(1, Math.round(w));
+    h = Math.max(1, Math.round(h));
+    l = Math.max(0, Math.min(Math.round(l), imgNatW - w));
+    t = Math.max(0, Math.min(Math.round(t), imgNatH - h));
+    return [l, t, Math.min(w, imgNatW - l), Math.min(h, imgNatH - t)];
+  }
+
+  function commit() {
+    const [l, t, w, h] = clampRect(cropL, cropT, cropW || imgNatW, cropH || imgNatH);
+    cropL = l; cropT = t; cropW = w; cropH = h;
+    emitAll();
+    render();
+  }
+
+  // ── Pointer events ─────────────────────────────────────────────────────────
+  canvas.addEventListener("pointerdown", (e) => {
+    if (isDisabled || !imageLoaded) return;
+    e.stopPropagation();
+    const [px, py] = canvasPos(e);
+    const [ix, iy] = toImg(px, py);
+    const handle = hitHandle(px, py);
+
+    if (handle) {
+      canvas.setPointerCapture(e.pointerId);
+      mode = "resizing"; activeHandle = handle;
+      dragStart = { ix, iy, l: cropL, t: cropT, w: ecW(), h: ecH() };
+    } else if (hitCrop(px, py) && !isMoveLocked()) {
+      canvas.setPointerCapture(e.pointerId);
+      mode = "moving"; canvas.style.cursor = "grabbing";
+      dragStart = { ix, iy, l: cropL, t: cropT, w: ecW(), h: ecH() };
+    } else if (!hitCrop(px, py) && !isDrawLocked()) {
+      canvas.setPointerCapture(e.pointerId);
+      mode = "drawing";
+      const six = Math.max(0, Math.min(ix, imgNatW));
+      const siy = Math.max(0, Math.min(iy, imgNatH));
+      dragStart = { ix: six, iy: siy };
+      cropL = six; cropT = siy; cropW = 0; cropH = 0;
+    }
+  });
+
+  canvas.addEventListener("pointermove", (e) => {
+    if (!imageLoaded) return;
+    e.stopPropagation();
+    const [px, py] = canvasPos(e);
+    const [ix, iy] = toImg(px, py);
+
+    if (mode === "idle") {
+      const h = hitHandle(px, py);
+      hoveredHandle = h;
+      if (h) canvas.style.cursor = CURSORS[h];
+      else if (hitCrop(px, py)) canvas.style.cursor = isMoveLocked() ? "not-allowed" : "move";
+      else canvas.style.cursor = isDrawLocked() ? "not-allowed" : "crosshair";
+      render();
+      return;
+    }
+
+    if (mode === "moving") {
+      const dx = ix - dragStart.ix, dy = iy - dragStart.iy;
+      cropW = dragStart.w; cropH = dragStart.h;
+      cropL = Math.max(0, Math.min(dragStart.l + dx, imgNatW - cropW));
+      cropT = Math.max(0, Math.min(dragStart.t + dy, imgNatH - cropH));
+    } else if (mode === "resizing") {
+      const { l, t, w, h } = dragStart;
+      let nl = l, nt = t, nr = l + w, nb = t + h;
+      const cix = Math.max(0, Math.min(ix, imgNatW));
+      const ciy = Math.max(0, Math.min(iy, imgNatH));
+      const id = activeHandle;
+      if (id.includes("n")) nt = Math.min(ciy, nb - 1);
+      if (id.includes("s")) nb = Math.max(ciy, nt + 1);
+      if (id.includes("w")) nl = Math.min(cix, nr - 1);
+      if (id.includes("e")) nr = Math.max(cix, nl + 1);
+
+      if (e.shiftKey && id.length === 2) {
+        const ratio = dragStart.w / dragStart.h;
+        const curW = nr - nl, curH = nb - nt;
+        if (Math.abs(curW - dragStart.w) >= Math.abs(curH - dragStart.h) * ratio) {
+          const ch = Math.round(curW / ratio);
+          if (id.includes("n")) nt = Math.max(0, nb - ch);
+          else nb = Math.min(imgNatH, nt + ch);
+        } else {
+          const cw = Math.round(curH * ratio);
+          if (id.includes("w")) nl = Math.max(0, nr - cw);
+          else nr = Math.min(imgNatW, nl + cw);
+        }
+      }
+
+      cropL = nl; cropT = nt; cropW = nr - nl; cropH = nb - nt;
+    } else if (mode === "drawing") {
+      const six = dragStart.ix, siy = dragStart.iy;
+      const eix = Math.max(0, Math.min(ix, imgNatW));
+      const eiy = Math.max(0, Math.min(iy, imgNatH));
+      if (e.shiftKey) {
+        const dx = eix - six, dy = eiy - siy;
+        const side = Math.max(Math.abs(dx), Math.abs(dy));
+        const maxW = dx < 0 ? six : imgNatW - six;
+        const maxH = dy < 0 ? siy : imgNatH - siy;
+        const s = Math.min(side, maxW, maxH);
+        cropW = s; cropH = s;
+        cropL = dx < 0 ? six - s : six;
+        cropT = dy < 0 ? siy - s : siy;
+      } else {
+        cropL = Math.min(six, eix); cropT = Math.min(siy, eiy);
+        cropW = Math.abs(eix - six); cropH = Math.abs(eiy - siy);
+      }
+    }
+    render();
+  });
+
+  canvas.addEventListener("pointerup", (e) => {
+    if (!imageLoaded || mode === "idle") return;
+    e.stopPropagation();
+    const prevMode = mode;
+    mode = "idle"; hoveredHandle = null; canvas.style.cursor = "crosshair";
+    if (prevMode !== "idle") commit();
+  });
+
+  canvas.addEventListener("pointercancel", () => {
+    mode = "idle"; hoveredHandle = null; canvas.style.cursor = "crosshair"; render();
+  });
+
+  canvas.addEventListener("mousedown", (e) => e.stopPropagation());
+  canvas.addEventListener("keydown",   (e) => e.stopPropagation());
+  canvasWrap.addEventListener("pointerdown", (e) => e.stopPropagation());
+  canvasWrap.addEventListener("mousedown",   (e) => e.stopPropagation());
+
+  // ── ResizeObserver ─────────────────────────────────────────────────────────
+  const ro = new ResizeObserver(() => { if (imageLoaded) resizeCanvas(); });
+  ro.observe(canvasWrap);
+
+  // ── Initial load ───────────────────────────────────────────────────────────
+  if (imageUrl) {
+    loadImage(imageUrl);
+  } else {
+    canvas.width = 400; canvas.height = 300; render();
+  }
+  syncUI();
+
+  // ── handleUpdate ───────────────────────────────────────────────────────────
+  function handleUpdate(newProps) {
+    onChangeRef = newProps.onChange;
+    isDisabled  = newProps.disabled || false;
+    latestValue = newProps.value || {};
+
+    const v = latestValue;
+    const newUrl  = v.image_url || "";
+    const newNatW = v.img_width  || 0;
+    const newNatH = v.img_height || 0;
+
+    const base = (u) => u ? u.split("?")[0] : "";
+    const urlChanged = base(newUrl) !== base(imageUrl);
+
+    if (urlChanged) {
+      imageUrl = newUrl; imgNatW = newNatW; imgNatH = newNatH;
+      imageLoaded = false;
+      loadImage(imageUrl);
+    } else {
+      if (newNatW) imgNatW = newNatW;
+      if (newNatH) imgNatH = newNatH;
+    }
+
+    if (v.locked !== undefined) lockedParams = v.locked || [];
+
+    if (mode === "idle") {
+      if ("left"   in v) cropL = v.left;
+      if ("top"    in v) cropT = v.top;
+      if ("width"  in v) cropW = v.width;
+      if ("height" in v) cropH = v.height;
+      if ("zoom"   in v) cropZoom   = v.zoom   ?? cropZoom;
+      if ("rotate" in v) cropRotate = v.rotate ?? cropRotate;
+    }
+
+    syncUI();
+    if (imageLoaded && !urlChanged) render();
+  }
+
+  // ── cleanup ────────────────────────────────────────────────────────────────
+  function cleanup() {
+    ro.disconnect();
+    wrapper.remove();
+    delete container._cropEditor;
+  }
+
+  container._cropEditor = { handleUpdate, cleanup, wrapper };
+  return { cleanup, update: handleUpdate };
+}

--- a/widgets/CropImageEditor/_footer.js
+++ b/widgets/CropImageEditor/_footer.js
@@ -1,6 +1,7 @@
 // Zoom + rotate slider controls and status bar for CropImageEditor.
 
 import { mkIcon } from './_icons.js';
+import { SLIDER_ACCENT } from './_styles.js';
 
 function makeSliderRow({ label, min, max, step, getVal, setVal, format, paramKey, defaultVal, isLocked, isDisabled, onRender, onEmit }) {
   const row = document.createElement("div");
@@ -14,7 +15,7 @@ function makeSliderRow({ label, min, max, step, getVal, setVal, format, paramKey
   slider.type = "range";
   slider.min = min; slider.max = max; slider.step = step;
   slider.value = getVal();
-  slider.style.cssText = "flex:1;accent-color:#2563eb;";
+  slider.style.cssText = `flex:1;accent-color:${SLIDER_ACCENT};`;
 
   const display = document.createElement("span");
   display.textContent = format(getVal());

--- a/widgets/CropImageEditor/_footer.js
+++ b/widgets/CropImageEditor/_footer.js
@@ -1,0 +1,143 @@
+// Zoom + rotate slider controls and status bar for CropImageEditor.
+
+import { mkIcon } from './_icons.js';
+
+function makeSliderRow({ label, min, max, step, getVal, setVal, format, paramKey, defaultVal, isLocked, isDisabled, onRender, onEmit }) {
+  const row = document.createElement("div");
+  row.style.cssText = "display:flex;align-items:center;gap:8px;";
+
+  const lbl = document.createElement("span");
+  lbl.textContent = label;
+  lbl.style.cssText = "font-size:11px;color:var(--muted-foreground);min-width:44px;";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.min = min; slider.max = max; slider.step = step;
+  slider.value = getVal();
+  slider.style.cssText = "flex:1;accent-color:#2563eb;";
+
+  const display = document.createElement("span");
+  display.textContent = format(getVal());
+  display.style.cssText = "font-size:11px;color:var(--foreground);min-width:38px;text-align:right;font-family:monospace;";
+
+  const resetBtn = document.createElement("button");
+  resetBtn.title = `Reset to ${format(defaultVal)}`;
+  resetBtn.style.cssText = [
+    "background:none", "border:none", "color:var(--muted-foreground)", "cursor:pointer",
+    "padding:0 2px", "line-height:1", "flex-shrink:0",
+    "display:flex", "align-items:center",
+  ].join(";");
+  resetBtn.appendChild(mkIcon("rotate-ccw", 13));
+  resetBtn.addEventListener("mouseenter", () => { if (!resetBtn.disabled) resetBtn.style.color = "var(--foreground)"; });
+  resetBtn.addEventListener("mouseleave", () => { resetBtn.style.color = "var(--muted-foreground)"; });
+
+  for (const el of [slider, resetBtn]) {
+    el.addEventListener("mousedown", (e) => e.stopPropagation());
+    el.addEventListener("pointerdown", (e) => e.stopPropagation());
+  }
+
+  slider.addEventListener("input", (e) => {
+    if (isLocked(paramKey) || isDisabled()) return;
+    e.stopPropagation();
+    setVal(parseFloat(e.target.value));
+    display.textContent = format(getVal());
+    onRender();
+  });
+
+  slider.addEventListener("change", (e) => {
+    if (isLocked(paramKey) || isDisabled()) return;
+    e.stopPropagation();
+    onEmit();
+  });
+
+  resetBtn.addEventListener("click", (e) => {
+    if (isLocked(paramKey) || isDisabled()) return;
+    e.stopPropagation();
+    setVal(defaultVal);
+    slider.value = defaultVal;
+    display.textContent = format(defaultVal);
+    onRender();
+    onEmit();
+  });
+
+  row.appendChild(lbl);
+  row.appendChild(slider);
+  row.appendChild(display);
+  row.appendChild(resetBtn);
+
+  function sync(lockedParams, disabled) {
+    const locked = lockedParams.includes(paramKey) || disabled;
+    slider.disabled = locked;
+    resetBtn.disabled = locked;
+    slider.value = getVal();
+    display.textContent = format(getVal());
+    row.style.opacity = locked ? "0.4" : "1";
+  }
+
+  return { row, sync };
+}
+
+export function createFooter({ getZoom, setZoom, getRotate, setRotate, isLocked, isDisabled, onRender, onEmit, version }) {
+  const controls = document.createElement("div");
+  controls.className = "nodrag nowheel";
+  controls.style.cssText = [
+    "background:var(--muted)", "border-radius:4px", "padding:6px 8px",
+    "display:flex", "flex-direction:column", "gap:5px",
+  ].join(";");
+
+  const zoomRow = makeSliderRow({
+    label: "Zoom", min: 10, max: 500, step: 1,
+    getVal: getZoom, setVal: setZoom,
+    format: (v) => Math.round(v) + "%",
+    paramKey: "zoom", defaultVal: 100,
+    isLocked, isDisabled, onRender, onEmit,
+  });
+
+  const rotateRow = makeSliderRow({
+    label: "Rotate", min: -180, max: 180, step: 1,
+    getVal: getRotate, setVal: setRotate,
+    format: (v) => (v >= 0 ? "+" : "") + Math.round(v) + "°",
+    paramKey: "rotate", defaultVal: 0,
+    isLocked, isDisabled, onRender, onEmit,
+  });
+
+  controls.appendChild(zoomRow.row);
+  controls.appendChild(rotateRow.row);
+
+  // ── Status bar ─────────────────────────────────────────────────────────────
+  const statusBar = document.createElement("div");
+  statusBar.style.cssText = [
+    "font-size:11px", "color:var(--muted-foreground)", "padding:4px 8px",
+    "background:var(--muted)", "border-radius:4px",
+    "display:flex", "justify-content:space-between", "align-items:center",
+  ].join(";");
+  const statusL = document.createElement("span");
+  const statusR = document.createElement("span");
+  statusR.style.cssText = "font-family:monospace;font-size:10px;color:var(--muted-foreground);opacity:0.6;";
+  statusR.textContent = `v${version}`;
+  statusBar.appendChild(statusL);
+  statusBar.appendChild(statusR);
+
+  function sync(lockedParams, disabled) {
+    zoomRow.sync(lockedParams, disabled);
+    rotateRow.sync(lockedParams, disabled);
+  }
+
+  function updateStatus({ imageLoaded, lockedParams, ecL, ecT, ecW, ecH }) {
+    if (!imageLoaded) {
+      statusL.textContent = "No image connected";
+      statusL.style.color = "";
+      return;
+    }
+    const coordLocked = ["left", "top", "width", "height"].filter(f => lockedParams.includes(f));
+    if (coordLocked.length > 0) {
+      statusL.style.color = "#f59e0b";
+      statusL.textContent = "\u{1F512} Connected: " + coordLocked.join(", ");
+      return;
+    }
+    statusL.style.color = "";
+    statusL.textContent = `x: ${Math.round(ecL)}  y: ${Math.round(ecT)}  →  ${Math.round(ecW)} × ${Math.round(ecH)} px`;
+  }
+
+  return { controls, statusBar, sync, updateStatus };
+}

--- a/widgets/CropImageEditor/_icons.js
+++ b/widgets/CropImageEditor/_icons.js
@@ -1,0 +1,20 @@
+// Lucide SVG icon paths (MIT licensed)
+
+export const ICON_PATHS = {
+  "rotate-ccw": `<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>`,
+};
+
+export function mkIcon(name, size = 14) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", size);
+  svg.setAttribute("height", size);
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.style.cssText = "display:block;flex-shrink:0;pointer-events:none;";
+  svg.innerHTML = ICON_PATHS[name] || "";
+  return svg;
+}

--- a/widgets/CropImageEditor/_sidebar.js
+++ b/widgets/CropImageEditor/_sidebar.js
@@ -122,7 +122,7 @@ export function createSidebar({ getImgSize, getCropRect, onApply }) {
   // ── Reset ────────────────────────────────────────────────────────────────────
   el.appendChild(makeBtn({ icon: "rotate-ccw", label: "Reset", title: "Reset crop to full image", onClick: () => {
     const { imgNatW, imgNatH } = getImgSize();
-    onApply({ left: 0, top: 0, width: imgNatW, height: imgNatH });
+    onApply({ left: 0, top: 0, width: imgNatW, height: imgNatH, zoom: 100, rotate: 0 });
   }}));
 
   // ── Aspect ratios ─────────────────────────────────────────────────────────────

--- a/widgets/CropImageEditor/_sidebar.js
+++ b/widgets/CropImageEditor/_sidebar.js
@@ -1,0 +1,96 @@
+// Preset sidebar for CropImageEditor — aspect-ratio shortcuts and reset.
+
+import { mkIcon } from './_icons.js';
+
+const RATIO_PRESETS = [
+  { label: "1:1",  rw: 1,  rh: 1  },
+  { label: "16:9", rw: 16, rh: 9  },
+  { label: "4:3",  rw: 4,  rh: 3  },
+  { label: "3:2",  rw: 3,  rh: 2  },
+  { label: "9:16", rw: 9,  rh: 16 },
+  { label: "2:3",  rw: 2,  rh: 3  },
+  { label: "3:4",  rw: 3,  rh: 4  },
+];
+
+// Scale from the shortest side of the current crop to the new ratio.
+// If the result exceeds the image boundary, clamp that dimension and
+// recalculate the other to maintain the ratio (i.e. as large as possible).
+// Always re-centers on the current crop center.
+function calcRatioRect(rw, rh, imgW, imgH, curL, curT, curW, curH) {
+  const s = Math.min(curW, curH) / Math.min(rw, rh);
+  let w = Math.round(rw * s);
+  let h = Math.round(rh * s);
+
+  // Clamp to image bounds while preserving ratio
+  if (w > imgW) { w = imgW; h = Math.round(w * rh / rw); }
+  if (h > imgH) { h = imgH; w = Math.round(h * rw / rh); }
+
+  const cx = curL + curW / 2;
+  const cy = curT + curH / 2;
+  const l = Math.max(0, Math.min(Math.round(cx - w / 2), imgW - w));
+  const t = Math.max(0, Math.min(Math.round(cy - h / 2), imgH - h));
+  return { left: l, top: t, width: w, height: h };
+}
+
+export function createSidebar({ getImgSize, getCropRect, onApply }) {
+  const el = document.createElement("div");
+  el.className = "nodrag nowheel";
+  el.style.cssText = [
+    "display:flex", "flex-direction:column", "gap:3px",
+    "width:56px", "flex-shrink:0",
+    "background:var(--muted)", "border-radius:6px", "padding:4px",
+    "overflow-y:auto", "box-sizing:border-box",
+  ].join(";");
+
+  const allBtns = [];
+
+  function makeBtn({ label, icon, title, onClick }) {
+    const btn = document.createElement("button");
+    btn.title = title;
+    btn.style.cssText = [
+      "width:100%", "padding:4px 2px", "border-radius:4px",
+      "border:1px solid var(--border)",
+      "background:var(--background)", "color:var(--foreground)", "cursor:pointer",
+      "font-size:10px", "font-weight:500", "line-height:1.3",
+      "white-space:nowrap", "box-sizing:border-box",
+      "display:flex", "align-items:center", "justify-content:center", "gap:3px",
+    ].join(";");
+    if (icon) btn.appendChild(mkIcon(icon, 12));
+    if (label) btn.append(label);
+    btn.addEventListener("mouseenter", () => { if (!btn.disabled) btn.style.background = "var(--accent)"; });
+    btn.addEventListener("mouseleave", () => { btn.style.background = "var(--background)"; });
+    for (const ev of ["mousedown", "pointerdown"]) btn.addEventListener(ev, (e) => e.stopPropagation());
+    btn.addEventListener("click", (e) => { e.stopPropagation(); if (!btn.disabled) onClick(); });
+    allBtns.push(btn);
+    return btn;
+  }
+
+  el.appendChild(makeBtn({ icon: "rotate-ccw", label: "Reset", title: "Reset crop to full image", onClick: () => {
+    const { imgNatW, imgNatH } = getImgSize();
+    onApply({ left: 0, top: 0, width: imgNatW, height: imgNatH });
+  }}));
+
+  const hr = document.createElement("div");
+  hr.style.cssText = "height:1px;background:var(--border);margin:2px 0;flex-shrink:0;";
+  el.appendChild(hr);
+
+  for (const { label, rw, rh } of RATIO_PRESETS) {
+    el.appendChild(makeBtn({ label, title: label, onClick: () => {
+      const { imgNatW, imgNatH } = getImgSize();
+      const { l, t, w, h } = getCropRect();
+      onApply(calcRatioRect(rw, rh, imgNatW, imgNatH, l, t, w, h));
+    }}));
+  }
+
+  function syncDisabled(lockedParams, disabled) {
+    const coordLocked = ["left", "top", "width", "height"].some(f => lockedParams.includes(f));
+    const off = coordLocked || disabled;
+    for (const btn of allBtns) {
+      btn.disabled = off;
+      btn.style.opacity = off ? "0.35" : "1";
+      btn.style.cursor  = off ? "not-allowed" : "pointer";
+    }
+  }
+
+  return { el, syncDisabled };
+}

--- a/widgets/CropImageEditor/_sidebar.js
+++ b/widgets/CropImageEditor/_sidebar.js
@@ -1,4 +1,4 @@
-// Preset sidebar for CropImageEditor — aspect-ratio shortcuts and reset.
+// Preset sidebar for CropImageEditor — aspect ratio, resolution, and position shortcuts.
 
 import { mkIcon } from './_icons.js';
 
@@ -12,24 +12,65 @@ const RATIO_PRESETS = [
   { label: "3:4",  rw: 3,  rh: 4  },
 ];
 
+const RESOLUTION_PRESETS = [
+  { label: "480p",  w: 854,  h: 480  },
+  { label: "720p",  w: 1280, h: 720  },
+  { label: "1080p", w: 1920, h: 1080 },
+  { label: "1440p", w: 2560, h: 1440 },
+  { label: "4K",    w: 3840, h: 2160 },
+];
+
+const POSITION_PRESETS = [
+  { label: "↖",    title: "Top Left",       pos: "top-left"      },
+  { label: "↑",    title: "Top Center",     pos: "top-center"    },
+  { label: "↗",    title: "Top Right",      pos: "top-right"     },
+  { label: "←",    title: "Left Center",    pos: "left-center"   },
+  { label: "⊕",    title: "Center",         pos: "center"        },
+  { label: "→",    title: "Right Center",   pos: "right-center"  },
+  { label: "↙",    title: "Bottom Left",    pos: "bottom-left"   },
+  { label: "↓",    title: "Bottom Center",  pos: "bottom-center" },
+  { label: "↘",    title: "Bottom Right",   pos: "bottom-right"  },
+];
+
 // Scale from the shortest side of the current crop to the new ratio.
-// If the result exceeds the image boundary, clamp that dimension and
-// recalculate the other to maintain the ratio (i.e. as large as possible).
-// Always re-centers on the current crop center.
 function calcRatioRect(rw, rh, imgW, imgH, curL, curT, curW, curH) {
   const s = Math.min(curW, curH) / Math.min(rw, rh);
   let w = Math.round(rw * s);
   let h = Math.round(rh * s);
-
-  // Clamp to image bounds while preserving ratio
   if (w > imgW) { w = imgW; h = Math.round(w * rh / rw); }
   if (h > imgH) { h = imgH; w = Math.round(h * rw / rh); }
-
-  const cx = curL + curW / 2;
-  const cy = curT + curH / 2;
+  const cx = curL + curW / 2, cy = curT + curH / 2;
   const l = Math.max(0, Math.min(Math.round(cx - w / 2), imgW - w));
   const t = Math.max(0, Math.min(Math.round(cy - h / 2), imgH - h));
   return { left: l, top: t, width: w, height: h };
+}
+
+// Center the new resolution on the current crop center, clamped to image bounds.
+function calcResolutionRect(newW, newH, imgW, imgH, curL, curT, curW, curH) {
+  const w = Math.min(newW, imgW);
+  const h = Math.min(newH, imgH);
+  const cx = curL + curW / 2, cy = curT + curH / 2;
+  const l = Math.max(0, Math.min(Math.round(cx - w / 2), imgW - w));
+  const t = Math.max(0, Math.min(Math.round(cy - h / 2), imgH - h));
+  return { left: l, top: t, width: w, height: h };
+}
+
+// Compute left/top for a named position, keeping current crop size.
+function calcPositionRect(posName, imgW, imgH, curL, curT, curW, curH) {
+  const w = curW, h = curH;
+  const positions = {
+    "center":        { l: Math.round((imgW - w) / 2), t: Math.round((imgH - h) / 2) },
+    "top-left":      { l: 0,           t: 0            },
+    "top-center":    { l: Math.round((imgW - w) / 2), t: 0 },
+    "top-right":     { l: imgW - w,    t: 0            },
+    "left-center":   { l: 0,           t: Math.round((imgH - h) / 2) },
+    "right-center":  { l: imgW - w,    t: Math.round((imgH - h) / 2) },
+    "bottom-left":   { l: 0,           t: imgH - h     },
+    "bottom-center": { l: Math.round((imgW - w) / 2), t: imgH - h },
+    "bottom-right":  { l: imgW - w,    t: imgH - h     },
+  };
+  const { l, t } = positions[posName] || positions["center"];
+  return { left: Math.max(0, l), top: Math.max(0, t), width: w, height: h };
 }
 
 export function createSidebar({ getImgSize, getCropRect, onApply }) {
@@ -37,7 +78,7 @@ export function createSidebar({ getImgSize, getCropRect, onApply }) {
   el.className = "nodrag nowheel";
   el.style.cssText = [
     "display:flex", "flex-direction:column", "gap:3px",
-    "width:56px", "flex-shrink:0",
+    "width:108px", "flex-shrink:0",
     "background:var(--muted)", "border-radius:6px", "padding:4px",
     "overflow-y:auto", "box-sizing:border-box",
   ].join(";");
@@ -65,22 +106,70 @@ export function createSidebar({ getImgSize, getCropRect, onApply }) {
     return btn;
   }
 
+  function makeDivider() {
+    const hr = document.createElement("div");
+    hr.style.cssText = "height:1px;background:var(--border);margin:2px 0;flex-shrink:0;";
+    return hr;
+  }
+
+  function makeLabel(text) {
+    const lbl = document.createElement("div");
+    lbl.textContent = text;
+    lbl.style.cssText = "font-size:9px;color:var(--muted-foreground);text-align:center;padding:2px 0;";
+    return lbl;
+  }
+
+  // ── Reset ────────────────────────────────────────────────────────────────────
   el.appendChild(makeBtn({ icon: "rotate-ccw", label: "Reset", title: "Reset crop to full image", onClick: () => {
     const { imgNatW, imgNatH } = getImgSize();
     onApply({ left: 0, top: 0, width: imgNatW, height: imgNatH });
   }}));
 
-  const hr = document.createElement("div");
-  hr.style.cssText = "height:1px;background:var(--border);margin:2px 0;flex-shrink:0;";
-  el.appendChild(hr);
-
+  // ── Aspect ratios ─────────────────────────────────────────────────────────────
+  el.appendChild(makeDivider());
+  el.appendChild(makeLabel("Ratio"));
+  const ratioGrid = document.createElement("div");
+  ratioGrid.style.cssText = "display:grid;grid-template-columns:repeat(2,1fr);gap:2px;";
   for (const { label, rw, rh } of RATIO_PRESETS) {
-    el.appendChild(makeBtn({ label, title: label, onClick: () => {
+    const btn = makeBtn({ label, title: label, onClick: () => {
       const { imgNatW, imgNatH } = getImgSize();
       const { l, t, w, h } = getCropRect();
       onApply(calcRatioRect(rw, rh, imgNatW, imgNatH, l, t, w, h));
-    }}));
+    }});
+    ratioGrid.appendChild(btn);
   }
+  el.appendChild(ratioGrid);
+
+  // ── Resolutions ───────────────────────────────────────────────────────────────
+  el.appendChild(makeDivider());
+  el.appendChild(makeLabel("Res"));
+  const resGrid = document.createElement("div");
+  resGrid.style.cssText = "display:grid;grid-template-columns:repeat(2,1fr);gap:2px;";
+  for (const { label, w: pw, h: ph } of RESOLUTION_PRESETS) {
+    const btn = makeBtn({ label, title: `${pw}×${ph}`, onClick: () => {
+      const { imgNatW, imgNatH } = getImgSize();
+      const { l, t, w, h } = getCropRect();
+      onApply(calcResolutionRect(pw, ph, imgNatW, imgNatH, l, t, w, h));
+    }});
+    resGrid.appendChild(btn);
+  }
+  el.appendChild(resGrid);
+
+  // ── Positions ─────────────────────────────────────────────────────────────────
+  el.appendChild(makeDivider());
+  el.appendChild(makeLabel("Pos"));
+  const posGrid = document.createElement("div");
+  posGrid.style.cssText = "display:grid;grid-template-columns:repeat(3,1fr);gap:2px;";
+  for (const { label, title, pos } of POSITION_PRESETS) {
+    const btn = makeBtn({ label, title, onClick: () => {
+      const { imgNatW, imgNatH } = getImgSize();
+      const { l, t, w, h } = getCropRect();
+      onApply(calcPositionRect(pos, imgNatW, imgNatH, l, t, w, h));
+    }});
+    btn.style.width = "100%";
+    posGrid.appendChild(btn);
+  }
+  el.appendChild(posGrid);
 
   function syncDisabled(lockedParams, disabled) {
     const coordLocked = ["left", "top", "width", "height"].some(f => lockedParams.includes(f));

--- a/widgets/CropImageEditor/_styles.js
+++ b/widgets/CropImageEditor/_styles.js
@@ -1,0 +1,18 @@
+export const WIDGET_VERSION = "1.0.0";
+
+// ── Geometry ───────────────────────────────────────────────────────────────────
+export const HANDLE_R = 6;
+
+// ── Canvas chrome ──────────────────────────────────────────────────────────────
+export const OVERLAY          = "rgba(0,0,0,0.55)";
+export const CROP_BORDER      = "rgba(255,255,255,0.9)";
+export const GUIDE            = "rgba(255,255,255,0.25)";
+export const TRANSFORM_PREVIEW = "#3b82f6";
+
+// ── Resize handles ─────────────────────────────────────────────────────────────
+// White fill + blue stroke matches the AnnotateImage widget convention.
+// Works in both light and dark themes since white is always visible over the image canvas.
+export const HANDLE_FILL         = "white";
+export const HANDLE_STROKE       = "#2563eb";
+export const HANDLE_STROKE_HOVER = "#60a5fa";
+export const HANDLE_LOCKED       = "rgba(150,150,150,0.5)";

--- a/widgets/CropImageEditor/_styles.js
+++ b/widgets/CropImageEditor/_styles.js
@@ -7,12 +7,16 @@ export const HANDLE_R = 6;
 export const OVERLAY          = "rgba(0,0,0,0.55)";
 export const CROP_BORDER      = "rgba(255,255,255,0.9)";
 export const GUIDE            = "rgba(255,255,255,0.25)";
-export const TRANSFORM_PREVIEW = "#3b82f6";
+export const TRANSFORM_PREVIEW = "#1bb0f4";
+export const TRANSFORM_OVERLAY = "rgba(0,0,0,0.45)";
+
+// ── Sliders ────────────────────────────────────────────────────────────────────
+export const SLIDER_ACCENT = "#a7c6c7";
 
 // ── Resize handles ─────────────────────────────────────────────────────────────
 // White fill + blue stroke matches the AnnotateImage widget convention.
 // Works in both light and dark themes since white is always visible over the image canvas.
-export const HANDLE_FILL         = "white";
-export const HANDLE_STROKE       = "#2563eb";
+export const HANDLE_FILL         = "black";
+export const HANDLE_STROKE       = "#ffffff";
 export const HANDLE_STROKE_HOVER = "#60a5fa";
 export const HANDLE_LOCKED       = "rgba(150,150,150,0.5)";


### PR DESCRIPTION
https://www.loom.com/share/1e6dbee8955944abb266d8eb872b1673

## Summary

- Replaces the modal crop editor button + numeric sliders with an inline `CropImageEditor` widget that renders the image and lets users drag/resize the crop rectangle directly in the node
- Fixes `'dict' object has no attribute 'value'` error when `input_image` - this was legacy and was also breaking macro paths. Using `_extract_image_path` 
- Hides the `input_image` property row (keeps the input socket) to reduce visual clutter
- Pre-publishes the full `crop_editor` dict before individual param publishes to eliminate the snap-then-jump artifact during drag

## Widget features

- Drag to move, drag handles to resize, drag outside crop to draw a new rect
- Shift-drag for square/locked-aspect-ratio operations
- Rule-of-thirds guide overlay and dashed blue zoom/rotate preview rect
- Sidebar with aspect ratio presets (1:1, 16:9, 4:3, 3:2, 9:16, 2:3, 3:4) — preserves the current crop's shortest dimension when switching ratios
- Reset button returns crop to full image
- Zoom and rotate sliders with reset controls
- Incoming wire connections lock the affected handles and sidebar buttons (read-only visual)
- Lucide icons for reset buttons; Tailwind CSS variables for full light/dark theme support
- Canvas letterboxes within available node height using `flex:1 1 0` + `Math.min(areaW/imgNatW, areaH/imgNatH)` scaling

## Widget file layout

```
widgets/CropImageEditor/
  CropImageEditor.js   ← main entry point
  _styles.js           ← visual constants
  _icons.js            ← Lucide SVG paths + mkIcon factory
  _sidebar.js          ← aspect ratio preset buttons
  _footer.js           ← zoom/rotate sliders + status bar
```

## Closes

Fixes #290
Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)