### PR TITLE
fix(mcp): inline ruleset helper after engine 0.86.0 removal

### DIFF
--- a/griptape_nodes_library/tasks/mcp_task.py
+++ b/griptape_nodes_library/tasks/mcp_task.py
@@ -4,6 +4,7 @@ from typing import Any
 from griptape.artifacts import BaseArtifact
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
 from griptape.events import ActionChunkEvent, FinishStructureRunEvent, StartStructureRunEvent, TextChunkEvent
+from griptape.rules import Rule, Ruleset
 from griptape.structures import Agent
 from griptape.tasks import PromptTask
 from griptape.tools import MCPTool
@@ -12,7 +13,6 @@ from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
@@ -22,6 +22,21 @@ from griptape_nodes_library.utils.mcp_utils import (
     get_server_config,
     validate_mcp_server,
 )
+
+
+def _create_ruleset_from_rules_string(rules_string: str | None, server_name: str) -> Ruleset | None:
+    """Build a Ruleset from an MCP server's rules-string config.
+
+    Returns None when the string is missing or whitespace-only so the caller
+    can skip without conditional ladders. Mirrors the helper that used to
+    live on `AgentManager._create_ruleset_from_rules_string` (removed in
+    engine 0.86.0); inlined here because the original was a pure Griptape
+    SDK call with a small naming convention — no reason to depend on a
+    private engine method to compose it. Closes #307.
+    """
+    if not rules_string or not rules_string.strip():
+        return None
+    return Ruleset(name=f"mcp_{server_name}_rules", rules=[Rule(rules_string.strip())])
 
 
 class MCPTaskNode(SuccessFailureNode):
@@ -220,7 +235,7 @@ class MCPTaskNode(SuccessFailureNode):
         # Get MCP server rules and create ruleset
         rules_string = server_config.get("rules")
         if rules_string:
-            mcp_ruleset = AgentManager._create_ruleset_from_rules_string(rules_string, mcp_server_name)
+            mcp_ruleset = _create_ruleset_from_rules_string(rules_string, mcp_server_name)
             if mcp_ruleset is not None:
                 rulesets = [*list(rulesets), mcp_ruleset]
 


### PR DESCRIPTION
Closes #307.

## Summary

Engine 0.86.0 removed `AgentManager._create_ruleset_from_rules_string` (private static method) as part of the pydantic-ai migration in [engine PR #4730](https://github.com/griptape-ai/griptape-nodes-engine/pull/4730). `mcp_task.py:223` was the only consumer.

The original helper used zero engine internals — just a `Ruleset(name=..., rules=[Rule(...)])` constructor with a 2-line empty-string guard and the naming convention `mcp_<server>_rules`. Inlining it into `mcp_task.py` as a module-level function follows the engine's lead (the leading underscore was a documented "don't reach across this" signal) and keeps the library independent of any private engine API for ruleset composition.

## Changes

`griptape_nodes_library/tasks/mcp_task.py`:

- **Add** `from griptape.rules import Rule, Ruleset` (resolves under the existing `griptape>=1.9.4` pin).
- **Drop** `from griptape_nodes.retained_mode.managers.agent_manager import AgentManager` (no longer used).
- **Add** module-level `_create_ruleset_from_rules_string(rules_string, server_name)` helper, byte-for-byte mirror of the engine's removed implementation.
- **Update** the call site at line 223 to call the local helper.

## Why now

Library PR [#288](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/288) is currently blocked: bumping its engine pin to 0.86.0 (necessary to pick up sequence-nodes work) surfaces this break. `main` is currently green only because it pins the older engine. Any future PR that bumps would hit the same wall — fixing it now removes the obstacle for #288 and any other branch that needs the new engine.

## Verification

- `make check` passes against the current main engine pin (no regression).
- Throwaway-bump simulation: temporarily setting `griptape-nodes-engine>=0.86.0` in `pyproject.toml` + re-locking + running `make check` produces `0 errors` (mcp_task pyright error is gone). Throwaway changes reverted before commit.
- No automated test harness exists for `mcp_task.py` today (pre-existing gap, not introduced by this fix). Manual smoke test for anyone with an MCP server configured with a non-empty `rules` string: drop a `MCPTaskNode` into a workflow, run, confirm the agent behaves the same as on the older engine.

## Naming convention preserved

The helper builds rulesets named `f"mcp_{server_name}_rules"` — matches the engine's old behavior byte-for-byte so any UX surface that displays ruleset names (e.g. agent rule listings) doesn't drift.