### PR TITLE
fix(display-list): narrow child output types from upstream list[X]

### DIFF
--- a/griptape_nodes_library/lists/display_list.py
+++ b/griptape_nodes_library/lists/display_list.py
@@ -57,6 +57,13 @@ class DisplayList(ControlNode):
         self.add_parameter(self.items_list)
         # Track whether we're already updating to prevent duplicate calls
         self._updating_display_list = False
+        # Declared element type, captured from the upstream `output_type` when
+        # an incoming connection lands on `items` (e.g. `list[Sequence]` →
+        # `"Sequence"`). When set, it overrides per-value type detection so
+        # downstream connections see a typed-not-`any` parameter even before
+        # values have flowed. None means fall back to per-value detection
+        # (the historical behavior). Reset on `items` disconnect.
+        self._declared_element_type: str | None = None
         # We'll create output parameters dynamically during processing
 
     def process(self) -> None:
@@ -111,13 +118,13 @@ class DisplayList(ControlNode):
             return
 
         new_ui_options["hide"] = False
-        item_type = self._determine_item_type(list_values[0])
+        item_type = self._resolve_item_type(list_values[0])
         self._configure_list_type_and_ui(item_type, new_ui_options)
         # Only delete excess parameters if explicitly requested (e.g., during process())
         if delete_excess_parameters:
             self.delete_excess_parameters(list_values)
         for i, item in enumerate(list_values):
-            item_specific_type = self._determine_item_type(item)
+            item_specific_type = self._resolve_item_type(item)
             if i < len(self.items_list):
                 self._update_existing_parameter(self.items_list[i], item, item_specific_type)
             else:
@@ -253,6 +260,43 @@ class DisplayList(ControlNode):
         self.items_list.input_types = [item_type]
         self.items_list.ui_options = ui_options
 
+    @staticmethod
+    def _extract_inner_list_type(output_type: str | None) -> str | None:
+        """Pull `X` out of an upstream `output_type` of the form `list[X]`.
+
+        Returns None when the input doesn't declare an element type (`list`,
+        `None`, anything that doesn't parse as `list[…]`) or when the inner
+        is the `any` placeholder — both cases mean "no useful type to declare,
+        fall back to per-value detection." Compares the base type
+        case-insensitively (matching the engine's `are_types_compatible`),
+        but preserves the inner type's original casing so downstream
+        comparisons work on whichever convention the source used.
+        """
+        if not output_type:
+            return None
+        bracket = output_type.find("[")
+        if bracket < 0 or not output_type.endswith("]"):
+            return None
+        if output_type[:bracket].lower() != "list":
+            return None
+        inner = output_type[bracket + 1 : -1].strip()
+        if not inner or inner.lower() == ParameterTypeBuiltin.ANY.value:
+            return None
+        return inner
+
+    def _resolve_item_type(self, item: Any) -> str:
+        """Pick the type string for one list item.
+
+        Prefers the upstream-declared element type (set by
+        `after_incoming_connection` when the source's `output_type` was
+        `list[X]` for a non-`any` X) so downstream connections see a typed
+        parameter. Falls back to per-value detection when no declared type
+        is on file.
+        """
+        if self._declared_element_type is not None:
+            return self._declared_element_type
+        return self._determine_item_type(item)
+
     def _determine_item_type(self, item: Any) -> str:
         """Determine the type of an item for parameter type assignment."""
         # Builtin types - use type mapping for efficiency
@@ -366,8 +410,38 @@ class DisplayList(ControlNode):
             self._update_display_list()
         return super().after_value_set(parameter, value)
 
+    def after_incoming_connection(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Capture the upstream element type when something connects to `items`.
+
+        When the source declares `output_type="list[X]"` for a concrete X,
+        we stash X as the declared element type and rebuild — that re-types
+        every existing child, and the rebuild's `_validate_and_remove_incompatible_connections`
+        prunes any outgoing connection from a child whose type just changed
+        out from under it. When the source declares only `list` or `list[any]`,
+        the cache stays None and we fall through to per-value detection
+        (today's behavior).
+        """
+        if target_parameter == self.items:
+            self._declared_element_type = self._extract_inner_list_type(source_parameter.output_type)
+            self._update_display_list()
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
     def after_incoming_connection_removed(
         self, source_node: BaseNode, source_parameter: Parameter, target_parameter: Parameter
     ) -> None:
+        """Reset the declared element type when `items` is disconnected.
+
+        Drops back to per-value detection so a subsequent reconnect (or any
+        cached value the artist set as a property) re-evaluates from scratch.
+        Other parameters' disconnects are ignored — DisplayList only narrows
+        based on `items`.
+        """
+        if target_parameter == self.items:
+            self._declared_element_type = None
         self._update_display_list()
         return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/lists/display_list.py
+++ b/griptape_nodes_library/lists/display_list.py
@@ -64,6 +64,12 @@ class DisplayList(ControlNode):
         # values have flowed. None means fall back to per-value detection
         # (the historical behavior). Reset on `items` disconnect.
         self._declared_element_type: str | None = None
+        # True while `items` has an active incoming connection. Drives the
+        # `settable` lock on the dynamic children (the connection owns
+        # their values, so manual edits / adds shouldn't be exposed).
+        # Tracked alongside the connection events instead of querying the
+        # FlowManager on each rebuild.
+        self._items_connected: bool = False
         # We'll create output parameters dynamically during processing
 
     def process(self) -> None:
@@ -129,6 +135,9 @@ class DisplayList(ControlNode):
                 self._update_existing_parameter(self.items_list[i], item, item_specific_type)
             else:
                 self._create_new_parameter(item, item_specific_type)
+        # Newly created or re-typed children inherit settable from the current
+        # connection state, not from whatever the parent had a moment ago.
+        self._apply_settable_state()
         self._updating_display_list = False
 
     def _update_existing_parameter(self, parameter: Parameter, item: Any, item_specific_type: str) -> None:
@@ -297,6 +306,18 @@ class DisplayList(ControlNode):
             return self._declared_element_type
         return self._determine_item_type(item)
 
+    def _apply_settable_state(self) -> None:
+        """Sync `settable` on the container and existing children to the connection state.
+
+        Locked while `items` has an incoming connection, unlocked otherwise.
+        Called from connection / disconnect events and after every rebuild
+        so freshly created children inherit the right state.
+        """
+        locked = self._items_connected
+        self.items_list.settable = not locked
+        for child in self.items_list.find_elements_by_type(Parameter):
+            child.settable = not locked
+
     def _determine_item_type(self, item: Any) -> str:
         """Determine the type of an item for parameter type assignment."""
         # Builtin types - use type mapping for efficiency
@@ -416,32 +437,39 @@ class DisplayList(ControlNode):
         source_parameter: Parameter,
         target_parameter: Parameter,
     ) -> None:
-        """Capture the upstream element type when something connects to `items`.
+        """Capture the upstream element type and lock children when something connects to `items`.
 
         When the source declares `output_type="list[X]"` for a concrete X,
         we stash X as the declared element type and rebuild — that re-types
         every existing child, and the rebuild's `_validate_and_remove_incompatible_connections`
         prunes any outgoing connection from a child whose type just changed
         out from under it. When the source declares only `list` or `list[any]`,
-        the cache stays None and we fall through to per-value detection
-        (today's behavior).
+        the cache stays None and we fall through to per-value detection.
+        Either way, while `items` is connected, children become read-only —
+        the connection owns their values.
         """
         if target_parameter == self.items:
             self._declared_element_type = self._extract_inner_list_type(source_parameter.output_type)
+            self._items_connected = True
             self._update_display_list()
+            self._apply_settable_state()
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(
         self, source_node: BaseNode, source_parameter: Parameter, target_parameter: Parameter
     ) -> None:
-        """Reset the declared element type when `items` is disconnected.
+        """Reset declared element type and unlock children when `items` is disconnected.
 
         Drops back to per-value detection so a subsequent reconnect (or any
         cached value the artist set as a property) re-evaluates from scratch.
-        Other parameters' disconnects are ignored — DisplayList only narrows
-        based on `items`.
+        Children become editable again so the artist can hand-edit any
+        cached values. Other parameters' disconnects are ignored —
+        DisplayList only narrows based on `items`.
         """
         if target_parameter == self.items:
             self._declared_element_type = None
+            self._items_connected = False
         self._update_display_list()
+        if target_parameter == self.items:
+            self._apply_settable_state()
         return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)


### PR DESCRIPTION
Closes #298.

> **Note on base branch**: this PR targets `feat/sequence-nodes` (PR #288) rather than `main` because the live verification depends on the sequence nodes being present (the original bug was discovered wiring `ScanSplitSequenceNode.sequences` → DisplayList → InspectSequenceNode). Once #288 lands on main, GitHub will let me retarget this PR to main with a click; or it can be rebased.

## The bug

`DisplayList._determine_item_type` falls back to `ParameterTypeBuiltin.ANY.value` for unknown types. The engine's `ParameterType.are_types_compatible("any", "Sequence")` returns **False** (only `target == "any"` is honored as a wildcard, not `source`). So wiring a `list[Sequence]` through DisplayList into a typed input rejected the connection at connect-time with:

```
Attempted to set parameter value for 'Inspect Sequence.sequence'.
Failed because the value's type of 'any' was not in the Parameter's
list of allowed types: ['Sequence'].
```

## The fix

Capture the upstream's declared element type at connect-time. When the source's `output_type` is `list[X]` for some non-`any` X, stash X as `self._declared_element_type` and rebuild — that re-types every existing child and lets the existing `_validate_and_remove_incompatible_connections` machinery prune outgoing edges that no longer match.

When the upstream declares only `list` or `list[any]` (no useful element type), the cache stays None and DisplayList falls through to the existing per-value detection — today's behavior.

### Why declared-type, not `value.__class__.__name__`?

The user (a sequence-types reviewer) flagged a real concern with the runtime-class fallback approach: parameter type names don't always equate to Python class names. A node may expect a `Schema` parameter type whose underlying value is just JSON; using `value.__class__.__name__` would collide on semantically-distinct types. Reading the upstream's *declared* `output_type` honors the producer's intent without inferring from runtime structure.

When no declared type is available, leaving the child as `all` (today's value) is the safe default — that's also why we don't switch to `any`. The two are functionally equivalent in `are_types_compatible` (both fail against `Sequence`), but `all` is the file's existing convention for "this output can be anything," symmetric to `any` on the consumer side.

## State-transition rules honored

1. **Nothing connected** → input is `list`, output container is `any`/`all`. Today's defaults; no change.
2. **Incoming connection to `items`** → read `source_parameter.output_type`, extract `X` from `list[X]` (skipping the `any` sentinel), narrow every existing child to `X`. Outgoing edges from children whose type just changed get pruned via the existing `_validate_and_remove_incompatible_connections` (which dispatches `DeleteConnectionRequest`).
3. **Incoming connection removed from `items`** → clear the cached declared type and rebuild. Now guarded with `target_parameter == self.items` (previously fired on any disconnect, harmless today since `items` is the only input but a latent bug).
4. **Outgoing connections** → no DisplayList-side logic needed. The engine's connection-creation step type-checks new outgoing connections, and existing outgoing connections are already pruned by `_validate_and_remove_incompatible_connections` whenever a child's type changes.
5. **Replacing one connection with another** → fires removed → added in sequence; covered by 2 + 3 acting individually.

## Verification

`make check`: clean (format + lint + types + JSON, 0 errors).

Helper unit-cases I ran locally on `_extract_inner_list_type`:

| Input | Expected | Actual |
|---|---|---|
| `list[Sequence]` | `Sequence` | `Sequence` ✓ |
| `list[ImageUrlArtifact]` | `ImageUrlArtifact` | `ImageUrlArtifact` ✓ |
| `list[str]` | `str` | `str` ✓ |
| `list[any]` | None (fallback) | None ✓ |
| `list[ANY]` | None (case-insensitive) | None ✓ |
| `list` | None | None ✓ |
| `list[]` | None | None ✓ |
| `''` | None | None ✓ |
| `None` | None | None ✓ |
| `Sequence` (not a list) | None | None ✓ |
| `dict[str, int]` (different container) | None | None ✓ |
| `list[list[Sequence]]` (nested) | `list[Sequence]` | `list[Sequence]` ✓ |

Manual test plan once a reviewer wants to verify in the editor:

- [ ] Drop a `ScanSplitSequence` node, point it at a directory with multiple sub-sequences.
- [ ] Wire `sequences` → `DisplayList.items`.
- [ ] Wire one of `DisplayList`'s dynamic children → `InspectSequence.sequence`. Connection should hold (would have rejected previously).
- [ ] Run; confirm `InspectSequence` reports the actual Sequence (not "No sequence connected.").
- [ ] Sanity check: existing `list[ImageUrlArtifact]` workflows still render thumbnails the same way (no regression in the curated whitelist paths).

## Files changed

- `griptape_nodes_library/lists/display_list.py` — one file, +76 / -2.