### PR TITLE
Feature: Add single-select mode to SelectFromGrid

### DIFF
--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -6,6 +6,7 @@ from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import (
     Parameter,
     ParameterMode,
+    ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
@@ -77,8 +78,7 @@ class SelectFromGrid(ControlNode):
 
         self.selected_items = Parameter(
             name="selected_items",
-            type="list",
-            output_type="list",
+            output_type=ParameterTypeBuiltin.ALL.value,
             allowed_modes={ParameterMode.OUTPUT},
             tooltip="The selected items from the grid, in the same format as the input list.",
         )
@@ -86,12 +86,13 @@ class SelectFromGrid(ControlNode):
 
         self.selected_item = Parameter(
             name="selected_item",
-            output_type="any",
+            output_type=ParameterTypeBuiltin.ALL.value,
             allowed_modes={ParameterMode.OUTPUT},
+            hide_property=True,
             tooltip="The selected item from the grid, in the same format as the input list.",
         )
-        self.selected_item.hide_property = True
         self.add_parameter(self.selected_item)
+        self.hide_parameter_by_name("selected_item")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter.name == self.list_input.name:
@@ -167,8 +168,12 @@ class SelectFromGrid(ControlNode):
             self.grid_param.name,
             {**current, "settings": settings, "selected_indices": []},
         )
-        self.selected_items.hide_property = not is_multi
-        self.selected_item.hide_property = is_multi
+        if is_multi:
+            self.show_parameter_by_name("selected_items")
+            self.hide_parameter_by_name("selected_item")
+        else:
+            self.hide_parameter_by_name("selected_items")
+            self.show_parameter_by_name("selected_item")
 
     def _update_output_from_grid(self, grid_value: Any) -> None:
         """Update the output parameter when the user changes the selection in the widget."""

--- a/griptape_nodes_library/lists/select_from_grid.py
+++ b/griptape_nodes_library/lists/select_from_grid.py
@@ -66,6 +66,15 @@ class SelectFromGrid(ControlNode):
         )
         self.add_parameter(self.grid_param)
 
+        self.multi_select = Parameter(
+            name="multi_select",
+            type="bool",
+            default_value=True,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="Allow selecting multiple items. When disabled, only one item can be selected at a time.",
+        )
+        self.add_parameter(self.multi_select)
+
         self.selected_items = Parameter(
             name="selected_items",
             type="list",
@@ -75,11 +84,22 @@ class SelectFromGrid(ControlNode):
         )
         self.add_parameter(self.selected_items)
 
+        self.selected_item = Parameter(
+            name="selected_item",
+            output_type="any",
+            allowed_modes={ParameterMode.OUTPUT},
+            tooltip="The selected item from the grid, in the same format as the input list.",
+        )
+        self.selected_item.hide_property = True
+        self.add_parameter(self.selected_item)
+
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter.name == self.list_input.name:
             self._sync_grid_items(value)
         elif parameter.name == self.grid_param.name:
             self._update_output_from_grid(value)
+        elif parameter.name == self.multi_select.name:
+            self._apply_multi_select(bool(value))
         return super().after_value_set(parameter, value)
 
     def process(self) -> None:
@@ -87,7 +107,13 @@ class SelectFromGrid(ControlNode):
         selected_indices = grid_value.get("selected_indices", [])
         list_values = self.get_parameter_value(self.list_input.name) or []
         selected = [list_values[i] for i in selected_indices if isinstance(i, int) and i < len(list_values)]
-        self.parameter_output_values[self.selected_items.name] = selected
+        is_multi = self.get_parameter_value(self.multi_select.name)
+        if is_multi is None:
+            is_multi = True
+        if is_multi:
+            self.parameter_output_values[self.selected_items.name] = selected
+        else:
+            self.parameter_output_values[self.selected_item.name] = selected[0] if selected else None
 
     def _sync_grid_items(self, list_values: Any) -> None:
         """Serialize the incoming list to widget-friendly items and push to the grid parameter."""
@@ -132,6 +158,18 @@ class SelectFromGrid(ControlNode):
                 {**base, "items": list(widget_items), "selected_indices": kept_indices},
             )
 
+    def _apply_multi_select(self, is_multi: bool) -> None:
+        """Switch between multi-select and single-select mode."""
+        current = self.get_parameter_value(self.grid_param.name) or {}
+        settings = dict(current.get("settings", {}))
+        settings["multi_select"] = is_multi
+        self.set_parameter_value(
+            self.grid_param.name,
+            {**current, "settings": settings, "selected_indices": []},
+        )
+        self.selected_items.hide_property = not is_multi
+        self.selected_item.hide_property = is_multi
+
     def _update_output_from_grid(self, grid_value: Any) -> None:
         """Update the output parameter when the user changes the selection in the widget."""
         if not isinstance(grid_value, dict):
@@ -139,8 +177,16 @@ class SelectFromGrid(ControlNode):
         selected_indices = grid_value.get("selected_indices", [])
         list_values = self.get_parameter_value(self.list_input.name) or []
         selected = [list_values[i] for i in selected_indices if isinstance(i, int) and i < len(list_values)]
-        self.parameter_output_values[self.selected_items.name] = selected
-        self.publish_update_to_parameter(self.selected_items.name, selected)
+        is_multi = self.get_parameter_value(self.multi_select.name)
+        if is_multi is None:
+            is_multi = True
+        if is_multi:
+            self.parameter_output_values[self.selected_items.name] = selected
+            self.publish_update_to_parameter(self.selected_items.name, selected)
+        else:
+            item = selected[0] if selected else None
+            self.parameter_output_values[self.selected_item.name] = item
+            self.publish_update_to_parameter(self.selected_item.name, item)
 
     def _serialize_item_placeholder(self, item: Any) -> dict[str, Any]:
         """Return a lightweight placeholder for an item with no resolved URL.


### PR DESCRIPTION
Closes #331

## Summary

- Adds a `multi_select` boolean property (default `true`) to `SelectFromGrid`
- When `multi_select` is `true` (default): existing `selected_items` list output is shown, `selected_item` is hidden
- When `multi_select` is `false`: a single `selected_item` output is shown (returns the first selected item or `None`), `selected_items` is hidden
- The grid widget's `settings.multi_select` is kept in sync with the toggle, so the widget enforces single-select mode in the UI
- Both output parameters use `ParameterTypeBuiltin.ALL.value` (matches the `GetFromList` pattern) so they connect to any downstream node regardless of element type
- Parameter visibility is managed with `show/hide_parameter_by_name` following established node patterns

## Test plan

- [ ] Drop a `SelectFromGrid` node — only `selected_items` output port is visible by default
- [ ] Toggle `multi_select` off — `selected_item` appears, `selected_items` disappears, grid resets selection to single-select mode
- [ ] Toggle `multi_select` back on — `selected_items` reappears, grid allows multiple selections again
- [ ] Connect `selected_item` to a downstream node (e.g. an image node) — confirm the port accepts the connection
- [ ] Run the node in both modes and confirm the correct output is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)