### PR TITLE
Conditionally validate the GT API Key before workflow run

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -594,13 +594,20 @@ class Agent(ControlNode):
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Performs pre-run validation checks for the node.
 
-        Currently checks if the Griptape Cloud API key is configured if the default
-        prompt driver is likely to be used.
+        The Griptape Cloud API key is only required when the node would fall back
+        to the default Griptape Cloud prompt driver. A connected agent carries its
+        own driver, and a connected prompt driver (Prompt Model Config) supplies its
+        own credentials, so neither needs the cloud key.
 
         Returns:
             A list of Exception objects if validation fails, otherwise None.
         """
         exceptions = []
+
+        # Mirror the driver-selection precedence in process(): a connected agent or a
+        # connected prompt driver bypass the default Griptape Cloud driver entirely.
+        if not self._uses_griptape_cloud_driver():
+            return None
 
         # Check to see if the API key is set.
         api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
@@ -612,6 +619,18 @@ class Agent(ControlNode):
 
         # Return any exceptions
         return exceptions if exceptions else None
+
+    def _uses_griptape_cloud_driver(self) -> bool:
+        """Return True when the node will build the default Griptape Cloud prompt driver.
+
+        A connected agent supplies its own driver, and a connected prompt driver
+        (``model`` resolved to a ``BasePromptDriver``) supplies its own credentials;
+        in both cases the Griptape Cloud API key is not needed.
+        """
+        if self.get_parameter_value("agent") is not None:
+            return False
+        model_input = self.get_parameter_value("model")
+        return not isinstance(model_input, BasePromptDriver)
 
     def _handle_additional_context(self, prompt: str, additional_context: str | int | float | dict[str, Any]) -> str:  # noqa: PYI041
         """Integrates additional context into the main prompt string.

--- a/tests/unit/agents/test_agent_validation.py
+++ b/tests/unit/agents/test_agent_validation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
+
+from griptape_nodes_library.agents.agent import API_KEY_ENV_VAR, Agent
+
+
+@pytest.fixture
+def agent_node() -> Agent:
+    return Agent(name="Agent")
+
+
+def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
+    """Make the engine's SecretsManager return *value* for any secret lookup."""
+    import griptape_nodes_library.agents.agent as agent_module
+
+    class _FakeSecrets:
+        def get_secret(self, _name: str) -> str | None:
+            return value
+
+    monkeypatch.setattr(agent_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
+
+
+def _stub_params(agent_node: Agent, monkeypatch: pytest.MonkeyPatch, *, model: object, agent: object) -> None:
+    """Override get_parameter_value for the model/agent params, passing others through."""
+    original = agent_node.get_parameter_value
+
+    def _get(name: str) -> object:
+        if name == "model":
+            return model
+        if name == "agent":
+            return agent
+        return original(name)
+
+    monkeypatch.setattr(agent_node, "get_parameter_value", _get)
+
+
+def _fake_prompt_driver() -> BasePromptDriver:
+    """A BasePromptDriver instance standing in for a connected Prompt Model Config."""
+
+    class _FakeDriver(BasePromptDriver):
+        def try_run(self, *_args: object, **_kwargs: object) -> object:  # pragma: no cover - never invoked
+            raise NotImplementedError
+
+        def try_stream(self, *_args: object, **_kwargs: object) -> object:  # pragma: no cover - never invoked
+            raise NotImplementedError
+
+    return _FakeDriver(model="fake-model", tokenizer=None)  # type: ignore[arg-type]
+
+
+def test_validation_fails_when_cloud_key_missing_and_default_driver_used(
+    agent_node: Agent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_secret(monkeypatch, None)
+    _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent=None)
+
+    exceptions = agent_node.validate_before_workflow_run()
+
+    assert exceptions is not None
+    assert len(exceptions) == 1
+    assert API_KEY_ENV_VAR in str(exceptions[0])
+
+
+def test_validation_passes_when_cloud_key_present_and_default_driver_used(
+    agent_node: Agent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_secret(monkeypatch, "gt-cloud-key")
+    _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent=None)
+
+    assert agent_node.validate_before_workflow_run() is None
+
+
+def test_validation_skips_cloud_key_when_prompt_driver_connected(
+    agent_node: Agent, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A connected Prompt Model Config (e.g. Anthropic) carries its own credentials,
+    # so the Griptape Cloud key must not be required. Regression test for issue #71.
+    _stub_secret(monkeypatch, None)
+    _stub_params(agent_node, monkeypatch, model=_fake_prompt_driver(), agent=None)
+
+    assert agent_node.validate_before_workflow_run() is None
+
+
+def test_validation_skips_cloud_key_when_agent_connected(agent_node: Agent, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A connected agent carries its own driver, so the cloud key is not required.
+    _stub_secret(monkeypatch, None)
+    _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent={"type": "Agent"})
+
+    assert agent_node.validate_before_workflow_run() is None


### PR DESCRIPTION
## What

Only require `GT_CLOUD_API_KEY` at workflow validation when the Agent node will actually fall back to the default `GriptapeCloudPromptDriver`.

`Agent.validate_before_workflow_run()` previously required the cloud key unconditionally, so a workflow using a non-cloud prompt driver (e.g. an Anthropic Prompt Model Config) failed validation with `GT_CLOUD_API_KEY is not defined` even though no cloud driver was used.

Original report came from [here](https://github.com/griptape-ai/griptape-nodes-library-nuke/issues/71).

## Changes

- `validate_before_workflow_run()` returns early (no key required) unless the node would build the default cloud driver.
- New helper `_uses_griptape_cloud_driver()` mirrors the driver-selection precedence already in `process()`:
  - a connected `agent` carries its own driver → no cloud key needed;
  - a `model` resolved to a `BasePromptDriver` (Prompt Model Config) supplies its own credentials → no cloud key needed;
  - only a plain model string / fallthrough to default → cloud key required.
- Added `tests/unit/agents/test_agent_validation.py` covering all four cases, including the regression: no key + connected prompt driver → validation passes.

## Verification

- `make check` passes (format, lint, pyright, JSON).
- New tests: 4/4 pass.

Closes #327