### PR TITLE
feat(tags): add tags to all nodes for filter search

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -67,17 +67,17 @@
     {
       "name": "SplatViewer",
       "path": "griptape_nodes_library/splat/widgets/SplatViewer.js",
-      "description": "Inline Gaussian splat viewer — auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
+      "description": "Inline Gaussian splat viewer \u2014 auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
     },
     {
       "name": "CropImageEditor",
       "path": "widgets/CropImageEditor/CropImageEditor.js",
-      "description": "Interactive crop editor — drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
+      "description": "Interactive crop editor \u2014 drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
     },
     {
       "name": "CropVideoEditor",
       "path": "widgets/CropVideoEditor/CropVideoEditor.js",
-      "description": "Interactive video crop editor — drag handles on a live video frame with frame scrubber, aspect ratio, resolution, and position presets."
+      "description": "Interactive video crop editor \u2014 drag handles on a live video frame with frame scrubber, aspect ratio, resolution, and position presets."
     }
   ],
   "categories": [
@@ -357,7 +357,12 @@
         "description": "Takes a list input and adds a value to the list at the specified index.",
         "display_name": "Add To List",
         "icon": "list-plus",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -367,7 +372,12 @@
         "category": "lists",
         "description": "Takes two lists and combines them into a single flattened list.",
         "display_name": "Combine Lists",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -377,7 +387,12 @@
         "category": "lists",
         "description": "Takes a list of items and creates a list.",
         "display_name": "Create List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -388,7 +403,13 @@
         "description": "Creates a boolean value.",
         "display_name": "Bool Input",
         "icon": "toggle-right",
-        "group": "general"
+        "group": "general",
+        "tags": [
+          "boolean",
+          "number",
+          "input",
+          "logic"
+        ]
       }
     },
     {
@@ -398,7 +419,12 @@
         "category": "lists",
         "description": "Creates a list of boolean values.",
         "display_name": "Create Bool List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "boolean"
+        ]
       }
     },
     {
@@ -408,7 +434,12 @@
         "category": "lists",
         "description": "Creates a list of float values.",
         "display_name": "Create Float List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "number"
+        ]
       }
     },
     {
@@ -418,7 +449,11 @@
         "category": "engine",
         "description": "Dynamically call any RequestPayload in the engine",
         "display_name": "Engine Node",
-        "icon": "Cog"
+        "icon": "Cog",
+        "tags": [
+          "workflow",
+          "engine"
+        ]
       }
     },
     {
@@ -428,7 +463,13 @@
         "category": "engine",
         "description": "Execute Python code with input variables and capture output",
         "display_name": "Execute Python",
-        "icon": "Code"
+        "icon": "Code",
+        "tags": [
+          "code",
+          "python",
+          "logic",
+          "data"
+        ]
       }
     },
     {
@@ -438,7 +479,12 @@
         "category": "lists",
         "description": "Creates a list of integer values.",
         "display_name": "Create Int List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "number"
+        ]
       }
     },
     {
@@ -448,7 +494,12 @@
         "category": "lists",
         "description": "Creates a list of text items",
         "display_name": "Create Text List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "text"
+        ]
       }
     },
     {
@@ -458,7 +509,12 @@
         "category": "lists",
         "description": "Creates a list of image items",
         "display_name": "Create Image List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "list",
+          "data",
+          "image"
+        ]
       }
     },
     {
@@ -468,7 +524,12 @@
         "category": "lists",
         "description": "Takes a list of items and gets an item at a specified index from the list.",
         "display_name": "Get From List",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -478,7 +539,12 @@
         "category": "lists",
         "description": "Lets the user select an  item from a list.",
         "display_name": "Select From List",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -488,7 +554,12 @@
         "category": "lists",
         "description": "Takes a list of items and gets the index of an item in the list.",
         "display_name": "Get Index Of Item",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -498,7 +569,12 @@
         "category": "lists",
         "description": "Takes a list of items and checks if the list contains an item.",
         "display_name": "Get List Contains Item",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -508,7 +584,12 @@
         "category": "lists",
         "description": "Takes a list of items and checks if the list is empty.",
         "display_name": "Get List Is Empty",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -518,7 +599,12 @@
         "category": "lists",
         "description": "Takes a list of items and gets the length of the list.",
         "display_name": "Get List Length",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -529,7 +615,12 @@
         "description": "Takes a list input and removes an item from the list at the specified index or by value.",
         "display_name": "Remove From List",
         "icon": "list-minus",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -540,7 +631,12 @@
         "description": "Takes a list input and replaces an item either by matching the item or by index.",
         "display_name": "Replace In List",
         "icon": "list-restart",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -551,7 +647,12 @@
         "description": "Takes a list input and splits it either by index or by item value, with options for keeping the split item.",
         "display_name": "Split List",
         "icon": "square-split-vertical",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -562,7 +663,12 @@
         "description": "Takes a list input and sorts it in ascending or descending order. When the list contains dictionaries, a Key dropdown appears to select which key to sort by.",
         "display_name": "Sort List",
         "icon": "arrow-up-down",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "logic"
+        ]
       }
     },
     {
@@ -573,7 +679,12 @@
         "description": "Takes a text string and splits it into a list based on a specified delimiter.",
         "display_name": "Split Text",
         "icon": "scissors",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "text",
+          "list",
+          "data"
+        ]
       }
     },
     {
@@ -583,7 +694,12 @@
         "category": "lists",
         "description": "Takes a list input and creates output parameters for each item in the list",
         "display_name": "Display List",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "list",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -593,7 +709,13 @@
         "category": "convert",
         "description": "Converts a list to dictionary keys with empty string values",
         "display_name": "List To Dict Keys",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "list",
+          "data",
+          "convert",
+          "dictionary"
+        ]
       }
     },
     {
@@ -603,7 +725,14 @@
         "category": "agents",
         "description": "Creates an AI agent with conversation memory and the ability to use tools",
         "display_name": "Agent",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "agent",
+          "ai",
+          "llm",
+          "conversation",
+          "memory"
+        ]
       }
     },
     {
@@ -612,7 +741,13 @@
       "metadata": {
         "category": "agents/memory",
         "description": "Displays the memory of an agent",
-        "display_name": "Display Agent Memory"
+        "display_name": "Display Agent Memory",
+        "tags": [
+          "agent",
+          "memory",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -621,7 +756,12 @@
       "metadata": {
         "category": "agents/memory",
         "description": "Replaces an item in the memory of an agent",
-        "display_name": "Replace Item In Agent Memory"
+        "display_name": "Replace Item In Agent Memory",
+        "tags": [
+          "agent",
+          "memory",
+          "data"
+        ]
       }
     },
     {
@@ -630,7 +770,13 @@
       "metadata": {
         "category": "agents/memory",
         "description": "Summarizes an agent's conversation memory and replaces it with a single summary run",
-        "display_name": "Summarize Agent Memory"
+        "display_name": "Summarize Agent Memory",
+        "tags": [
+          "agent",
+          "memory",
+          "text",
+          "summarize"
+        ]
       }
     },
     {
@@ -639,7 +785,11 @@
       "metadata": {
         "category": "agents/memory",
         "description": "Clears an agent's conversation memory",
-        "display_name": "Clear Agent Memory"
+        "display_name": "Clear Agent Memory",
+        "tags": [
+          "agent",
+          "memory"
+        ]
       }
     },
     {
@@ -650,7 +800,12 @@
         "description": "Loads audio files into your workflow",
         "display_name": "Load Audio",
         "icon": "file-up",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "audio",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -661,7 +816,12 @@
         "description": "Saves audio files from your workflow",
         "display_name": "Save Audio",
         "icon": "file-down",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "audio",
+          "file",
+          "save"
+        ]
       }
     },
     {
@@ -672,7 +832,13 @@
         "description": "Can record audio from your microphone.",
         "display_name": "Microphone",
         "icon": "mic",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "audio",
+          "input",
+          "recording",
+          "capture"
+        ]
       }
     },
     {
@@ -683,7 +849,14 @@
         "description": "Transcribe audio files into text.\nRequires an OpenAI API key.",
         "display_name": "Transcribe Audio",
         "icon": "ear",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "audio",
+          "text",
+          "speech-to-text",
+          "openai",
+          "api"
+        ]
       }
     },
     {
@@ -694,7 +867,14 @@
         "description": "Generate speech from text using Eleven Labs text-to-speech models",
         "display_name": "Eleven Labs Text to Speech Generation",
         "icon": "mic",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "audio",
+          "text-to-speech",
+          "elevenlabs",
+          "generation",
+          "api"
+        ]
       }
     },
     {
@@ -705,7 +885,14 @@
         "description": "Generate sound effects from text prompts using Eleven Labs",
         "display_name": "Eleven Labs Sound Effect Generation",
         "icon": "volume-2",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "audio",
+          "sound-effects",
+          "elevenlabs",
+          "generation",
+          "api"
+        ]
       }
     },
     {
@@ -716,7 +903,14 @@
         "description": "Generate music from text prompts using Eleven Labs",
         "display_name": "Eleven Labs Music Generation",
         "icon": "music",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "audio",
+          "music",
+          "elevenlabs",
+          "generation",
+          "api"
+        ]
       }
     },
     {
@@ -727,7 +921,12 @@
         "description": "Combine multiple audio tracks into a single audio file using ffmpeg",
         "display_name": "Combine Audio",
         "icon": "layers",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "audio",
+          "combine",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -738,7 +937,12 @@
         "description": "Extract detailed information from an audio file including duration, format, bitrate, and sample rate",
         "display_name": "Audio Details",
         "icon": "info",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "audio",
+          "data",
+          "metadata"
+        ]
       }
     },
     {
@@ -749,7 +953,12 @@
         "description": "Loads video files into your workflow",
         "display_name": "Load Video",
         "icon": "file-video",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "video",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -760,7 +969,11 @@
         "description": "Display a video",
         "display_name": "Display Video",
         "icon": "monitor-play",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "video",
+          "display"
+        ]
       }
     },
     {
@@ -771,7 +984,12 @@
         "description": "Resize a video using multiple scaling modes with FFmpeg",
         "display_name": "Resize Video",
         "icon": "picture-in-picture",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "resize",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -782,7 +1000,12 @@
         "description": "Interactively crop a video with drag handles, frame scrubber, and aspect ratio presets",
         "display_name": "Crop Video",
         "icon": "crop",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "crop",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -793,7 +1016,12 @@
         "description": "Save a video to a file",
         "display_name": "Save Video",
         "icon": "file-down",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "video",
+          "file",
+          "save"
+        ]
       }
     },
     {
@@ -804,7 +1032,12 @@
         "description": "Extract metadata from video files including aspect ratio",
         "display_name": "Get Video Metadata",
         "icon": "info",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "video",
+          "data",
+          "metadata"
+        ]
       }
     },
     {
@@ -815,7 +1048,14 @@
         "description": "Generate a video using Seedance 1.x models via Griptape Cloud model proxy.",
         "display_name": "Seedance Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "seedance"
+        ]
       }
     },
     {
@@ -826,7 +1066,14 @@
         "description": "Generate a video using Seedance 2.0 models with multimodal support via Griptape Cloud model proxy.",
         "display_name": "Seedance 2.0 Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "seedance"
+        ]
       }
     },
     {
@@ -837,7 +1084,15 @@
         "description": "Generate videos using Grok models via Griptape model proxy",
         "display_name": "Grok Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "grok",
+          "xai"
+        ]
       }
     },
     {
@@ -848,7 +1103,15 @@
         "description": "Edit videos using Grok models via Griptape model proxy",
         "display_name": "Grok Video Edit",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "edit",
+          "ai",
+          "api",
+          "grok",
+          "xai"
+        ]
       }
     },
     {
@@ -859,7 +1122,15 @@
         "description": "Identify whether an image contains human, human-like, anthropomorphic, or similar subjects using OmniHuman 1.5",
         "display_name": "OmniHuman Subject Recognition",
         "icon": "User",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "video",
+          "image",
+          "ai",
+          "api",
+          "omnihuman",
+          "recognition"
+        ]
       }
     },
     {
@@ -870,7 +1141,15 @@
         "description": "Detect and locate subjects in an image, returning masks and bounding boxes using OmniHuman 1.5",
         "display_name": "OmniHuman Subject Detection",
         "icon": "ScanFace",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "video",
+          "image",
+          "ai",
+          "api",
+          "omnihuman",
+          "detection"
+        ]
       }
     },
     {
@@ -881,7 +1160,15 @@
         "description": "Generate talking head videos from image and audio using OmniHuman 1.5",
         "display_name": "OmniHuman Video Generation",
         "icon": "UserCircle",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "omnihuman",
+          "talking-head"
+        ]
       }
     },
     {
@@ -892,7 +1179,14 @@
         "description": "Generate a video using the MiniMax Hailuo models via Griptape Cloud model proxy.",
         "display_name": "MiniMax Hailuo Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "minimax"
+        ]
       }
     },
     {
@@ -903,7 +1197,14 @@
         "description": "Generate a video from text using Kling AI models via Griptape Cloud model proxy.",
         "display_name": "Kling Text to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "text-to-video",
+          "ai",
+          "api",
+          "kling"
+        ]
       }
     },
     {
@@ -914,7 +1215,14 @@
         "description": "Generate a video from an image using Kling AI models via Griptape Cloud model proxy.",
         "display_name": "Kling Image to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "image-to-video",
+          "ai",
+          "api",
+          "kling"
+        ]
       }
     },
     {
@@ -925,7 +1233,14 @@
         "description": "Generate a video from text using LTX AI models via Griptape Cloud model proxy.",
         "display_name": "LTX Text to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "text-to-video",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -936,7 +1251,14 @@
         "description": "Generate a video from an image using LTX AI models via Griptape Cloud model proxy.",
         "display_name": "LTX Image to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "image-to-video",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -947,7 +1269,14 @@
         "description": "Generate a video from audio using LTX AI models via Griptape Cloud model proxy.",
         "display_name": "LTX Audio to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "audio-to-video",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -958,7 +1287,14 @@
         "description": "Regenerate a segment of an existing video using LTX AI models via Griptape Cloud model proxy.",
         "display_name": "LTX Video Retake",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "edit",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -969,7 +1305,14 @@
         "description": "Extend an existing video by 2-20 seconds on the start or end using LTX AI models via Griptape Cloud model proxy.",
         "display_name": "LTX Video Extend",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "extend",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -980,7 +1323,15 @@
         "description": "Upgrade an SDR video to HDR using LTX AI via Griptape Cloud model proxy; returns a ZIP of per-frame EXR images.",
         "display_name": "LTX Video to Video HDR",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "hdr",
+          "upscale",
+          "ai",
+          "api",
+          "ltx"
+        ]
       }
     },
     {
@@ -991,7 +1342,14 @@
         "description": "Extend an existing Kling AI video by 4-5 seconds via Griptape Cloud model proxy.",
         "display_name": "Kling Video Extension",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "extend",
+          "ai",
+          "api",
+          "kling"
+        ]
       }
     },
     {
@@ -1002,7 +1360,14 @@
         "description": "Generate videos using Kling Omni AI with advanced templating and multi-modal references via Griptape Cloud model proxy.",
         "display_name": "Kling Omni Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "kling"
+        ]
       }
     },
     {
@@ -1013,7 +1378,14 @@
         "description": "Transfer character actions from a reference video to a reference image using Kling Motion Control via Griptape Cloud model proxy.",
         "display_name": "Kling Motion Control",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "motion-control",
+          "ai",
+          "api",
+          "kling"
+        ]
       }
     },
     {
@@ -1024,7 +1396,15 @@
         "description": "Generate video using Sora 2 models via Griptape Cloud model proxy",
         "display_name": "Sora 2 Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "sora",
+          "openai"
+        ]
       }
     },
     {
@@ -1035,7 +1415,14 @@
         "description": "Generate videos from text using WAN models via Griptape model proxy",
         "display_name": "WAN Text to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "text-to-video",
+          "ai",
+          "api",
+          "wan"
+        ]
       }
     },
     {
@@ -1046,7 +1433,15 @@
         "description": "Generate video using Google Veo 3 models via Griptape Cloud model proxy",
         "display_name": "Veo 3 Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "veo",
+          "google"
+        ]
       }
     },
     {
@@ -1057,7 +1452,14 @@
         "description": "Generate videos from images using WAN models via Griptape model proxy",
         "display_name": "WAN Image to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "image-to-video",
+          "ai",
+          "api",
+          "wan"
+        ]
       }
     },
     {
@@ -1068,7 +1470,14 @@
         "description": "Generate animated videos from images using WAN Animate models via Griptape model proxy",
         "display_name": "WAN Animate Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "animation",
+          "ai",
+          "api",
+          "wan"
+        ]
       }
     },
     {
@@ -1079,7 +1488,14 @@
         "description": "Generate videos from reference videos using WAN models via Griptape model proxy",
         "display_name": "WAN Reference to Video Generation",
         "icon": "Sparkles",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "video",
+          "reference-to-video",
+          "ai",
+          "api",
+          "wan"
+        ]
       }
     },
     {
@@ -1090,7 +1506,14 @@
         "description": "Upscale video using SeedVR models via Griptape Cloud model proxy",
         "display_name": "SeedVR Video Upscale",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "upscale",
+          "ai",
+          "api",
+          "seedvr"
+        ]
       }
     },
     {
@@ -1101,7 +1524,12 @@
         "description": "Split a video into multiple parts using ffmpeg with timecode support",
         "display_name": "Split Video",
         "icon": "scissors",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "split",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1112,7 +1540,12 @@
         "description": "Trim a video to a specific start and end point using timecodes or frame ranges",
         "display_name": "Trim Video",
         "icon": "scissors",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "trim",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1123,7 +1556,12 @@
         "description": "Concatenate multiple videos into a single video file with configurable format and codec options",
         "display_name": "Concatenate Videos",
         "icon": "link",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "video",
+          "combine",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1134,7 +1572,12 @@
         "description": "Combine a list of mask videos into a single consolidated mask video using pixel-wise max operation per frame",
         "display_name": "Combine Masks Video",
         "icon": "layers",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "video",
+          "mask",
+          "composite"
+        ]
       }
     },
     {
@@ -1145,7 +1588,12 @@
         "description": "Adjust mask size in a video by dilating (expanding) or eroding (shrinking) the mask frame-by-frame",
         "display_name": "Adjust Mask Size",
         "icon": "maximize-2",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "mask",
+          "composite"
+        ]
       }
     },
     {
@@ -1156,7 +1604,12 @@
         "description": "Hold video frames for a specified number of frames, creating a stepped video effect",
         "display_name": "Hold Video Frames",
         "icon": "pause-circle",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "effect",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1167,7 +1620,13 @@
         "description": "Add realistic film grain to video using sophisticated noise generation and luminance masking",
         "display_name": "Add Film Grain",
         "icon": "film",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "effect",
+          "grain",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1178,7 +1637,13 @@
         "description": "Add a vignette effect to video with adjustable lens angle, center position, and aspect ratio",
         "display_name": "Add Vignette",
         "icon": "circle-dot",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "effect",
+          "vignette",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1189,7 +1654,12 @@
         "description": "Reverse video playback with options to reverse, mute, or keep original audio",
         "display_name": "Reverse Video",
         "icon": "rewind",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "effect",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1200,7 +1670,12 @@
         "description": "Flip video horizontally, vertically, or both directions",
         "display_name": "Flip Video",
         "icon": "flip-horizontal",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "flip",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1211,7 +1686,12 @@
         "description": "Blur a video using fast ffmpeg filters (boxblur, gblur, avgblur) with adjustable radius/sigma",
         "display_name": "Blur Video",
         "icon": "droplets",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "blur",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1222,7 +1702,13 @@
         "description": "Adjust video brightness, contrast, saturation, and gamma with precise controls",
         "display_name": "Adjust Video EQ",
         "icon": "sliders",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "color",
+          "grade",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1233,7 +1719,12 @@
         "description": "Transfer color characteristics from a reference image to a video frame-by-frame using color matching algorithms",
         "display_name": "Video Color Match",
         "icon": "palette",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "video",
+          "color",
+          "composite"
+        ]
       }
     },
     {
@@ -1244,7 +1735,13 @@
         "description": "Add RGB shift (chromatic aberration) effect with individual channel control, static or animated glitches, and VHS-style base effects with configurable noise, chroma shift, blur, and motion trails",
         "display_name": "Add RGB Shift",
         "icon": "palette",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "effect",
+          "glitch",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1255,7 +1752,12 @@
         "description": "Change the playback speed of a video using FFmpeg's setpts filter with automatic audio speed adjustment",
         "display_name": "Change Speed",
         "icon": "zap",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "speed",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1266,7 +1768,13 @@
         "description": "Add color curves (color grading) effect to video using FFmpeg's curves filter with presets and custom curve options",
         "display_name": "Add Color Curves",
         "icon": "palette",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "video",
+          "color",
+          "grade",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1277,7 +1785,12 @@
         "description": "Add an overlay video on top of a base video using FFmpeg's overlay filter with alpha channel control",
         "display_name": "Add Overlay",
         "icon": "layers",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "video",
+          "composite",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1288,7 +1801,12 @@
         "description": "Extract the last frame from a video and output it as an Image",
         "display_name": "Extract Last Frame",
         "icon": "film",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "video",
+          "image",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1299,7 +1817,12 @@
         "description": "Extract audio from a video and output it as an audio file with configurable format and quality settings",
         "display_name": "Extract Audio",
         "icon": "volume-2",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "video",
+          "audio",
+          "ffmpeg"
+        ]
       }
     },
     {
@@ -1309,7 +1832,13 @@
         "category": "convert",
         "description": "Converts incoming value to a boolean",
         "display_name": "To Bool",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "boolean",
+          "number",
+          "logic"
+        ]
       }
     },
     {
@@ -1319,7 +1848,12 @@
         "category": "convert",
         "description": "Converts incoming value to a dictionary",
         "display_name": "To Dictionary",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "data",
+          "dictionary"
+        ]
       }
     },
     {
@@ -1329,7 +1863,13 @@
         "category": "convert",
         "description": "Extract lists of keys and values from a dictionary",
         "display_name": "Dict to List",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "data",
+          "dictionary",
+          "list"
+        ]
       }
     },
     {
@@ -1340,7 +1880,12 @@
         "description": "Extract values from JSON using JMESPath expressions (e.g., '[*].assignee' for all assignees)",
         "display_name": "JSON Extract Value",
         "icon": "search",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "json",
+          "data",
+          "extract"
+        ]
       }
     },
     {
@@ -1351,7 +1896,12 @@
         "description": "Create a JSON node from input data",
         "display_name": "JSON Input",
         "icon": "file-json",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "json",
+          "data",
+          "input"
+        ]
       }
     },
     {
@@ -1362,7 +1912,13 @@
         "description": "Generate a JSON schema from an example JSON structure for Agent nodes. Provide an example of the data structure you want, and this node will automatically create a schema that can be used with Agent nodes for structured output validation.",
         "display_name": "Create Agent Schema",
         "icon": "file-code",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "json",
+          "agent",
+          "schema",
+          "data"
+        ]
       }
     },
     {
@@ -1373,7 +1929,12 @@
         "description": "Display JSON data with automatic repair and formatting",
         "display_name": "Display JSON",
         "icon": "eye",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "json",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -1384,7 +1945,11 @@
         "description": "Replace values in JSON using dot notation paths",
         "display_name": "JSON Replace",
         "icon": "edit",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "json",
+          "data"
+        ]
       }
     },
     {
@@ -1395,7 +1960,12 @@
         "description": "Find items in JSON arrays based on search criteria",
         "display_name": "JSON Find",
         "icon": "search",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "json",
+          "data",
+          "search"
+        ]
       }
     },
     {
@@ -1406,7 +1976,12 @@
         "description": "Create a YAML node from input data",
         "display_name": "YAML Input",
         "icon": "file-code",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "yaml",
+          "data",
+          "input"
+        ]
       }
     },
     {
@@ -1417,7 +1992,12 @@
         "description": "Display YAML data with formatting",
         "display_name": "Display YAML",
         "icon": "eye",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "yaml",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -1428,7 +2008,12 @@
         "description": "Extract values from YAML using JMESPath expressions (e.g., '[*].name' for all names)",
         "display_name": "YAML Extract Value",
         "icon": "search",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "yaml",
+          "data",
+          "extract"
+        ]
       }
     },
     {
@@ -1439,7 +2024,11 @@
         "description": "Replace values in YAML using dot notation paths",
         "display_name": "YAML Replace",
         "icon": "pencil",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "yaml",
+          "data"
+        ]
       }
     },
     {
@@ -1450,7 +2039,12 @@
         "description": "Create an XML node from input data",
         "display_name": "XML Input",
         "icon": "file-code",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "xml",
+          "data",
+          "input"
+        ]
       }
     },
     {
@@ -1461,7 +2055,12 @@
         "description": "Display XML data with formatting",
         "display_name": "Display XML",
         "icon": "eye",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "xml",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -1472,7 +2071,12 @@
         "description": "Extract values from XML using XPath expressions (e.g., '//book/title', '//item/@id')",
         "display_name": "XML Extract Value",
         "icon": "search",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "xml",
+          "data",
+          "extract"
+        ]
       }
     },
     {
@@ -1483,7 +2087,11 @@
         "description": "Replace values in XML using XPath expressions",
         "display_name": "XML Replace",
         "icon": "pencil",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "xml",
+          "data"
+        ]
       }
     },
     {
@@ -1494,7 +2102,12 @@
         "description": "Create an HTML node from input data",
         "display_name": "HTML Input",
         "icon": "file-code",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "html",
+          "data",
+          "input"
+        ]
       }
     },
     {
@@ -1505,7 +2118,12 @@
         "description": "Display HTML data with formatting",
         "display_name": "Display HTML",
         "icon": "eye",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "html",
+          "data",
+          "display"
+        ]
       }
     },
     {
@@ -1516,7 +2134,12 @@
         "description": "Extract values from HTML using XPath expressions (e.g., '//h1', '//a/@href', '//div[@class=\"main\"]')",
         "display_name": "HTML Extract Value",
         "icon": "search",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "html",
+          "data",
+          "extract"
+        ]
       }
     },
     {
@@ -1526,7 +2149,12 @@
         "category": "convert",
         "description": "Converts incoming value to a float",
         "display_name": "To Float",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "number",
+          "float"
+        ]
       }
     },
     {
@@ -1537,7 +2165,12 @@
         "category": "convert",
         "description": "Converts incoming value to an integer",
         "display_name": "To Integer",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "number",
+          "integer"
+        ]
       }
     },
     {
@@ -1547,7 +2180,11 @@
         "category": "convert",
         "description": "Converts incoming value to text",
         "display_name": "To Text",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "text"
+        ]
       }
     },
     {
@@ -1557,7 +2194,12 @@
         "category": "convert",
         "description": "Converts incoming value to JSON data",
         "display_name": "To JSON",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "data",
+          "json"
+        ]
       }
     },
     {
@@ -1567,7 +2209,12 @@
         "category": "convert",
         "description": "Converts any input to a list",
         "display_name": "To List",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "data",
+          "list"
+        ]
       }
     },
     {
@@ -1577,7 +2224,12 @@
         "category": "dict",
         "description": "Creates a dictionary from key-value pairs",
         "display_name": "Create Dictionary",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "data",
+          "dictionary",
+          "create"
+        ]
       }
     },
     {
@@ -1587,7 +2239,12 @@
         "category": "dict",
         "description": "Displays dictionary data",
         "display_name": "Display Dictionary",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "data",
+          "dictionary",
+          "display"
+        ]
       }
     },
     {
@@ -1597,7 +2254,12 @@
         "category": "dict",
         "description": "Create a Key Value Pair",
         "display_name": "Key Value Pair",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "data",
+          "dictionary",
+          "key-value"
+        ]
       }
     },
     {
@@ -1608,7 +2270,13 @@
         "description": "Loads a dictionary from disk",
         "display_name": "Load Dictionary",
         "group": "Input/Output",
-        "icon": "file-up"
+        "icon": "file-up",
+        "tags": [
+          "data",
+          "dictionary",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -1618,7 +2286,12 @@
         "category": "dict",
         "description": "Merges multiple Key/Value Pairs into a single dictionary",
         "display_name": "Merge Key Value Pairs",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "data",
+          "dictionary",
+          "merge"
+        ]
       }
     },
     {
@@ -1629,7 +2302,13 @@
         "description": "Save dictionary data to a file",
         "display_name": "Save Dictionary",
         "icon": "file-down",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "data",
+          "dictionary",
+          "file",
+          "save"
+        ]
       }
     },
     {
@@ -1640,7 +2319,12 @@
         "description": "Get a value from a dictionary by key with optional default handling",
         "display_name": "Get Dictionary Value by Key",
         "icon": "key",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "data",
+          "dictionary",
+          "extract"
+        ]
       }
     },
     {
@@ -1651,7 +2335,12 @@
         "description": "Check if a dictionary has a value for a specific key",
         "display_name": "Has Dictionary Value for Key",
         "icon": "search-check",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "data",
+          "dictionary",
+          "logic"
+        ]
       }
     },
     {
@@ -1665,7 +2354,14 @@
           "dark": "logos/griptape_cloud.svg",
           "light": "logos/griptape_cloud_dark.svg"
         },
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "api",
+          "driver",
+          "config",
+          "griptape"
+        ]
       }
     },
     {
@@ -1679,7 +2375,15 @@
           "dark": "logos/grok.svg",
           "light": "logos/grok_dark.svg"
         },
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "api",
+          "driver",
+          "config",
+          "grok",
+          "xai"
+        ]
       }
     },
     {
@@ -1693,7 +2397,14 @@
           "dark": "logos/openai.svg",
           "light": "logos/openai_dark.svg"
         },
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "api",
+          "driver",
+          "config",
+          "openai"
+        ]
       }
     },
     {
@@ -1706,7 +2417,16 @@
         "icon": {
           "dark": "logos/aws.svg",
           "light": "logos/aws_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "aws",
+          "bedrock",
+          "llm"
+        ]
       }
     },
     {
@@ -1719,7 +2439,15 @@
         "icon": {
           "dark": "logos/anthropic.svg",
           "light": "logos/anthropic_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "anthropic",
+          "llm"
+        ]
       }
     },
     {
@@ -1729,7 +2457,15 @@
         "category": "agents/prompt_models",
         "description": "Prompt Models available from Cohere",
         "display_name": "Cohere Prompt",
-        "icon": "logos/cohere.svg"
+        "icon": "logos/cohere.svg",
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "cohere",
+          "llm"
+        ]
       }
     },
     {
@@ -1742,7 +2478,15 @@
         "icon": {
           "dark": "logos/griptape_cloud.svg",
           "light": "logos/griptape_cloud_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "griptape",
+          "llm"
+        ]
       }
     },
     {
@@ -1755,7 +2499,16 @@
         "icon": {
           "dark": "logos/grok.svg",
           "light": "logos/grok_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "grok",
+          "xai",
+          "llm"
+        ]
       }
     },
     {
@@ -1768,7 +2521,15 @@
         "icon": {
           "dark": "logos/groq.svg",
           "light": "logos/groq_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "groq",
+          "llm"
+        ]
       }
     },
     {
@@ -1777,7 +2538,16 @@
       "metadata": {
         "category": "agents/prompt_models",
         "description": "Prompt Models available from NVIDIA",
-        "display_name": "NIM Prompt"
+        "display_name": "NIM Prompt",
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "nvidia",
+          "nim",
+          "llm"
+        ]
       }
     },
     {
@@ -1790,7 +2560,15 @@
         "icon": {
           "dark": "logos/ollama.svg",
           "light": "logos/ollama_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "driver",
+          "config",
+          "ollama",
+          "llm",
+          "local"
+        ]
       }
     },
     {
@@ -1803,7 +2581,15 @@
         "icon": {
           "dark": "logos/openai.svg",
           "light": "logos/openai_dark.svg"
-        }
+        },
+        "tags": [
+          "agent",
+          "api",
+          "driver",
+          "config",
+          "openai",
+          "llm"
+        ]
       }
     },
     {
@@ -1813,7 +2599,11 @@
         "category": "image",
         "description": "Display an image",
         "display_name": "Display Image",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "image",
+          "display"
+        ]
       }
     },
     {
@@ -1823,7 +2613,11 @@
         "category": "image",
         "description": "Can be used to compare two images",
         "display_name": "Compare Images",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "image",
+          "compare"
+        ]
       }
     },
     {
@@ -1833,7 +2627,13 @@
         "category": "image",
         "description": "Can be used to describe an image",
         "display_name": "Describe Image",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "image",
+          "text",
+          "ai",
+          "vision"
+        ]
       }
     },
     {
@@ -1843,7 +2643,12 @@
         "category": "image",
         "description": "Display a mask from an image's alpha channel.",
         "display_name": "Display Mask",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "image",
+          "mask",
+          "display"
+        ]
       }
     },
     {
@@ -1853,7 +2658,12 @@
         "category": "image",
         "description": "Display a channel from an image's color channels (red, green, blue, or alpha). Defaults to red channel. Outputs to 'output' parameter.",
         "display_name": "Display Channel",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "image",
+          "display",
+          "channel"
+        ]
       }
     },
     {
@@ -1863,7 +2673,12 @@
         "category": "image",
         "description": "Generates an image using Griptape Cloud, or other provided image generation models",
         "display_name": "Generate Image",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "generation",
+          "ai"
+        ]
       }
     },
     {
@@ -1873,7 +2688,12 @@
         "category": "image",
         "description": "Generate standard color bar test patterns including SMPTE, EBU, ARIB, and various test patterns for video calibration",
         "display_name": "Create Color Bars",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "test-pattern",
+          "color"
+        ]
       }
     },
     {
@@ -1884,7 +2704,14 @@
         "description": "Generate images using Seedream models via Griptape model proxy",
         "display_name": "Seedream Image Generation",
         "group": "create",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "seedream"
+        ]
       }
     },
     {
@@ -1895,7 +2722,15 @@
         "description": "Generate images using Grok models via Griptape model proxy",
         "display_name": "Grok Image Generation",
         "group": "create",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "grok",
+          "xai"
+        ]
       }
     },
     {
@@ -1906,7 +2741,15 @@
         "description": "Edit images using Grok models via Griptape model proxy",
         "display_name": "Grok Image Edit",
         "group": "edit",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "edit",
+          "ai",
+          "api",
+          "grok",
+          "xai"
+        ]
       }
     },
     {
@@ -1917,7 +2760,14 @@
         "description": "Generate images using FLUX.1 models via Griptape model proxy",
         "display_name": "FLUX.1 Image Generation",
         "group": "create",
-        "icon": "Zap"
+        "icon": "Zap",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "flux"
+        ]
       }
     },
     {
@@ -1928,7 +2778,14 @@
         "description": "Generate images using FLUX.2 models via Griptape model proxy",
         "display_name": "FLUX.2 Image Generation",
         "group": "create",
-        "icon": "Zap"
+        "icon": "Zap",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "flux"
+        ]
       }
     },
     {
@@ -1939,7 +2796,14 @@
         "description": "Generate images using Qwen models via Griptape model proxy",
         "display_name": "Qwen Image Generation",
         "group": "create",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "qwen"
+        ]
       }
     },
     {
@@ -1950,7 +2814,14 @@
         "description": "Edit images using Qwen image editing models via Griptape model proxy",
         "display_name": "Qwen Image Edit",
         "group": "edit",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "edit",
+          "ai",
+          "api",
+          "qwen"
+        ]
       }
     },
     {
@@ -1961,7 +2832,14 @@
         "description": "Generate images using Wan 2.7 models via Griptape model proxy",
         "display_name": "Wan Image Generation",
         "group": "create",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "wan"
+        ]
       }
     },
     {
@@ -1972,7 +2850,13 @@
         "description": "Create an image with text rendered on it",
         "display_name": "Create Text Image",
         "group": "create",
-        "icon": "Type"
+        "icon": "Type",
+        "tags": [
+          "image",
+          "text",
+          "composite",
+          "create"
+        ]
       }
     },
     {
@@ -1983,7 +2867,13 @@
         "description": "Overlay text onto an existing image",
         "display_name": "Add Text to Existing Image",
         "group": "edit",
-        "icon": "Type"
+        "icon": "Type",
+        "tags": [
+          "image",
+          "text",
+          "composite",
+          "overlay"
+        ]
       }
     },
     {
@@ -1994,7 +2884,13 @@
         "description": "Draw bounding boxes on images from coordinate dictionaries. Each box requires x, y, width, and height as integers.",
         "display_name": "Add Bounding Boxes",
         "icon": "square-dashed",
-        "group": "detection"
+        "group": "detection",
+        "tags": [
+          "image",
+          "annotation",
+          "composite",
+          "detection"
+        ]
       }
     },
     {
@@ -2005,7 +2901,14 @@
         "description": "Upscales an image using SeedVR models (seedvr-2.0) via Griptape model proxy",
         "display_name": "SeedVR Image Upscale",
         "group": "edit",
-        "icon": "Sparkles"
+        "icon": "Sparkles",
+        "tags": [
+          "image",
+          "upscale",
+          "ai",
+          "api",
+          "seedvr"
+        ]
       }
     },
     {
@@ -2015,7 +2918,12 @@
         "category": "image",
         "description": "Invert a mask image.",
         "display_name": "Invert Mask",
-        "group": "mask"
+        "group": "mask",
+        "tags": [
+          "image",
+          "mask",
+          "filter"
+        ]
       }
     },
     {
@@ -2025,7 +2933,12 @@
         "category": "image",
         "description": "Invert a full image (creates a negative).",
         "display_name": "Invert Image",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "filter",
+          "negative"
+        ]
       }
     },
     {
@@ -2035,7 +2948,13 @@
         "category": "image",
         "description": "Replace a specific color in an image with transparency",
         "display_name": "Set Color to Transparent",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "mask",
+          "transparency",
+          "composite"
+        ]
       }
     },
     {
@@ -2046,7 +2965,12 @@
         "description": "Loads an image from disk",
         "display_name": "Load Image",
         "icon": "image-up",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "image",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -2057,7 +2981,13 @@
         "description": "Calculate aspect ratios with preset selection and dimension modifiers",
         "display_name": "Aspect Ratio",
         "icon": "ratio",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "data",
+          "logic",
+          "dimensions"
+        ]
       }
     },
     {
@@ -2068,7 +2998,13 @@
         "description": "Pick the candidate aspect ratio whose numeric value is nearest to the target",
         "display_name": "Get Closest Aspect Ratio",
         "icon": "ratio",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "data",
+          "logic",
+          "dimensions"
+        ]
       }
     },
     {
@@ -2079,7 +3015,12 @@
         "description": "Extract detailed information from an image including dimensions, aspect ratio, color space, and format",
         "display_name": "Image Details",
         "icon": "info",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "image",
+          "data",
+          "metadata"
+        ]
       }
     },
     {
@@ -2090,7 +3031,12 @@
         "description": "Crop, zoom, rotate, and pan images with precise control over transformations",
         "display_name": "Crop Image",
         "icon": "crop",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "crop",
+          "transform"
+        ]
       }
     },
     {
@@ -2101,7 +3047,12 @@
         "description": "Bash an image together with lots of other images",
         "display_name": "Image Bash",
         "icon": "images",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "image",
+          "composite",
+          "combine"
+        ]
       }
     },
     {
@@ -2112,7 +3063,13 @@
         "description": "Merge images together in different layouts with grid options and dynamic image input list",
         "display_name": "Merge Images",
         "group": "merge",
-        "icon": "squares-unite"
+        "icon": "squares-unite",
+        "tags": [
+          "image",
+          "composite",
+          "combine",
+          "grid"
+        ]
       }
     },
     {
@@ -2123,7 +3080,12 @@
         "description": "Display multiple images in a grid or masonry layout with customizable styling options",
         "display_name": "Display Image Grid",
         "group": "display",
-        "icon": "grid-3x3"
+        "icon": "grid-3x3",
+        "tags": [
+          "image",
+          "display",
+          "grid"
+        ]
       }
     },
     {
@@ -2133,7 +3095,12 @@
         "category": "image",
         "description": "Apply a mask to an image.",
         "display_name": "Apply Mask",
-        "group": "mask"
+        "group": "mask",
+        "tags": [
+          "image",
+          "mask",
+          "composite"
+        ]
       }
     },
     {
@@ -2143,7 +3110,12 @@
         "category": "image",
         "description": "Combine a list of masks into a single consolidated mask.",
         "display_name": "Combine Masks",
-        "group": "mask"
+        "group": "mask",
+        "tags": [
+          "image",
+          "mask",
+          "composite"
+        ]
       }
     },
     {
@@ -2153,7 +3125,12 @@
         "category": "image",
         "description": "Paint a mask on an image.",
         "display_name": "Paint Mask",
-        "group": "mask"
+        "group": "mask",
+        "tags": [
+          "image",
+          "mask",
+          "draw"
+        ]
       }
     },
     {
@@ -2164,7 +3141,12 @@
         "description": "Extend canvas around an image to fit target aspect ratios or custom dimensions",
         "display_name": "Extend Canvas",
         "icon": "frame",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "composite",
+          "expand"
+        ]
       }
     },
     {
@@ -2175,7 +3157,12 @@
         "description": "Extract key colors from an image",
         "display_name": "Extract Key Colors",
         "icon": "palette",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "image",
+          "data",
+          "color"
+        ]
       }
     },
     {
@@ -2186,7 +3173,12 @@
         "description": "Save an image to a file",
         "display_name": "Save Image",
         "icon": "image-down",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "image",
+          "file",
+          "save"
+        ]
       }
     },
     {
@@ -2197,7 +3189,13 @@
         "description": "Write custom key-value metadata to PNG images using PNG text chunks",
         "display_name": "Write Image Metadata",
         "icon": "tag",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "image",
+          "data",
+          "metadata",
+          "file"
+        ]
       }
     },
     {
@@ -2208,7 +3206,13 @@
         "description": "Read custom metadata from images (EXIF for JPEG/TIFF/MPO, PNG chunks for PNG)",
         "display_name": "Read Image Metadata",
         "icon": "tag",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "image",
+          "data",
+          "metadata",
+          "file"
+        ]
       }
     },
     {
@@ -2219,7 +3223,13 @@
         "description": "Capture an image using the device's camera",
         "display_name": "Webcam",
         "icon": "webcam",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "image",
+          "input",
+          "capture",
+          "camera"
+        ]
       }
     },
     {
@@ -2230,7 +3240,12 @@
         "description": "Resize images with separate parameters for target size (pixels) and percentage scale, plus resample filter options. Previously named \"Rescale Image\".",
         "display_name": "Resize Image",
         "icon": "image-upscale",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "resize",
+          "transform"
+        ]
       }
     },
     {
@@ -2241,7 +3256,13 @@
         "description": "Adjust image brightness, contrast, saturation, and gamma using PIL's ImageEnhance with precise controls",
         "display_name": "Adjust Image EQ",
         "icon": "sliders",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "color",
+          "filter",
+          "enhance"
+        ]
       }
     },
     {
@@ -2252,7 +3273,13 @@
         "description": "Adjust image levels similar to Photoshop's levels adjustment with input levels (shadows, midtones, highlights) and output levels",
         "display_name": "Adjust Image Levels",
         "icon": "bar-chart-3",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "color",
+          "filter",
+          "levels"
+        ]
       }
     },
     {
@@ -2263,7 +3290,13 @@
         "description": "Convert image to grayscale",
         "display_name": "Grayscale Image",
         "icon": "image",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "filter",
+          "color",
+          "convert"
+        ]
       }
     },
     {
@@ -2274,7 +3307,12 @@
         "description": "Flip image horizontally, vertically, or both directions",
         "display_name": "Flip Image",
         "icon": "flip-horizontal",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "transform",
+          "flip"
+        ]
       }
     },
     {
@@ -2285,7 +3323,12 @@
         "description": "Apply a Gaussian blur to an image",
         "display_name": "Gaussian Blur Image",
         "icon": "sparkles",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "image",
+          "blur",
+          "filter"
+        ]
       }
     },
     {
@@ -2296,7 +3339,13 @@
         "description": "Apply Gaussian-blurred alpha channel fade to image edges for smooth compositing with configurable fade distance, blur radius, edge shape (square/rounded), and selective edge control",
         "display_name": "Gaussian Edge Fade",
         "icon": "circle-dot-dashed",
-        "group": "mask"
+        "group": "mask",
+        "tags": [
+          "image",
+          "filter",
+          "composite",
+          "fade"
+        ]
       }
     },
     {
@@ -2307,7 +3356,15 @@
         "description": "Generate images using Google models via Griptape model proxy",
         "display_name": "Google Nano Banana Image Generation",
         "group": "create",
-        "icon": "sparkles"
+        "icon": "sparkles",
+        "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "google",
+          "nano-banana"
+        ]
       }
     },
     {
@@ -2320,6 +3377,11 @@
         "group": "create",
         "icon": "sparkles",
         "tags": [
+          "image",
+          "generation",
+          "ai",
+          "api",
+          "openai",
           "gpt-image",
           "gpt-image-2",
           "gpt-image-1",
@@ -2334,7 +3396,13 @@
         "category": "image",
         "description": "Convert multiple images to a single PDF file",
         "display_name": "Images to PDF",
-        "icon": "file-text"
+        "icon": "file-text",
+        "tags": [
+          "image",
+          "file",
+          "pdf",
+          "convert"
+        ]
       }
     },
     {
@@ -2345,7 +3413,13 @@
         "description": "Apply a beautiful bloom/glow effect to images with configurable intensity and radius for dreamy, ethereal results",
         "display_name": "Bloom Effect",
         "icon": "sparkles",
-        "group": "effects"
+        "group": "effects",
+        "tags": [
+          "image",
+          "effect",
+          "filter",
+          "glow"
+        ]
       }
     },
     {
@@ -2356,7 +3430,13 @@
         "description": "Compose two images using various blend modes with positioning and advanced compositing options for creative image manipulation",
         "display_name": "Image Blend Compositor",
         "icon": "layers",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "image",
+          "composite",
+          "blend",
+          "layer"
+        ]
       }
     },
     {
@@ -2367,7 +3447,12 @@
         "description": "Create a note node to provide helpful context in your workflow",
         "display_name": "Note",
         "icon": "notepad-text",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "workflow",
+          "annotation",
+          "note"
+        ]
       }
     },
     {
@@ -2379,7 +3464,12 @@
         "display_name": "Group",
         "icon": "group",
         "group": "create",
-        "is_node_group": true
+        "is_node_group": true,
+        "tags": [
+          "workflow",
+          "organization",
+          "group"
+        ]
       }
     },
     {
@@ -2390,7 +3480,12 @@
         "description": "Create a color picker node to select a color in various formats",
         "display_name": "ColorPicker",
         "icon": "pipette",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "color",
+          "input",
+          "picker"
+        ]
       }
     },
     {
@@ -2401,7 +3496,12 @@
         "description": "Log messages to the console with configurable log levels, timestamps, and formatting",
         "display_name": "Logger",
         "icon": "file-text",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "debug",
+          "workflow",
+          "log"
+        ]
       }
     },
     {
@@ -2412,7 +3512,11 @@
         "description": "A simple pass-through node that can be used as a visual marker or reroute point",
         "display_name": "Dot",
         "icon": "circle",
-        "group": "misc"
+        "group": "misc",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -2423,7 +3527,13 @@
         "description": "Askulator was once a humble desk calculator in a university math lab. One day, lightning struck the building during a particularly spicy differential equations final. Now imbued with the power of language... and attitude... it nodes among us. Solving math, interpreting riddles, and offering just a hint of sarcasm.",
         "display_name": "Askulator",
         "icon": "message-circle-question-mark",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "text",
+          "agent",
+          "math",
+          "fun"
+        ]
       }
     },
     {
@@ -2434,7 +3544,12 @@
         "description": "Create a float value",
         "display_name": "Float Input",
         "icon": "decimals-arrow-right",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "number",
+          "input",
+          "float"
+        ]
       }
     },
     {
@@ -2444,7 +3559,12 @@
         "category": "number",
         "description": "Create an integer value",
         "display_name": "Integer Input",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "number",
+          "input",
+          "integer"
+        ]
       }
     },
     {
@@ -2454,7 +3574,12 @@
         "category": "number",
         "description": "Display a float value",
         "display_name": "Display Float",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "number",
+          "display",
+          "float"
+        ]
       }
     },
     {
@@ -2464,7 +3589,12 @@
         "category": "number",
         "description": "Display an integer value",
         "display_name": "Display Integer",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "number",
+          "display",
+          "integer"
+        ]
       }
     },
     {
@@ -2475,7 +3605,12 @@
         "description": "Perform mathematical operations on numbers",
         "display_name": "Math",
         "icon": "calculator",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "number",
+          "math",
+          "logic"
+        ]
       }
     },
     {
@@ -2486,7 +3621,13 @@
         "description": "Evaluate mathematical expressions with variable inputs (a-h) and math functions",
         "display_name": "Math Expression",
         "icon": "function-square",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "number",
+          "math",
+          "logic",
+          "expression"
+        ]
       }
     },
     {
@@ -2496,7 +3637,13 @@
         "category": "agents/rules",
         "description": "Give an agent a set of rules and behaviors to follow",
         "display_name": "Ruleset",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "agent",
+          "rules",
+          "config",
+          "behavior"
+        ]
       }
     },
     {
@@ -2506,7 +3653,13 @@
         "category": "agents/rules",
         "description": "Combine rulesets to give an agent a more complex set of behaviors",
         "display_name": "Ruleset List",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "agent",
+          "rules",
+          "config",
+          "behavior"
+        ]
       }
     },
     {
@@ -2517,7 +3670,12 @@
         "description": "LoadText node",
         "display_name": "Load Text",
         "icon": "file-text",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "text",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -2528,7 +3686,11 @@
         "description": "MergeTexts node",
         "display_name": "Merge Texts",
         "icon": "merge",
-        "group": "merge"
+        "group": "merge",
+        "tags": [
+          "text",
+          "combine"
+        ]
       }
     },
     {
@@ -2539,7 +3701,11 @@
         "description": "Selects a random character, word, sentence, or paragraph from input text, or generates random content if no input is provided.",
         "display_name": "Random Text",
         "icon": "dices",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "text",
+          "random"
+        ]
       }
     },
     {
@@ -2550,7 +3716,12 @@
         "description": "Get the date and time",
         "display_name": "Date and Time",
         "icon": "calendar",
-        "group": "tasks"
+        "group": "tasks",
+        "tags": [
+          "text",
+          "utility",
+          "datetime"
+        ]
       }
     },
     {
@@ -2560,7 +3731,11 @@
         "category": "text",
         "description": "DisplayText node",
         "display_name": "Display Text",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "text",
+          "display"
+        ]
       }
     },
     {
@@ -2570,7 +3745,12 @@
         "category": "text",
         "description": "Displays text as markdown",
         "display_name": "Display Text As Markdown",
-        "group": "display"
+        "group": "display",
+        "tags": [
+          "text",
+          "display",
+          "markdown"
+        ]
       }
     },
     {
@@ -2580,7 +3760,13 @@
         "category": "text",
         "description": "Evaluate the results of some text against some criteria",
         "display_name": "Evaluate Text Result",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "text",
+          "agent",
+          "ai",
+          "evaluation"
+        ]
       }
     },
     {
@@ -2591,7 +3777,12 @@
         "description": "Save text to a file",
         "display_name": "Save Text",
         "icon": "file-down",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "text",
+          "file",
+          "save"
+        ]
       }
     },
     {
@@ -2602,7 +3793,13 @@
         "description": "Scrape the web for information",
         "display_name": "Scrape Web",
         "icon": "globe",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "text",
+          "web",
+          "api",
+          "scrape"
+        ]
       }
     },
     {
@@ -2613,7 +3810,12 @@
         "description": "Perform search and replace operations on text content with support for regex and case sensitivity",
         "display_name": "Search Replace Text",
         "icon": "regex",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "text",
+          "search",
+          "replace"
+        ]
       }
     },
     {
@@ -2624,7 +3826,13 @@
         "description": "Search the web for information",
         "display_name": "Search Web",
         "icon": "binoculars",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "text",
+          "web",
+          "api",
+          "search"
+        ]
       }
     },
     {
@@ -2635,7 +3843,13 @@
         "description": "Summarize text",
         "display_name": "Summarize Text",
         "icon": "message-square-text",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "text",
+          "agent",
+          "ai",
+          "summarize"
+        ]
       }
     },
     {
@@ -2646,7 +3860,11 @@
         "description": "TextInput node",
         "display_name": "Text Input",
         "icon": "text-cursor",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "text",
+          "input"
+        ]
       }
     },
     {
@@ -2656,7 +3874,12 @@
         "category": "text",
         "description": "Validates that file paths exist and are readable Python files",
         "display_name": "File Path Validator",
-        "icon": "file-check"
+        "icon": "file-check",
+        "tags": [
+          "text",
+          "file",
+          "validate"
+        ]
       }
     },
     {
@@ -2667,7 +3890,12 @@
         "description": "Give an agent the ability to use a calculator",
         "display_name": "Calculator",
         "icon": "calculator",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "math",
+          "agent"
+        ]
       }
     },
     {
@@ -2678,7 +3906,12 @@
         "description": "Give an agent the ability to know what day and time it is",
         "display_name": "Date Time",
         "icon": "calendar",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "agent",
+          "datetime"
+        ]
       }
     },
     {
@@ -2689,7 +3922,12 @@
         "description": "Give an agent the ability to load files from disk",
         "display_name": "File Manager",
         "icon": "folder",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "file",
+          "agent"
+        ]
       }
     },
     {
@@ -2700,7 +3938,13 @@
         "description": "Give an agent the ability to use an MCP tool",
         "display_name": "MCP Task",
         "icon": "network",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "agent",
+          "mcp",
+          "api"
+        ]
       }
     },
     {
@@ -2711,7 +3955,12 @@
         "description": "Combine tools to give an agent a more complex set of tools",
         "display_name": "Tool List",
         "icon": "list-check",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "agent",
+          "list"
+        ]
       }
     },
     {
@@ -2722,7 +3971,14 @@
         "description": "Give an agent the ability to search the web",
         "display_name": "Web Search",
         "icon": "binoculars",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "web",
+          "agent",
+          "api",
+          "search"
+        ]
       }
     },
     {
@@ -2733,7 +3989,13 @@
         "description": "Give an agent the ability to scrape the web for information",
         "display_name": "Web Scraper",
         "icon": "globe",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "tool",
+          "web",
+          "agent",
+          "scrape"
+        ]
       }
     },
     {
@@ -2743,7 +4005,11 @@
         "category": "workflows",
         "description": "Define the start of a workflow and pass parameters into the flow",
         "display_name": "Start Flow",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -2753,7 +4019,11 @@
         "category": "workflows",
         "description": "Define the end of a workflow and return parameters from the flow",
         "display_name": "End Flow",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -2763,7 +4033,11 @@
         "category": "execution_flow",
         "description": "Provides a node to allow you to redirect a flow, matching inputs and outputs",
         "display_name": "Reroute",
-        "group": "flow control"
+        "group": "flow control",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -2773,7 +4047,12 @@
         "category": "execution_flow",
         "description": "Create a branching workflow based on whether a value is true or false",
         "display_name": "IfElse",
-        "group": "comparison"
+        "group": "comparison",
+        "tags": [
+          "workflow",
+          "execution",
+          "condition"
+        ]
       }
     },
     {
@@ -2783,7 +4062,12 @@
         "category": "execution_flow",
         "description": "Branch your workflow based on a comparison of two numbers",
         "display_name": "Compare Numbers",
-        "group": "comparison"
+        "group": "comparison",
+        "tags": [
+          "workflow",
+          "execution",
+          "condition"
+        ]
       }
     },
     {
@@ -2793,7 +4077,12 @@
         "category": "execution_flow",
         "description": "Branch your workflow based on a comparison of two strings",
         "display_name": "Compare Strings",
-        "group": "comparison"
+        "group": "comparison",
+        "tags": [
+          "workflow",
+          "execution",
+          "condition"
+        ]
       }
     },
     {
@@ -2803,7 +4092,11 @@
         "category": "execution_flow",
         "description": "Let's you choose which direction you want a flow to go, based on the output of previous nodes",
         "display_name": "Output Selector",
-        "group": "flow control"
+        "group": "flow control",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -2814,7 +4107,12 @@
         "description": "Start node for iterating through a list of items and running a flow for each one",
         "display_name": "ForEach Start",
         "icon": "list-start",
-        "group": "iteration"
+        "group": "iteration",
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2825,7 +4123,12 @@
         "description": "End node that completes a loop iteration and connects back to the ForEachStartNode",
         "display_name": "ForEach End",
         "icon": "list-end",
-        "group": "iteration"
+        "group": "iteration",
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2837,7 +4140,12 @@
         "display_name": "ForEach Group",
         "icon": "repeat",
         "group": "iteration",
-        "is_node_group": true
+        "is_node_group": true,
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2849,7 +4157,12 @@
         "display_name": "For Loop Group",
         "icon": "repeat",
         "group": "iteration",
-        "is_node_group": true
+        "is_node_group": true,
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2861,7 +4174,12 @@
         "display_name": "Retry Group",
         "icon": "refresh-cw",
         "group": "iteration",
-        "is_node_group": true
+        "is_node_group": true,
+        "tags": [
+          "workflow",
+          "execution",
+          "retry"
+        ]
       }
     },
     {
@@ -2872,7 +4190,12 @@
         "description": "Groups multiple nodes together for organization and parallel execution",
         "display_name": "Subflow Node Group",
         "icon": "Layers",
-        "is_node_group": true
+        "is_node_group": true,
+        "tags": [
+          "workflow",
+          "execution",
+          "subflow"
+        ]
       }
     },
     {
@@ -2882,7 +4205,12 @@
         "category": "execution_flow",
         "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
         "display_name": "Workflow Node",
-        "icon": "Layers"
+        "icon": "Layers",
+        "tags": [
+          "workflow",
+          "execution",
+          "subflow"
+        ]
       }
     },
     {
@@ -2892,7 +4220,12 @@
         "category": "convert",
         "description": "Convert an agent into a tool that another agent can use",
         "display_name": "Agent To Tool",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "convert",
+          "agent",
+          "tool"
+        ]
       }
     },
     {
@@ -2902,7 +4235,13 @@
         "category": "3D",
         "description": "Loads a GLTF file into your workflow",
         "display_name": "Load GLTF",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "3d",
+          "file",
+          "load",
+          "gltf"
+        ]
       }
     },
     {
@@ -2912,7 +4251,12 @@
         "category": "3D",
         "description": "Loads a 3D file into your workflow",
         "display_name": "Load 3D",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "3d",
+          "file",
+          "load"
+        ]
       }
     },
     {
@@ -2922,7 +4266,14 @@
         "category": "3D",
         "description": "Generate 3D models using Rodin Gen-2 via Griptape model proxy",
         "display_name": "Rodin 3D Generation",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "3d",
+          "generation",
+          "ai",
+          "api",
+          "rodin"
+        ]
       }
     },
     {
@@ -2932,7 +4283,14 @@
         "category": "3D",
         "description": "Generate 3D models from a text prompt using Tripo via Griptape model proxy",
         "display_name": "Tripo Text to 3D",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "3d",
+          "text-to-3d",
+          "ai",
+          "api",
+          "tripo"
+        ]
       }
     },
     {
@@ -2942,7 +4300,14 @@
         "category": "3D",
         "description": "Generate 3D models from a reference image using Tripo via Griptape model proxy",
         "display_name": "Tripo Image to 3D",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "3d",
+          "image-to-3d",
+          "ai",
+          "api",
+          "tripo"
+        ]
       }
     },
     {
@@ -2952,7 +4317,15 @@
         "category": "Splat",
         "description": "Generate 3D worlds using World Labs Marble via Griptape model proxy",
         "display_name": "World Labs World Generation",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "splat",
+          "3d",
+          "generation",
+          "ai",
+          "api",
+          "world-labs"
+        ]
       }
     },
     {
@@ -2963,7 +4336,13 @@
         "description": "Convert an SPZ Gaussian splat to PLY format for use in Blender, Unreal, and other 3D tools",
         "display_name": "Convert SPZ to PLY",
         "icon": "box",
-        "group": "Transform"
+        "group": "Transform",
+        "tags": [
+          "splat",
+          "3d",
+          "convert",
+          "file"
+        ]
       }
     },
     {
@@ -2974,7 +4353,12 @@
         "description": "Start node for iterating through a range of numbers with a specified step value",
         "display_name": "For Loop Start",
         "icon": "repeat",
-        "group": "iteration"
+        "group": "iteration",
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2985,7 +4369,12 @@
         "description": "End node that completes a loop iteration and connects back to the ForLoopStartNode",
         "display_name": "For Loop End",
         "icon": "repeat",
-        "group": "iteration"
+        "group": "iteration",
+        "tags": [
+          "workflow",
+          "execution",
+          "loop"
+        ]
       }
     },
     {
@@ -2996,7 +4385,11 @@
         "description": "Cancel the workflow execution with a custom reason",
         "display_name": "Cancel Workflow",
         "icon": "x-circle",
-        "group": "flow control"
+        "group": "flow control",
+        "tags": [
+          "workflow",
+          "execution"
+        ]
       }
     },
     {
@@ -3007,7 +4400,12 @@
         "description": "Create or update a variable with a specified name, type, and value. Creates new variables or updates existing ones intelligently.",
         "display_name": "Create Variable",
         "icon": "PlusCircle",
-        "group": "create"
+        "group": "create",
+        "tags": [
+          "data",
+          "variable",
+          "workflow"
+        ]
       }
     },
     {
@@ -3018,7 +4416,12 @@
         "description": "Retrieve the value of an existing variable",
         "display_name": "Get Variable",
         "icon": "ArrowDown",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "data",
+          "variable",
+          "workflow"
+        ]
       }
     },
     {
@@ -3029,7 +4432,12 @@
         "description": "Set the value of a variable, creating it if it does not exist",
         "display_name": "Set Variable",
         "icon": "ArrowUp",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "data",
+          "variable",
+          "workflow"
+        ]
       }
     },
     {
@@ -3040,7 +4448,13 @@
         "description": "Check whether a variable exists",
         "display_name": "Has Variable",
         "icon": "QuestionMarkCircle",
-        "group": "describe"
+        "group": "describe",
+        "tags": [
+          "data",
+          "variable",
+          "workflow",
+          "logic"
+        ]
       }
     },
     {
@@ -3050,7 +4464,12 @@
         "category": "filesystem",
         "description": "Configure file save paths using situation templates and macro expansion. Outputs a File object with an unresolved macro path.",
         "display_name": "File Output Settings",
-        "icon": "FolderCog"
+        "icon": "FolderCog",
+        "tags": [
+          "file",
+          "workflow",
+          "config"
+        ]
       }
     },
     {
@@ -3060,7 +4479,12 @@
         "category": "files",
         "description": "List files in a directory with optional pattern matching and recursive search",
         "display_name": "List Files",
-        "icon": "FolderOpen"
+        "icon": "FolderOpen",
+        "tags": [
+          "file",
+          "data",
+          "list"
+        ]
       }
     },
     {
@@ -3070,7 +4494,10 @@
         "category": "files",
         "description": "Delete a file or directory from the file system. Directories are deleted with all their contents.",
         "display_name": "Delete File",
-        "icon": "Trash"
+        "icon": "Trash",
+        "tags": [
+          "file"
+        ]
       }
     },
     {
@@ -3080,7 +4507,11 @@
         "category": "files",
         "description": "Extract path components from a file path (filename, stem, extension, parent, query params)",
         "display_name": "FilePath Components",
-        "icon": "FileText"
+        "icon": "FileText",
+        "tags": [
+          "file",
+          "path"
+        ]
       }
     },
     {
@@ -3090,7 +4521,11 @@
         "category": "files",
         "description": "Join multiple path components together to create a file path using appropriate path separators",
         "display_name": "Path Join",
-        "icon": "Combine"
+        "icon": "Combine",
+        "tags": [
+          "file",
+          "path"
+        ]
       }
     },
     {
@@ -3101,7 +4536,12 @@
         "description": "Load a local PDF file and extract its text content, with outputs for the full joined text, a per-page list, and page count.",
         "display_name": "Load PDF",
         "icon": "file-text",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "file",
+          "text",
+          "pdf"
+        ]
       }
     },
     {
@@ -3111,7 +4551,11 @@
         "category": "files",
         "description": "Add or replace a file extension on a path, with option to strip query parameters",
         "display_name": "Path Add Extension",
-        "icon": "FileText"
+        "icon": "FileText",
+        "tags": [
+          "file",
+          "path"
+        ]
       }
     },
     {
@@ -3121,7 +4565,10 @@
         "category": "files",
         "description": "Copy files and/or directories from source to destination. Supports glob patterns and multiple sources.",
         "display_name": "Copy Files",
-        "icon": "Copy"
+        "icon": "Copy",
+        "tags": [
+          "file"
+        ]
       }
     },
     {
@@ -3131,7 +4578,10 @@
         "category": "files",
         "description": "Create a folder at a specified path with optional parent directory creation.",
         "display_name": "Create Folder",
-        "icon": "FolderPlus"
+        "icon": "FolderPlus",
+        "tags": [
+          "file"
+        ]
       }
     },
     {
@@ -3141,7 +4591,10 @@
         "category": "files",
         "description": "Move files and/or directories from source to destination. Implemented as copy + delete. Supports glob patterns and multiple sources.",
         "display_name": "Move Files",
-        "icon": "ArrowRight"
+        "icon": "ArrowRight",
+        "tags": [
+          "file"
+        ]
       }
     },
     {
@@ -3151,7 +4604,10 @@
         "category": "files",
         "description": "Rename a file or directory. Can rename to a new name in the same directory or to a full path.",
         "display_name": "Rename File",
-        "icon": "Edit"
+        "icon": "Edit",
+        "tags": [
+          "file"
+        ]
       }
     },
     {
@@ -3161,7 +4617,11 @@
         "category": "files",
         "description": "Get the system temporary directory path. Works cross-platform (Windows, macOS, Linux).",
         "display_name": "Temp Directory",
-        "icon": "Folder"
+        "icon": "Folder",
+        "tags": [
+          "file",
+          "temp"
+        ]
       }
     },
     {
@@ -3171,7 +4631,11 @@
         "category": "files",
         "description": "Generate a unique temporary filename using Python's tempfile module. Supports optional directory, suffix, prefix, and can return absolute path or just filename.",
         "display_name": "Temp Filename",
-        "icon": "FileText"
+        "icon": "FileText",
+        "tags": [
+          "file",
+          "temp"
+        ]
       }
     },
     {
@@ -3181,7 +4645,11 @@
         "category": "files",
         "description": "Select a file or directory from the project and resolve it to a macro path.",
         "display_name": "Select From Project",
-        "icon": "FolderOpen"
+        "icon": "FolderOpen",
+        "tags": [
+          "file",
+          "project"
+        ]
       }
     },
     {
@@ -3191,7 +4659,12 @@
         "category": "files",
         "description": "Save a file to the project using situation-based path resolution.",
         "display_name": "Save To Project",
-        "icon": "Save"
+        "icon": "Save",
+        "tags": [
+          "file",
+          "project",
+          "save"
+        ]
       }
     },
     {
@@ -3202,7 +4675,14 @@
         "description": "Enhance images using Topaz Labs models via Griptape model proxy. Supports enhance, denoise, and sharpen operations.",
         "display_name": "Topaz Image Enhance",
         "icon": "Sparkles",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "enhance",
+          "ai",
+          "api",
+          "topaz"
+        ]
       }
     },
     {
@@ -3213,7 +4693,12 @@
         "description": "Split a grid image into individual images (auto or manual grid detection).",
         "display_name": "Image Grid Splitter",
         "icon": "grid-3x3",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "grid",
+          "split"
+        ]
       }
     },
     {
@@ -3224,7 +4709,13 @@
         "description": "Transfer color characteristics from a reference image to a target image using various color matching algorithms.",
         "display_name": "Color Match",
         "icon": "palette",
-        "group": "edit"
+        "group": "edit",
+        "tags": [
+          "image",
+          "color",
+          "filter",
+          "grade"
+        ]
       }
     },
     {
@@ -3235,7 +4726,13 @@
         "description": "Load a Gaussian splat from a URL or local file with an inline 3D viewer",
         "display_name": "Load Splat",
         "icon": "box",
-        "group": "Input/Output"
+        "group": "Input/Output",
+        "tags": [
+          "splat",
+          "3d",
+          "load",
+          "file"
+        ]
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Adds `tags` metadata to all 268 nodes in `griptape_nodes_library.json`
- Tags are designed to power the filter tabs in the Add Node command palette (Agents, Image, Video, Audio, 3D, Text, Data, Files, Logic, Tools, API, Flow)
- Each node gets a primary category tag matching its filter plus richer secondary tags for search (provider names, capabilities, etc.)

## Tagging conventions

- **Agents** → `agent` + `llm`, `memory`, `rules`, etc.
- **Image/Video/Audio/3D** → category tag + provider (`flux`, `kling`, `elevenlabs`, `grok`, `wan`, etc.) + capability (`generation`, `upscale`, `composite`, `ffmpeg`, etc.)
- **Text** → `text` (string scalars only — compound tags like `text-to-speech` intentionally also carry `text` so TTS shows under the Text filter)
- **Data** → `data` for in-memory structured containers (list, dict, JSON, YAML, XML) only — scalar primitives excluded
- **Files** → `file` for disk I/O operations
- **Logic** → `logic`, `number`, `integer`, `float`, `boolean`, `math` (aligns with the exact-match allowlist in the frontend)
- **Tools** → `tool` for agent-usable tool nodes
- **API** → `api` for proxy/driver nodes (LLM providers, image/video generation services)
- **Flow** → `workflow` + `execution` as unified tags for all control-flow nodes (replaces fragmented `flow`, `loop`, `branching`, `routing` sub-tags); `loop`, `subflow`, `condition`, `retry` kept as secondary descriptors

Closes #304