### PR TITLE
Add sort_by and sort_order parameters to ListFiles node

### DIFF
--- a/griptape_nodes_library/files/list_files.py
+++ b/griptape_nodes_library/files/list_files.py
@@ -23,7 +23,7 @@ LIST_OPTIONS = [
     "List files only",
     "List folders only",
 ]
-SORT_OPTIONS = ["None", "Alphabetical", "Date Modified"]
+SORT_OPTIONS = ["Unsorted", "Alphabetical", "Date Modified"]
 ORDER_OPTIONS = ["Ascending", "Descending"]
 
 
@@ -328,7 +328,7 @@ class ListFiles(SuccessFailureNode):
         sort_by = self.get_parameter_value("sort_by")
         sort_order = self.get_parameter_value("sort_order")
 
-        if sort_by != SORT_OPTIONS[0]:  # not "None"
+        if sort_by != SORT_OPTIONS[0]:  # not "Unsorted"
             reverse = sort_order == ORDER_OPTIONS[1]  # "Descending"
             if sort_by == SORT_OPTIONS[1]:  # "Alphabetical"
                 filtered_entries.sort(key=lambda e: e.name.casefold(), reverse=reverse)

--- a/griptape_nodes_library/files/list_files.py
+++ b/griptape_nodes_library/files/list_files.py
@@ -93,7 +93,7 @@ class ListFiles(SuccessFailureNode):
             name="sort_by",
             allow_output=False,
             default_value=SORT_OPTIONS[0],
-            tooltip="Sort results. 'None' preserves filesystem order; 'Alphabetical' sorts by name; 'Date Modified' sorts by last modification time.",
+            tooltip="Sort results. 'Unsorted' preserves filesystem order; 'Alphabetical' sorts by name; 'Date Modified' sorts by last modification time.",
             traits={Options(choices=SORT_OPTIONS)},
         )
 
@@ -101,7 +101,7 @@ class ListFiles(SuccessFailureNode):
             name="sort_order",
             allow_output=False,
             default_value=ORDER_OPTIONS[0],
-            tooltip="Sort direction: 'Ascending' (A→Z or oldest→newest) or 'Descending' (Z→A or newest→oldest). Ignored when sort_by is 'None'.",
+            tooltip="Sort direction: 'Ascending' (A→Z or oldest→newest) or 'Descending' (Z→A or newest→oldest). Ignored when sort_by is 'Unsorted'.",
             traits={Options(choices=ORDER_OPTIONS)},
         )
 

--- a/griptape_nodes_library/files/list_files.py
+++ b/griptape_nodes_library/files/list_files.py
@@ -23,6 +23,8 @@ LIST_OPTIONS = [
     "List files only",
     "List folders only",
 ]
+SORT_OPTIONS = ["None", "Alphabetical", "Date Modified"]
+ORDER_OPTIONS = ["Ascending", "Descending"]
 
 
 class ListFiles(SuccessFailureNode):
@@ -87,6 +89,22 @@ class ListFiles(SuccessFailureNode):
             tooltip="Whether to return absolute paths. If False, returns paths as provided by the system (may be relative or absolute).",
         )
 
+        self.sort_by = ParameterString(
+            name="sort_by",
+            allow_output=False,
+            default_value=SORT_OPTIONS[0],
+            tooltip="Sort results. 'None' preserves filesystem order; 'Alphabetical' sorts by name; 'Date Modified' sorts by last modification time.",
+            traits={Options(choices=SORT_OPTIONS)},
+        )
+
+        self.sort_order = ParameterString(
+            name="sort_order",
+            allow_output=False,
+            default_value=ORDER_OPTIONS[0],
+            tooltip="Sort direction: 'Ascending' (A→Z or oldest→newest) or 'Descending' (Z→A or newest→oldest). Ignored when sort_by is 'None'.",
+            traits={Options(choices=ORDER_OPTIONS)},
+        )
+
         self.add_parameter(self.directory_path)
         self.add_parameter(self.match_pattern)
         self.add_parameter(self.match_pattern_case_sensitive)
@@ -94,6 +112,8 @@ class ListFiles(SuccessFailureNode):
         self.add_parameter(self.recursive)
         self.add_parameter(self.show_hidden)
         self.add_parameter(self.use_absolute_paths)
+        self.add_parameter(self.sort_by)
+        self.add_parameter(self.sort_order)
 
         # Add output parameters
         self.add_parameter(
@@ -305,6 +325,23 @@ class ListFiles(SuccessFailureNode):
                 match_pattern=match_pattern,
                 match_pattern_case_sensitive=match_pattern_case_sensitive,
             )
+        sort_by = self.get_parameter_value("sort_by")
+        sort_order = self.get_parameter_value("sort_order")
+
+        if sort_by != SORT_OPTIONS[0]:  # not "None"
+            reverse = sort_order == ORDER_OPTIONS[1]  # "Descending"
+            if sort_by == SORT_OPTIONS[1]:  # "Alphabetical"
+                filtered_entries.sort(key=lambda e: e.name.casefold(), reverse=reverse)
+            elif sort_by == SORT_OPTIONS[2]:  # "Date Modified"
+
+                def _mtime(e) -> float:
+                    try:
+                        return Path(e.absolute_path).stat().st_mtime
+                    except OSError:
+                        return 0.0
+
+                filtered_entries.sort(key=_mtime, reverse=reverse)
+
         file_paths = self._convert_paths(filtered_entries, use_absolute_paths=use_absolute_paths)
         file_names = [entry.name for entry in filtered_entries]
 


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/323

<img width="770" height="913" alt="image" src="https://github.com/user-attachments/assets/0cab7611-1978-41c7-9ab4-8c111e21163e" />

## Summary

- Adds a `sort_by` parameter to the `ListFiles` node with three options: `Unsorted`, `Alphabetical`, and `Date Modified`
- Adds a `sort_order` parameter with `Ascending` and `Descending` options
- Sorting is applied after all filtering and recursive collection, so it works correctly in both flat and recursive modes
- `Date Modified` uses `Path.stat().st_mtime` — cross-platform (Windows, macOS, Linux)

## Backwards compatibility

The default value for `sort_by` is `"Unsorted"`, which preserves the existing filesystem-order behavior. Existing workflows that use `ListFiles` will not be affected.

## Test plan

- [x] List files with `sort_by = Alphabetical`, `sort_order = Ascending` — confirm A→Z order
- [x] List files with `sort_by = Alphabetical`, `sort_order = Descending` — confirm Z→A order
- [x] List files with `sort_by = Date Modified`, `sort_order = Ascending` — confirm oldest→newest
- [x] List files with `sort_by = Date Modified`, `sort_order = Descending` — confirm newest→oldest
- [x] List files with `sort_by = Unsorted` — confirm existing behavior unchanged
- [x] Run with `recursive = True` — confirm sorting applies across all collected entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)