### PR TITLE
feat(proxy): declare model invocations for permission gating

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.79.0",
-    "engine_version": "0.86.0",
+    "engine_version": "0.87.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -17,6 +17,8 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.base_events import ResultPayload
+from griptape_nodes.retained_mode.events.model_events import DeclareModelInvocationRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
@@ -595,6 +597,20 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._set_status_results(was_successful=False, result_details=error_msg)
         self._handle_failure_exception(e)
 
+    async def _declare_model_invocation(self, api_model_id: str) -> ResultPayload:
+        """Declare the impending model invocation so the permission layer can gate it.
+
+        Dispatches a DeclareModelInvocationRequest carrying the concrete model,
+        the provider it routes to, and this node's name. The engine clears the
+        call by default; a registered policy can deny it, in which case the
+        result reports failure. The proxy enforces server-side as well; this
+        runs first, so a denied call fails fast and never leaves the engine.
+        """
+        provider_id = self._api_key_provider.provider_id if self._api_key_provider else None
+        return await GriptapeNodes.ahandle_request(
+            DeclareModelInvocationRequest(model=api_model_id, provider_id=provider_id, node_name=self.name)
+        )
+
     async def _submit_and_poll(self, headers: dict[str, str]) -> tuple[str, dict[str, Any]] | None:
         """Submit generation request and poll for completion.
 
@@ -615,6 +631,16 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         api_model_id = self._get_api_model_id()
         if not api_model_id:
             self._handle_missing_model_id()
+            return None
+
+        # Declare the invocation so the engine's permission layer can gate it
+        # before any network call. The proxy still enforces server-side; this is
+        # the engine-side gate, so a denied invocation fails fast here.
+        declaration = await self._declare_model_invocation(api_model_id)
+        if declaration.failed():
+            self._set_safe_defaults()
+            details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+            self._set_status_results(was_successful=False, result_details=details)
             return None
 
         # Submit request to get generation ID

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -11,6 +11,10 @@ __all__ = [
 
 @dataclass(frozen=True)
 class ProxyApiKeyProviderConfig:
+    # `provider_id` is the canonical, stable key a permission policy gates on,
+    # and the identifier the model catalog uses for this provider. Keep it
+    # lowercase/snake_case and in sync with the catalog's provider keys.
+    provider_id: str
     api_key_name: str
     provider_name: str
     api_key_url: str
@@ -19,16 +23,19 @@ class ProxyApiKeyProviderConfig:
 
 
 BLACK_FOREST_LABS = ProxyApiKeyProviderConfig(
+    provider_id="black_forest_labs",
     api_key_name="BFL_API_KEY",
     provider_name="BlackForest Labs",
     api_key_url="https://dashboard.bfl.ai/api/keys",
 )
 ELEVENLABS = ProxyApiKeyProviderConfig(
+    provider_id="elevenlabs",
     api_key_name="ELEVENLABS_API_KEY",
     provider_name="ElevenLabs",
     api_key_url="https://elevenlabs.io/app/settings/api-keys",
 )
 GOOGLE = ProxyApiKeyProviderConfig(
+    provider_id="google",
     api_key_name="GOOGLE_SERVICE_ACCOUNT_JSON",
     provider_name="Google Cloud",
     api_key_url="https://console.cloud.google.com/iam-admin/serviceaccounts",
@@ -36,56 +43,67 @@ GOOGLE = ProxyApiKeyProviderConfig(
     parameter_display_name="Credentials Provider",
 )
 GROK = ProxyApiKeyProviderConfig(
+    provider_id="xai",
     api_key_name="GROK_API_KEY",
     provider_name="xAI",
     api_key_url="https://console.x.ai",
 )
 DASHSCOPE = ProxyApiKeyProviderConfig(
+    provider_id="dashscope",
     api_key_name="DASHSCOPE_API_KEY",
     provider_name="Alibaba Cloud Model Studio",
     api_key_url="https://bailian.console.aliyun.com/",
 )
 SEED = ProxyApiKeyProviderConfig(
+    provider_id="bytedance_seed",
     api_key_name="SEED_API_KEY",
     provider_name="ByteDance Seed",
     api_key_url="https://seed.bytedance.com/",
 )
 TOPAZ = ProxyApiKeyProviderConfig(
+    provider_id="topaz",
     api_key_name="TOPAZ_API_KEY",
     provider_name="Topaz Labs",
     api_key_url="https://developer.topazlabs.com/",
 )
 RODIN = ProxyApiKeyProviderConfig(
+    provider_id="hyper3d",
     api_key_name="RODIN_API_KEY",
     provider_name="Hyper3D Rodin",
     api_key_url="https://hyper3d.ai/",
 )
 LTX = ProxyApiKeyProviderConfig(
+    provider_id="ltx",
     api_key_name="LTX_API_KEY",
     provider_name="LTX Studio",
     api_key_url="https://docs.ltx.video/welcome",
 )
 KLING = ProxyApiKeyProviderConfig(
+    provider_id="kling",
     api_key_name="KLING_API_KEY",
     provider_name="Kling AI",
     api_key_url="https://app.klingai.com/global/dev",
 )
 MINIMAX = ProxyApiKeyProviderConfig(
+    provider_id="minimax",
     api_key_name="MINIMAX_API_KEY",
     provider_name="MiniMax",
     api_key_url="https://minimax.io/",
 )
 OPENAI = ProxyApiKeyProviderConfig(
+    provider_id="openai",
     api_key_name="OPENAI_API_KEY",
     provider_name="OpenAI",
     api_key_url="https://platform.openai.com/api-keys",
 )
 WORLD_LABS = ProxyApiKeyProviderConfig(
+    provider_id="world_labs",
     api_key_name="WORLD_LABS_API_KEY",
     provider_name="World Labs",
     api_key_url="https://platform.worldlabs.ai/api-keys",
 )
 TRIPO = ProxyApiKeyProviderConfig(
+    provider_id="tripo",
     api_key_name="TRIPO_API_KEY",
     provider_name="Tripo 3D",
     api_key_url="https://platform.tripo3d.ai/api-keys",

--- a/griptape_nodes_library/proxy/proxy_auth_provider_parameter.py
+++ b/griptape_nodes_library/proxy/proxy_auth_provider_parameter.py
@@ -33,6 +33,10 @@ class ProxyAuthProviderParameter:
     def secret_name(self) -> str:
         return self._provider_config.api_key_name
 
+    @property
+    def provider_id(self) -> str:
+        return self._provider_config.provider_id
+
     def add_parameters(self) -> None:
         self._node.add_parameter(
             ParameterBool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes>=0.86.0",
+  "griptape-nodes-engine>=0.87.0",
   "lxml>=5.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -702,26 +702,8 @@ loaders-pdf = [
 ]
 
 [[package]]
-name = "griptape-nodes"
-version = "0.86.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griptape-nodes-engine" },
-    { name = "websockets" },
-    { name = "xdg-base-dirs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/3a/97beac1c42dd29919b7b86591c33a93c059a89286beddad7377a9b8580f6/griptape_nodes-0.86.0.tar.gz", hash = "sha256:8efb8de8a7de6db7c0e98b04814d611211890716e8158efb5021bebfc7bfc88a", size = 375682, upload-time = "2026-06-09T19:09:39.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/ee/9c8412394064a7c69c63d371e08835e06f2f8dd37ac68cc2c955d4eb9143/griptape_nodes-0.86.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:6b9e779728b8e75006388c1dbf7677050c743979dd5508583c606b97919fc0d1", size = 6144343, upload-time = "2026-06-09T19:09:40.385Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/ee/1150bf8f5babe5cd665c8d1657b85b969545b2c2eae6d6a31134a99e5b34/griptape_nodes-0.86.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3e8711d0dc73c13e6c16ca0122e116ca5d906155e355f64913d8a6a1a6144de", size = 5941195, upload-time = "2026-06-09T19:09:34.035Z" },
-    { url = "https://files.pythonhosted.org/packages/58/a3/3b3a69ce6cf6a7b2a155e24b9d514f167eee7d9fe1b98f5775eb518e8960/griptape_nodes-0.86.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d406f95d9f1da85aba174f81a2a96e36a0075b5cc7a6938e46001be1d280e513", size = 9192193, upload-time = "2026-06-09T19:09:35.602Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/d0/0c5fcad96e33340ed170cd114a50b048a7ebb729783d6f89337f46073ac7/griptape_nodes-0.86.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f545eb160c848452a13c6ab793160d947154c35838647bea1af11d21c2f3637a", size = 9010779, upload-time = "2026-06-09T19:09:37.294Z" },
-    { url = "https://files.pythonhosted.org/packages/25/68/0d91633e06868ef294b3e0e8c86cfa0175563d2188c6b5e0957bc87f414e/griptape_nodes-0.86.0-cp312-cp312-win_amd64.whl", hash = "sha256:220c310e2b15d22b16e264af833a4dce2ba53eaae039ad745c0653decafd4911", size = 5408437, upload-time = "2026-06-09T19:09:32.318Z" },
-]
-
-[[package]]
 name = "griptape-nodes-engine"
-version = "0.86.0"
+version = "0.87.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -759,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/63/7576e18166d298b70b6f725c6f6122e83d4332c6c588b88cd16e1c3cf5b4/griptape_nodes_engine-0.86.0.tar.gz", hash = "sha256:d1fb3dff1d0bf1d853fe0c18e2a8494ef75733ae218d4005f90cbc3de11e6311", size = 861154, upload-time = "2026-06-09T17:37:13.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/67/6ba3507209b6b12a2ecb814f15af33c3ed8db082b0122aef12b063833e6a/griptape_nodes_engine-0.87.0.tar.gz", hash = "sha256:1415f3597c6f709d87b3e81658335d636a245b830d5416f541050b4f1051cd67", size = 911352, upload-time = "2026-06-18T19:23:36.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/4f/feba7a64450fb7a24c1d598d70903dfaab197710cfc1d99ce50c27ad2ca1/griptape_nodes_engine-0.86.0-py3-none-any.whl", hash = "sha256:65331096e669cdd138235e82c3ce60b411cd516009652854362e3def058b3143", size = 1083808, upload-time = "2026-06-09T17:37:14.536Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/eb/f2fc731c97bae08f67143026145da7ef7c42bb5dba0c8a25641c401b14c5/griptape_nodes_engine-0.87.0-py3-none-any.whl", hash = "sha256:04514f228e2655d215d14cf0163a9efa7a6b8fad18b77bfce0fe73bec1c11c87", size = 1141817, upload-time = "2026-06-18T19:23:37.506Z" },
 ]
 
 [[package]]
@@ -772,7 +754,7 @@ dependencies = [
     { name = "asteval" },
     { name = "color-matcher" },
     { name = "griptape", extra = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"] },
-    { name = "griptape-nodes" },
+    { name = "griptape-nodes-engine" },
     { name = "jmespath" },
     { name = "json-repair" },
     { name = "json-schema-to-pydantic" },
@@ -799,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes", specifier = ">=0.86.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.87.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
Proxy nodes invoke third-party models in their own process, so the engine's permission layer never sees the call and entitlements can't be applied to it before it leaves the engine. The Griptape proxy enforces server-side for the calls routed through it, but there is no engine-side point where a policy can gate a model invocation or where it can be metered and audited. This wires every proxy node into the `DeclareModelInvocationRequest` the engine added in https://github.com/griptape-ai/griptape-nodes-engine/pull/4808.

`GriptapeProxyNode` is the single base class all proxy nodes inherit, so the integration is one dispatch in `_submit_and_poll`, right after the concrete model id is resolved and before the generation is submitted. A denial fails the node fast, before any network call. The declaration carries the two facts the node owns at call time: `model` from `_get_api_model_id()` and the `provider_id` it routes to, plus `node_name`. `provider_id` is a new canonical key added to each `ProxyApiKeyProviderConfig`, since a node previously knew its provider only as a display name and an `api_key_name`, neither of which a policy can reliably match on. Those keys are the identifier a policy gates on and should track the model catalog's provider keys as that work lands.

The denial check is `declaration.failed()` rather than an `isinstance` against `DeclareModelInvocationResultFailure`. A policy denial surfaces as `PermissionDeniedResult`, which lives in `griptape-nodes-app` and is not importable here, so an `isinstance` check against the engine failure type would silently miss every real denial. `failed()` catches both and matches the request's documented contract that any failure means do not invoke.

Scope is the proxy nodes. Other model-invoking nodes (the Agent and prompt-driver nodes, local models) are a separate follow-up alongside the model-catalog work. The nine pre-existing `test_griptape_proxy_node_byok.py` failures are unrelated and present on `main` without this change.
