### PR TITLE
Migrate nano banana models off of preview model endpoints

### DIFF
--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -46,11 +46,11 @@ class GoogleImageGeneration(GriptapeProxyNode):
     API_KEY_NAME = "GT_CLOUD_API_KEY"
     DEFAULT_MODEL: ClassVar[str] = "Nano Banana Pro"
     SUPPORTED_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
-        "Nano Banana Pro": "gemini-3-pro-image-preview",
-        "Nano Banana 2": "gemini-3.1-flash-image-preview",
+        "Nano Banana Pro": "gemini-3-pro-image",
+        "Nano Banana 2": "gemini-3.1-flash-image",
     }
     DEPRECATED_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
-        "nano-banana-3-pro": "gemini-3-pro-image-preview",
+        "nano-banana-3-pro": "gemini-3-pro-image",
     }
     ALL_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
         **SUPPORTED_MODELS_TO_API_MODELS,


### PR DESCRIPTION
non-preview models have been added to Griptape Cloud, library can now be updated

<img width="1213" height="945" alt="image" src="https://github.com/user-attachments/assets/87502444-c94c-4edd-8fad-490ee3771c5c" />


Closes https://github.com/griptape-ai/griptape-cloud/issues/1987