### PR TITLE
Nano Banana outputs JPEG, not PNG

### DIFF
--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -272,7 +272,7 @@ class GoogleImageGeneration(GriptapeProxyNode):
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
-            default_filename="google_image.png",
+            default_filename="google_image.jpeg",
         )
         self._output_file.add_parameter()
 


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/4760

Still thinking on a deeper fix for auto-casting