### PR TITLE
Add SelectFromGrid node and widget

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -78,6 +78,11 @@
       "name": "CropVideoEditor",
       "path": "widgets/CropVideoEditor/CropVideoEditor.js",
       "description": "Interactive video crop editor — drag handles on a live video frame with frame scrubber, aspect ratio, resolution, and position presets."
+    },
+    {
+      "name": "SelectFromGrid",
+      "path": "widgets/SelectFromGrid/SelectFromGrid.js",
+      "description": "Interactive grid selector — displays list items as thumbnails (images, video, audio, text) and lets the user click to select one or more."
     }
   ],
   "categories": [
@@ -544,6 +549,23 @@
           "list",
           "data",
           "logic"
+        ]
+      }
+    },
+    {
+      "class_name": "SelectFromGrid",
+      "file_path": "griptape_nodes_library/lists/select_from_grid.py",
+      "metadata": {
+        "category": "lists",
+        "description": "Displays list items as a clickable grid of thumbnails. Supports images, video, audio, text, and dicts. Selected items are passed to the output.",
+        "display_name": "Select From Grid",
+        "group": "describe",
+        "tags": [
+          "list",
+          "data",
+          "image",
+          "grid",
+          "select"
         ]
       }
     },

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -56,7 +56,7 @@ class SelectFromGrid(ControlNode):
                 "items": [],
                 "selected_indices": [],
                 "columns": 3,
-                "layout": "masonry",
+                "layout": "grid",
                 "settings": {"multi_select": True},
             },
             tooltip="Interactive grid selector — click items to select them.",

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -95,13 +95,20 @@ class SelectFromGrid(ControlNode):
             return
 
         widget_items = [self._serialize_item(item) for item in list_values]
+
+        # Preserve the selection when the list length is unchanged (e.g. node re-run
+        # with the same inputs). Reset only when items are added or removed, because
+        # existing selected indices may no longer point to the right items.
+        current_len = len(current.get("items", []))
+        kept_indices = current.get("selected_indices", []) if len(widget_items) == current_len else []
+
         self.set_parameter_value(
             self.grid_param.name,
             {
                 "columns": current.get("columns", 3),
                 "layout": current.get("layout", "square"),
                 "items": widget_items,
-                "selected_indices": [],
+                "selected_indices": kept_indices,
             },
         )
 

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -19,6 +19,7 @@ from griptape_nodes.traits.widget import Widget
 from griptape_nodes_library.utils.audio_utils import is_audio_url_artifact
 from griptape_nodes_library.utils.video_utils import is_video_url_artifact
 
+# Used only when list items are plain strings — artifacts are detected by type, not extension.
 _IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"})
 _VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".mov", ".avi", ".mkv"})
 _AUDIO_EXTENSIONS = frozenset({".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"})
@@ -221,7 +222,7 @@ class SelectFromGrid(ControlNode):
 
             img = Image.open(io.BytesIO(image_bytes))
             if max(img.width, img.height) > _THUMBNAIL_MAX_DIM:
-                img.thumbnail((_THUMBNAIL_MAX_DIM, _THUMBNAIL_MAX_DIM), Image.LANCZOS)
+                img.thumbnail((_THUMBNAIL_MAX_DIM, _THUMBNAIL_MAX_DIM), Image.Resampling.LANCZOS)
             out = io.BytesIO()
             try:
                 img.save(out, format="WEBP", quality=75)

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -181,7 +181,7 @@ class SelectFromGrid(ControlNode):
 
         # Video artifacts
         if is_video_url_artifact(item):
-            url = self._resolve_url_string(item.value)
+            url = self._resolve_url_string(getattr(item, "value", ""))
             return {"type": "video", "url": url}
 
         # Audio artifacts

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from typing import Any
 
@@ -247,7 +248,11 @@ class SelectFromGrid(ControlNode):
         if isinstance(artifact, ImageArtifact):
             try:
                 thumb, ext = self._make_thumbnail(artifact.value)
-                return GriptapeNodes.StaticFilesManager().save_static_file(thumb, f"grid_thumb_{id(artifact)}.{ext}")
+                # Same image bytes always produce the same filename, so if the same image
+                # appears more than once it reuses the existing file instead of writing another.
+                # Follows the pattern in add_text_to_existing_image.py.
+                content_hash = hashlib.md5(artifact.value).hexdigest()[:16]  # noqa: S324
+                return GriptapeNodes.StaticFilesManager().save_static_file(thumb, f"grid_thumb_{content_hash}.{ext}")
             except Exception:
                 return ""
         # ImageUrlArtifact — value is a URL string (possibly macro://)

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -52,7 +52,7 @@ class SelectFromGrid(ControlNode):
                 "items": [],
                 "selected_indices": [],
                 "columns": 3,
-                "layout": "square",
+                "layout": "masonry",
                 "settings": {"multi_select": True},
             },
             tooltip="Interactive grid selector — click items to select them.",
@@ -90,7 +90,7 @@ class SelectFromGrid(ControlNode):
 
         base: dict = {
             "columns": current.get("columns", 3),
-            "layout": current.get("layout", "square"),
+            "layout": current.get("layout", "grid"),
             "settings": current.get("settings", {"multi_select": True}),
         }
 
@@ -238,9 +238,7 @@ class SelectFromGrid(ControlNode):
         if isinstance(artifact, ImageArtifact):
             try:
                 thumb, ext = self._make_thumbnail(artifact.value)
-                return GriptapeNodes.StaticFilesManager().save_static_file(
-                    thumb, f"grid_thumb_{id(artifact)}.{ext}"
-                )
+                return GriptapeNodes.StaticFilesManager().save_static_file(thumb, f"grid_thumb_{id(artifact)}.{ext}")
             except Exception:
                 return ""
         # ImageUrlArtifact — value is a URL string (possibly macro://)
@@ -262,16 +260,12 @@ class SelectFromGrid(ControlNode):
 
             image_bytes = pathlib.Path(resolved).read_bytes()
             thumb, ext = self._make_thumbnail(image_bytes)
-            return GriptapeNodes.StaticFilesManager().save_static_file(
-                thumb, f"grid_thumb_{hash(resolved)}.{ext}"
-            )
+            return GriptapeNodes.StaticFilesManager().save_static_file(thumb, f"grid_thumb_{hash(resolved)}.{ext}")
         except Exception:
             pass
         # Fallback: resolve to a static download URL without thumbnailing
         try:
-            result = GriptapeNodes.handle_request(
-                CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved)
-            )
+            result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
             if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
                 return result.url
         except Exception:
@@ -289,9 +283,7 @@ class SelectFromGrid(ControlNode):
         except Exception:
             resolved = path
         try:
-            result = GriptapeNodes.handle_request(
-                CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved)
-            )
+            result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
             if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
                 return result.url
         except Exception:

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -1,0 +1,249 @@
+import json
+from typing import Any
+
+from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
+from griptape_nodes.exe_types.core_types import (
+    Parameter,
+    ParameterMode,
+)
+from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.files.file import File
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlFromPathResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.widget import Widget
+
+from griptape_nodes_library.utils.audio_utils import is_audio_url_artifact
+from griptape_nodes_library.utils.video_utils import is_video_url_artifact
+
+_IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"})
+_VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".mov", ".avi", ".mkv"})
+_AUDIO_EXTENSIONS = frozenset({".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"})
+
+_THUMBNAIL_MAX_DIM = 300
+
+
+class SelectFromGrid(ControlNode):
+    """Displays a list of items in a selectable grid widget.
+
+    Accepts a list of strings, image/video/audio artifacts, or dicts. The user
+    selects items by clicking thumbnails in the grid. The output is a filtered
+    list containing only the selected items in the same format as the input.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.list_input = Parameter(
+            name="list",
+            input_types=["list"],
+            type="list",
+            allowed_modes={ParameterMode.INPUT},
+            tooltip="List of items to display in the grid. Supports strings, image/video/audio artifacts, and dicts.",
+        )
+        self.add_parameter(self.list_input)
+
+        self.grid_param = ParameterDict(
+            name="grid",
+            default_value={"items": [], "selected_indices": [], "columns": 3, "layout": "square"},
+            tooltip="Interactive grid selector — click items to select them.",
+            allowed_modes={ParameterMode.PROPERTY},
+            traits={Widget(name="SelectFromGrid", library="Griptape Nodes Library")},
+        )
+        self.add_parameter(self.grid_param)
+
+        self.selected_items = Parameter(
+            name="selected_items",
+            type="list",
+            output_type="list",
+            allowed_modes={ParameterMode.OUTPUT},
+            tooltip="The selected items from the grid, in the same format as the input list.",
+        )
+        self.add_parameter(self.selected_items)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == self.list_input.name:
+            self._sync_grid_items(value)
+        elif parameter.name == self.grid_param.name:
+            self._update_output_from_grid(value)
+        return super().after_value_set(parameter, value)
+
+    def process(self) -> None:
+        grid_value = self.get_parameter_value(self.grid_param.name) or {}
+        selected_indices = grid_value.get("selected_indices", [])
+        list_values = self.get_parameter_value(self.list_input.name) or []
+        selected = [list_values[i] for i in selected_indices if isinstance(i, int) and i < len(list_values)]
+        self.parameter_output_values[self.selected_items.name] = selected
+
+    def _sync_grid_items(self, list_values: Any) -> None:
+        """Serialize the incoming list to widget-friendly items and push to the grid parameter."""
+        current = self.get_parameter_value(self.grid_param.name) or {}
+
+        if not isinstance(list_values, list):
+            self.set_parameter_value(
+                self.grid_param.name,
+                {
+                    "columns": current.get("columns", 3),
+                    "layout": current.get("layout", "square"),
+                    "items": [],
+                    "selected_indices": [],
+                },
+            )
+            return
+
+        widget_items = [self._serialize_item(item) for item in list_values]
+        self.set_parameter_value(
+            self.grid_param.name,
+            {
+                "columns": current.get("columns", 3),
+                "layout": current.get("layout", "square"),
+                "items": widget_items,
+                "selected_indices": [],
+            },
+        )
+
+    def _update_output_from_grid(self, grid_value: Any) -> None:
+        """Update the output parameter when the user changes the selection in the widget."""
+        if not isinstance(grid_value, dict):
+            return
+        selected_indices = grid_value.get("selected_indices", [])
+        list_values = self.get_parameter_value(self.list_input.name) or []
+        selected = [list_values[i] for i in selected_indices if isinstance(i, int) and i < len(list_values)]
+        self.parameter_output_values[self.selected_items.name] = selected
+        self.publish_update_to_parameter(self.selected_items.name, selected)
+
+    def _serialize_item(self, item: Any) -> dict[str, Any]:
+        """Convert a Python item to a JSON-serializable dict for the grid widget."""
+        # Dicts with a "value" key — display the inner value, optionally with a label
+        if isinstance(item, dict) and "value" in item:
+            result = self._serialize_item(item["value"])
+            if "label" in item:
+                result["label"] = str(item["label"])
+            return result
+
+        # Image artifacts
+        if isinstance(item, (ImageUrlArtifact, ImageArtifact)):
+            url = self._resolve_artifact_url(item)
+            return {"type": "image", "url": url}
+
+        # Video artifacts
+        if is_video_url_artifact(item):
+            url = self._resolve_url_string(item.value)
+            return {"type": "video", "url": url}
+
+        # Audio artifacts
+        if is_audio_url_artifact(item) or isinstance(item, AudioArtifact):
+            url = self._resolve_url_string(getattr(item, "value", ""))
+            return {"type": "audio", "url": url}
+
+        # Strings — detect media by file extension
+        if isinstance(item, str):
+            lower = item.lower()
+            dot = lower.rfind(".")
+            ext = lower[dot:] if dot != -1 else ""
+            if ext in _IMAGE_EXTENSIONS:
+                return {"type": "image", "url": self._resolve_image_url(item)}
+            if ext in _VIDEO_EXTENSIONS:
+                return {"type": "video", "url": self._resolve_url_string(item)}
+            if ext in _AUDIO_EXTENSIONS:
+                return {"type": "audio", "url": self._resolve_url_string(item)}
+            return {"type": "text", "value": item}
+
+        # Dicts without a "value" key — render as formatted JSON
+        if isinstance(item, dict):
+            return {"type": "dict", "value": json.dumps(item, indent=2, default=str)}
+
+        # Primitives and anything else
+        return {"type": "text", "value": str(item)}
+
+    def _make_thumbnail(self, image_bytes: bytes) -> tuple[bytes, str]:
+        """Resize image bytes to _THUMBNAIL_MAX_DIM on the longest side.
+
+        Returns (thumbnail_bytes, extension). Falls back to original bytes + "png" on error.
+        """
+        try:
+            import io
+
+            from PIL import Image
+
+            img = Image.open(io.BytesIO(image_bytes))
+            if max(img.width, img.height) > _THUMBNAIL_MAX_DIM:
+                img.thumbnail((_THUMBNAIL_MAX_DIM, _THUMBNAIL_MAX_DIM), Image.LANCZOS)
+            out = io.BytesIO()
+            try:
+                img.save(out, format="WEBP", quality=75)
+                return out.getvalue(), "webp"
+            except Exception:
+                out = io.BytesIO()
+                img.save(out, format="PNG")
+                return out.getvalue(), "png"
+        except Exception:
+            return image_bytes, "png"
+
+    def _resolve_artifact_url(self, artifact: ImageUrlArtifact | ImageArtifact) -> str:
+        """Resolve an image artifact to a browser-accessible thumbnail URL."""
+        if isinstance(artifact, ImageArtifact):
+            try:
+                thumb, ext = self._make_thumbnail(artifact.value)
+                return GriptapeNodes.StaticFilesManager().save_static_file(
+                    thumb, f"grid_thumb_{id(artifact)}.{ext}"
+                )
+            except Exception:
+                return ""
+        # ImageUrlArtifact — value is a URL string (possibly macro://)
+        return self._resolve_image_url(artifact.value)
+
+    def _resolve_image_url(self, path: str) -> str:
+        """Resolve a path to a browser URL, thumbnailing local image files."""
+        if not path:
+            return ""
+        if path.startswith(("http://", "https://")):
+            return path
+        try:
+            resolved = File(path).resolve()
+        except Exception:
+            resolved = path
+        # Load, thumbnail, and serve the local file
+        try:
+            import pathlib
+
+            image_bytes = pathlib.Path(resolved).read_bytes()
+            thumb, ext = self._make_thumbnail(image_bytes)
+            return GriptapeNodes.StaticFilesManager().save_static_file(
+                thumb, f"grid_thumb_{hash(resolved)}.{ext}"
+            )
+        except Exception:
+            pass
+        # Fallback: resolve to a static download URL without thumbnailing
+        try:
+            result = GriptapeNodes.handle_request(
+                CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved)
+            )
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                return result.url
+        except Exception:
+            pass
+        return path
+
+    def _resolve_url_string(self, path: str) -> str:
+        """Resolve a file path or macro:// URL to a browser-accessible HTTP URL."""
+        if not path:
+            return ""
+        if path.startswith(("http://", "https://")):
+            return path
+        try:
+            resolved = File(path).resolve()
+        except Exception:
+            resolved = path
+        try:
+            result = GriptapeNodes.handle_request(
+                CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved)
+            )
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                return result.url
+        except Exception:
+            pass
+        return path

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -25,6 +25,9 @@ _VIDEO_EXTENSIONS = frozenset({".mp4", ".webm", ".mov", ".avi", ".mkv"})
 _AUDIO_EXTENSIONS = frozenset({".mp3", ".wav", ".ogg", ".flac", ".aac", ".m4a"})
 
 _THUMBNAIL_MAX_DIM = 300
+# Thumbnails are resolved in chunks so the browser receives incremental updates
+# rather than waiting for all items to be processed in one silent blocking pass.
+_RESOLVE_CHUNK_SIZE = 100
 
 
 class SelectFromGrid(ControlNode):
@@ -116,12 +119,17 @@ class SelectFromGrid(ControlNode):
             {**base, "items": placeholder_items, "selected_indices": kept_indices},
         )
 
-        # Phase 2 — resolve each item's thumbnail/URL and push the completed list.
-        widget_items = [self._serialize_item(item) for item in list_values]
-        self.set_parameter_value(
-            self.grid_param.name,
-            {**base, "items": widget_items, "selected_indices": kept_indices},
-        )
+        # Phase 2 — resolve thumbnails in chunks and push after each chunk so the
+        # browser receives incremental updates instead of waiting for all items.
+        widget_items = list(placeholder_items)
+        for chunk_start in range(0, len(list_values), _RESOLVE_CHUNK_SIZE):
+            chunk_end = min(chunk_start + _RESOLVE_CHUNK_SIZE, len(list_values))
+            for i in range(chunk_start, chunk_end):
+                widget_items[i] = self._serialize_item(list_values[i])
+            self.set_parameter_value(
+                self.grid_param.name,
+                {**base, "items": list(widget_items), "selected_indices": kept_indices},
+            )
 
     def _update_output_from_grid(self, grid_value: Any) -> None:
         """Update the output parameter when the user changes the selection in the widget."""

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -48,7 +48,13 @@ class SelectFromGrid(ControlNode):
 
         self.grid_param = ParameterDict(
             name="grid",
-            default_value={"items": [], "selected_indices": [], "columns": 3, "layout": "square"},
+            default_value={
+                "items": [],
+                "selected_indices": [],
+                "columns": 3,
+                "layout": "square",
+                "settings": {"multi_select": True},
+            },
             tooltip="Interactive grid selector — click items to select them.",
             allowed_modes={ParameterMode.PROPERTY},
             traits={Widget(name="SelectFromGrid", library="Griptape Nodes Library")},
@@ -82,34 +88,38 @@ class SelectFromGrid(ControlNode):
         """Serialize the incoming list to widget-friendly items and push to the grid parameter."""
         current = self.get_parameter_value(self.grid_param.name) or {}
 
+        base: dict = {
+            "columns": current.get("columns", 3),
+            "layout": current.get("layout", "square"),
+            "settings": current.get("settings", {"multi_select": True}),
+        }
+
         if not isinstance(list_values, list):
             self.set_parameter_value(
                 self.grid_param.name,
-                {
-                    "columns": current.get("columns", 3),
-                    "layout": current.get("layout", "square"),
-                    "items": [],
-                    "selected_indices": [],
-                },
+                {**base, "items": [], "selected_indices": []},
             )
             return
-
-        widget_items = [self._serialize_item(item) for item in list_values]
 
         # Preserve the selection when the list length is unchanged (e.g. node re-run
         # with the same inputs). Reset only when items are added or removed, because
         # existing selected indices may no longer point to the right items.
         current_len = len(current.get("items", []))
-        kept_indices = current.get("selected_indices", []) if len(widget_items) == current_len else []
+        placeholder_items = [self._serialize_item_placeholder(item) for item in list_values]
+        kept_indices = current.get("selected_indices", []) if len(placeholder_items) == current_len else []
 
+        # Phase 1 — push placeholders immediately so the widget shows spinners
+        # while thumbnail generation is in progress.
         self.set_parameter_value(
             self.grid_param.name,
-            {
-                "columns": current.get("columns", 3),
-                "layout": current.get("layout", "square"),
-                "items": widget_items,
-                "selected_indices": kept_indices,
-            },
+            {**base, "items": placeholder_items, "selected_indices": kept_indices},
+        )
+
+        # Phase 2 — resolve each item's thumbnail/URL and push the completed list.
+        widget_items = [self._serialize_item(item) for item in list_values]
+        self.set_parameter_value(
+            self.grid_param.name,
+            {**base, "items": widget_items, "selected_indices": kept_indices},
         )
 
     def _update_output_from_grid(self, grid_value: Any) -> None:
@@ -121,6 +131,39 @@ class SelectFromGrid(ControlNode):
         selected = [list_values[i] for i in selected_indices if isinstance(i, int) and i < len(list_values)]
         self.parameter_output_values[self.selected_items.name] = selected
         self.publish_update_to_parameter(self.selected_items.name, selected)
+
+    def _serialize_item_placeholder(self, item: Any) -> dict[str, Any]:
+        """Return a lightweight placeholder for an item with no resolved URL.
+
+        The JS widget renders a loading spinner for any image/video item whose
+        url is absent, allowing the grid to appear immediately while Phase 2
+        resolves thumbnails.
+        """
+        if isinstance(item, dict) and "value" in item:
+            result = self._serialize_item_placeholder(item["value"])
+            if "label" in item:
+                result["label"] = str(item["label"])
+            return result
+        if isinstance(item, (ImageUrlArtifact, ImageArtifact)):
+            return {"type": "image", "url": ""}
+        if is_video_url_artifact(item):
+            return {"type": "video", "url": ""}
+        if is_audio_url_artifact(item) or isinstance(item, AudioArtifact):
+            return {"type": "audio", "url": ""}
+        if isinstance(item, str):
+            lower = item.lower()
+            dot = lower.rfind(".")
+            ext = lower[dot:] if dot != -1 else ""
+            if ext in _IMAGE_EXTENSIONS:
+                return {"type": "image", "url": ""}
+            if ext in _VIDEO_EXTENSIONS:
+                return {"type": "video", "url": ""}
+            if ext in _AUDIO_EXTENSIONS:
+                return {"type": "audio", "url": ""}
+            return {"type": "text", "value": item}
+        if isinstance(item, dict):
+            return {"type": "dict", "value": ""}
+        return {"type": "text", "value": str(item)}
 
     def _serialize_item(self, item: Any) -> dict[str, Any]:
         """Convert a Python item to a JSON-serializable dict for the grid widget."""

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -1,282 +1,44 @@
-const WIDGET_VERSION = "1.1.0";
+import { ACCENT, ACCENT_RGB, CARD_HUES, CARD_HEIGHTS, injectStyles } from './_styles.js';
+import { mkIcon } from './_icons.js';
+import { createToolbar } from './_toolbar.js';
 
-const ACCENT       = "#7a9db8";
-const ACCENT_RGB   = "122,157,184";
-
-const STYLES = `
-.sfg-widget {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px;
-  height: 100%;
-  box-sizing: border-box;
-  overflow: hidden;
-  user-select: none;
-  -webkit-user-select: none;
-}
-
-.sfg-controls {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  padding-bottom: 4px;
-  border-bottom: 1px solid var(--border);
-}
-
-.sfg-label {
-  font-size: 11px;
-  color: var(--muted-foreground);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  white-space: nowrap;
-}
-
-.sfg-slider {
-  width: 80px;
-  accent-color: ${ACCENT};
-  cursor: pointer;
-  flex-shrink: 0;
-}
-.sfg-slider:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.sfg-layout-btns {
-  display: flex;
-  gap: 4px;
-}
-.sfg-layout-btn {
-  padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: 10px;
-  cursor: pointer;
-  line-height: 18px;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
-}
-.sfg-layout-btn:hover { background: var(--muted); color: var(--foreground); }
-.sfg-layout-btn.active {
-  background: rgba(${ACCENT_RGB},0.2);
-  border-color: ${ACCENT};
-  color: var(--foreground);
-}
-.sfg-layout-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-
-.sfg-count {
-  margin-left: auto;
-  font-size: 10px;
-  color: var(--muted-foreground);
-}
-.sfg-count.active { color: var(--foreground); }
-
-.sfg-clear-btn {
-  padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: 10px;
-  cursor: pointer;
-  line-height: 18px;
-  transition: background 0.12s, color 0.12s;
-  flex-shrink: 0;
-}
-.sfg-clear-btn:hover { background: var(--muted); color: var(--foreground); }
-.sfg-clear-btn.active { color: var(--foreground); border-color: rgba(${ACCENT_RGB},0.5); }
-.sfg-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-
-/* ── Grid layouts ─────────────────────────────────────────────── */
-.sfg-grid {
-  display: grid;
-  gap: 5px;
-  position: relative;
-  flex: 1 1 0;
-  min-height: 0;
-  min-width: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-}
-.sfg-grid::-webkit-scrollbar { width: 6px; }
-.sfg-grid::-webkit-scrollbar-track { background: transparent; }
-.sfg-grid::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-
-.sfg-grid.layout-masonry {
-  display: flex;
-  align-items: flex-start;
-}
-.sfg-masonry-col {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 5px;
-  min-width: 0;
-}
-
-/* ── Lasso / box-select rect ──────────────────────────────────── */
-.sfg-lasso {
-  position: absolute;
-  border: 1.5px dashed ${ACCENT};
-  background: rgba(${ACCENT_RGB},0.10);
-  border-radius: 3px;
-  pointer-events: none;
-  z-index: 10;
-}
-
-/* ── Cells ────────────────────────────────────────────────────── */
-.sfg-cell {
-  position: relative;
-  border-radius: 5px;
-  overflow: hidden;
-  cursor: pointer;
-  border: 2px solid transparent;
-  background: var(--muted);
-  transition: border-color 0.12s;
-  box-sizing: border-box;
-}
-.sfg-cell:hover { border-color: rgba(${ACCENT_RGB},0.45); }
-.sfg-cell.pending { border-color: rgba(${ACCENT_RGB},0.7); background: rgba(${ACCENT_RGB},0.08); }
-.sfg-cell.selected { border-color: ${ACCENT}; }
-
-/* Checkmark badge on selected cells */
-.sfg-cell.selected::after {
-  content: "";
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: ${ACCENT}
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E")
-    no-repeat center / 11px;
-  z-index: 3;
-  pointer-events: none;
-}
-
-/* ── Square inner frame ───────────────────────────────────────── */
-.sfg-cell-inner {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #111;
-}
-.layout-masonry .sfg-cell-inner {
-  aspect-ratio: unset;
-}
-
-/* ── Media elements ───────────────────────────────────────────── */
-.sfg-cell img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  pointer-events: none;
-}
-.layout-masonry .sfg-cell img {
-  height: auto;
-}
-
-.sfg-cell video {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  pointer-events: none;
-}
-.layout-masonry .sfg-cell video {
-  height: auto;
-}
-
-/* ── Audio card ───────────────────────────────────────────────── */
-.sfg-audio-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 12px 8px;
-  width: 100%;
-  box-sizing: border-box;
-  background: rgba(0,0,0,0.3);
-}
-.sfg-audio-icon {
-  font-size: 28px;
-  line-height: 1;
-  pointer-events: none;
-}
-.sfg-audio-card audio {
-  width: 100%;
-  height: 28px;
-  accent-color: ${ACCENT};
-}
-
-/* ── Text / dict cards ────────────────────────────────────────── */
-.sfg-text-card {
-  padding: 10px;
-  font-size: 11px;
-  color: var(--foreground);
-  word-break: break-word;
-  text-align: center;
-  min-height: 60px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-.sfg-dict-card {
-  padding: 8px;
-  font-size: 9px;
-  font-family: monospace;
-  color: var(--muted-foreground);
-  white-space: pre;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-height: 110px;
-  display: -webkit-box;
-  -webkit-line-clamp: 7;
-  -webkit-box-orient: vertical;
-}
-
-/* ── Label overlay ────────────────────────────────────────────── */
-.sfg-item-label {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 3px 5px;
-  font-size: 10px;
-  background: rgba(0,0,0,0.55);
-  color: #fff;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  z-index: 2;
-  pointer-events: none;
-}
-
-/* ── Empty state ──────────────────────────────────────────────── */
-.sfg-empty {
-  padding: 24px 12px;
-  text-align: center;
-  color: var(--muted-foreground);
-  font-size: 12px;
-}
-`;
-
-function injectStyles() {
-  if (document.getElementById("sfg-widget-styles")) return;
-  const el = document.createElement("style");
-  el.id = "sfg-widget-styles";
-  el.textContent = STYLES;
-  document.head.appendChild(el);
-}
+// ── SelectFromGrid widget ──────────────────────────────────────────────────────
+//
+// Displays a list of items as a clickable grid. The user selects items by
+// clicking or drag-selecting (lasso); the selection is written back to the
+// node via onChange as `selected_indices`.
+//
+// VALUE SHAPE (ParameterDict "grid")
+// ─────────────────────────────────
+//   items            array   Serialised list items (set by the Python node).
+//   selected_indices array   Zero-based indices of currently selected items.
+//   columns          number  Number of columns (1–8). User-adjustable via slider.
+//   layout           string  "square" | "masonry". User-adjustable via toggle.
+//   settings         object  Node-author configuration — not shown to the user.
+//
+// SETTINGS (set once in the Python node, preserved across list updates)
+// ─────────────────────────────────────────────────────────────────────
+//   multi_select  boolean  (default: true)
+//     true  — multiple items can be selected; lasso drag-select is enabled.
+//     false — at most one item may be selected at a time; lasso is disabled.
+//
+// PYTHON USAGE EXAMPLE
+// ─────────────────────
+//   # Subclass SelectFromGrid and change a setting in __init__:
+//
+//   class PickOneImage(SelectFromGrid):
+//       def __init__(self, name: str, metadata: dict | None = None) -> None:
+//           super().__init__(name, metadata)
+//           self.grid_param.default_value["settings"] = {"multi_select": False}
+//
+// ITEM TYPES (produced by select_from_grid.py _serialize_item)
+// ─────────────────────────────────────────────────────────────
+//   { type: "image", url: string }
+//   { type: "video", url: string }
+//   { type: "audio", url: string }
+//   { type: "dict",  value: string }   — formatted JSON
+//   { type: "text",  value: string }   — rendered as a styled quote card
+//   Any item may also carry an optional "label" string displayed as an overlay.
 
 export default function SelectFromGrid(container, props) {
   // ── Mount guard ───────────────────────────────────────────────────────────
@@ -291,69 +53,33 @@ export default function SelectFromGrid(container, props) {
   // ── State ─────────────────────────────────────────────────────────────────
   let latestValue = props.value || {};
   let onChangeRef = props.onChange;
-  let isDisabled = props.disabled || false;
+  let isDisabled  = props.disabled || false;
 
-  let items = latestValue.items || [];
+  let items           = latestValue.items           || [];
   let selectedIndices = latestValue.selected_indices || [];
-  let columns = latestValue.columns || 3;
-  let layout = latestValue.layout || "square";
+  let columns         = latestValue.columns          || 3;
+  let layout          = latestValue.layout           || "square";
+  let multiSelect     = (latestValue.settings?.multi_select) !== false;
 
   // ── DOM: wrapper ──────────────────────────────────────────────────────────
   const wrapper = document.createElement("div");
   wrapper.className = "sfg-widget nodrag nowheel";
 
-  // ── DOM: controls ─────────────────────────────────────────────────────────
-  const controls = document.createElement("div");
-  controls.className = "sfg-controls";
+  // ── Toolbar ───────────────────────────────────────────────────────────────
+  const { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled } =
+    createToolbar({
+      layout, columns, isDisabled,
+      onColumnsChange(n) { columns = n; renderGrid(); emitChange(); },
+      onLayoutChange(l)  { layout  = l; renderGrid(); emitChange(); },
+      onClear()          {
+        if (selectedIndices.length === 0) return;
+        selectedIndices = [];
+        grid.querySelectorAll(".sfg-cell.selected").forEach((c) => c.classList.remove("selected"));
+        updateCount();
+        emitChange();
+      },
+    });
 
-  const colLabel = document.createElement("label");
-  colLabel.className = "sfg-label";
-  colLabel.textContent = "Columns ";
-
-  const colSlider = document.createElement("input");
-  colSlider.type = "range";
-  colSlider.className = "sfg-slider";
-  colSlider.min = 1;
-  colSlider.max = 8;
-  colSlider.value = columns;
-  colSlider.disabled = isDisabled;
-  colLabel.appendChild(colSlider);
-
-  const colVal = document.createElement("span");
-  colVal.textContent = columns;
-  colLabel.appendChild(colVal);
-
-  const layoutBtns = document.createElement("div");
-  layoutBtns.className = "sfg-layout-btns";
-
-  const squareBtn = document.createElement("button");
-  squareBtn.type = "button";
-  squareBtn.className = "sfg-layout-btn" + (layout === "square" ? " active" : "");
-  squareBtn.textContent = "Square";
-  squareBtn.disabled = isDisabled;
-
-  const masonryBtn = document.createElement("button");
-  masonryBtn.type = "button";
-  masonryBtn.className = "sfg-layout-btn" + (layout === "masonry" ? " active" : "");
-  masonryBtn.textContent = "Masonry";
-  masonryBtn.disabled = isDisabled;
-
-  layoutBtns.appendChild(squareBtn);
-  layoutBtns.appendChild(masonryBtn);
-
-  const countEl = document.createElement("span");
-  countEl.className = "sfg-count";
-
-  const clearBtn = document.createElement("button");
-  clearBtn.type = "button";
-  clearBtn.className = "sfg-clear-btn";
-  clearBtn.textContent = "Clear";
-  clearBtn.disabled = isDisabled;
-
-  controls.appendChild(colLabel);
-  controls.appendChild(layoutBtns);
-  controls.appendChild(countEl);
-  controls.appendChild(clearBtn);
   wrapper.appendChild(controls);
 
   // ── DOM: grid ─────────────────────────────────────────────────────────────
@@ -387,6 +113,13 @@ export default function SelectFromGrid(container, props) {
     grid.style.gridTemplateColumns = isMasonry ? "" : `repeat(${columns}, 1fr)`;
   }
 
+  function mkSpinner() {
+    const s = document.createElement("div");
+    s.className = "sfg-spinner";
+    s.appendChild(mkIcon("loader-circle", 22));
+    return s;
+  }
+
   function buildCellContent(cell, item, idx) {
     cell.dataset.idx = idx;
     const inner = document.createElement("div");
@@ -394,25 +127,46 @@ export default function SelectFromGrid(container, props) {
 
     switch (item.type) {
       case "image": {
+        inner.classList.add("sfg-loading");
+        const spinner = mkSpinner();
+        inner.appendChild(spinner);
         if (item.url) {
           const img = document.createElement("img");
-          img.src = item.url;
-          img.alt = item.label || "";
-          img.loading = "lazy";
+          img.src      = item.url;
+          img.alt      = item.label || "";
+          img.loading  = "lazy";
           img.decoding = "async";
+          const fadeIn = () => {
+            inner.classList.remove("sfg-loading");
+            img.classList.add("sfg-loaded");
+            spinner.style.opacity = "0";
+            spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
+          };
+          img.addEventListener("load",  fadeIn);
+          img.addEventListener("error", () => { inner.classList.remove("sfg-loading"); spinner.remove(); });
           inner.appendChild(img);
         }
         break;
       }
       case "video": {
+        inner.classList.add("sfg-loading");
+        const spinner = mkSpinner();
+        inner.appendChild(spinner);
         if (item.url) {
           const vid = document.createElement("video");
-          vid.src = item.url;
-          vid.muted = true;
-          vid.loop = true;
+          vid.src         = item.url;
+          vid.muted       = true;
+          vid.loop        = true;
           vid.playsInline = true;
-          vid.preload = "metadata";
-          vid.addEventListener("loadedmetadata", () => { vid.currentTime = 0.001; });
+          vid.preload     = "metadata";
+          vid.addEventListener("loadedmetadata", () => {
+            inner.classList.remove("sfg-loading");
+            vid.currentTime = 0.001;
+            vid.classList.add("sfg-loaded");
+            spinner.style.opacity = "0";
+            spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
+          });
+          vid.addEventListener("error", () => { inner.classList.remove("sfg-loading"); spinner.remove(); });
           cell.addEventListener("mouseenter", () => void vid.play().catch(() => {}));
           cell.addEventListener("mouseleave", () => { vid.pause(); vid.currentTime = 0; });
           inner.appendChild(vid);
@@ -422,16 +176,13 @@ export default function SelectFromGrid(container, props) {
       case "audio": {
         const card = document.createElement("div");
         card.className = "sfg-audio-card";
-        const icon = document.createElement("div");
-        icon.className = "sfg-audio-icon";
-        icon.textContent = "🎵";
-        card.appendChild(icon);
+        card.appendChild(mkIcon("music", 28));
         if (item.url) {
           const audio = document.createElement("audio");
-          audio.src = item.url;
+          audio.src      = item.url;
           audio.controls = true;
           audio.addEventListener("pointerdown", (e) => e.stopPropagation());
-          audio.addEventListener("click", (e) => e.stopPropagation());
+          audio.addEventListener("click",       (e) => e.stopPropagation());
           card.appendChild(audio);
         }
         inner.appendChild(card);
@@ -439,16 +190,28 @@ export default function SelectFromGrid(container, props) {
       }
       case "dict": {
         const dictEl = document.createElement("div");
-        dictEl.className = "sfg-dict-card";
+        dictEl.className   = "sfg-dict-card";
         dictEl.textContent = item.value || "{}";
         inner.appendChild(dictEl);
         break;
       }
       default: {
+        const displayText = item.value !== undefined ? String(item.value) : (item.label || "");
+
+        const hue  = CARD_HUES[idx % CARD_HUES.length];
+        const card = document.createElement("div");
+        card.className        = "sfg-quote-card";
+        card.style.background = `hsla(${hue}, 22%, 50%, 0.09)`;
+        if (layout === "masonry") {
+          card.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
+        }
+
         const textEl = document.createElement("div");
-        textEl.className = "sfg-text-card";
-        textEl.textContent = item.value !== undefined ? item.value : (item.label || "");
-        inner.appendChild(textEl);
+        textEl.className   = "sfg-quote-text";
+        textEl.textContent = displayText;
+        card.appendChild(textEl);
+        inner.appendChild(card);
+        break;
       }
     }
 
@@ -456,7 +219,7 @@ export default function SelectFromGrid(container, props) {
 
     if (item.label) {
       const lbl = document.createElement("div");
-      lbl.className = "sfg-item-label";
+      lbl.className   = "sfg-item-label";
       lbl.textContent = item.label;
       cell.appendChild(lbl);
     }
@@ -468,7 +231,7 @@ export default function SelectFromGrid(container, props) {
 
     if (items.length === 0) {
       const empty = document.createElement("div");
-      empty.className = "sfg-empty";
+      empty.className   = "sfg-empty";
       empty.textContent = "Connect a list to display items here";
       grid.appendChild(empty);
       updateCount();
@@ -476,7 +239,6 @@ export default function SelectFromGrid(container, props) {
     }
 
     if (layout === "masonry") {
-      // Build N flex column wrappers and distribute items round-robin
       const cols = Array.from({ length: columns }, () => {
         const col = document.createElement("div");
         col.className = "sfg-masonry-col";
@@ -504,7 +266,7 @@ export default function SelectFromGrid(container, props) {
   // Allow the grid to scroll without React Flow intercepting wheel events
   grid.addEventListener("wheel", (e) => { e.stopPropagation(); }, { passive: true });
 
-  // ── Box-select / click via event delegation on the grid ───────────────────
+  // ── Box-select / click via event delegation ───────────────────────────────
   let dragState = null;
   const DRAG_THRESHOLD = 5;
 
@@ -521,13 +283,17 @@ export default function SelectFromGrid(container, props) {
     e.stopPropagation();
 
     const gridRect = grid.getBoundingClientRect();
-    const startX = e.clientX - gridRect.left + grid.scrollLeft;
-    const startY = e.clientY - gridRect.top + grid.scrollTop;
+    const startX   = e.clientX - gridRect.left + grid.scrollLeft;
+    const startY   = e.clientY - gridRect.top  + grid.scrollTop;
 
-    const lasso = document.createElement("div");
-    lasso.className = "sfg-lasso";
-    Object.assign(lasso.style, { left: startX + "px", top: startY + "px", width: "0", height: "0" });
-    grid.appendChild(lasso);
+    // Lasso is only created in multi-select mode
+    let lasso = null;
+    if (multiSelect) {
+      lasso = document.createElement("div");
+      lasso.className = "sfg-lasso";
+      Object.assign(lasso.style, { left: startX + "px", top: startY + "px", width: "0", height: "0" });
+      grid.appendChild(lasso);
+    }
 
     dragState = { startX, startY, lasso, dragging: false, startCell: findCellEl(e.target) };
     grid.setPointerCapture(e.pointerId);
@@ -537,34 +303,32 @@ export default function SelectFromGrid(container, props) {
     if (!dragState) return;
     const gridRect = grid.getBoundingClientRect();
     const curX = e.clientX - gridRect.left + grid.scrollLeft;
-    const curY = e.clientY - gridRect.top + grid.scrollTop;
-    const dx = curX - dragState.startX;
-    const dy = curY - dragState.startY;
+    const curY = e.clientY - gridRect.top  + grid.scrollTop;
+    const dx   = curX - dragState.startX;
+    const dy   = curY - dragState.startY;
 
-    if (!dragState.dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
-      dragState.dragging = true;
-    }
-    if (dragState.dragging) {
-      const selLeft = Math.min(dragState.startX, curX);
-      const selTop = Math.min(dragState.startY, curY);
-      const selRight = Math.max(dragState.startX, curX);
+    if (!dragState.dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) dragState.dragging = true;
+
+    if (dragState.dragging && dragState.lasso) {
+      const selLeft   = Math.min(dragState.startX, curX);
+      const selTop    = Math.min(dragState.startY, curY);
+      const selRight  = Math.max(dragState.startX, curX);
       const selBottom = Math.max(dragState.startY, curY);
 
       Object.assign(dragState.lasso.style, {
-        left: selLeft + "px",
-        top: selTop + "px",
-        width: Math.abs(dx) + "px",
+        left:   selLeft  + "px",
+        top:    selTop   + "px",
+        width:  Math.abs(dx) + "px",
         height: Math.abs(dy) + "px",
       });
 
-      // Mark cells that the lasso covers (and aren't already selected) as pending
       grid.querySelectorAll(".sfg-cell").forEach((cell) => {
-        const r = cell.getBoundingClientRect();
+        const r     = cell.getBoundingClientRect();
         const gRect = grid.getBoundingClientRect();
         const cLeft = r.left - gRect.left + grid.scrollLeft;
-        const cTop = r.top - gRect.top + grid.scrollTop;
-        const overlaps = cLeft < selRight && (cLeft + r.width) > selLeft &&
-                         cTop < selBottom && (cTop + r.height) > selTop;
+        const cTop  = r.top  - gRect.top  + grid.scrollTop;
+        const overlaps = cLeft < selRight  && (cLeft + r.width)  > selLeft &&
+                         cTop  < selBottom && (cTop  + r.height) > selTop;
         const idx = parseInt(cell.dataset.idx, 10);
         cell.classList.toggle("pending", overlaps && !selectedIndices.includes(idx));
       });
@@ -573,28 +337,27 @@ export default function SelectFromGrid(container, props) {
 
   grid.addEventListener("pointerup", (e) => {
     if (!dragState) return;
-    dragState.lasso.remove();
+    if (dragState.lasso) dragState.lasso.remove();
     grid.querySelectorAll(".sfg-cell.pending").forEach((c) => c.classList.remove("pending"));
 
-    if (dragState.dragging) {
-      const gridRect = grid.getBoundingClientRect();
-      const curX = e.clientX - gridRect.left + grid.scrollLeft;
-      const curY = e.clientY - gridRect.top + grid.scrollTop;
-      const selLeft = Math.min(dragState.startX, curX);
-      const selTop = Math.min(dragState.startY, curY);
-      const selRight = Math.max(dragState.startX, curX);
+    if (dragState.dragging && dragState.lasso) {
+      // Multi-select lasso: add all cells in the rect to the selection
+      const gridRect  = grid.getBoundingClientRect();
+      const curX      = e.clientX - gridRect.left + grid.scrollLeft;
+      const curY      = e.clientY - gridRect.top  + grid.scrollTop;
+      const selLeft   = Math.min(dragState.startX, curX);
+      const selTop    = Math.min(dragState.startY, curY);
+      const selRight  = Math.max(dragState.startX, curX);
       const selBottom = Math.max(dragState.startY, curY);
 
       let changed = false;
       grid.querySelectorAll(".sfg-cell").forEach((cell) => {
-        const r = cell.getBoundingClientRect();
-        const gridRect2 = grid.getBoundingClientRect();
-        const cLeft = r.left - gridRect2.left + grid.scrollLeft;
-        const cTop = r.top - gridRect2.top + grid.scrollTop;
-        const cRight = cLeft + r.width;
-        const cBottom = cTop + r.height;
-
-        if (cLeft < selRight && cRight > selLeft && cTop < selBottom && cBottom > selTop) {
+        const r      = cell.getBoundingClientRect();
+        const gRect2 = grid.getBoundingClientRect();
+        const cLeft  = r.left - gRect2.left + grid.scrollLeft;
+        const cTop   = r.top  - gRect2.top  + grid.scrollTop;
+        if (cLeft < selRight && (cLeft + r.width) > selLeft &&
+            cTop  < selBottom && (cTop  + r.height) > selTop) {
           const idx = parseInt(cell.dataset.idx, 10);
           if (!isNaN(idx) && !selectedIndices.includes(idx)) {
             selectedIndices = [...selectedIndices, idx];
@@ -605,12 +368,23 @@ export default function SelectFromGrid(container, props) {
       });
 
       if (changed) { updateCount(); emitChange(); }
-    } else if (dragState.startCell) {
+    } else if (!dragState.dragging && dragState.startCell) {
+      // Click — toggle selection; in single-select mode clear all others first
       const idx = parseInt(dragState.startCell.dataset.idx, 10);
       if (!isNaN(idx)) {
-        const pos = selectedIndices.indexOf(idx);
-        if (pos === -1) selectedIndices = [...selectedIndices, idx];
-        else selectedIndices = selectedIndices.filter((i) => i !== idx);
+        const alreadySelected = selectedIndices.includes(idx);
+        if (multiSelect) {
+          if (alreadySelected) selectedIndices = selectedIndices.filter((i) => i !== idx);
+          else                 selectedIndices = [...selectedIndices, idx];
+        } else {
+          if (alreadySelected) {
+            selectedIndices = [];
+          } else {
+            // Deselect the previously selected cell visually before updating state
+            grid.querySelectorAll(".sfg-cell.selected").forEach((c) => c.classList.remove("selected"));
+            selectedIndices = [idx];
+          }
+        }
         dragState.startCell.classList.toggle("selected", selectedIndices.includes(idx));
         updateCount();
         emitChange();
@@ -622,51 +396,10 @@ export default function SelectFromGrid(container, props) {
 
   grid.addEventListener("pointercancel", () => {
     if (dragState) {
-      dragState.lasso.remove();
+      if (dragState.lasso) dragState.lasso.remove();
       grid.querySelectorAll(".sfg-cell.pending").forEach((c) => c.classList.remove("pending"));
       dragState = null;
     }
-  });
-
-  // ── Wire controls ─────────────────────────────────────────────────────────
-  colSlider.addEventListener("pointerdown", (e) => e.stopPropagation());
-  colSlider.addEventListener("input", () => {
-    columns = parseInt(colSlider.value, 10);
-    colVal.textContent = columns;
-    renderGrid();
-    emitChange();
-  });
-
-  squareBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
-  squareBtn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    if (isDisabled) return;
-    layout = "square";
-    squareBtn.classList.add("active");
-    masonryBtn.classList.remove("active");
-    renderGrid();
-    emitChange();
-  });
-
-  masonryBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
-  masonryBtn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    if (isDisabled) return;
-    layout = "masonry";
-    masonryBtn.classList.add("active");
-    squareBtn.classList.remove("active");
-    renderGrid();
-    emitChange();
-  });
-
-  clearBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
-  clearBtn.addEventListener("click", (e) => {
-    e.stopPropagation();
-    if (isDisabled || selectedIndices.length === 0) return;
-    selectedIndices = [];
-    grid.querySelectorAll(".sfg-cell.selected").forEach((c) => c.classList.remove("selected"));
-    updateCount();
-    emitChange();
   });
 
   // ── Initial render ────────────────────────────────────────────────────────
@@ -675,17 +408,15 @@ export default function SelectFromGrid(container, props) {
   // ── Update handler ────────────────────────────────────────────────────────
   function handleUpdate(newProps) {
     onChangeRef = newProps.onChange;
-    isDisabled = newProps.disabled || false;
-    colSlider.disabled = isDisabled;
-    squareBtn.disabled = isDisabled;
-    masonryBtn.disabled = isDisabled;
-    clearBtn.disabled = isDisabled;
+    isDisabled  = newProps.disabled || false;
+    setDisabled(isDisabled);
 
-    const newVal = newProps.value || {};
-    const newItems = newVal.items || [];
-    const newSelected = newVal.selected_indices || [];
-    const newColumns = newVal.columns || 3;
-    const newLayout = newVal.layout || "square";
+    const newVal        = newProps.value || {};
+    const newItems      = newVal.items             || [];
+    const newSelected   = newVal.selected_indices   || [];
+    const newColumns    = newVal.columns            || 3;
+    const newLayout     = newVal.layout             || "square";
+    const newMultiSelect = (newVal.settings?.multi_select) !== false;
 
     let needsRender = false;
 
@@ -693,28 +424,32 @@ export default function SelectFromGrid(container, props) {
       items = newItems;
       needsRender = true;
     }
-
     if (JSON.stringify(newSelected) !== JSON.stringify(selectedIndices)) {
       selectedIndices = newSelected;
       needsRender = true;
     }
-
     if (newColumns !== columns) {
       columns = newColumns;
-      colSlider.value = columns;
+      colSlider.value   = columns;
       colVal.textContent = columns;
       needsRender = true;
     }
-
     if (newLayout !== layout) {
       layout = newLayout;
-      squareBtn.classList.toggle("active", layout === "square");
+      squareBtn.classList.toggle("active",  layout === "square");
       masonryBtn.classList.toggle("active", layout === "masonry");
       needsRender = true;
     }
+    if (newMultiSelect !== multiSelect) {
+      multiSelect = newMultiSelect;
+      // If switching to single-select with multiple items selected, clear down to none
+      if (!multiSelect && selectedIndices.length > 1) {
+        selectedIndices = [];
+        needsRender = true;
+      }
+    }
 
     latestValue = newVal;
-
     if (needsRender) renderGrid();
   }
 

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -66,7 +66,7 @@ export default function SelectFromGrid(container, props) {
   wrapper.className = "sfg-widget nodrag nowheel";
 
   // ── Toolbar ───────────────────────────────────────────────────────────────
-  const { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled } =
+  const { controls, colSlider, colVal, gridBtn, masonryBtn, countEl, clearBtn, setDisabled } =
     createToolbar({
       layout, columns, isDisabled,
       onColumnsChange(n) { columns = n; renderGrid(/* skeleton */ true); },
@@ -227,6 +227,15 @@ export default function SelectFromGrid(container, props) {
       spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
     };
 
+    const showError = () => {
+      inner.classList.remove("sfg-loading");
+      if (spinner) spinner.remove();
+      const card = document.createElement("div");
+      card.className = "sfg-error-card";
+      card.appendChild(mkIcon("alert-circle", 28));
+      inner.appendChild(card);
+    };
+
     switch (item.type) {
       case "image": {
         const img    = document.createElement("img");
@@ -238,10 +247,7 @@ export default function SelectFromGrid(container, props) {
           img.classList.add("sfg-loaded");
           fadeOutSpinner();
         });
-        img.addEventListener("error", () => {
-          inner.classList.remove("sfg-loading");
-          if (spinner) spinner.remove();
-        });
+        img.addEventListener("error", showError);
         inner.appendChild(img);
         break;
       }
@@ -258,10 +264,7 @@ export default function SelectFromGrid(container, props) {
           vid.classList.add("sfg-loaded");
           fadeOutSpinner();
         });
-        vid.addEventListener("error", () => {
-          inner.classList.remove("sfg-loading");
-          if (spinner) spinner.remove();
-        });
+        vid.addEventListener("error", showError);
         cell.addEventListener("mouseenter", () => void vid.play().catch(() => {}));
         cell.addEventListener("mouseleave", () => { vid.pause(); vid.currentTime = 0; });
         inner.appendChild(vid);
@@ -279,6 +282,14 @@ export default function SelectFromGrid(container, props) {
           audio.controls = true;
           audio.addEventListener("pointerdown", (e) => e.stopPropagation());
           audio.addEventListener("click",       (e) => e.stopPropagation());
+          audio.addEventListener("error", () => {
+            card.replaceWith((() => {
+              const e = document.createElement("div");
+              e.className = "sfg-error-card";
+              e.appendChild(mkIcon("alert-circle", 28));
+              return e;
+            })());
+          });
           card.appendChild(audio);
         }
         inner.appendChild(card);
@@ -550,7 +561,7 @@ export default function SelectFromGrid(container, props) {
     }
     if (newLayout !== layout) {
       layout = newLayout;
-      squareBtn.classList.toggle("active",  layout === "grid");
+      gridBtn.classList.toggle("active",  layout === "grid");
       masonryBtn.classList.toggle("active", layout === "masonry");
       needsRender = true;
     }

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -1,4 +1,4 @@
-import { ACCENT, ACCENT_RGB, CARD_HUES, CARD_HEIGHTS, injectStyles } from './_styles.js';
+import { CARD_HUES, CARD_HEIGHTS, injectStyles } from './_styles.js';
 import { mkIcon } from './_icons.js';
 import { createToolbar } from './_toolbar.js';
 
@@ -13,7 +13,7 @@ import { createToolbar } from './_toolbar.js';
 //   items            array   Serialised list items (set by the Python node).
 //   selected_indices array   Zero-based indices of currently selected items.
 //   columns          number  Number of columns (1–8). User-adjustable via slider.
-//   layout           string  "square" | "masonry". User-adjustable via toggle.
+//   layout           string  "grid" | "masonry". User-adjustable via toggle.
 //   settings         object  Node-author configuration — not shown to the user.
 //
 // SETTINGS (set once in the Python node, preserved across list updates)
@@ -58,7 +58,7 @@ export default function SelectFromGrid(container, props) {
   let items           = latestValue.items           || [];
   let selectedIndices = latestValue.selected_indices || [];
   let columns         = latestValue.columns          || 3;
-  let layout          = latestValue.layout           || "square";
+  let layout          = latestValue.layout           || "grid";
   let multiSelect     = (latestValue.settings?.multi_select) !== false;
 
   // ── DOM: wrapper ──────────────────────────────────────────────────────────
@@ -69,8 +69,9 @@ export default function SelectFromGrid(container, props) {
   const { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled } =
     createToolbar({
       layout, columns, isDisabled,
-      onColumnsChange(n) { columns = n; renderGrid(); emitChange(); },
-      onLayoutChange(l)  { layout  = l; renderGrid(); emitChange(); },
+      onColumnsChange(n) { columns = n; renderGrid(/* skeleton */ true); },
+      onColumnsCommit(n) { columns = n; animateGridChange(); emitChange(); },
+      onLayoutChange(l)  { layout = l; animateGridChange(); emitChange(); },
       onClear()          {
         if (selectedIndices.length === 0) return;
         selectedIndices = [];
@@ -107,11 +108,30 @@ export default function SelectFromGrid(container, props) {
     clearBtn.classList.toggle("active", has);
   }
 
+  function updateGridRows() {
+    // Set grid-auto-rows to the pixel column width so cells are always 1:1.
+    // CSS aspect-ratio on grid items is unreliable for row-track sizing cross-browser.
+    const gap = 5;
+    const w   = grid.clientWidth;
+    const rowH = (w - (columns - 1) * gap) / columns;
+    grid.style.gridAutoRows = rowH > 0 ? `${rowH}px` : "";
+  }
+
   function applyGridLayout() {
     const isMasonry = layout === "masonry";
     grid.classList.toggle("layout-masonry", isMasonry);
-    grid.style.gridTemplateColumns = isMasonry ? "" : `repeat(${columns}, 1fr)`;
+    if (isMasonry) {
+      grid.style.gridTemplateColumns = "";
+      grid.style.gridAutoRows = "";
+    } else {
+      grid.style.gridTemplateColumns = `repeat(${columns}, 1fr)`;
+      updateGridRows();
+    }
   }
+
+  // Keep grid rows square when the node is resized
+  const gridRO = new ResizeObserver(() => { if (layout !== "masonry") updateGridRows(); });
+  gridRO.observe(grid);
 
   function mkSpinner() {
     const s = document.createElement("div");
@@ -120,10 +140,21 @@ export default function SelectFromGrid(container, props) {
     return s;
   }
 
-  function buildCellContent(cell, item, idx) {
+  function buildCellContent(cell, item, idx, skeleton = false) {
     cell.dataset.idx = idx;
     const inner = document.createElement("div");
     inner.className = "sfg-cell-inner";
+
+    if (skeleton) {
+      // During column-slider drag: hued placeholder only — no media loading.
+      inner.style.background = `hsla(${CARD_HUES[idx % CARD_HUES.length]}, 22%, 50%, 0.09)`;
+      if (layout === "masonry") {
+        inner.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
+      }
+      // Grid cells get their height from grid-auto-rows; no extra class needed.
+      cell.appendChild(inner);
+      return;
+    }
 
     switch (item.type) {
       case "image": {
@@ -225,7 +256,45 @@ export default function SelectFromGrid(container, props) {
     }
   }
 
-  function renderGrid() {
+  function animateGridChange() {
+    const cells = [...grid.querySelectorAll(".sfg-cell")];
+    const EXIT_MS = 110;
+
+    // Phase 1 — scale + fade existing cells out with a short stagger
+    cells.forEach((cell, i) => {
+      const delay = Math.min(i * 6, 40);
+      cell.style.transition =
+        `opacity ${EXIT_MS}ms ease ${delay}ms, transform ${EXIT_MS}ms ease ${delay}ms`;
+      cell.style.opacity   = "0";
+      cell.style.transform = "scale(0.82)";
+    });
+
+    setTimeout(() => {
+      renderGrid();
+
+      // Phase 3 — start new cells invisible/shrunk, then animate in with stagger
+      const entering = [...grid.querySelectorAll(".sfg-cell")];
+      entering.forEach((cell) => {
+        cell.style.transition = "none";
+        cell.style.opacity    = "0";
+        cell.style.transform  = "scale(0.88)";
+      });
+
+      // Two rAF passes ensure the browser has committed the hidden state
+      // before we start the entering transition.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        entering.forEach((cell, i) => {
+          const delay = Math.min(i * 12, 90);
+          cell.style.transition =
+            `opacity 0.2s ease ${delay}ms, transform 0.22s cubic-bezier(0.34,1.56,0.64,1) ${delay}ms`;
+          cell.style.opacity   = "";
+          cell.style.transform = "";
+        });
+      }));
+    }, EXIT_MS + Math.min(cells.length * 6, 40) + 20);
+  }
+
+  function renderGrid(skeleton = false) {
     grid.innerHTML = "";
     applyGridLayout();
 
@@ -248,14 +317,14 @@ export default function SelectFromGrid(container, props) {
       items.forEach((item, idx) => {
         const cell = document.createElement("div");
         cell.className = "sfg-cell" + (selectedIndices.includes(idx) ? " selected" : "");
-        buildCellContent(cell, item, idx);
+        buildCellContent(cell, item, idx, skeleton);
         cols[idx % columns].appendChild(cell);
       });
     } else {
       items.forEach((item, idx) => {
         const cell = document.createElement("div");
         cell.className = "sfg-cell" + (selectedIndices.includes(idx) ? " selected" : "");
-        buildCellContent(cell, item, idx);
+        buildCellContent(cell, item, idx, skeleton);
         grid.appendChild(cell);
       });
     }
@@ -415,7 +484,7 @@ export default function SelectFromGrid(container, props) {
     const newItems      = newVal.items             || [];
     const newSelected   = newVal.selected_indices   || [];
     const newColumns    = newVal.columns            || 3;
-    const newLayout     = newVal.layout             || "square";
+    const newLayout     = newVal.layout             || "grid";
     const newMultiSelect = (newVal.settings?.multi_select) !== false;
 
     let needsRender = false;
@@ -436,7 +505,7 @@ export default function SelectFromGrid(container, props) {
     }
     if (newLayout !== layout) {
       layout = newLayout;
-      squareBtn.classList.toggle("active",  layout === "square");
+      squareBtn.classList.toggle("active",  layout === "grid");
       masonryBtn.classList.toggle("active", layout === "masonry");
       needsRender = true;
     }
@@ -455,6 +524,7 @@ export default function SelectFromGrid(container, props) {
 
   // ── Cleanup ───────────────────────────────────────────────────────────────
   function cleanup() {
+    gridRO.disconnect();
     wrapper.remove();
     delete container._sfgInst;
   }

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -70,6 +70,7 @@ const STYLES = `
   font-size: 10px;
   color: var(--muted-foreground);
 }
+.sfg-count.active { color: var(--foreground); }
 
 .sfg-clear-btn {
   padding: 2px 8px;
@@ -84,6 +85,7 @@ const STYLES = `
   flex-shrink: 0;
 }
 .sfg-clear-btn:hover { background: var(--muted); color: var(--foreground); }
+.sfg-clear-btn.active { color: var(--foreground); border-color: rgba(${ACCENT_RGB},0.5); }
 .sfg-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ── Grid layouts ─────────────────────────────────────────────── */
@@ -137,6 +139,7 @@ const STYLES = `
   box-sizing: border-box;
 }
 .sfg-cell:hover { border-color: rgba(${ACCENT_RGB},0.45); }
+.sfg-cell.pending { border-color: rgba(${ACCENT_RGB},0.7); background: rgba(${ACCENT_RGB},0.08); }
 .sfg-cell.selected { border-color: ${ACCENT}; }
 
 /* Checkmark badge on selected cells */
@@ -372,7 +375,10 @@ export default function SelectFromGrid(container, props) {
   }
 
   function updateCount() {
-    countEl.textContent = selectedIndices.length > 0 ? `${selectedIndices.length} selected` : "";
+    const has = selectedIndices.length > 0;
+    countEl.textContent = has ? `${selectedIndices.length} selected` : "";
+    countEl.classList.toggle("active", has);
+    clearBtn.classList.toggle("active", has);
   }
 
   function applyGridLayout() {
@@ -539,11 +545,28 @@ export default function SelectFromGrid(container, props) {
       dragState.dragging = true;
     }
     if (dragState.dragging) {
+      const selLeft = Math.min(dragState.startX, curX);
+      const selTop = Math.min(dragState.startY, curY);
+      const selRight = Math.max(dragState.startX, curX);
+      const selBottom = Math.max(dragState.startY, curY);
+
       Object.assign(dragState.lasso.style, {
-        left: Math.min(dragState.startX, curX) + "px",
-        top: Math.min(dragState.startY, curY) + "px",
+        left: selLeft + "px",
+        top: selTop + "px",
         width: Math.abs(dx) + "px",
         height: Math.abs(dy) + "px",
+      });
+
+      // Mark cells that the lasso covers (and aren't already selected) as pending
+      grid.querySelectorAll(".sfg-cell").forEach((cell) => {
+        const r = cell.getBoundingClientRect();
+        const gRect = grid.getBoundingClientRect();
+        const cLeft = r.left - gRect.left + grid.scrollLeft;
+        const cTop = r.top - gRect.top + grid.scrollTop;
+        const overlaps = cLeft < selRight && (cLeft + r.width) > selLeft &&
+                         cTop < selBottom && (cTop + r.height) > selTop;
+        const idx = parseInt(cell.dataset.idx, 10);
+        cell.classList.toggle("pending", overlaps && !selectedIndices.includes(idx));
       });
     }
   });
@@ -551,6 +574,7 @@ export default function SelectFromGrid(container, props) {
   grid.addEventListener("pointerup", (e) => {
     if (!dragState) return;
     dragState.lasso.remove();
+    grid.querySelectorAll(".sfg-cell.pending").forEach((c) => c.classList.remove("pending"));
 
     if (dragState.dragging) {
       const gridRect = grid.getBoundingClientRect();
@@ -597,7 +621,11 @@ export default function SelectFromGrid(container, props) {
   });
 
   grid.addEventListener("pointercancel", () => {
-    if (dragState) { dragState.lasso.remove(); dragState = null; }
+    if (dragState) {
+      dragState.lasso.remove();
+      grid.querySelectorAll(".sfg-cell.pending").forEach((c) => c.classList.remove("pending"));
+      dragState = null;
+    }
   });
 
   // ── Wire controls ─────────────────────────────────────────────────────────
@@ -605,7 +633,7 @@ export default function SelectFromGrid(container, props) {
   colSlider.addEventListener("input", () => {
     columns = parseInt(colSlider.value, 10);
     colVal.textContent = columns;
-    applyGridLayout();
+    renderGrid();
     emitChange();
   });
 

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -133,6 +133,14 @@ export default function SelectFromGrid(container, props) {
   const gridRO = new ResizeObserver(() => { if (layout !== "masonry") updateGridRows(); });
   gridRO.observe(grid);
 
+  // Lazy-hydrate media cells as they scroll into view
+  const cellObserver = new IntersectionObserver(
+    (entries) => entries.forEach(({ isIntersecting, target }) => {
+      if (isIntersecting) hydrateCell(target);
+    }),
+    { root: grid, rootMargin: "300px 0px", threshold: 0 }
+  );
+
   function mkSpinner() {
     const s = document.createElement("div");
     s.className = "sfg-spinner";
@@ -146,103 +154,40 @@ export default function SelectFromGrid(container, props) {
     inner.className = "sfg-cell-inner";
 
     if (skeleton) {
-      // During column-slider drag: hued placeholder only — no media loading.
       inner.style.background = `hsla(${CARD_HUES[idx % CARD_HUES.length]}, 22%, 50%, 0.09)`;
-      if (layout === "masonry") {
-        inner.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
-      }
-      // Grid cells get their height from grid-auto-rows; no extra class needed.
+      if (layout === "masonry") inner.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
       cell.appendChild(inner);
       return;
     }
 
-    switch (item.type) {
-      case "image": {
-        inner.classList.add("sfg-loading");
-        const spinner = mkSpinner();
-        inner.appendChild(spinner);
-        if (item.url) {
-          const img = document.createElement("img");
-          img.src      = item.url;
-          img.alt      = item.label || "";
-          img.loading  = "lazy";
-          img.decoding = "async";
-          const fadeIn = () => {
-            inner.classList.remove("sfg-loading");
-            img.classList.add("sfg-loaded");
-            spinner.style.opacity = "0";
-            spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
-          };
-          img.addEventListener("load",  fadeIn);
-          img.addEventListener("error", () => { inner.classList.remove("sfg-loading"); spinner.remove(); });
-          inner.appendChild(img);
-        }
-        break;
-      }
-      case "video": {
-        inner.classList.add("sfg-loading");
-        const spinner = mkSpinner();
-        inner.appendChild(spinner);
-        if (item.url) {
-          const vid = document.createElement("video");
-          vid.src         = item.url;
-          vid.muted       = true;
-          vid.loop        = true;
-          vid.playsInline = true;
-          vid.preload     = "metadata";
-          vid.addEventListener("loadedmetadata", () => {
-            inner.classList.remove("sfg-loading");
-            vid.currentTime = 0.001;
-            vid.classList.add("sfg-loaded");
-            spinner.style.opacity = "0";
-            spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
-          });
-          vid.addEventListener("error", () => { inner.classList.remove("sfg-loading"); spinner.remove(); });
-          cell.addEventListener("mouseenter", () => void vid.play().catch(() => {}));
-          cell.addEventListener("mouseleave", () => { vid.pause(); vid.currentTime = 0; });
-          inner.appendChild(vid);
-        }
-        break;
-      }
-      case "audio": {
-        const card = document.createElement("div");
-        card.className = "sfg-audio-card";
-        card.appendChild(mkIcon("music", 28));
-        if (item.url) {
-          const audio = document.createElement("audio");
-          audio.src      = item.url;
-          audio.controls = true;
-          audio.addEventListener("pointerdown", (e) => e.stopPropagation());
-          audio.addEventListener("click",       (e) => e.stopPropagation());
-          card.appendChild(audio);
-        }
-        inner.appendChild(card);
-        break;
-      }
-      case "dict": {
-        const dictEl = document.createElement("div");
-        dictEl.className   = "sfg-dict-card";
-        dictEl.textContent = item.value || "{}";
-        inner.appendChild(dictEl);
-        break;
-      }
-      default: {
-        const displayText = item.value !== undefined ? String(item.value) : (item.label || "");
+    const isMedia = item.type === "image" || item.type === "video" || item.type === "audio";
 
-        const hue  = CARD_HUES[idx % CARD_HUES.length];
-        const card = document.createElement("div");
-        card.className        = "sfg-quote-card";
-        card.style.background = `hsla(${hue}, 22%, 50%, 0.09)`;
-        if (layout === "masonry") {
-          card.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
+    if (isMedia) {
+      // Spinner placeholder only — media element created lazily by cellObserver
+      inner.classList.add("sfg-loading");
+      inner.appendChild(mkSpinner());
+    } else {
+      switch (item.type) {
+        case "dict": {
+          const dictEl = document.createElement("div");
+          dictEl.className   = "sfg-dict-card";
+          dictEl.textContent = item.value || "{}";
+          inner.appendChild(dictEl);
+          break;
         }
-
-        const textEl = document.createElement("div");
-        textEl.className   = "sfg-quote-text";
-        textEl.textContent = displayText;
-        card.appendChild(textEl);
-        inner.appendChild(card);
-        break;
+        default: {
+          const hue  = CARD_HUES[idx % CARD_HUES.length];
+          const card = document.createElement("div");
+          card.className        = "sfg-quote-card";
+          card.style.background = `hsla(${hue}, 22%, 50%, 0.09)`;
+          if (layout === "masonry") card.style.minHeight = CARD_HEIGHTS[idx % CARD_HEIGHTS.length] + "px";
+          const textEl = document.createElement("div");
+          textEl.className   = "sfg-quote-text";
+          textEl.textContent = item.value !== undefined ? String(item.value) : (item.label || "");
+          card.appendChild(textEl);
+          inner.appendChild(card);
+          break;
+        }
       }
     }
 
@@ -253,6 +198,92 @@ export default function SelectFromGrid(container, props) {
       lbl.className   = "sfg-item-label";
       lbl.textContent = item.label;
       cell.appendChild(lbl);
+    }
+
+    if (isMedia) cellObserver.observe(cell);
+  }
+
+  function hydrateCell(cell) {
+    if (cell.dataset.hydrated === "true") return;
+
+    const idx  = parseInt(cell.dataset.idx, 10);
+    const item = items[idx];
+    if (!item) return;
+
+    // If the URL hasn't arrived yet (phase-1 placeholder), wait — phase 2 will
+    // trigger a full renderGrid() which rebuilds the cell with the real URL.
+    if ((item.type === "image" || item.type === "video") && !item.url) return;
+
+    cell.dataset.hydrated = "true";
+    cellObserver.unobserve(cell);
+
+    const inner   = cell.querySelector(".sfg-cell-inner");
+    if (!inner) return;
+    const spinner = inner.querySelector(".sfg-spinner");
+
+    const fadeOutSpinner = () => {
+      if (!spinner) return;
+      spinner.style.opacity = "0";
+      spinner.addEventListener("transitionend", () => spinner.remove(), { once: true });
+    };
+
+    switch (item.type) {
+      case "image": {
+        const img    = document.createElement("img");
+        img.src      = item.url;
+        img.alt      = item.label || "";
+        img.decoding = "async";
+        img.addEventListener("load", () => {
+          inner.classList.remove("sfg-loading");
+          img.classList.add("sfg-loaded");
+          fadeOutSpinner();
+        });
+        img.addEventListener("error", () => {
+          inner.classList.remove("sfg-loading");
+          if (spinner) spinner.remove();
+        });
+        inner.appendChild(img);
+        break;
+      }
+      case "video": {
+        const vid       = document.createElement("video");
+        vid.src         = item.url;
+        vid.muted       = true;
+        vid.loop        = true;
+        vid.playsInline = true;
+        vid.preload     = "metadata";
+        vid.addEventListener("loadedmetadata", () => {
+          inner.classList.remove("sfg-loading");
+          vid.currentTime = 0.001;
+          vid.classList.add("sfg-loaded");
+          fadeOutSpinner();
+        });
+        vid.addEventListener("error", () => {
+          inner.classList.remove("sfg-loading");
+          if (spinner) spinner.remove();
+        });
+        cell.addEventListener("mouseenter", () => void vid.play().catch(() => {}));
+        cell.addEventListener("mouseleave", () => { vid.pause(); vid.currentTime = 0; });
+        inner.appendChild(vid);
+        break;
+      }
+      case "audio": {
+        inner.classList.remove("sfg-loading");
+        if (spinner) spinner.remove();
+        const card = document.createElement("div");
+        card.className = "sfg-audio-card";
+        card.appendChild(mkIcon("music", 28));
+        if (item.url) {
+          const audio    = document.createElement("audio");
+          audio.src      = item.url;
+          audio.controls = true;
+          audio.addEventListener("pointerdown", (e) => e.stopPropagation());
+          audio.addEventListener("click",       (e) => e.stopPropagation());
+          card.appendChild(audio);
+        }
+        inner.appendChild(card);
+        break;
+      }
     }
   }
 
@@ -347,13 +378,37 @@ export default function SelectFromGrid(container, props) {
     return null;
   }
 
+  // Convert a viewport point to the grid's local (pre-transform) coordinate space.
+  // When React Flow zooms the canvas it applies a CSS scale to an ancestor; all
+  // getBoundingClientRect values are in post-scale screen pixels, but CSS position
+  // values (left/top) and scrollLeft/scrollTop are in pre-scale local pixels.
+  function clientToLocal(clientX, clientY) {
+    const gr    = grid.getBoundingClientRect();
+    const scale = gr.width > 0 ? gr.width / grid.offsetWidth : 1;
+    return {
+      x: (clientX - gr.left) / scale + grid.scrollLeft,
+      y: (clientY - gr.top)  / scale + grid.scrollTop,
+    };
+  }
+
+  // Return a cell's rect in the same local coordinate space as clientToLocal.
+  function cellLocalRect(cell) {
+    const cr    = cell.getBoundingClientRect();
+    const gr    = grid.getBoundingClientRect();
+    const scale = gr.width > 0 ? gr.width / grid.offsetWidth : 1;
+    return {
+      left:   (cr.left - gr.left) / scale + grid.scrollLeft,
+      top:    (cr.top  - gr.top)  / scale + grid.scrollTop,
+      width:  cr.width  / scale,
+      height: cr.height / scale,
+    };
+  }
+
   grid.addEventListener("pointerdown", (e) => {
     if (isDisabled || e.button !== 0) return;
     e.stopPropagation();
 
-    const gridRect = grid.getBoundingClientRect();
-    const startX   = e.clientX - gridRect.left + grid.scrollLeft;
-    const startY   = e.clientY - gridRect.top  + grid.scrollTop;
+    const { x: startX, y: startY } = clientToLocal(e.clientX, e.clientY);
 
     // Lasso is only created in multi-select mode
     let lasso = null;
@@ -370,11 +425,9 @@ export default function SelectFromGrid(container, props) {
 
   grid.addEventListener("pointermove", (e) => {
     if (!dragState) return;
-    const gridRect = grid.getBoundingClientRect();
-    const curX = e.clientX - gridRect.left + grid.scrollLeft;
-    const curY = e.clientY - gridRect.top  + grid.scrollTop;
-    const dx   = curX - dragState.startX;
-    const dy   = curY - dragState.startY;
+    const { x: curX, y: curY } = clientToLocal(e.clientX, e.clientY);
+    const dx = curX - dragState.startX;
+    const dy = curY - dragState.startY;
 
     if (!dragState.dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) dragState.dragging = true;
 
@@ -392,12 +445,9 @@ export default function SelectFromGrid(container, props) {
       });
 
       grid.querySelectorAll(".sfg-cell").forEach((cell) => {
-        const r     = cell.getBoundingClientRect();
-        const gRect = grid.getBoundingClientRect();
-        const cLeft = r.left - gRect.left + grid.scrollLeft;
-        const cTop  = r.top  - gRect.top  + grid.scrollTop;
-        const overlaps = cLeft < selRight  && (cLeft + r.width)  > selLeft &&
-                         cTop  < selBottom && (cTop  + r.height) > selTop;
+        const { left: cLeft, top: cTop, width: cW, height: cH } = cellLocalRect(cell);
+        const overlaps = cLeft < selRight  && (cLeft + cW) > selLeft &&
+                         cTop  < selBottom && (cTop  + cH) > selTop;
         const idx = parseInt(cell.dataset.idx, 10);
         cell.classList.toggle("pending", overlaps && !selectedIndices.includes(idx));
       });
@@ -411,9 +461,7 @@ export default function SelectFromGrid(container, props) {
 
     if (dragState.dragging && dragState.lasso) {
       // Multi-select lasso: add all cells in the rect to the selection
-      const gridRect  = grid.getBoundingClientRect();
-      const curX      = e.clientX - gridRect.left + grid.scrollLeft;
-      const curY      = e.clientY - gridRect.top  + grid.scrollTop;
+      const { x: curX, y: curY } = clientToLocal(e.clientX, e.clientY);
       const selLeft   = Math.min(dragState.startX, curX);
       const selTop    = Math.min(dragState.startY, curY);
       const selRight  = Math.max(dragState.startX, curX);
@@ -421,12 +469,9 @@ export default function SelectFromGrid(container, props) {
 
       let changed = false;
       grid.querySelectorAll(".sfg-cell").forEach((cell) => {
-        const r      = cell.getBoundingClientRect();
-        const gRect2 = grid.getBoundingClientRect();
-        const cLeft  = r.left - gRect2.left + grid.scrollLeft;
-        const cTop   = r.top  - gRect2.top  + grid.scrollTop;
-        if (cLeft < selRight && (cLeft + r.width) > selLeft &&
-            cTop  < selBottom && (cTop  + r.height) > selTop) {
+        const { left: cLeft, top: cTop, width: cW, height: cH } = cellLocalRect(cell);
+        if (cLeft < selRight && (cLeft + cW) > selLeft &&
+            cTop  < selBottom && (cTop  + cH) > selTop) {
           const idx = parseInt(cell.dataset.idx, 10);
           if (!isNaN(idx) && !selectedIndices.includes(idx)) {
             selectedIndices = [...selectedIndices, idx];
@@ -525,6 +570,7 @@ export default function SelectFromGrid(container, props) {
   // ── Cleanup ───────────────────────────────────────────────────────────────
   function cleanup() {
     gridRO.disconnect();
+    cellObserver.disconnect();
     wrapper.remove();
     delete container._sfgInst;
   }

--- a/widgets/SelectFromGrid/SelectFromGrid.js
+++ b/widgets/SelectFromGrid/SelectFromGrid.js
@@ -1,0 +1,701 @@
+const WIDGET_VERSION = "1.1.0";
+
+const ACCENT       = "#7a9db8";
+const ACCENT_RGB   = "122,157,184";
+
+const STYLES = `
+.sfg-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.sfg-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sfg-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.sfg-slider {
+  width: 80px;
+  accent-color: ${ACCENT};
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.sfg-slider:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.sfg-layout-btns {
+  display: flex;
+  gap: 4px;
+}
+.sfg-layout-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  cursor: pointer;
+  line-height: 18px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sfg-layout-btn:hover { background: var(--muted); color: var(--foreground); }
+.sfg-layout-btn.active {
+  background: rgba(${ACCENT_RGB},0.2);
+  border-color: ${ACCENT};
+  color: var(--foreground);
+}
+.sfg-layout-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.sfg-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--muted-foreground);
+}
+
+.sfg-clear-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  cursor: pointer;
+  line-height: 18px;
+  transition: background 0.12s, color 0.12s;
+  flex-shrink: 0;
+}
+.sfg-clear-btn:hover { background: var(--muted); color: var(--foreground); }
+.sfg-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Grid layouts ─────────────────────────────────────────────── */
+.sfg-grid {
+  display: grid;
+  gap: 5px;
+  position: relative;
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.sfg-grid::-webkit-scrollbar { width: 6px; }
+.sfg-grid::-webkit-scrollbar-track { background: transparent; }
+.sfg-grid::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+.sfg-grid.layout-masonry {
+  display: flex;
+  align-items: flex-start;
+}
+.sfg-masonry-col {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 5px;
+  min-width: 0;
+}
+
+/* ── Lasso / box-select rect ──────────────────────────────────── */
+.sfg-lasso {
+  position: absolute;
+  border: 1.5px dashed ${ACCENT};
+  background: rgba(${ACCENT_RGB},0.10);
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* ── Cells ────────────────────────────────────────────────────── */
+.sfg-cell {
+  position: relative;
+  border-radius: 5px;
+  overflow: hidden;
+  cursor: pointer;
+  border: 2px solid transparent;
+  background: var(--muted);
+  transition: border-color 0.12s;
+  box-sizing: border-box;
+}
+.sfg-cell:hover { border-color: rgba(${ACCENT_RGB},0.45); }
+.sfg-cell.selected { border-color: ${ACCENT}; }
+
+/* Checkmark badge on selected cells */
+.sfg-cell.selected::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: ${ACCENT}
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E")
+    no-repeat center / 11px;
+  z-index: 3;
+  pointer-events: none;
+}
+
+/* ── Square inner frame ───────────────────────────────────────── */
+.sfg-cell-inner {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111;
+}
+.layout-masonry .sfg-cell-inner {
+  aspect-ratio: unset;
+}
+
+/* ── Media elements ───────────────────────────────────────────── */
+.sfg-cell img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+.layout-masonry .sfg-cell img {
+  height: auto;
+}
+
+.sfg-cell video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+.layout-masonry .sfg-cell video {
+  height: auto;
+}
+
+/* ── Audio card ───────────────────────────────────────────────── */
+.sfg-audio-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 8px;
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(0,0,0,0.3);
+}
+.sfg-audio-icon {
+  font-size: 28px;
+  line-height: 1;
+  pointer-events: none;
+}
+.sfg-audio-card audio {
+  width: 100%;
+  height: 28px;
+  accent-color: ${ACCENT};
+}
+
+/* ── Text / dict cards ────────────────────────────────────────── */
+.sfg-text-card {
+  padding: 10px;
+  font-size: 11px;
+  color: var(--foreground);
+  word-break: break-word;
+  text-align: center;
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sfg-dict-card {
+  padding: 8px;
+  font-size: 9px;
+  font-family: monospace;
+  color: var(--muted-foreground);
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 110px;
+  display: -webkit-box;
+  -webkit-line-clamp: 7;
+  -webkit-box-orient: vertical;
+}
+
+/* ── Label overlay ────────────────────────────────────────────── */
+.sfg-item-label {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3px 5px;
+  font-size: 10px;
+  background: rgba(0,0,0,0.55);
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Empty state ──────────────────────────────────────────────── */
+.sfg-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+`;
+
+function injectStyles() {
+  if (document.getElementById("sfg-widget-styles")) return;
+  const el = document.createElement("style");
+  el.id = "sfg-widget-styles";
+  el.textContent = STYLES;
+  document.head.appendChild(el);
+}
+
+export default function SelectFromGrid(container, props) {
+  // ── Mount guard ───────────────────────────────────────────────────────────
+  if (container._sfgInst?.wrapper?.isConnected) {
+    container._sfgInst.handleUpdate(props);
+    return { cleanup: container._sfgInst.cleanup, update: container._sfgInst.handleUpdate };
+  }
+  if (container._sfgInst) delete container._sfgInst;
+
+  injectStyles();
+
+  // ── State ─────────────────────────────────────────────────────────────────
+  let latestValue = props.value || {};
+  let onChangeRef = props.onChange;
+  let isDisabled = props.disabled || false;
+
+  let items = latestValue.items || [];
+  let selectedIndices = latestValue.selected_indices || [];
+  let columns = latestValue.columns || 3;
+  let layout = latestValue.layout || "square";
+
+  // ── DOM: wrapper ──────────────────────────────────────────────────────────
+  const wrapper = document.createElement("div");
+  wrapper.className = "sfg-widget nodrag nowheel";
+
+  // ── DOM: controls ─────────────────────────────────────────────────────────
+  const controls = document.createElement("div");
+  controls.className = "sfg-controls";
+
+  const colLabel = document.createElement("label");
+  colLabel.className = "sfg-label";
+  colLabel.textContent = "Columns ";
+
+  const colSlider = document.createElement("input");
+  colSlider.type = "range";
+  colSlider.className = "sfg-slider";
+  colSlider.min = 1;
+  colSlider.max = 8;
+  colSlider.value = columns;
+  colSlider.disabled = isDisabled;
+  colLabel.appendChild(colSlider);
+
+  const colVal = document.createElement("span");
+  colVal.textContent = columns;
+  colLabel.appendChild(colVal);
+
+  const layoutBtns = document.createElement("div");
+  layoutBtns.className = "sfg-layout-btns";
+
+  const squareBtn = document.createElement("button");
+  squareBtn.type = "button";
+  squareBtn.className = "sfg-layout-btn" + (layout === "square" ? " active" : "");
+  squareBtn.textContent = "Square";
+  squareBtn.disabled = isDisabled;
+
+  const masonryBtn = document.createElement("button");
+  masonryBtn.type = "button";
+  masonryBtn.className = "sfg-layout-btn" + (layout === "masonry" ? " active" : "");
+  masonryBtn.textContent = "Masonry";
+  masonryBtn.disabled = isDisabled;
+
+  layoutBtns.appendChild(squareBtn);
+  layoutBtns.appendChild(masonryBtn);
+
+  const countEl = document.createElement("span");
+  countEl.className = "sfg-count";
+
+  const clearBtn = document.createElement("button");
+  clearBtn.type = "button";
+  clearBtn.className = "sfg-clear-btn";
+  clearBtn.textContent = "Clear";
+  clearBtn.disabled = isDisabled;
+
+  controls.appendChild(colLabel);
+  controls.appendChild(layoutBtns);
+  controls.appendChild(countEl);
+  controls.appendChild(clearBtn);
+  wrapper.appendChild(controls);
+
+  // ── DOM: grid ─────────────────────────────────────────────────────────────
+  const grid = document.createElement("div");
+  grid.className = "sfg-grid";
+  wrapper.appendChild(grid);
+
+  container.appendChild(wrapper);
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+  function emitChange() {
+    onChangeRef({
+      ...(latestValue || {}),
+      items,
+      selected_indices: selectedIndices,
+      columns,
+      layout,
+    });
+  }
+
+  function updateCount() {
+    countEl.textContent = selectedIndices.length > 0 ? `${selectedIndices.length} selected` : "";
+  }
+
+  function applyGridLayout() {
+    const isMasonry = layout === "masonry";
+    grid.classList.toggle("layout-masonry", isMasonry);
+    grid.style.gridTemplateColumns = isMasonry ? "" : `repeat(${columns}, 1fr)`;
+  }
+
+  function buildCellContent(cell, item, idx) {
+    cell.dataset.idx = idx;
+    const inner = document.createElement("div");
+    inner.className = "sfg-cell-inner";
+
+    switch (item.type) {
+      case "image": {
+        if (item.url) {
+          const img = document.createElement("img");
+          img.src = item.url;
+          img.alt = item.label || "";
+          img.loading = "lazy";
+          img.decoding = "async";
+          inner.appendChild(img);
+        }
+        break;
+      }
+      case "video": {
+        if (item.url) {
+          const vid = document.createElement("video");
+          vid.src = item.url;
+          vid.muted = true;
+          vid.loop = true;
+          vid.playsInline = true;
+          vid.preload = "metadata";
+          vid.addEventListener("loadedmetadata", () => { vid.currentTime = 0.001; });
+          cell.addEventListener("mouseenter", () => void vid.play().catch(() => {}));
+          cell.addEventListener("mouseleave", () => { vid.pause(); vid.currentTime = 0; });
+          inner.appendChild(vid);
+        }
+        break;
+      }
+      case "audio": {
+        const card = document.createElement("div");
+        card.className = "sfg-audio-card";
+        const icon = document.createElement("div");
+        icon.className = "sfg-audio-icon";
+        icon.textContent = "🎵";
+        card.appendChild(icon);
+        if (item.url) {
+          const audio = document.createElement("audio");
+          audio.src = item.url;
+          audio.controls = true;
+          audio.addEventListener("pointerdown", (e) => e.stopPropagation());
+          audio.addEventListener("click", (e) => e.stopPropagation());
+          card.appendChild(audio);
+        }
+        inner.appendChild(card);
+        break;
+      }
+      case "dict": {
+        const dictEl = document.createElement("div");
+        dictEl.className = "sfg-dict-card";
+        dictEl.textContent = item.value || "{}";
+        inner.appendChild(dictEl);
+        break;
+      }
+      default: {
+        const textEl = document.createElement("div");
+        textEl.className = "sfg-text-card";
+        textEl.textContent = item.value !== undefined ? item.value : (item.label || "");
+        inner.appendChild(textEl);
+      }
+    }
+
+    cell.appendChild(inner);
+
+    if (item.label) {
+      const lbl = document.createElement("div");
+      lbl.className = "sfg-item-label";
+      lbl.textContent = item.label;
+      cell.appendChild(lbl);
+    }
+  }
+
+  function renderGrid() {
+    grid.innerHTML = "";
+    applyGridLayout();
+
+    if (items.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "sfg-empty";
+      empty.textContent = "Connect a list to display items here";
+      grid.appendChild(empty);
+      updateCount();
+      return;
+    }
+
+    if (layout === "masonry") {
+      // Build N flex column wrappers and distribute items round-robin
+      const cols = Array.from({ length: columns }, () => {
+        const col = document.createElement("div");
+        col.className = "sfg-masonry-col";
+        grid.appendChild(col);
+        return col;
+      });
+      items.forEach((item, idx) => {
+        const cell = document.createElement("div");
+        cell.className = "sfg-cell" + (selectedIndices.includes(idx) ? " selected" : "");
+        buildCellContent(cell, item, idx);
+        cols[idx % columns].appendChild(cell);
+      });
+    } else {
+      items.forEach((item, idx) => {
+        const cell = document.createElement("div");
+        cell.className = "sfg-cell" + (selectedIndices.includes(idx) ? " selected" : "");
+        buildCellContent(cell, item, idx);
+        grid.appendChild(cell);
+      });
+    }
+
+    updateCount();
+  }
+
+  // Allow the grid to scroll without React Flow intercepting wheel events
+  grid.addEventListener("wheel", (e) => { e.stopPropagation(); }, { passive: true });
+
+  // ── Box-select / click via event delegation on the grid ───────────────────
+  let dragState = null;
+  const DRAG_THRESHOLD = 5;
+
+  function findCellEl(el) {
+    while (el && el !== grid) {
+      if (el.classList.contains("sfg-cell")) return el;
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  grid.addEventListener("pointerdown", (e) => {
+    if (isDisabled || e.button !== 0) return;
+    e.stopPropagation();
+
+    const gridRect = grid.getBoundingClientRect();
+    const startX = e.clientX - gridRect.left + grid.scrollLeft;
+    const startY = e.clientY - gridRect.top + grid.scrollTop;
+
+    const lasso = document.createElement("div");
+    lasso.className = "sfg-lasso";
+    Object.assign(lasso.style, { left: startX + "px", top: startY + "px", width: "0", height: "0" });
+    grid.appendChild(lasso);
+
+    dragState = { startX, startY, lasso, dragging: false, startCell: findCellEl(e.target) };
+    grid.setPointerCapture(e.pointerId);
+  });
+
+  grid.addEventListener("pointermove", (e) => {
+    if (!dragState) return;
+    const gridRect = grid.getBoundingClientRect();
+    const curX = e.clientX - gridRect.left + grid.scrollLeft;
+    const curY = e.clientY - gridRect.top + grid.scrollTop;
+    const dx = curX - dragState.startX;
+    const dy = curY - dragState.startY;
+
+    if (!dragState.dragging && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
+      dragState.dragging = true;
+    }
+    if (dragState.dragging) {
+      Object.assign(dragState.lasso.style, {
+        left: Math.min(dragState.startX, curX) + "px",
+        top: Math.min(dragState.startY, curY) + "px",
+        width: Math.abs(dx) + "px",
+        height: Math.abs(dy) + "px",
+      });
+    }
+  });
+
+  grid.addEventListener("pointerup", (e) => {
+    if (!dragState) return;
+    dragState.lasso.remove();
+
+    if (dragState.dragging) {
+      const gridRect = grid.getBoundingClientRect();
+      const curX = e.clientX - gridRect.left + grid.scrollLeft;
+      const curY = e.clientY - gridRect.top + grid.scrollTop;
+      const selLeft = Math.min(dragState.startX, curX);
+      const selTop = Math.min(dragState.startY, curY);
+      const selRight = Math.max(dragState.startX, curX);
+      const selBottom = Math.max(dragState.startY, curY);
+
+      let changed = false;
+      grid.querySelectorAll(".sfg-cell").forEach((cell) => {
+        const r = cell.getBoundingClientRect();
+        const gridRect2 = grid.getBoundingClientRect();
+        const cLeft = r.left - gridRect2.left + grid.scrollLeft;
+        const cTop = r.top - gridRect2.top + grid.scrollTop;
+        const cRight = cLeft + r.width;
+        const cBottom = cTop + r.height;
+
+        if (cLeft < selRight && cRight > selLeft && cTop < selBottom && cBottom > selTop) {
+          const idx = parseInt(cell.dataset.idx, 10);
+          if (!isNaN(idx) && !selectedIndices.includes(idx)) {
+            selectedIndices = [...selectedIndices, idx];
+            cell.classList.add("selected");
+            changed = true;
+          }
+        }
+      });
+
+      if (changed) { updateCount(); emitChange(); }
+    } else if (dragState.startCell) {
+      const idx = parseInt(dragState.startCell.dataset.idx, 10);
+      if (!isNaN(idx)) {
+        const pos = selectedIndices.indexOf(idx);
+        if (pos === -1) selectedIndices = [...selectedIndices, idx];
+        else selectedIndices = selectedIndices.filter((i) => i !== idx);
+        dragState.startCell.classList.toggle("selected", selectedIndices.includes(idx));
+        updateCount();
+        emitChange();
+      }
+    }
+
+    dragState = null;
+  });
+
+  grid.addEventListener("pointercancel", () => {
+    if (dragState) { dragState.lasso.remove(); dragState = null; }
+  });
+
+  // ── Wire controls ─────────────────────────────────────────────────────────
+  colSlider.addEventListener("pointerdown", (e) => e.stopPropagation());
+  colSlider.addEventListener("input", () => {
+    columns = parseInt(colSlider.value, 10);
+    colVal.textContent = columns;
+    applyGridLayout();
+    emitChange();
+  });
+
+  squareBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  squareBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (isDisabled) return;
+    layout = "square";
+    squareBtn.classList.add("active");
+    masonryBtn.classList.remove("active");
+    renderGrid();
+    emitChange();
+  });
+
+  masonryBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  masonryBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (isDisabled) return;
+    layout = "masonry";
+    masonryBtn.classList.add("active");
+    squareBtn.classList.remove("active");
+    renderGrid();
+    emitChange();
+  });
+
+  clearBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  clearBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (isDisabled || selectedIndices.length === 0) return;
+    selectedIndices = [];
+    grid.querySelectorAll(".sfg-cell.selected").forEach((c) => c.classList.remove("selected"));
+    updateCount();
+    emitChange();
+  });
+
+  // ── Initial render ────────────────────────────────────────────────────────
+  renderGrid();
+
+  // ── Update handler ────────────────────────────────────────────────────────
+  function handleUpdate(newProps) {
+    onChangeRef = newProps.onChange;
+    isDisabled = newProps.disabled || false;
+    colSlider.disabled = isDisabled;
+    squareBtn.disabled = isDisabled;
+    masonryBtn.disabled = isDisabled;
+    clearBtn.disabled = isDisabled;
+
+    const newVal = newProps.value || {};
+    const newItems = newVal.items || [];
+    const newSelected = newVal.selected_indices || [];
+    const newColumns = newVal.columns || 3;
+    const newLayout = newVal.layout || "square";
+
+    let needsRender = false;
+
+    if (JSON.stringify(newItems) !== JSON.stringify(items)) {
+      items = newItems;
+      needsRender = true;
+    }
+
+    if (JSON.stringify(newSelected) !== JSON.stringify(selectedIndices)) {
+      selectedIndices = newSelected;
+      needsRender = true;
+    }
+
+    if (newColumns !== columns) {
+      columns = newColumns;
+      colSlider.value = columns;
+      colVal.textContent = columns;
+      needsRender = true;
+    }
+
+    if (newLayout !== layout) {
+      layout = newLayout;
+      squareBtn.classList.toggle("active", layout === "square");
+      masonryBtn.classList.toggle("active", layout === "masonry");
+      needsRender = true;
+    }
+
+    latestValue = newVal;
+
+    if (needsRender) renderGrid();
+  }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+  function cleanup() {
+    wrapper.remove();
+    delete container._sfgInst;
+  }
+
+  container._sfgInst = { wrapper, handleUpdate, cleanup };
+  return { cleanup, update: handleUpdate };
+}

--- a/widgets/SelectFromGrid/_icons.js
+++ b/widgets/SelectFromGrid/_icons.js
@@ -3,6 +3,7 @@
 export const ICON_PATHS = {
   "music":         `<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>`,
   "loader-circle": `<path d="M21 12a9 9 0 1 1-6.219-8.56"/>`,
+  "alert-circle":  `<circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>`,
 };
 
 export function mkIcon(name, size = 14) {

--- a/widgets/SelectFromGrid/_icons.js
+++ b/widgets/SelectFromGrid/_icons.js
@@ -1,0 +1,21 @@
+// Lucide SVG icon paths (MIT licensed)
+
+export const ICON_PATHS = {
+  "music":         `<path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/>`,
+  "loader-circle": `<path d="M21 12a9 9 0 1 1-6.219-8.56"/>`,
+};
+
+export function mkIcon(name, size = 14) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", size);
+  svg.setAttribute("height", size);
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.style.cssText = "display:block;flex-shrink:0;pointer-events:none;";
+  svg.innerHTML = ICON_PATHS[name] || "";
+  return svg;
+}

--- a/widgets/SelectFromGrid/_styles.js
+++ b/widgets/SelectFromGrid/_styles.js
@@ -1,0 +1,285 @@
+export const WIDGET_VERSION = "1.1.0";
+
+export const ACCENT     = "#7a9db8";
+export const ACCENT_RGB = "122,157,184";
+
+// Hue palette + masonry heights for text/quote cards — cycled by item index
+export const CARD_HUES    = [202, 162, 267, 322, 42, 82, 132, 232];
+export const CARD_HEIGHTS = [95, 125, 105, 145, 85, 130, 115, 155];
+
+export const STYLES = `
+.sfg-widget {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.sfg-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sfg-label {
+  font-size: 11px;
+  color: var(--muted-foreground);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.sfg-slider {
+  width: 80px;
+  accent-color: ${ACCENT};
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.sfg-slider:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.sfg-layout-btns { display: flex; gap: 4px; }
+.sfg-layout-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  cursor: pointer;
+  line-height: 18px;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.sfg-layout-btn:hover { background: var(--muted); color: var(--foreground); }
+.sfg-layout-btn.active {
+  background: rgba(${ACCENT_RGB},0.2);
+  border-color: ${ACCENT};
+  color: var(--foreground);
+}
+.sfg-layout-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.sfg-count { margin-left: auto; font-size: 10px; color: var(--muted-foreground); }
+.sfg-count.active { color: var(--foreground); }
+
+.sfg-clear-btn {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  cursor: pointer;
+  line-height: 18px;
+  transition: background 0.12s, color 0.12s;
+  flex-shrink: 0;
+}
+.sfg-clear-btn:hover { background: var(--muted); color: var(--foreground); }
+.sfg-clear-btn.active { color: var(--foreground); border-color: rgba(${ACCENT_RGB},0.5); }
+.sfg-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Grid layouts ─────────────────────────────────────────────── */
+.sfg-grid {
+  display: grid;
+  gap: 5px;
+  position: relative;
+  flex: 1 1 0;
+  min-height: 0;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.sfg-grid::-webkit-scrollbar { width: 6px; }
+.sfg-grid::-webkit-scrollbar-track { background: transparent; }
+.sfg-grid::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+.sfg-grid.layout-masonry { display: flex; align-items: flex-start; }
+.sfg-masonry-col { display: flex; flex-direction: column; flex: 1; gap: 5px; min-width: 0; }
+
+/* ── Loading spinner ──────────────────────────────────────────── */
+@keyframes sfg-spin { to { transform: rotate(360deg); } }
+.sfg-spinner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--muted);
+  z-index: 2;
+  pointer-events: none;
+}
+.sfg-spinner svg {
+  color: ${ACCENT};
+  opacity: 0.7;
+  animation: sfg-spin 0.9s linear infinite;
+}
+
+/* ── Lasso / box-select rect ──────────────────────────────────── */
+.sfg-lasso {
+  position: absolute;
+  border: 1.5px dashed ${ACCENT};
+  background: rgba(${ACCENT_RGB},0.10);
+  border-radius: 3px;
+  pointer-events: none;
+  z-index: 10;
+}
+
+/* ── Cells ────────────────────────────────────────────────────── */
+.sfg-cell {
+  position: relative;
+  border-radius: 5px;
+  overflow: hidden;
+  cursor: pointer;
+  border: 2px solid transparent;
+  background: var(--muted);
+  transition: border-color 0.12s;
+  box-sizing: border-box;
+}
+.sfg-cell:hover  { border-color: rgba(${ACCENT_RGB},0.45); }
+.sfg-cell.pending  { border-color: rgba(${ACCENT_RGB},0.7); background: rgba(${ACCENT_RGB},0.08); }
+.sfg-cell.selected { border-color: ${ACCENT}; }
+
+/* Checkmark badge */
+.sfg-cell.selected::after {
+  content: "";
+  position: absolute;
+  top: 4px; right: 4px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: ${ACCENT}
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E")
+    no-repeat center / 11px;
+  z-index: 3;
+  pointer-events: none;
+}
+
+/* ── Square inner frame ───────────────────────────────────────── */
+.sfg-cell-inner {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #111;
+}
+.layout-masonry .sfg-cell-inner { aspect-ratio: unset; }
+
+/* Placeholder shape for masonry cells while their media is loading.
+   Keeps the cell from collapsing to 0 so the spinner is visible and
+   the eventual height change is from a reasonable size rather than zero. */
+.layout-masonry .sfg-cell-inner.sfg-loading { aspect-ratio: 4 / 3; }
+
+/* ── Media elements ───────────────────────────────────────────── */
+.sfg-cell img {
+  width: 100%; height: 100%; object-fit: cover; display: block; pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.sfg-cell img.sfg-loaded { opacity: 1; }
+.layout-masonry .sfg-cell img { height: auto; }
+
+.sfg-cell video {
+  width: 100%; height: 100%; object-fit: cover; display: block; pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.sfg-cell video.sfg-loaded { opacity: 1; }
+.layout-masonry .sfg-cell video { height: auto; }
+
+.sfg-spinner { transition: opacity 0.2s ease; }
+
+/* ── Audio card ───────────────────────────────────────────────── */
+.sfg-audio-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 8px;
+  width: 100%;
+  box-sizing: border-box;
+  background: rgba(0,0,0,0.3);
+  color: var(--muted-foreground);
+}
+.sfg-audio-card audio { width: 100%; height: 28px; accent-color: ${ACCENT}; }
+
+/* ── Quote card (text items) ──────────────────────────────────── */
+.sfg-quote-card {
+  padding: 14px 12px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.sfg-quote-text {
+  font-size: 11px;
+  color: var(--foreground);
+  line-height: 1.55;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Dict card ────────────────────────────────────────────────── */
+.sfg-dict-card {
+  padding: 8px;
+  font-size: 9px;
+  font-family: monospace;
+  color: var(--muted-foreground);
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-height: 110px;
+  display: -webkit-box;
+  -webkit-line-clamp: 7;
+  -webkit-box-orient: vertical;
+}
+
+/* ── Label overlay ────────────────────────────────────────────── */
+.sfg-item-label {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  padding: 3px 5px;
+  font-size: 10px;
+  background: rgba(0,0,0,0.55);
+  color: #fff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Empty state ──────────────────────────────────────────────── */
+.sfg-empty {
+  padding: 24px 12px;
+  text-align: center;
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+`;
+
+export function injectStyles() {
+  if (document.getElementById("sfg-widget-styles")) return;
+  const el = document.createElement("style");
+  el.id = "sfg-widget-styles";
+  el.textContent = STYLES;
+  document.head.appendChild(el);
+}

--- a/widgets/SelectFromGrid/_styles.js
+++ b/widgets/SelectFromGrid/_styles.js
@@ -1,13 +1,20 @@
 export const WIDGET_VERSION = "1.1.0";
 
-export const ACCENT     = "#7a9db8";
-export const ACCENT_RGB = "122,157,184";
-
 // Hue palette + masonry heights for text/quote cards — cycled by item index
 export const CARD_HUES    = [202, 162, 267, 322, 42, 82, 132, 232];
 export const CARD_HEIGHTS = [95, 125, 105, 145, 85, 130, 115, 155];
 
 export const STYLES = `
+/* ── Theme-aware accent colour ────────────────────────────────── */
+:root {
+  --sfg-accent: #2563eb;
+  --sfg-accent-rgb: 37, 99, 235;
+}
+.dark {
+  --sfg-accent: #7a9db8;
+  --sfg-accent-rgb: 122, 157, 184;
+}
+
 .sfg-widget {
   display: flex;
   flex-direction: column;
@@ -40,7 +47,7 @@ export const STYLES = `
 
 .sfg-slider {
   width: 80px;
-  accent-color: ${ACCENT};
+  accent-color: var(--sfg-accent);
   cursor: pointer;
   flex-shrink: 0;
 }
@@ -60,8 +67,8 @@ export const STYLES = `
 }
 .sfg-layout-btn:hover { background: var(--muted); color: var(--foreground); }
 .sfg-layout-btn.active {
-  background: rgba(${ACCENT_RGB},0.2);
-  border-color: ${ACCENT};
+  background: rgba(var(--sfg-accent-rgb), 0.2);
+  border-color: var(--sfg-accent);
   color: var(--foreground);
 }
 .sfg-layout-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -82,7 +89,7 @@ export const STYLES = `
   flex-shrink: 0;
 }
 .sfg-clear-btn:hover { background: var(--muted); color: var(--foreground); }
-.sfg-clear-btn.active { color: var(--foreground); border-color: rgba(${ACCENT_RGB},0.5); }
+.sfg-clear-btn.active { color: var(--foreground); border-color: rgba(var(--sfg-accent-rgb), 0.5); }
 .sfg-clear-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ── Grid layouts ─────────────────────────────────────────────── */
@@ -97,6 +104,7 @@ export const STYLES = `
   overflow-x: hidden;
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+  align-content: start;
 }
 .sfg-grid::-webkit-scrollbar { width: 6px; }
 .sfg-grid::-webkit-scrollbar-track { background: transparent; }
@@ -118,7 +126,7 @@ export const STYLES = `
   pointer-events: none;
 }
 .sfg-spinner svg {
-  color: ${ACCENT};
+  color: var(--sfg-accent);
   opacity: 0.7;
   animation: sfg-spin 0.9s linear infinite;
 }
@@ -126,8 +134,8 @@ export const STYLES = `
 /* ── Lasso / box-select rect ──────────────────────────────────── */
 .sfg-lasso {
   position: absolute;
-  border: 1.5px dashed ${ACCENT};
-  background: rgba(${ACCENT_RGB},0.10);
+  border: 1.5px dashed var(--sfg-accent);
+  background: rgba(var(--sfg-accent-rgb), 0.10);
   border-radius: 3px;
   pointer-events: none;
   z-index: 10;
@@ -144,9 +152,9 @@ export const STYLES = `
   transition: border-color 0.12s;
   box-sizing: border-box;
 }
-.sfg-cell:hover  { border-color: rgba(${ACCENT_RGB},0.45); }
-.sfg-cell.pending  { border-color: rgba(${ACCENT_RGB},0.7); background: rgba(${ACCENT_RGB},0.08); }
-.sfg-cell.selected { border-color: ${ACCENT}; }
+.sfg-cell:hover   { border-color: rgba(var(--sfg-accent-rgb), 0.45); }
+.sfg-cell.pending { border-color: rgba(var(--sfg-accent-rgb), 0.7); background: rgba(var(--sfg-accent-rgb), 0.08); }
+.sfg-cell.selected { border-color: var(--sfg-accent); }
 
 /* Checkmark badge */
 .sfg-cell.selected::after {
@@ -155,24 +163,28 @@ export const STYLES = `
   top: 4px; right: 4px;
   width: 18px; height: 18px;
   border-radius: 50%;
-  background: ${ACCENT}
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E")
-    no-repeat center / 11px;
+  background-color: var(--sfg-accent);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 11px;
   z-index: 3;
   pointer-events: none;
 }
 
-/* ── Square inner frame ───────────────────────────────────────── */
+/* ── Grid inner frame ─────────────────────────────────────────── */
 .sfg-cell-inner {
   width: 100%;
-  aspect-ratio: 1 / 1;
   overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
   background: #111;
 }
-.layout-masonry .sfg-cell-inner { aspect-ratio: unset; }
+
+/* Grid mode: grid-auto-rows (set via JS ResizeObserver) makes rows = column width.
+   The inner fills the measured square cell completely. */
+.sfg-grid:not(.layout-masonry) .sfg-cell-inner { height: 100%; }
 
 /* Placeholder shape for masonry cells while their media is loading.
    Keeps the cell from collapsing to 0 so the spinner is visible and
@@ -181,20 +193,20 @@ export const STYLES = `
 
 /* ── Media elements ───────────────────────────────────────────── */
 .sfg-cell img {
-  width: 100%; height: 100%; object-fit: cover; display: block; pointer-events: none;
+  width: 100%; height: 100%; object-fit: contain; display: block; pointer-events: none;
   opacity: 0;
   transition: opacity 0.25s ease;
 }
 .sfg-cell img.sfg-loaded { opacity: 1; }
-.layout-masonry .sfg-cell img { height: auto; }
+.layout-masonry .sfg-cell img { height: auto; object-fit: cover; }
 
 .sfg-cell video {
-  width: 100%; height: 100%; object-fit: cover; display: block; pointer-events: none;
+  width: 100%; height: 100%; object-fit: contain; display: block; pointer-events: none;
   opacity: 0;
   transition: opacity 0.25s ease;
 }
 .sfg-cell video.sfg-loaded { opacity: 1; }
-.layout-masonry .sfg-cell video { height: auto; }
+.layout-masonry .sfg-cell video { height: auto; object-fit: cover; }
 
 .sfg-spinner { transition: opacity 0.2s ease; }
 
@@ -211,7 +223,7 @@ export const STYLES = `
   background: rgba(0,0,0,0.3);
   color: var(--muted-foreground);
 }
-.sfg-audio-card audio { width: 100%; height: 28px; accent-color: ${ACCENT}; }
+.sfg-audio-card audio { width: 100%; height: 28px; accent-color: var(--sfg-accent); }
 
 /* ── Quote card (text items) ──────────────────────────────────── */
 .sfg-quote-card {

--- a/widgets/SelectFromGrid/_styles.js
+++ b/widgets/SelectFromGrid/_styles.js
@@ -210,6 +210,17 @@ export const STYLES = `
 
 .sfg-spinner { transition: opacity 0.2s ease; }
 
+/* ── Error card (failed media load) ──────────────────────────── */
+.sfg-error-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--muted-foreground);
+  opacity: 0.35;
+}
+
 /* ── Audio card ───────────────────────────────────────────────── */
 .sfg-audio-card {
   display: flex;

--- a/widgets/SelectFromGrid/_toolbar.js
+++ b/widgets/SelectFromGrid/_toolbar.js
@@ -1,0 +1,111 @@
+// _toolbar.js — Controls bar for the SelectFromGrid widget.
+//
+// Layout:
+//   [Columns ──●── N]  [Square] [Masonry]  · · ·  [N selected]  [Clear]
+//
+// createToolbar(opts) →
+//   { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled }
+
+export function createToolbar({ layout, columns, isDisabled, onColumnsChange, onLayoutChange, onClear }) {
+
+  const controls = document.createElement("div");
+  controls.className = "sfg-controls";
+
+  // ── Column slider ──────────────────────────────────────────────────────────
+
+  const colLabel = document.createElement("label");
+  colLabel.className = "sfg-label";
+  colLabel.textContent = "Columns ";
+
+  const colSlider = document.createElement("input");
+  colSlider.type = "range";
+  colSlider.className = "sfg-slider";
+  colSlider.min = 1;
+  colSlider.max = 8;
+  colSlider.value = columns;
+  colSlider.disabled = isDisabled;
+  colLabel.appendChild(colSlider);
+
+  const colVal = document.createElement("span");
+  colVal.textContent = columns;
+  colLabel.appendChild(colVal);
+
+  // ── Layout toggle buttons ──────────────────────────────────────────────────
+
+  const layoutBtns = document.createElement("div");
+  layoutBtns.className = "sfg-layout-btns";
+
+  const squareBtn = document.createElement("button");
+  squareBtn.type = "button";
+  squareBtn.className = "sfg-layout-btn" + (layout === "square" ? " active" : "");
+  squareBtn.textContent = "Square";
+  squareBtn.disabled = isDisabled;
+
+  const masonryBtn = document.createElement("button");
+  masonryBtn.type = "button";
+  masonryBtn.className = "sfg-layout-btn" + (layout === "masonry" ? " active" : "");
+  masonryBtn.textContent = "Masonry";
+  masonryBtn.disabled = isDisabled;
+
+  layoutBtns.appendChild(squareBtn);
+  layoutBtns.appendChild(masonryBtn);
+
+  // ── Selection count + clear ────────────────────────────────────────────────
+
+  const countEl = document.createElement("span");
+  countEl.className = "sfg-count";
+
+  const clearBtn = document.createElement("button");
+  clearBtn.type = "button";
+  clearBtn.className = "sfg-clear-btn";
+  clearBtn.textContent = "Clear";
+  clearBtn.disabled = isDisabled;
+
+  // ── Assemble ───────────────────────────────────────────────────────────────
+
+  controls.appendChild(colLabel);
+  controls.appendChild(layoutBtns);
+  controls.appendChild(countEl);
+  controls.appendChild(clearBtn);
+
+  // ── Wire events ────────────────────────────────────────────────────────────
+
+  colSlider.addEventListener("pointerdown", (e) => e.stopPropagation());
+  colSlider.addEventListener("input", () => {
+    colVal.textContent = colSlider.value;
+    onColumnsChange(parseInt(colSlider.value, 10));
+  });
+
+  squareBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  squareBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    squareBtn.classList.add("active");
+    masonryBtn.classList.remove("active");
+    onLayoutChange("square");
+  });
+
+  masonryBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  masonryBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    masonryBtn.classList.add("active");
+    squareBtn.classList.remove("active");
+    onLayoutChange("masonry");
+  });
+
+  clearBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  clearBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    onClear();
+  });
+
+  // ── Toolbar API ────────────────────────────────────────────────────────────
+
+  function setDisabled(disabled) {
+    colSlider.disabled  = disabled;
+    squareBtn.disabled  = disabled;
+    masonryBtn.disabled = disabled;
+    clearBtn.disabled   = disabled;
+  }
+
+  return { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled };
+}

--- a/widgets/SelectFromGrid/_toolbar.js
+++ b/widgets/SelectFromGrid/_toolbar.js
@@ -4,7 +4,7 @@
 //   [Columns ──●── N]  [Grid] [Masonry]  · · ·  [N selected]  [Clear]
 //
 // createToolbar(opts) →
-//   { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled }
+//   { controls, colSlider, colVal, gridBtn, masonryBtn, countEl, clearBtn, setDisabled }
 
 export function createToolbar({ layout, columns, isDisabled, onColumnsChange, onColumnsCommit, onLayoutChange, onClear }) {
 
@@ -35,11 +35,11 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
   const layoutBtns = document.createElement("div");
   layoutBtns.className = "sfg-layout-btns";
 
-  const squareBtn = document.createElement("button");
-  squareBtn.type = "button";
-  squareBtn.className = "sfg-layout-btn" + (layout === "grid" ? " active" : "");
-  squareBtn.textContent = "Grid";
-  squareBtn.disabled = isDisabled;
+  const gridBtn = document.createElement("button");
+  gridBtn.type = "button";
+  gridBtn.className = "sfg-layout-btn" + (layout === "grid" ? " active" : "");
+  gridBtn.textContent = "Grid";
+  gridBtn.disabled = isDisabled;
 
   const masonryBtn = document.createElement("button");
   masonryBtn.type = "button";
@@ -47,7 +47,7 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
   masonryBtn.textContent = "Masonry";
   masonryBtn.disabled = isDisabled;
 
-  layoutBtns.appendChild(squareBtn);
+  layoutBtns.appendChild(gridBtn);
   layoutBtns.appendChild(masonryBtn);
 
   // ── Selection count + clear ────────────────────────────────────────────────
@@ -79,10 +79,10 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
     if (onColumnsCommit) onColumnsCommit(parseInt(colSlider.value, 10));
   });
 
-  squareBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
-  squareBtn.addEventListener("click", (e) => {
+  gridBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  gridBtn.addEventListener("click", (e) => {
     e.stopPropagation();
-    squareBtn.classList.add("active");
+    gridBtn.classList.add("active");
     masonryBtn.classList.remove("active");
     onLayoutChange("grid");
   });
@@ -91,7 +91,7 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
   masonryBtn.addEventListener("click", (e) => {
     e.stopPropagation();
     masonryBtn.classList.add("active");
-    squareBtn.classList.remove("active");
+    gridBtn.classList.remove("active");
     onLayoutChange("masonry");
   });
 
@@ -105,10 +105,10 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
 
   function setDisabled(disabled) {
     colSlider.disabled  = disabled;
-    squareBtn.disabled  = disabled;
+    gridBtn.disabled  = disabled;
     masonryBtn.disabled = disabled;
     clearBtn.disabled   = disabled;
   }
 
-  return { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled };
+  return { controls, colSlider, colVal, gridBtn, masonryBtn, countEl, clearBtn, setDisabled };
 }

--- a/widgets/SelectFromGrid/_toolbar.js
+++ b/widgets/SelectFromGrid/_toolbar.js
@@ -1,12 +1,12 @@
 // _toolbar.js — Controls bar for the SelectFromGrid widget.
 //
 // Layout:
-//   [Columns ──●── N]  [Square] [Masonry]  · · ·  [N selected]  [Clear]
+//   [Columns ──●── N]  [Grid] [Masonry]  · · ·  [N selected]  [Clear]
 //
 // createToolbar(opts) →
 //   { controls, colSlider, colVal, squareBtn, masonryBtn, countEl, clearBtn, setDisabled }
 
-export function createToolbar({ layout, columns, isDisabled, onColumnsChange, onLayoutChange, onClear }) {
+export function createToolbar({ layout, columns, isDisabled, onColumnsChange, onColumnsCommit, onLayoutChange, onClear }) {
 
   const controls = document.createElement("div");
   controls.className = "sfg-controls";
@@ -37,8 +37,8 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
 
   const squareBtn = document.createElement("button");
   squareBtn.type = "button";
-  squareBtn.className = "sfg-layout-btn" + (layout === "square" ? " active" : "");
-  squareBtn.textContent = "Square";
+  squareBtn.className = "sfg-layout-btn" + (layout === "grid" ? " active" : "");
+  squareBtn.textContent = "Grid";
   squareBtn.disabled = isDisabled;
 
   const masonryBtn = document.createElement("button");
@@ -75,13 +75,16 @@ export function createToolbar({ layout, columns, isDisabled, onColumnsChange, on
     colVal.textContent = colSlider.value;
     onColumnsChange(parseInt(colSlider.value, 10));
   });
+  colSlider.addEventListener("change", () => {
+    if (onColumnsCommit) onColumnsCommit(parseInt(colSlider.value, 10));
+  });
 
   squareBtn.addEventListener("pointerdown", (e) => e.stopPropagation());
   squareBtn.addEventListener("click", (e) => {
     e.stopPropagation();
     squareBtn.classList.add("active");
     masonryBtn.classList.remove("active");
-    onLayoutChange("square");
+    onLayoutChange("grid");
   });
 
   masonryBtn.addEventListener("pointerdown", (e) => e.stopPropagation());


### PR DESCRIPTION
Fixes #303 

https://github.com/user-attachments/assets/1fff7343-a5cd-4c52-beba-ff3ce0b7a865


<img width="789" height="938" alt="image" src="https://github.com/user-attachments/assets/10118e0d-bf7b-4202-81f5-c3ff3cdff02f" />

## Summary

- Adds `SelectFromGrid` base node and widget — displays a list of items (images, video, audio, text, dicts) in a selectable grid
- Grid and Masonry layout modes with animated switching
- Column slider with live skeleton preview and animated commit on release
- Single- and multi-select modes (lasso drag-select), controllable via `settings.multi_select`
- IntersectionObserver-based lazy hydration — media elements only created when cells scroll near the viewport, keeping large lists fast
- 2-phase Python push: placeholders with spinners appear immediately, resolved thumbnails fade in
- Spinner → media crossfade transition; error state (alert-circle icon) on failed loads
- Theme-aware accent colour via CSS custom properties (`--sfg-accent` / `--sfg-accent-rgb`) for light and dark mode
- Square grid cells maintained via JS `ResizeObserver` + `grid-auto-rows` (reliable cross-browser)
- Lasso drag-select corrected for React Flow canvas zoom via scale-aware coordinate conversion
- Module split: `_styles.js`, `_icons.js`, `_toolbar.js` matching existing widget conventions

## Test plan

- [ ] Connect a mixed list (images, video, audio, text, dicts) and verify all cell types render
- [ ] Verify spinner → media crossfade on load; verify error icon appears on a broken URL
- [ ] Click to select / deselect; verify `selected_items` output updates
- [ ] Lasso drag-select at various canvas zoom levels
- [ ] Toggle Grid ↔ Masonry — verify animated transition and layout is preserved on server round-trip
- [ ] Drag column slider — verify skeleton preview, no server calls during drag, animated commit on release
- [ ] Resize the node — verify grid cells stay square
- [ ] Set `multi_select: False` in a subclass and verify single-select behaviour
- [ ] Light mode: verify selection ring and active buttons are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)