### PR TITLE
fix(kling): sync model capabilities, dynamic duration/mode UI across all three nodes

### DIFF
--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -1032,9 +1032,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             supports_tail = capabilities.get("supports_tail_frame", False)
             if not supports_tail:
                 exceptions.append(
-                    ValueError(
-                        f"{self.name}: Model {model_name} does not support end frame (image_tail)."
-                    )
+                    ValueError(f"{self.name}: Model {model_name} does not support end frame (image_tail).")
                 )
 
             if supports_tail and mode != "pro":

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -80,33 +80,43 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         "Kling v2.1 Master": "kling-v2-1-master",
         "Kling v2.1": "kling-v2-1",
         "Kling v2 Master": "kling-v2-master",
+        "Kling v1.6": "kling-v1-6",
         "Kling v1.5": "kling-v1-5",
         "Kling v1": "kling-v1",
     }
 
     # Model capability definitions
+    # modes: [] means no mode selection (model has a single fixed quality tier)
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "kling-v3": {
             "modes": V3_MODE_CHOICES,
-            "durations": [5, 10],
+            "durations": list(range(3, 16)),
             "supports_sound": False,
-            "supports_tail_frame": False,
+            "supports_tail_frame": True,
             "supports_multi_shot": True,
         },
         "kling-v1": {
             "modes": BASE_MODE_CHOICES,
-            "durations": [5],
-            "supports_sound": False,
-            "supports_tail_frame": False,
-        },
-        "kling-v1-5": {
-            "modes": [MODE_PRO],
             "durations": [5, 10],
             "supports_sound": False,
-            "supports_tail_frame": False,
+            "supports_tail_frame": True,
+            # tail frame only works at 5s — enforced in validation
+            "tail_frame_durations": [5],
+        },
+        "kling-v1-5": {
+            "modes": BASE_MODE_CHOICES,
+            "durations": [5, 10],
+            "supports_sound": False,
+            "supports_tail_frame": True,  # pro mode only — enforced by existing pro-mode validation
+        },
+        "kling-v1-6": {
+            "modes": BASE_MODE_CHOICES,
+            "durations": [5, 10],
+            "supports_sound": False,
+            "supports_tail_frame": True,  # pro mode only
         },
         "kling-v2-master": {
-            "modes": BASE_MODE_CHOICES,
+            "modes": [],
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
@@ -115,25 +125,25 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
-            "supports_tail_frame": True,  # Only with pro mode
+            "supports_tail_frame": True,  # pro mode only
         },
         "kling-v2-1-master": {
-            "modes": BASE_MODE_CHOICES,
+            "modes": [],
             "durations": [5, 10],
             "supports_sound": False,
             "supports_tail_frame": False,
         },
         "kling-v2-5-turbo": {
-            "modes": [MODE_PRO],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": False,
-            "supports_tail_frame": True,  # Only with pro mode
+            "supports_tail_frame": True,  # pro mode only
         },
         "kling-v2-6": {
-            "modes": [MODE_PRO],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "supports_sound": True,
-            "supports_tail_frame": False,
+            "supports_tail_frame": True,  # pro mode only, no audio
         },
     }
 
@@ -156,6 +166,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
                             "Kling v2.1 Master",
                             "Kling v2.1",
                             "Kling v2 Master",
+                            "Kling v1.6",
                             "Kling v1.5",
                             "Kling v1",
                         ]
@@ -261,7 +272,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="image_tail",
                 default_value=None,
-                tooltip="End frame image (optional). Supported on kling-v2-1 and kling-v2-5-turbo with pro mode.",
+                tooltip="End frame image (optional). Requires pro mode. See model capabilities for per-model support.",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "End Frame"},
             )
@@ -285,9 +296,9 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             ParameterInt(
                 name="duration",
                 default_value=5,
-                tooltip="Video length in seconds",
+                tooltip="Video length in seconds. Range varies by model.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[5, 10])},
+                traits={Options(choices=list(range(3, 16)))},
             )
             ParameterString(
                 name="sound",
@@ -372,19 +383,38 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         if parameter.name == "model_name":
             self._update_parameter_visibility_for_model(value)
             self._update_multi_shot_parameter_visibility()
+            self._update_duration_choices()
+        elif parameter.name == "image_tail":
+            self._update_duration_choices()
         elif parameter.name in {"multi_shot", "shot_type", "shot_count"}:
             self._update_multi_shot_parameter_visibility()
+        elif parameter.name == "mode":
+            self._update_mode_dependent_features()
+
+    def _update_duration_choices(self) -> None:
+        """Update duration dropdown based on current model and image_tail state."""
+        model_name = self.get_parameter_value("model_name") or "Kling v3.0"
+        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+        new_durations = list(capabilities.get("durations", [5, 10]))
+        # kling-v1: end frame restricts to 5s only
+        if self.get_parameter_value("image_tail") and capabilities.get("tail_frame_durations"):
+            new_durations = list(capabilities["tail_frame_durations"])
+        current_duration = self.get_parameter_value("duration")
+        if current_duration in new_durations:
+            self._update_option_choices("duration", new_durations, current_duration)  # type: ignore[arg-type]
+        else:
+            self._update_option_choices("duration", new_durations, new_durations[0])  # type: ignore[arg-type]
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility based on selected model."""
-        # Map user-facing name to model ID
         model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
         # Show mask features for all models
         self.show_parameter_by_name(["static_mask", "dynamic_masks"])
 
         # Show/hide image_tail (end frame) based on model support
-        capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
         if capabilities.get("supports_tail_frame", False):
             self.show_parameter_by_name("image_tail")
         else:
@@ -401,33 +431,23 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
     def _apply_generation_settings_visibility(self, model_id: str) -> None:
         """Apply mode/duration/sound visibility for selected model."""
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
-        self._update_mode_choices(capabilities.get("modes", BASE_MODE_CHOICES))
+        modes = capabilities.get("modes", BASE_MODE_CHOICES)
 
-        if model_id == "kling-v1":
-            self.show_parameter_by_name("mode")
-            self.hide_parameter_by_name(["duration", "sound"])
-            if self.get_parameter_value("duration") != DEFAULT_DURATION_5S:
-                self.set_parameter_value("duration", DEFAULT_DURATION_5S)
-            return
+        self.show_parameter_by_name("duration")
 
-        if model_id in {"kling-v1-5", "kling-v2-5-turbo"}:
-            self.hide_parameter_by_name(["mode", "sound"])
-            self.show_parameter_by_name("duration")
-            if self.get_parameter_value("mode") != "pro":
-                self.set_parameter_value("mode", "pro")
-            return
-
-        if model_id == "kling-v2-6":
+        if not modes:
+            # No mode selection for this model — hide selector, keep value as pro
             self.hide_parameter_by_name("mode")
-            self.show_parameter_by_name(["duration", "sound"])
-            if self.get_parameter_value("mode") != "pro":
-                self.set_parameter_value("mode", "pro")
-            if self.get_parameter_value("duration") not in [5, 10]:
-                self.set_parameter_value("duration", 5)
-            return
+            if self.get_parameter_value("mode") != MODE_PRO:
+                self.set_parameter_value("mode", MODE_PRO)
+        else:
+            self.show_parameter_by_name("mode")
+            self._update_mode_choices(modes)
 
-        self.show_parameter_by_name(["mode", "duration"])
-        self.hide_parameter_by_name("sound")
+        if capabilities.get("supports_sound", False):
+            self._update_mode_dependent_features()
+        else:
+            self.hide_parameter_by_name("sound")
 
     def _update_mode_choices(self, supported_modes: list[str]) -> None:
         """Keep the mode dropdown aligned with the selected model."""
@@ -437,6 +457,19 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             next_mode = supported_modes[0]
 
         self._update_option_choices("mode", supported_modes, next_mode)
+
+    def _update_mode_dependent_features(self) -> None:
+        """Show/hide features that depend on the current mode (e.g. sound for kling-v2-6)."""
+        model_name = self.get_parameter_value("model_name") or ""
+        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        if model_id == "kling-v2-6":
+            mode = self.get_parameter_value("mode") or MODE_PRO
+            if mode == MODE_PRO:
+                self.show_parameter_by_name("sound")
+            else:
+                self.hide_parameter_by_name("sound")
+                if self.get_parameter_value("sound") != "off":
+                    self.set_parameter_value("sound", "off")
 
     def _hide_multi_shot_inputs(self) -> None:
         """Hide multi-shot-specific UI inputs."""
@@ -973,13 +1006,14 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         # Validate model-specific constraints
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+        model_modes = capabilities.get("modes", BASE_MODE_CHOICES)
 
-        if mode not in capabilities.get("modes", BASE_MODE_CHOICES):
-            valid_modes = capabilities.get("modes", [])
+        # Skip mode validation for no-mode models (modes: []) — mode is always pro internally
+        if model_modes and mode not in model_modes:
             exceptions.append(
                 ValueError(
                     f"{self.name}: Model {model_name} does not support mode '{mode}'. "
-                    f"Valid modes: {', '.join(valid_modes)}"
+                    f"Valid modes: {', '.join(model_modes)}"
                 )
             )
 
@@ -999,13 +1033,22 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             if not supports_tail:
                 exceptions.append(
                     ValueError(
-                        f"{self.name}: Model {model_name} does not support end frame (image_tail). "
-                        f"Only Kling v2.1 and Kling v2.5 Turbo with pro mode support end frames."
+                        f"{self.name}: Model {model_name} does not support end frame (image_tail)."
                     )
                 )
 
             if supports_tail and mode != "pro":
                 exceptions.append(ValueError(f"{self.name}: End frame (image_tail) requires pro mode."))
+
+            # kling-v1 tail frame only works at 5s
+            tail_frame_durations = capabilities.get("tail_frame_durations")
+            if supports_tail and tail_frame_durations and duration not in tail_frame_durations:
+                exceptions.append(
+                    ValueError(
+                        f"{self.name}: {model_name} end frame only supports "
+                        f"{tail_frame_durations}s duration (got {duration}s)."
+                    )
+                )
 
         # Validate dynamic_masks JSON if provided
         if dynamic_masks:

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -53,8 +53,20 @@ MODEL_NAME_MAP: dict[str, dict[str, str]] = {
     },
 }
 MODEL_CAPABILITIES: dict[str, dict[str, Any]] = {
-    "kling-video-o1": {"modes": BASE_MODE_CHOICES, "supports_4k_with_reference_video": False},
-    "kling-v3-omni": {"modes": [MODE_STD, MODE_PRO, MODE_4K], "supports_4k_with_reference_video": False},
+    "kling-video-o1": {
+        "modes": BASE_MODE_CHOICES,
+        "durations": list(range(3, 11)),
+        # Text-to-video and start-frame-only generation restrict to 5s or 10s
+        "restricted_durations": [5, 10],
+        "supports_4k_with_reference_video": False,
+    },
+    "kling-v3-omni": {
+        "modes": [MODE_STD, MODE_PRO, MODE_4K],
+        "durations": list(range(3, 16)),
+        # When reference video is set (std/pro), duration caps at 10s
+        "reference_video_max_duration": 10,
+        "supports_4k_with_reference_video": False,
+    },
 }
 
 
@@ -208,7 +220,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             artifact_url_parameter=ParameterVideo(
                 name="reference_video",
                 tooltip="Reference video for editing or style reference (optional, max 1)",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                allowed_modes={ParameterMode.INPUT},
                 ui_options={"placeholder_text": "https://example.com/video.mp4"},
             ),
             disclaimer_message="The Kling Omni service utilizes this URL to access the video for generation.",
@@ -248,9 +260,9 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             ParameterInt(
                 name="duration",
                 default_value=5,
-                tooltip="Video length in seconds (3-10s). Only 5/10s for text-to-video and first-frame generation.",
+                tooltip="Video length in seconds. Range and restrictions vary by model.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[3, 4, 5, 6, 7, 8, 9, 10])},
+                traits={Options(choices=list(range(3, 16)))},
             )
         self.add_node_element(gen_settings_group)
 
@@ -304,8 +316,30 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         """Handle parameter value changes to normalize image inputs."""
         super().after_value_set(parameter, value)
 
-        if parameter.name in {"model_name", "reference_video"}:
+        if parameter.name in {"model_name", "reference_video", "end_frame_image"}:
             self._update_mode_choices()
+            # Update duration choices inline (WAN pattern)
+            model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
+            model_config = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])
+            capabilities = MODEL_CAPABILITIES.get(model_config["payload_model_name"], {})
+            has_reference_video = bool(self.get_parameter_value("reference_video"))
+            has_end_frame = bool(self.get_parameter_value("end_frame_image"))
+            new_durations = list(capabilities.get("durations", list(range(3, 11))))
+            # kling-video-o1: text/start-frame-only → [5, 10]; end frame or reference video → full [3–10]
+            restricted_durations = capabilities.get("restricted_durations")
+            if restricted_durations and not has_reference_video and not has_end_frame:
+                new_durations = list(restricted_durations)
+            # kling-v3-omni: reference video with std/pro mode caps at 10s
+            ref_video_max = capabilities.get("reference_video_max_duration")
+            if ref_video_max and has_reference_video:
+                new_durations = [d for d in new_durations if d <= ref_video_max]
+            if not new_durations:
+                new_durations = [5]
+            current_duration = self.get_parameter_value("duration")
+            if current_duration in new_durations:
+                self._update_option_choices("duration", new_durations, current_duration)  # type: ignore[arg-type]
+            else:
+                self._update_option_choices("duration", new_durations, new_durations[0])  # type: ignore[arg-type]
 
         if parameter.name in {"multi_shot", "shot_count"}:
             self._update_multi_shot_parameter_visibility()
@@ -749,14 +783,34 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
                 )
             )
 
-        # Validate duration constraints for text/first-frame generation
-        is_text_or_first_frame = not has_base_video
-        if is_text_or_first_frame and duration not in [5, 10]:
-            exceptions.append(
-                ValueError(
-                    f"{self.name} text-to-video and first-frame generation only support 5 or 10 second durations (got {duration}s)."
+        # kling-video-o1: text-to-video and start-frame-only generation restrict to 5s or 10s
+        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
+        payload_model = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])["payload_model_name"]
+        capabilities = MODEL_CAPABILITIES.get(payload_model, {})
+
+        if payload_model == "kling-video-o1":
+            is_text_or_first_frame = not has_base_video and not end_frame_image
+            restricted = capabilities.get("restricted_durations", [5, 10])
+            if is_text_or_first_frame and duration not in restricted:
+                exceptions.append(
+                    ValueError(
+                        f"{self.name} kling-video-o1 text-to-video and start-frame-only generation "
+                        f"only support {restricted} second durations (got {duration}s)."
+                    )
                 )
-            )
+
+        # kling-v3-omni: reference video with std/pro mode caps duration at 10s
+        if payload_model == "kling-v3-omni" and has_video:
+            video_refer_type = self.get_parameter_value("video_refer_type") or "base"
+            mode = self.get_parameter_value("mode") or DEFAULT_MODE
+            ref_video_max = capabilities.get("reference_video_max_duration", 10)
+            if mode != MODE_4K and duration > ref_video_max:
+                exceptions.append(
+                    ValueError(
+                        f"{self.name} kling-v3-omni with reference video (std/pro mode) "
+                        f"supports a maximum duration of {ref_video_max}s (got {duration}s)."
+                    )
+                )
 
         return exceptions if exceptions else None
 

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -70,10 +70,11 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
     }
 
     # Model capability definitions
+    # modes: [] means no mode selection (model has a single fixed quality tier)
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "kling-v3": {
             "modes": V3_MODE_CHOICES,
-            "durations": [5, 10],
+            "durations": list(range(3, 16)),
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
             "supports_multi_shot": True,
@@ -85,25 +86,25 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             "supports_sound": False,
         },
         "kling-v2-master": {
-            "modes": BASE_MODE_CHOICES,
+            "modes": [],
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-1-master": {
-            "modes": BASE_MODE_CHOICES,
+            "modes": [],
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-5-turbo": {
-            "modes": [MODE_PRO],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
-            "aspect_ratios": ["16:9"],
+            "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": False,
         },
         "kling-v2-6": {
-            "modes": [MODE_PRO],
+            "modes": BASE_MODE_CHOICES,
             "durations": [5, 10],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
             "supports_sound": True,
@@ -248,9 +249,9 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             ParameterInt(
                 name="duration",
                 default_value=5,
-                tooltip="Video Length, unit: s (seconds)",
+                tooltip="Video length in seconds. Range varies by model.",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[5, 10])},
+                traits={Options(choices=list(range(3, 16)))},
             )
 
             ParameterString(
@@ -319,33 +320,48 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         if parameter.name == "model_name":
             self._update_parameter_visibility_for_model(value)
             self._update_multi_shot_parameter_visibility()
+            # Update duration choices inline (WAN pattern)
+            model_id = self.MODEL_NAME_MAP.get(value, value)
+            capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+            new_durations = capabilities.get("durations", [5, 10])
+            current_duration = self.get_parameter_value("duration")
+            if current_duration in new_durations:
+                self._update_option_choices("duration", new_durations, current_duration)  # type: ignore[arg-type]
+            else:
+                self._update_option_choices("duration", new_durations, new_durations[0])  # type: ignore[arg-type]
         elif parameter.name in {"multi_shot", "shot_type", "shot_count"}:
             self._update_multi_shot_parameter_visibility()
+        elif parameter.name == "mode":
+            self._update_mode_dependent_features()
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility based on selected model."""
-        # Map user-facing name to model ID
         model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
-        self._update_mode_choices(capabilities.get("modes", BASE_MODE_CHOICES))
+        modes = capabilities.get("modes", BASE_MODE_CHOICES)
 
-        if model_id == "kling-v2-5-turbo":
-            self.hide_parameter_by_name(["mode", "aspect_ratio"])
-            current_aspect = self.get_parameter_value("aspect_ratio")
-            if current_aspect != "16:9":
-                self.set_parameter_value("aspect_ratio", "16:9")
-            current_duration = self.get_parameter_value("duration")
-            if current_duration not in [5, 10]:
-                self.set_parameter_value("duration", 5)
-            self.hide_parameter_by_name("sound")
-        elif model_id == "kling-v2-6":
+        self.show_parameter_by_name("duration")
+
+        if not modes:
+            # No mode selection for this model — hide selector, keep value as pro
             self.hide_parameter_by_name("mode")
-            self.show_parameter_by_name(["aspect_ratio", "duration", "sound"])
-            current_duration = self.get_parameter_value("duration")
-            if current_duration not in [5, 10]:
-                self.set_parameter_value("duration", 5)
+            if self.get_parameter_value("mode") != MODE_PRO:
+                self.set_parameter_value("mode", MODE_PRO)
         else:
-            self.show_parameter_by_name(["mode", "aspect_ratio", "duration"])
+            self.show_parameter_by_name("mode")
+            self._update_mode_choices(modes)
+
+        aspect_ratios = capabilities.get("aspect_ratios", ["16:9", "9:16", "1:1"])
+        if len(aspect_ratios) == 1:
+            self.hide_parameter_by_name("aspect_ratio")
+            if self.get_parameter_value("aspect_ratio") != aspect_ratios[0]:
+                self.set_parameter_value("aspect_ratio", aspect_ratios[0])
+        else:
+            self.show_parameter_by_name("aspect_ratio")
+
+        if capabilities.get("supports_sound", False):
+            self._update_mode_dependent_features()
+        else:
             self.hide_parameter_by_name("sound")
 
         if model_id == V3_MODEL_ID:
@@ -367,6 +383,19 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             next_mode = supported_modes[0]
 
         self._update_option_choices("mode", supported_modes, next_mode)
+
+    def _update_mode_dependent_features(self) -> None:
+        """Show/hide features that depend on the current mode (e.g. sound for kling-v2-6)."""
+        model_name = self.get_parameter_value("model_name") or ""
+        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        if model_id == "kling-v2-6":
+            mode = self.get_parameter_value("mode") or MODE_PRO
+            if mode == MODE_PRO:
+                self.show_parameter_by_name("sound")
+            else:
+                self.hide_parameter_by_name("sound")
+                if self.get_parameter_value("sound") != "off":
+                    self.set_parameter_value("sound", "off")
 
     def _update_multi_shot_parameter_visibility(self) -> None:
         """Toggle prompt and shot inputs for v3 multi-shot configurations."""
@@ -772,13 +801,14 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "16:9"
 
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
+        model_modes = capabilities.get("modes", BASE_MODE_CHOICES)
 
-        if mode not in capabilities.get("modes", BASE_MODE_CHOICES):
-            valid_modes = capabilities.get("modes", [])
+        # Skip mode validation for no-mode models (modes: []) — mode is always pro internally
+        if model_modes and mode not in model_modes:
             exceptions.append(
                 ValueError(
                     f"{self.name}: Model {model_name} does not support mode '{mode}'. "
-                    f"Valid modes: {', '.join(valid_modes)}"
+                    f"Valid modes: {', '.join(model_modes)}"
                 )
             )
 

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -321,7 +321,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             self._update_parameter_visibility_for_model(value)
             self._update_multi_shot_parameter_visibility()
             # Update duration choices inline (WAN pattern)
-            model_id = self.MODEL_NAME_MAP.get(value, value)
+            model_id = self.MODEL_NAME_MAP.get(str(value), str(value))
             capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
             new_durations = capabilities.get("durations", [5, 10])
             current_duration = self.get_parameter_value("duration")


### PR DESCRIPTION
Closes #289

## What changed

Three Kling AI video generation nodes had hardcoded parameter constraints that no longer matched what the Kling API actually supports per model. This PR makes duration dropdowns, mode selectors, end-frame visibility, and sound visibility all accurately reflect real API capabilities — and update dynamically in the UI as inputs change.

## Model support matrix

### Kling Omni (`kling_omni_video_generation.py`)

| Model | Duration (no inputs) | Duration (with end frame or ref video) | Modes |
|-------|---------------------|----------------------------------------|-------|
| kling-video-o1 | 5s, 10s | 3–10s | std, pro |
| kling-v3-omni | 3–15s | 3–10s (ref video, std/pro) | std, pro, 4k (drops 4k when ref video set) |

### Text-to-Video (`kling_text_to_video_generation.py`)

| Model | Duration | Modes | Sound |
|-------|----------|-------|-------|
| kling-v3 | 3–15s | std, pro, 4k | — |
| kling-v2-6 | 5s, 10s | std, pro | pro only |
| kling-v2-5-turbo | 5s, 10s | std, pro | — |
| kling-v2-1-master | 5s, 10s | hidden (no mode) | — |
| kling-v2-master | 5s, 10s | hidden (no mode) | — |
| kling-v1-6 | 5s, 10s | std, pro | — |

### Image-to-Video (`kling_image_to_video_generation.py`)

| Model | Duration | Modes | End frame |
|-------|----------|-------|-----------|
| kling-v3 | 3–15s | std, pro, 4k | ✅ |
| kling-v2-6 | 5s, 10s | std, pro | ✅ pro only |
| kling-v2-5-turbo | 5s, 10s | std, pro | ✅ pro only |
| kling-v2-1 | 5s, 10s | std, pro | ✅ pro only |
| kling-v2-1-master | 5s, 10s | hidden | ❌ |
| kling-v2-master | 5s, 10s | hidden | ❌ |
| kling-v1-6 | 5s, 10s | std, pro | ✅ pro only (new) |
| kling-v1-5 | 5s, 10s | std, pro | ✅ pro only |
| kling-v1 | 5s, 10s (no end frame) / 5s only (with end frame) | std, pro | ✅ 5s only |

## Key behaviours

- **Duration dropdowns update dynamically** — switching models, connecting/disconnecting `reference_video`, `end_frame_image`, or `image_tail` immediately updates the available choices (no page reload needed)
- **kling-v2-6 sound** follows mode: visible when pro, hidden + reset to "off" when std
- **kling-v2-master / kling-v2-1-master** mode selector hidden (these models have a single fixed quality tier)
- **kling-v1 + end frame** shrinks duration to 5s only in the UI (API restriction)
- **kling-v1-6** added to image-to-video model list

## Tests performed (manual, in node editor)

### Kling Omni
- [x] kling-video-o1, no inputs → Duration shows 5s and 10s only
- [x] kling-video-o1 + connect end_frame_image → Duration expands to 3–10s
- [x] kling-video-o1 + connect reference_video → Duration expands to 3–10s
- [x] kling-video-o1, disconnect inputs → Duration shrinks back to 5s/10s
- [x] kling-v3-omni, no reference video → Duration shows 3–15s
- [x] kling-v3-omni + connect reference_video → Duration shrinks to 3–10s
- [x] kling-v3-omni + reference_video → mode selector drops 4k

### Text-to-Video
- [x] kling-v3 → Duration shows 3–15s; mode shows std/pro/4k
- [x] kling-v2-6 → Mode selector shows std and pro; duration shows 5s/10s
- [x] kling-v2-6, mode=std → Sound hidden
- [x] kling-v2-6, mode=pro → Sound visible
- [x] kling-v2-6, switch pro→std → Sound hides and resets to "off"
- [x] kling-v2-5-turbo → Mode selector shows std and pro
- [x] kling-v2-1-master → Mode selector hidden
- [x] kling-v2-master → Mode selector hidden

### Image-to-Video
- [x] kling-v3 → Duration shows 3–15s; mode shows std/pro/4k; end frame visible
- [x] kling-v2-6 → Mode shows std/pro; end frame visible
- [x] kling-v2-6, mode=std → Sound hidden
- [x] kling-v2-6, mode=pro → Sound visible
- [x] kling-v2-5-turbo → Mode shows std/pro
- [x] kling-v2-1-master → Mode hidden; end frame hidden
- [x] kling-v2-master → Mode hidden; end frame hidden
- [x] kling-v1-5 → End frame visible
- [x] kling-v1 → Duration shows 5s/10s; end frame visible
- [x] kling-v1 + connect image_tail → Duration shrinks to 5s only; disconnect → returns to 5s/10s
- [x] kling-v1-6 → Model in dropdown; mode shows std/pro; end frame visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)