### PR TITLE
Add Seedance provider reference assets

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -212,6 +212,15 @@
       }
     },
     {
+      "video/seedance": {
+        "color": "border-pink-500",
+        "title": "Seedance",
+        "description": "Seedance reference assets and supporting nodes",
+        "icon": "Link",
+        "group": "create"
+      }
+    },
+    {
       "image": {
         "color": "border-purple-500",
         "title": "Image",
@@ -1154,6 +1163,25 @@
           "ai",
           "api",
           "seedance"
+        ]
+      }
+    },
+    {
+      "class_name": "SeedanceHumanReferenceAsset",
+      "file_path": "griptape_nodes_library/video/seedance_human_reference_asset.py",
+      "metadata": {
+        "category": "video/seedance",
+        "description": "Package an image, video, or audio as a private-asset reference for Seedance 2.0 human-reference inputs.",
+        "display_name": "Seedance Human Reference Asset",
+        "icon": "Link",
+        "group": "create",
+        "tags": [
+          "seedance",
+          "reference",
+          "asset",
+          "image",
+          "video",
+          "audio"
         ]
       }
     },

--- a/griptape_nodes_library/assets/__init__.py
+++ b/griptape_nodes_library/assets/__init__.py
@@ -1,0 +1,33 @@
+"""BytePlus private-asset support: custom artifacts + loader node."""
+
+from griptape_nodes_library.assets.byteplus_provider_asset_reference import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    ASSET_KINDS,
+    ASSET_REFERENCE_TYPE_NAMES,
+    BytePlusAudioAssetReference,
+    BytePlusImageAssetReference,
+    BytePlusVideoAssetReference,
+    create_provider_asset_reference,
+    get_provider_asset_kind,
+    get_provider_asset_value,
+    is_provider_asset_reference,
+    reference_type_name_for_kind,
+)
+
+__all__ = [
+    "ASSET_KINDS",
+    "ASSET_KIND_AUDIO",
+    "ASSET_KIND_IMAGE",
+    "ASSET_KIND_VIDEO",
+    "ASSET_REFERENCE_TYPE_NAMES",
+    "BytePlusAudioAssetReference",
+    "BytePlusImageAssetReference",
+    "BytePlusVideoAssetReference",
+    "create_provider_asset_reference",
+    "get_provider_asset_kind",
+    "get_provider_asset_value",
+    "is_provider_asset_reference",
+    "reference_type_name_for_kind",
+]

--- a/griptape_nodes_library/assets/byteplus_provider_asset_reference.py
+++ b/griptape_nodes_library/assets/byteplus_provider_asset_reference.py
@@ -1,0 +1,173 @@
+"""Custom artifacts marking media as a BytePlus private-asset reference.
+
+A provider-asset reference wraps a media value (a public URL, a project macro
+path, a workspace static-files path, or a ``data:`` URI) and carries the asset
+*kind* (Image/Video/Audio). The `Seedance20VideoGeneration` node accepts
+these types on its existing reference inputs and, at generation time, registers
+the media as a BytePlus private asset via the Griptape Cloud proxy and references
+it in the request as ``asset://{asset_id}``.
+
+There is one concrete class per kind — `BytePlusImageAssetReference`,
+`BytePlusVideoAssetReference`, `BytePlusAudioAssetReference` — and the class name
+deliberately contains the kind word ("Image"/"Video"/"Audio"). The Griptape
+Nodes UI selects a media preview by substring-matching the serialized ``type``
+against those words (and renders ``src = value``), so per-kind names get the
+media to preview natively without any GUI changes.
+
+Independently of ``type``, every reference also stamps a sentinel + the kind into
+``meta`` (which is ``serializable=True`` and survives the ``to_dict()`` / JSON
+round trip). The Seedance node detects "this item is a private asset" from that
+sentinel, so detection does not depend on the ``type`` string. The helper
+functions below work whether a reference arrives as a live instance or a
+serialized dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from attrs import define
+from griptape.artifacts.url_artifact import UrlArtifact
+
+ASSET_KIND_IMAGE = "Image"
+ASSET_KIND_VIDEO = "Video"
+ASSET_KIND_AUDIO = "Audio"
+ASSET_KINDS = [ASSET_KIND_IMAGE, ASSET_KIND_VIDEO, ASSET_KIND_AUDIO]
+
+# meta keys — both are serializable and survive the JSON boundary.
+ASSET_SENTINEL_KEY = "byteplus_provider_asset"
+ASSET_KIND_META_KEY = "asset_kind"
+
+__all__ = [
+    "ASSET_KINDS",
+    "ASSET_KIND_AUDIO",
+    "ASSET_KIND_IMAGE",
+    "ASSET_KIND_VIDEO",
+    "ASSET_REFERENCE_TYPE_NAMES",
+    "BytePlusAudioAssetReference",
+    "BytePlusImageAssetReference",
+    "BytePlusVideoAssetReference",
+    "create_provider_asset_reference",
+    "get_provider_asset_kind",
+    "get_provider_asset_value",
+    "is_provider_asset_reference",
+    "reference_type_name_for_kind",
+]
+
+
+@define
+class _BytePlusAssetReferenceBase(UrlArtifact):
+    """Shared behavior for the per-kind provider-asset references.
+
+    Concrete subclasses fix the kind; prefer the module-level
+    `create_provider_asset_reference(value, asset_kind)` factory or each
+    subclass's `create(value)` over the attrs constructor so the kind/sentinel
+    land in ``meta``.
+    """
+
+    # ClassVar so attrs treats it as a class constant, not an instance field.
+    _ASSET_KIND: ClassVar[str] = ""  # overridden per concrete subclass
+
+    @classmethod
+    def create(cls, value: str, meta: dict[str, Any] | None = None) -> _BytePlusAssetReferenceBase:
+        merged_meta = {
+            **(meta or {}),
+            ASSET_SENTINEL_KEY: True,
+            ASSET_KIND_META_KEY: cls._ASSET_KIND,
+        }
+        return cls(value=value, meta=merged_meta)
+
+    @property
+    def asset_kind(self) -> str | None:
+        return self.meta.get(ASSET_KIND_META_KEY)
+
+
+@define
+class BytePlusImageAssetReference(_BytePlusAssetReferenceBase):
+    """An image to register as a BytePlus private asset."""
+
+    _ASSET_KIND: ClassVar[str] = ASSET_KIND_IMAGE
+
+
+@define
+class BytePlusVideoAssetReference(_BytePlusAssetReferenceBase):
+    """A video to register as a BytePlus private asset."""
+
+    _ASSET_KIND: ClassVar[str] = ASSET_KIND_VIDEO
+
+
+@define
+class BytePlusAudioAssetReference(_BytePlusAssetReferenceBase):
+    """Audio to register as a BytePlus private asset."""
+
+    _ASSET_KIND: ClassVar[str] = ASSET_KIND_AUDIO
+
+
+# kind <-> concrete class / type-name maps.
+_KIND_TO_CLASS: dict[str, type[_BytePlusAssetReferenceBase]] = {
+    ASSET_KIND_IMAGE: BytePlusImageAssetReference,
+    ASSET_KIND_VIDEO: BytePlusVideoAssetReference,
+    ASSET_KIND_AUDIO: BytePlusAudioAssetReference,
+}
+ASSET_REFERENCE_TYPE_NAMES: dict[str, str] = {kind: cls.__name__ for kind, cls in _KIND_TO_CLASS.items()}
+_REFERENCE_TYPE_NAME_SET = set(ASSET_REFERENCE_TYPE_NAMES.values())
+
+
+def reference_type_name_for_kind(asset_kind: str) -> str:
+    """Return the artifact type-name string for a kind (e.g. 'BytePlusImageAssetReference')."""
+    cls = _KIND_TO_CLASS.get(asset_kind)
+    if cls is None:
+        msg = f"Unsupported asset_kind '{asset_kind}'. Supported: {', '.join(ASSET_KINDS)}."
+        raise ValueError(msg)
+    return cls.__name__
+
+
+def create_provider_asset_reference(value: str, asset_kind: str, meta: dict[str, Any] | None = None) -> UrlArtifact:
+    """Build the per-kind provider-asset reference for ``asset_kind``."""
+    cls = _KIND_TO_CLASS.get(asset_kind)
+    if cls is None:
+        msg = f"Unsupported asset_kind '{asset_kind}'. Supported: {', '.join(ASSET_KINDS)}."
+        raise ValueError(msg)
+    return cls.create(value, meta=meta)
+
+
+def is_provider_asset_reference(val: Any) -> bool:
+    """Return True if ``val`` is a provider-asset reference (instance or dict).
+
+    Detection uses a dual signal so it survives serialization: the per-kind
+    ``type`` name set by ``to_dict()`` and a sentinel stored in ``meta``.
+    """
+    if isinstance(val, _BytePlusAssetReferenceBase):
+        return True
+    if isinstance(val, dict):
+        if val.get("type") in _REFERENCE_TYPE_NAME_SET:
+            return True
+        meta = val.get("meta")
+        if isinstance(meta, dict) and meta.get(ASSET_SENTINEL_KEY) is True:
+            return True
+    return False
+
+
+def get_provider_asset_kind(val: Any) -> str | None:
+    """Read the asset kind (Image/Video/Audio) from an instance or serialized dict."""
+    if isinstance(val, _BytePlusAssetReferenceBase):
+        return val.asset_kind
+    if isinstance(val, dict):
+        meta = val.get("meta")
+        if isinstance(meta, dict):
+            kind = meta.get(ASSET_KIND_META_KEY)
+            if isinstance(kind, str):
+                return kind
+    return None
+
+
+def get_provider_asset_value(val: Any) -> str | None:
+    """Read the underlying media value from an instance or serialized dict."""
+    if isinstance(val, _BytePlusAssetReferenceBase):
+        return val.value
+    if isinstance(val, dict):
+        for key in ("value", "url"):
+            candidate = val.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+    return None

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import re
 import threading
 from abc import ABC, abstractmethod
@@ -21,6 +20,7 @@ from griptape_nodes.retained_mode.events.base_events import ResultPayload
 from griptape_nodes.retained_mode.events.model_events import DeclareModelInvocationRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key, resolve_proxy_base
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
 
@@ -66,10 +66,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
 
         # Compute API base once; GT_CLOUD_PROXY_BASE_URL overrides just the proxy
         # without affecting other engine systems that use GT_CLOUD_BASE_URL.
-        base = os.getenv("GT_CLOUD_PROXY_BASE_URL") or os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
-        base_slash = base if base.endswith("/") else base + "/"
-        api_base = urljoin(base_slash, "api/")
-        self._proxy_base = urljoin(api_base, "proxy/v2/")
+        self._proxy_base = resolve_proxy_base()
         self._user_auth_info: str | None = None
         self._api_key_provider: ProxyAuthProviderParameter | None = None
         self._initialize_api_key_provider()
@@ -259,10 +256,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         Raises:
             ValueError: If API key is missing
         """
-        proxy_key = os.getenv("GT_CLOUD_PROXY_API_KEY")
-        if proxy_key:
-            return proxy_key
-        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_NAME)
+        api_key = resolve_proxy_api_key(self.API_KEY_NAME)
         if not api_key:
             self._set_safe_defaults()
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."

--- a/griptape_nodes_library/proxy/provider_asset_access.py
+++ b/griptape_nodes_library/proxy/provider_asset_access.py
@@ -1,0 +1,180 @@
+"""Resolve Griptape Cloud proxy config and check provider-asset (BytePlus private asset) access.
+
+Provider-asset registration (used by Seedance 2.0 human-reference inputs) is an org-gated
+feature. The only way to tell whether an org/API key may use it is to call the provider-asset
+API and inspect the response, so this module exposes a small access check that probes
+``GET proxy/v2/assets/<id>`` and classifies the result.
+
+These helpers also centralize the proxy base-URL and API-key resolution so that nodes which are
+not ``GriptapeProxyNode`` subclasses (e.g. the human-reference-asset DataNode) can reach the
+proxy without duplicating that logic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import suppress
+from dataclasses import dataclass
+from enum import Enum
+from urllib.parse import urljoin
+
+import httpx
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = [
+    "ProviderAssetAccess",
+    "ProviderAssetAccessOutcome",
+    "check_provider_asset_access",
+    "resolve_proxy_api_key",
+    "resolve_proxy_base",
+]
+
+# Secret name for the Griptape Cloud API key (mirrors GriptapeProxyNode.API_KEY_NAME).
+API_KEY_NAME = "GT_CLOUD_API_KEY"
+
+# Probe asset id used purely to reach the provider-asset handler. It is not expected to exist;
+# an access-granted org returns a 404 "provider asset not found" for it.
+_PROBE_ASSET_ID = "griptape-access-probe-0000"
+_ASSET_NOT_FOUND_MARKER = "provider asset not found"
+_ACCESS_CHECK_TIMEOUT = 10  # seconds; keep short so it never blocks graph load for long
+
+
+class ProviderAssetAccessOutcome(Enum):
+    """How the access probe resolved.
+
+    GRANTED — the request reached the provider-asset handler (the entitlement gate is applied
+    before the handler runs, so reaching it proves access): HTTP 200, or 404 with the
+    "provider asset not found" marker.
+
+    DENIED — the org is not entitled to the feature. The backend gates this specifically with
+    HTTP 403 (feature flag off, model-proxy entitlement missing, or a license policy denial).
+    This is the only outcome that should tell the user to request access from Foundry.
+
+    INDETERMINATE — the probe could not determine entitlement: a missing key, an auth error
+    (401), a server error (5xx), a network/timeout failure, or any unexpected status. The cause
+    is real but is NOT a no-access signal, so callers should surface the underlying error rather
+    than claim the org lacks access, and should not block on it alone.
+    """
+
+    GRANTED = "granted"
+    DENIED = "denied"
+    INDETERMINATE = "indeterminate"
+
+
+def resolve_proxy_base() -> str:
+    """Return the proxy v2 base URL (``.../api/proxy/v2/``).
+
+    GT_CLOUD_PROXY_BASE_URL overrides just the proxy without affecting other engine systems
+    that use GT_CLOUD_BASE_URL.
+    """
+    base = os.getenv("GT_CLOUD_PROXY_BASE_URL") or os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
+    base_slash = base if base.endswith("/") else base + "/"
+    api_base = urljoin(base_slash, "api/")
+    return urljoin(api_base, "proxy/v2/")
+
+
+def resolve_proxy_api_key(secret_name: str = API_KEY_NAME) -> str | None:
+    """Return the API key for proxy requests, or None if unavailable.
+
+    GT_CLOUD_PROXY_API_KEY overrides the key used for proxy requests without affecting other
+    engine systems that use the ``secret_name`` secret (GT_CLOUD_API_KEY by default).
+    """
+    proxy_key = os.getenv("GT_CLOUD_PROXY_API_KEY")
+    if proxy_key:
+        return proxy_key
+    with suppress(Exception):
+        return GriptapeNodes.SecretsManager().get_secret(secret_name)
+    return None
+
+
+@dataclass
+class ProviderAssetAccess:
+    """Result of a provider-asset access probe.
+
+    `outcome` classifies the probe (see `ProviderAssetAccessOutcome`); `detail` is a
+    human-readable explanation. `has_access` is a convenience for "the org may use the feature"
+    (GRANTED only). Callers distinguish DENIED (block + tell the user to request access) from
+    INDETERMINATE (surface the underlying error; do not assert no-access).
+    """
+
+    outcome: ProviderAssetAccessOutcome
+    detail: str
+
+    @property
+    def has_access(self) -> bool:
+        return self.outcome is ProviderAssetAccessOutcome.GRANTED
+
+    @property
+    def is_denied(self) -> bool:
+        return self.outcome is ProviderAssetAccessOutcome.DENIED
+
+
+def check_provider_asset_access() -> ProviderAssetAccess:
+    """Probe ``GET proxy/v2/assets/<probe>`` and classify whether the org may use the feature.
+
+    The backend applies the entitlement gate before the asset handler, so the probe distinguishes
+    three outcomes (see `ProviderAssetAccessOutcome`): GRANTED (reached the handler: 200, or 404
+    with the not-found marker), DENIED (HTTP 403 entitlement gate), or INDETERMINATE (missing key,
+    401 auth, 5xx server error, network/timeout, or any unexpected status). Only DENIED means the
+    org lacks access; INDETERMINATE surfaces the real cause without claiming no-access.
+    """
+    api_key = resolve_proxy_api_key()
+    if not api_key:
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.INDETERMINATE,
+            detail=f"Missing {API_KEY_NAME}. Set it in the environment/config to use provider-asset references.",
+        )
+
+    url = urljoin(resolve_proxy_base(), f"assets/{_PROBE_ASSET_ID}")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        response = httpx.get(url, headers=headers, timeout=_ACCESS_CHECK_TIMEOUT)
+    except Exception as e:  # network/timeout — cause is real but not a no-access signal.
+        logger.info("Provider-asset access probe failed to reach %s: %s", url, e)
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.INDETERMINATE,
+            detail=f"Could not reach the Griptape Cloud provider-asset API ({e}). Check connectivity and try again.",
+        )
+
+    status = response.status_code
+    body = response.text or ""
+
+    # Reached the provider-asset handler -> access granted. A 404 must carry the asset-not-found
+    # marker: an entitled org's probe of a non-existent asset returns 404 "provider asset not
+    # found", whereas no entitlement is gated upstream with 403. Matching the marker (rather than
+    # any 404) avoids mistaking some other 404 for access.
+    if status == httpx.codes.OK:
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.GRANTED, detail="Provider-asset access confirmed."
+        )
+    if status == httpx.codes.NOT_FOUND and _ASSET_NOT_FOUND_MARKER in body.lower():
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.GRANTED, detail="Provider-asset access confirmed."
+        )
+
+    # The entitlement gate denies with 403 specifically (feature flag off, model-proxy
+    # entitlement missing, or a license policy denial). This is the only no-access outcome.
+    if status == httpx.codes.FORBIDDEN:
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.DENIED,
+            detail=(
+                "This organization does not have access to provider-asset references. "
+                "An admin needs to request access to this feature from Foundry."
+            ),
+        )
+
+    # Auth error — a real, distinct cause, but not an entitlement signal.
+    if status == httpx.codes.UNAUTHORIZED:
+        return ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.INDETERMINATE,
+            detail=f"{API_KEY_NAME} was rejected by Griptape Cloud (HTTP 401). Verify the key is valid.",
+        )
+
+    # Server error or any other unexpected status — surface it as-is, do not claim no-access.
+    return ProviderAssetAccess(
+        outcome=ProviderAssetAccessOutcome.INDETERMINATE,
+        detail=f"Could not verify provider-asset access (HTTP {status} from Griptape Cloud).",
+    )

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -459,8 +459,10 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             self._public_reference_video_parameter_1.delete_uploaded_artifact()
             self._public_reference_video_parameter_2.delete_uploaded_artifact()
             self._public_reference_video_parameter_3.delete_uploaded_artifact()
-            # The backend deletes the provider asset on terminal generation state, but the
-            # transient GTC static-storage upload made to feed CreateProviderAsset is ours
+            # Provider assets are reclaimed by the backend: a submitted generation deletes its
+            # linked assets on terminal state, and assets we register but never submit (e.g. a
+            # build failure after registration) are reclaimed by the backend's orphan sweeper.
+            # The transient GTC static-storage upload made to feed CreateProviderAsset is ours
             # to clean up, along with the scratch parameter created to perform the upload (its
             # name is unique per call, so leaving it would accumulate parameters on the node).
             for helper, scratch_name in self._pending_asset_uploads:
@@ -921,7 +923,12 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         return await self._poll_provider_asset(str(provider_asset_id), headers)
 
     async def _poll_provider_asset(self, provider_asset_id: str, headers: dict[str, str]) -> str:
-        """Poll GET proxy/v2/assets/<id> until ACTIVE; return the provider asset id."""
+        """Poll GET proxy/v2/assets/<id> until ACTIVE; return the provider asset id.
+
+        Transient errors (a network blip, a 5xx, or the eventual-consistency 404 right after the
+        asset id is minted) are logged and retried until attempts are exhausted, mirroring the
+        base class's generation poll. Only a terminal status (FAILED/DELETED) fails immediately.
+        """
         get_url = urljoin(self._proxy_base, f"assets/{provider_asset_id}")
         async with httpx.AsyncClient() as client:
             for attempt in range(ASSET_MAX_ATTEMPTS):
@@ -930,8 +937,12 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                     response.raise_for_status()
                     result_json = response.json()
                 except Exception as e:
-                    msg = f"{self.name}: failed to poll private asset {provider_asset_id}: {e}"
-                    raise RuntimeError(msg) from e
+                    # Transient — log and retry rather than aborting an otherwise-successful run.
+                    self._log(
+                        f"{self.name} error polling private asset {provider_asset_id} (attempt {attempt + 1}): {e}"
+                    )
+                    await asyncio.sleep(ASSET_POLL_INTERVAL)
+                    continue
 
                 status = result_json.get("status", "unknown")
                 self._log(f"{self.name} private asset {provider_asset_id} status: {status} (attempt {attempt + 1})")

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json as _json
 import logging
+from contextlib import suppress
 from typing import Any, ClassVar
+from urllib.parse import urljoin
+from uuid import uuid4
 
+import httpx
 from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
@@ -23,6 +28,15 @@ from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
 
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    ASSET_REFERENCE_TYPE_NAMES,
+    get_provider_asset_kind,
+    get_provider_asset_value,
+    is_provider_asset_reference,
+)
 from griptape_nodes_library.media import coerce_media_url_or_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
 
@@ -37,6 +51,17 @@ MODEL_NAME_SEEDANCE_2_0 = "Seedance 2.0"
 MODEL_NAME_SEEDANCE_2_0_FAST = "Seedance 2.0 Fast"
 SEEDANCE_2_0_MODEL_ID = "dreamina-seedance-2-0-260128"
 SEEDANCE_2_0_FAST_MODEL_ID = "dreamina-seedance-2-0-fast-260128"
+
+# Provider-asset (private asset) registration via the GTC proxy. Only the Seedance 2.0 model
+# supports private-asset references; Seedance 2.0 Fast does not.
+ASSET_PROVIDER = "byteplus_ark"
+ASSET_POLL_INTERVAL = 3  # seconds
+ASSET_MAX_ATTEMPTS = 60  # ~3 min cap, independent of the generation timeout
+ASSET_STATUS_ACTIVE = "ACTIVE"
+ASSET_STATUS_FAILED = "FAILED"
+ASSET_STATUS_DELETED = "DELETED"
+# Skip provider-side moderation on private-asset ingestion (content is already moderated upstream).
+ASSET_MODERATION = {"Strategy": "Skip"}
 
 
 class Seedance20VideoGeneration(GriptapeProxyNode):
@@ -75,6 +100,11 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate video via Seedance 2.0 through Griptape Cloud model proxy"
+
+        # Transient (helper, scratch parameter name) pairs created while registering private
+        # assets; the upload and the scratch parameter are both cleaned up in
+        # _process_generation's finally block so they don't accumulate on the node across runs.
+        self._pending_asset_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
         # Model selection
         self.add_parameter(
@@ -143,9 +173,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterList(
                 name="reference_images",
-                input_types=["ImageUrlArtifact", "ImageArtifact", "str"],
+                input_types=["ImageUrlArtifact", "ImageArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_IMAGE]],
                 default_value=[],
-                tooltip="Optional reference images (0-9 images)",
+                tooltip="Optional reference images (0-9 images). Connect a Seedance Human Reference Asset to register an image as a private asset (Seedance 2.0 only).",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Images", "expander": True, "hide_property": True},
                 max_items=9,
@@ -156,7 +186,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             node=self,
             artifact_url_parameter=Parameter(
                 name="reference_video_1",
-                input_types=["VideoUrlArtifact"],
+                input_types=["VideoUrlArtifact", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_VIDEO]],
                 type="VideoUrlArtifact",
                 default_value="",
                 tooltip=(
@@ -175,7 +205,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             node=self,
             artifact_url_parameter=Parameter(
                 name="reference_video_2",
-                input_types=["VideoUrlArtifact"],
+                input_types=["VideoUrlArtifact", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_VIDEO]],
                 type="VideoUrlArtifact",
                 default_value="",
                 tooltip=(
@@ -196,7 +226,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             node=self,
             artifact_url_parameter=Parameter(
                 name="reference_video_3",
-                input_types=["VideoUrlArtifact"],
+                input_types=["VideoUrlArtifact", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_VIDEO]],
                 type="VideoUrlArtifact",
                 default_value="",
                 tooltip=(
@@ -216,9 +246,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterList(
                 name="reference_audio",
-                input_types=["AudioArtifact", "AudioUrlArtifact", "str"],
+                input_types=["AudioArtifact", "AudioUrlArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_AUDIO]],
                 default_value=[],
-                tooltip="Optional reference audio (0-3 audio files, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported.",
+                tooltip="Optional reference audio (0-3 audio files, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported. Connect a Seedance Human Reference Asset to register audio as a private asset (Seedance 2.0 only).",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Audio", "expander": True, "hide_property": True},
                 max_items=3,
@@ -422,12 +452,23 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         return self.MODEL_NAME_MAP.get(raw_model_id, raw_model_id)
 
     async def _process_generation(self) -> None:
+        self._pending_asset_uploads = []
         try:
             await super()._process_generation()
         finally:
             self._public_reference_video_parameter_1.delete_uploaded_artifact()
             self._public_reference_video_parameter_2.delete_uploaded_artifact()
             self._public_reference_video_parameter_3.delete_uploaded_artifact()
+            # The backend deletes the provider asset on terminal generation state, but the
+            # transient GTC static-storage upload made to feed CreateProviderAsset is ours
+            # to clean up, along with the scratch parameter created to perform the upload (its
+            # name is unique per call, so leaving it would accumulate parameters on the node).
+            for helper, scratch_name in self._pending_asset_uploads:
+                with suppress(Exception):
+                    helper.delete_uploaded_artifact()
+                with suppress(Exception):
+                    self.remove_parameter_element_by_name(scratch_name)
+            self._pending_asset_uploads = []
 
     def validate_before_node_run(self) -> list[Exception] | None:
         """Validate parameters before execution."""
@@ -579,6 +620,72 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             )
             raise ValueError(msg)
 
+        # Private-asset references require Seedance 2.0 and Griptape auth (not Fast, not BYOK).
+        # Gate first so the user gets a specific message before the per-kind check.
+        self._validate_private_asset_model(params)
+        self._validate_private_asset_auth(params)
+
+        # Private-asset reference kind must match the receiving input (early feedback; the
+        # authoritative check happens at build time in _append_private_asset).
+        if self._private_assets_active(params["model_id"]):
+            self._validate_private_asset_kinds(params)
+
+    def _iter_reference_asset_checks(self, params: dict[str, Any]) -> list[tuple[Any, str]]:
+        """List (reference value, expected kind) pairs across all multimodal reference inputs."""
+        checks: list[tuple[Any, str]] = []
+        for item in params.get("reference_images") or []:
+            checks.append((item, ASSET_KIND_IMAGE))
+        for name in ("reference_video_1", "reference_video_2", "reference_video_3"):
+            value = params.get(name)
+            if value:
+                checks.append((value, ASSET_KIND_VIDEO))
+        for item in params.get("reference_audio") or []:
+            checks.append((item, ASSET_KIND_AUDIO))
+        return checks
+
+    def _validate_private_asset_model(self, params: dict[str, Any]) -> None:
+        """Raise if a private-asset reference is connected while the model doesn't support it."""
+        if self._supports_private_assets(params["model_id"]):
+            return
+        for value, _ in self._iter_reference_asset_checks(params):
+            if is_provider_asset_reference(value):
+                msg = (
+                    f"{self.name}: Seedance 2.0 Fast does not support private-asset references "
+                    "(Seedance Human Reference Asset). Switch the model to Seedance 2.0, or remove the "
+                    "private-asset reference inputs."
+                )
+                raise ValueError(msg)
+
+    def _validate_private_asset_auth(self, params: dict[str, Any]) -> None:
+        """Raise if a private-asset reference is connected while the node uses BYOK auth.
+
+        Provider assets are registered through the Griptape Cloud proxy on the org's behalf, so
+        they are unavailable when the user brings their own provider key.
+        """
+        if not self._is_byok_enabled():
+            return
+        for value, _ in self._iter_reference_asset_checks(params):
+            if is_provider_asset_reference(value):
+                msg = (
+                    f"{self.name}: private-asset references (Seedance Human Reference Asset) require "
+                    "Griptape authentication and are not available when using your own provider key. "
+                    "Switch off the customer key option, or remove the private-asset reference inputs."
+                )
+                raise ValueError(msg)
+
+    def _validate_private_asset_kinds(self, params: dict[str, Any]) -> None:
+        """Raise if a private-asset reference's kind doesn't match its receiving input."""
+        for value, expected_kind in self._iter_reference_asset_checks(params):
+            if is_provider_asset_reference(value):
+                actual_kind = get_provider_asset_kind(value)
+                if actual_kind != expected_kind:
+                    msg = (
+                        f"{self.name}: a {actual_kind or 'unknown'} private-asset reference is connected to a "
+                        f"{expected_kind} reference input. Set the Seedance Human Reference Asset's Asset Kind "
+                        f"to {expected_kind}, or connect it to the matching reference input."
+                    )
+                    raise ValueError(msg)
+
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Seedance 2.0 API."""
         params = self._get_parameters()
@@ -625,28 +732,71 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
         if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
             self._log(f"{self.name} building multimodal content")
-            # Multimodal mode: reference images/videos/audio
-            for ref_image in params.get("reference_images", [])[:9]:
-                ref_url = await self._prepare_frame_url_async(ref_image, frame_label="reference_image")
-                if ref_url:
-                    content_list.append({"type": "image_url", "image_url": {"url": ref_url}, "role": "reference_image"})
+            supports_assets = self._private_assets_active(params["model_id"])
+            order_log: list[str] = []
 
-            for ref_video in self._get_reference_video_inputs(params):
-                video_url = self._get_reference_video_url(ref_video["parameter_name"], ref_video["value"])
-                if not video_url:
-                    msg = (
-                        f"{self.name}: {ref_video['parameter_name']} only supports public URLs, uploaded asset URLs, "
-                        "or asset:// IDs. Seedance 2.0 does not accept video base64."
+            # Reference images (Image 1..N within this list, normal or private asset).
+            for idx, ref_image in enumerate(params.get("reference_images", [])[:9], start=1):
+                if supports_assets and is_provider_asset_reference(ref_image):
+                    asset_url = await self._append_private_asset(
+                        ref_image, expected_kind=ASSET_KIND_IMAGE, label=f"reference image {idx}"
                     )
-                    raise ValueError(msg)
-                content_list.append({"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"})
-
-            for ref_audio in params.get("reference_audio", [])[:3]:
-                audio_url = await self._prepare_audio_url_async(ref_audio, audio_label="reference_audio")
-                if audio_url:
                     content_list.append(
-                        {"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"}
+                        {"type": "image_url", "image_url": {"url": asset_url}, "role": "reference_image"}
                     )
+                    order_log.append(f"Image {idx}: private asset")
+                else:
+                    ref_url = await self._prepare_frame_url_async(ref_image, frame_label="reference_image")
+                    if ref_url:
+                        content_list.append(
+                            {"type": "image_url", "image_url": {"url": ref_url}, "role": "reference_image"}
+                        )
+                        order_log.append(f"Image {idx}: reference")
+
+            # Reference videos (Video 1..3 by slot).
+            for idx, ref_video in enumerate(self._get_reference_video_inputs(params), start=1):
+                value = ref_video["value"]
+                if supports_assets and is_provider_asset_reference(value):
+                    asset_url = await self._append_private_asset(
+                        value, expected_kind=ASSET_KIND_VIDEO, label=f"reference video {idx}"
+                    )
+                    content_list.append(
+                        {"type": "video_url", "video_url": {"url": asset_url}, "role": "reference_video"}
+                    )
+                    order_log.append(f"Video {idx}: private asset")
+                else:
+                    video_url = self._get_reference_video_url(ref_video["parameter_name"], value)
+                    if not video_url:
+                        msg = (
+                            f"{self.name}: {ref_video['parameter_name']} only supports public URLs, uploaded asset URLs, "
+                            "or asset:// IDs. Seedance 2.0 does not accept video base64."
+                        )
+                        raise ValueError(msg)
+                    content_list.append(
+                        {"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"}
+                    )
+                    order_log.append(f"Video {idx}: reference")
+
+            # Reference audio (Audio 1..N within this list, normal or private asset).
+            for idx, ref_audio in enumerate(params.get("reference_audio", [])[:3], start=1):
+                if supports_assets and is_provider_asset_reference(ref_audio):
+                    asset_url = await self._append_private_asset(
+                        ref_audio, expected_kind=ASSET_KIND_AUDIO, label=f"reference audio {idx}"
+                    )
+                    content_list.append(
+                        {"type": "audio_url", "audio_url": {"url": asset_url}, "role": "reference_audio"}
+                    )
+                    order_log.append(f"Audio {idx}: private asset")
+                else:
+                    audio_url = await self._prepare_audio_url_async(ref_audio, audio_label="reference_audio")
+                    if audio_url:
+                        content_list.append(
+                            {"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"}
+                        )
+                        order_log.append(f"Audio {idx}: reference")
+
+            if order_log:
+                self._log(f"{self.name} resolved reference order: " + "; ".join(order_log))
         elif input_mode == INPUT_MODE_FIRST_LAST_FRAME:
             self._log(f"{self.name} building first/last-frame content")
             # First/Last Frame mode
@@ -663,6 +813,148 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         else:
             # Text Only mode: no media inputs
             self._log(f"{self.name} text-only mode, no media inputs")
+
+    # --- Provider private-asset registration (Seedance 2.0 only) ----------------------------
+
+    def _proxy_headers(self) -> dict[str, str]:
+        """Bearer headers for the GTC proxy (same auth as the generation requests)."""
+        return {"Authorization": f"Bearer {self._validate_api_key()}", "Content-Type": "application/json"}
+
+    async def _append_private_asset(self, ref: Any, *, expected_kind: str, label: str) -> str:
+        """Resolve a private-asset reference to an `asset://{asset_id}` URL.
+
+        Cross-checks the reference kind against the receiving input, obtains a public URL for
+        the media, registers it as a provider private asset via the proxy, and polls until ACTIVE.
+        """
+        actual_kind = get_provider_asset_kind(ref)
+        if actual_kind != expected_kind:
+            msg = (
+                f"{self.name}: {label} received a {actual_kind or 'unknown'} private-asset reference, "
+                f"but this input requires a {expected_kind} reference. "
+                f"Set the Seedance Human Reference Asset's Asset Kind to {expected_kind}."
+            )
+            raise ValueError(msg)
+
+        public_url = self._resolve_public_url_for_asset(ref, asset_kind=expected_kind)
+        headers = self._proxy_headers()
+        asset_id = await self._create_provider_asset(public_url, expected_kind, headers)
+        return f"asset://{asset_id}"
+
+    def _resolve_public_url_for_asset(self, ref: Any, *, asset_kind: str) -> str:
+        """Return a publicly fetchable URL for the reference's media.
+
+        Already-public http(s) URLs pass through. Otherwise the media is uploaded to GTC static
+        storage via a transient PublicArtifactUrlParameter (tracked for cleanup). CreateProviderAsset
+        requires a fetchable URL — data URIs / unresolvable inputs raise.
+        """
+        media_value = get_provider_asset_value(ref)
+        if not media_value:
+            msg = f"{self.name}: private-asset reference has no media value to register."
+            raise ValueError(msg)
+
+        if media_value.startswith(("http://", "https://")) and "localhost" not in media_value:
+            return media_value
+
+        artifact_type = {
+            ASSET_KIND_IMAGE: "ImageUrlArtifact",
+            ASSET_KIND_VIDEO: "VideoUrlArtifact",
+            ASSET_KIND_AUDIO: "AudioUrlArtifact",
+        }[asset_kind]
+
+        # Adding this scratch parameter during aprocess trips the strict-mode
+        # "parameter-mutation-during-aprocess" warning. That is expected and harmless here: the
+        # parameter is a transient, worker-local helper that only exists to feed the upload
+        # (PublicArtifactUrlParameter reads its value locally) and is removed before the run ends,
+        # so there is nothing for the orchestrator to stay in sync with.
+        scratch_name = f"_asset_upload_{uuid4().hex}"
+        helper = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=Parameter(
+                name=scratch_name,
+                input_types=[artifact_type],
+                type=artifact_type,
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.PROPERTY},
+                hide=True,
+                hide_property=True,
+            ),
+        )
+        helper.add_input_parameters()
+        self._pending_asset_uploads.append((helper, scratch_name))
+        self.set_parameter_value(scratch_name, media_value)
+
+        public_url = helper.get_public_url_for_parameter()
+        if not (public_url.startswith(("http://", "https://")) and "localhost" not in public_url):
+            msg = (
+                f"{self.name}: could not obtain a public URL for the {asset_kind} private asset. "
+                "Provider asset registration requires a publicly fetchable URL (data URIs are not supported)."
+            )
+            raise RuntimeError(msg)
+        return public_url
+
+    async def _create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
+        """POST proxy/v2/assets and poll to ACTIVE; return the provider asset id."""
+        create_url = urljoin(self._proxy_base, "assets")
+        payload = {
+            "url": public_url,
+            "provider": ASSET_PROVIDER,
+            "provider_body": {"asset_type": asset_kind, "moderation": ASSET_MODERATION},
+        }
+        self._log(f"{self.name} registering {asset_kind} private asset via {create_url}")
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(create_url, json=payload, headers=headers, timeout=60)
+                response.raise_for_status()
+                response_json = response.json()
+        except httpx.HTTPStatusError as e:
+            msg = f"{self.name}: failed to create private asset: HTTP {e.response.status_code} - {e.response.text}"
+            raise RuntimeError(msg) from e
+        except Exception as e:
+            msg = f"{self.name}: failed to create private asset: {e}"
+            raise RuntimeError(msg) from e
+
+        provider_asset_id = response_json.get("provider_asset_id")
+        if not provider_asset_id:
+            msg = f"{self.name}: CreateProviderAsset returned no provider_asset_id."
+            raise RuntimeError(msg)
+        return await self._poll_provider_asset(str(provider_asset_id), headers)
+
+    async def _poll_provider_asset(self, provider_asset_id: str, headers: dict[str, str]) -> str:
+        """Poll GET proxy/v2/assets/<id> until ACTIVE; return the provider asset id."""
+        get_url = urljoin(self._proxy_base, f"assets/{provider_asset_id}")
+        async with httpx.AsyncClient() as client:
+            for attempt in range(ASSET_MAX_ATTEMPTS):
+                try:
+                    response = await client.get(get_url, headers=headers, timeout=60)
+                    response.raise_for_status()
+                    result_json = response.json()
+                except Exception as e:
+                    msg = f"{self.name}: failed to poll private asset {provider_asset_id}: {e}"
+                    raise RuntimeError(msg) from e
+
+                status = result_json.get("status", "unknown")
+                self._log(f"{self.name} private asset {provider_asset_id} status: {status} (attempt {attempt + 1})")
+
+                if status == ASSET_STATUS_ACTIVE:
+                    asset_id = result_json.get("asset_id")
+                    if not asset_id:
+                        msg = f"{self.name}: private asset {provider_asset_id} is ACTIVE but no asset_id was returned."
+                        raise RuntimeError(msg)
+                    return str(asset_id)
+
+                if status in (ASSET_STATUS_FAILED, ASSET_STATUS_DELETED):
+                    detail = result_json.get("status_detail")
+                    msg = f"{self.name}: private asset {provider_asset_id} ended with status {status}: {detail}"
+                    raise RuntimeError(msg)
+
+                await asyncio.sleep(ASSET_POLL_INTERVAL)
+
+        msg = (
+            f"{self.name}: private asset {provider_asset_id} did not become ACTIVE within "
+            f"{ASSET_MAX_ATTEMPTS * ASSET_POLL_INTERVAL} seconds."
+        )
+        raise RuntimeError(msg)
 
     async def _prepare_frame_url_async(self, frame_input: Any, *, frame_label: str) -> str | None:
         """Convert frame input to a usable URL."""
@@ -895,6 +1187,24 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
     @staticmethod
     def _supports_1080p(model_id: str) -> bool:
         return model_id == SEEDANCE_2_0_MODEL_ID
+
+    @staticmethod
+    def _supports_private_assets(model_id: str) -> bool:
+        """Private-asset references are supported by Seedance 2.0 only (not 2.0 Fast)."""
+        return model_id == SEEDANCE_2_0_MODEL_ID
+
+    def _is_byok_enabled(self) -> bool:
+        """Whether the node is configured to use the customer's own key (BYOK) instead of Griptape auth."""
+        return bool(self._api_key_provider and self._api_key_provider.is_user_auth_enabled())
+
+    def _private_assets_active(self, model_id: str) -> bool:
+        """Whether private-asset registration applies for this run.
+
+        Requires the Seedance 2.0 model AND Griptape auth: provider assets are registered through
+        the Griptape Cloud proxy on the org's behalf, which does not apply when the user brings
+        their own provider key (BYOK).
+        """
+        return self._supports_private_assets(model_id) and not self._is_byok_enabled()
 
     @staticmethod
     def _summarize_image_input(val: Any) -> str:

--- a/griptape_nodes_library/video/seedance_human_reference_asset.py
+++ b/griptape_nodes_library/video/seedance_human_reference_asset.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
+from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
+from griptape.artifacts.url_artifact import UrlArtifact
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.traits.options import Options
+from griptape_nodes.utils.artifact_normalization import normalize_artifact_input
+
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    ASSET_KINDS,
+    create_provider_asset_reference,
+    reference_type_name_for_kind,
+)
+from griptape_nodes_library.media import MediaKind, coerce_media_url_or_data_uri
+from griptape_nodes_library.proxy.provider_asset_access import (
+    ProviderAssetAccess,
+    ProviderAssetAccessOutcome,
+    check_provider_asset_access,
+)
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["SeedanceHumanReferenceAsset"]
+
+# asset_kind -> (media input parameter name, coercion kind)
+_KIND_TO_PARAM: dict[str, tuple[str, MediaKind]] = {
+    ASSET_KIND_IMAGE: ("image", "image"),
+    ASSET_KIND_VIDEO: ("video", "video"),
+    ASSET_KIND_AUDIO: ("audio", "audio"),
+}
+
+# Badge shown on asset_kind when the org cannot use the provider-asset feature.
+_ACCESS_BADGE_TITLE = "Provider-asset access required"
+
+
+class SeedanceHumanReferenceAsset(DataNode):
+    """Package media as a private-asset reference for Seedance 2.0 human-reference inputs.
+
+    Use this node for human-reference inputs (e.g. AIGC virtual-portrait images) that should be
+    registered as provider private assets, rather than plugging media directly into the
+    Seedance 2.0 reference inputs.
+
+    Choose the asset kind (Image/Video/Audio) and supply the matching media. The node outputs a
+    provider-asset reference carrying that media and kind; connect it into the matching reference
+    input on the Seedance 2.0 node (Reference Images, Reference Video, or Reference Audio). The
+    Seedance node registers the asset with the provider at generation time and references it via
+    `asset://{asset_id}`. Private-asset references are only supported by the Seedance 2.0 model
+    (not Seedance 2.0 Fast).
+
+    Access to the provider-asset feature is org-gated. If the configured API key cannot use the
+    provider-asset APIs, this node shows an error and asks an admin to request access from Foundry.
+
+    Inputs:
+        - asset_kind (str): "Image", "Video", or "Audio" (default: Image)
+        - image/video/audio: The reference media for the selected kind
+
+    Outputs:
+        - asset_reference: The packaged provider-asset reference
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "video/seedance"
+        self.description = "Package media as a provider private-asset reference for Seedance 2.0"
+
+        self.add_parameter(
+            ParameterString(
+                name="asset_kind",
+                default_value=ASSET_KIND_IMAGE,
+                tooltip="The kind of reference media to register as a provider private asset",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"display_name": "Asset Kind"},
+                traits={Options(choices=ASSET_KINDS)},
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="image",
+                default_value=None,
+                tooltip="Reference image to register as a provider private asset",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"display_name": "Image", "clickable_file_browser": True, "expander": True},
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="video",
+                default_value=None,
+                tooltip="Reference video to register as a provider private asset",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"display_name": "Video", "clickable_file_browser": True, "expander": True},
+            )
+        )
+
+        self.add_parameter(
+            ParameterAudio(
+                name="audio",
+                default_value=None,
+                tooltip="Reference audio to register as a provider private asset",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"display_name": "Audio", "clickable_file_browser": True, "expander": True},
+            )
+        )
+
+        # Output type/output_type is swapped per Asset Kind in _update_media_visibility so the
+        # connection (and edge color) matches the matching Seedance 2.0 reference input.
+        initial_type = reference_type_name_for_kind(ASSET_KIND_IMAGE)
+        self._asset_reference_param = Parameter(
+            name="asset_reference",
+            type=initial_type,
+            output_type=initial_type,
+            default_value=None,
+            tooltip="The packaged private-asset reference. Connect into a Seedance 2.0 reference input.",
+            allowed_modes={ParameterMode.OUTPUT},
+            settable=False,
+            ui_options={"display_name": "Asset Reference", "pulse_on_run": True},
+        )
+        self.add_parameter(self._asset_reference_param)
+
+        self._update_media_visibility()
+
+        # Org-gated feature: probe access at construction so the error surfaces immediately in
+        # the editor as a badge. The probe is best-effort (suppressed, short timeout, fail-closed)
+        # so it never raises out of construction, though it can block for up to the probe timeout.
+        # It is re-probed at run time (validate_before_node_run) because entitlement can change
+        # after the graph is loaded.
+        self._access: ProviderAssetAccess | None = None
+        self._refresh_access()
+
+    def _refresh_access(self) -> ProviderAssetAccess:
+        """Re-probe provider-asset access, update the badge, and cache/return the result.
+
+        Never raises: a probe failure is reported as INDETERMINATE and surfaced as a badge
+        rather than breaking node construction. Only a confirmed denial (403) shows the
+        error/Foundry badge; an indeterminate probe shows a non-blocking warning.
+        """
+        access = ProviderAssetAccess(
+            outcome=ProviderAssetAccessOutcome.INDETERMINATE,
+            detail="Provider-asset access could not be determined.",
+        )
+        with suppress(Exception):
+            access = check_provider_asset_access()
+        self._access = access
+
+        kind_param = self.get_parameter_by_name("asset_kind")
+        if kind_param is not None:
+            if access.outcome is ProviderAssetAccessOutcome.GRANTED:
+                kind_param.clear_badge()
+            elif access.outcome is ProviderAssetAccessOutcome.DENIED:
+                kind_param.set_badge(variant="error", title=_ACCESS_BADGE_TITLE, message=access.detail)
+            else:
+                # Indeterminate: real but non-entitlement cause — warn, don't assert no-access.
+                kind_param.set_badge(variant="warning", title="Provider-asset access unverified", message=access.detail)
+        return access
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Toggle the visible media input on kind change; normalize media; publish the output."""
+        if parameter.name == "asset_kind":
+            self._update_media_visibility()
+
+        if parameter.name == "image":
+            artifact = normalize_artifact_input(value, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+            if artifact != value:
+                self.set_parameter_value("image", artifact)
+        elif parameter.name == "audio":
+            artifact = normalize_artifact_input(value, AudioUrlArtifact, accepted_types=(AudioArtifact,))
+            if artifact != value:
+                self.set_parameter_value("audio", artifact)
+
+        # Recompute the reference output reactively so a downstream node can preview it
+        # without first running this node.
+        if parameter.name in ("asset_kind", "image", "video", "audio"):
+            self._publish_asset_reference()
+
+        return super().after_value_set(parameter, value)
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Block the run only on a confirmed no-access (403) result.
+
+        An indeterminate probe (auth error, server error, connectivity) is not treated as
+        no-access: the run proceeds and the real failure surfaces from the actual API call
+        rather than being masked by a misleading "request access" error.
+        """
+        exceptions = super().validate_before_node_run() or []
+
+        access = self._refresh_access()
+        if access.is_denied:
+            exceptions.append(ValueError(f"{self.name}: {access.detail}"))
+
+        return exceptions if exceptions else None
+
+    def _update_media_visibility(self) -> None:
+        """Show only the media input matching the selected asset kind and retype the output."""
+        kind = self.get_parameter_value("asset_kind") or ASSET_KIND_IMAGE
+        visible_param = _KIND_TO_PARAM.get(kind, _KIND_TO_PARAM[ASSET_KIND_IMAGE])[0]
+        for param_name in ("image", "video", "audio"):
+            if param_name == visible_param:
+                self.show_parameter_by_name(param_name)
+            else:
+                self.hide_parameter_by_name(param_name)
+
+        # Retype the output so the connection (and edge color) matches the receiving
+        # Seedance 2.0 reference input for this kind.
+        reference_type = reference_type_name_for_kind(kind)
+        self._asset_reference_param.type = reference_type
+        self._asset_reference_param.output_type = reference_type
+
+    def _build_asset_reference(self) -> UrlArtifact | None:
+        """Build the reference from the current kind + media inputs (None if no media)."""
+        kind = self.get_parameter_value("asset_kind") or ASSET_KIND_IMAGE
+        param_name, coerce_kind = _KIND_TO_PARAM.get(kind, _KIND_TO_PARAM[ASSET_KIND_IMAGE])
+
+        media = self.get_parameter_value(param_name)
+        media_value = coerce_media_url_or_data_uri(media, kind=coerce_kind) if media is not None else None
+        if not media_value:
+            logger.info("%s: no %s media provided; asset_reference is None", self.name, kind)
+            return None
+
+        return create_provider_asset_reference(value=media_value, asset_kind=kind)
+
+    def _publish_asset_reference(self) -> None:
+        """Compute and publish the output so connected nodes update without a run."""
+        self.publish_update_to_parameter("asset_reference", self._build_asset_reference())
+
+    def process(self) -> None:
+        self.parameter_output_values["asset_reference"] = self._build_asset_reference()

--- a/griptape_nodes_library/video/seedance_human_reference_asset.py
+++ b/griptape_nodes_library/video/seedance_human_reference_asset.py
@@ -134,20 +134,26 @@ class SeedanceHumanReferenceAsset(DataNode):
 
         self._update_media_visibility()
 
-        # Org-gated feature: probe access at construction so the error surfaces immediately in
-        # the editor as a badge. The probe is best-effort (suppressed, short timeout, fail-closed)
-        # so it never raises out of construction, though it can block for up to the probe timeout.
-        # It is re-probed at run time (validate_before_node_run) because entitlement can change
-        # after the graph is loaded.
+        # Org-gated feature. The access probe is deliberately NOT run from __init__: construction
+        # happens on graph load/add/paste and must stay cheap and non-blocking. Instead it runs
+        # lazily the first time the user interacts with the node (after_value_set) to surface an
+        # editor badge, and authoritatively at run time (validate_before_node_run).
         self._access: ProviderAssetAccess | None = None
-        self._refresh_access()
+        self._access_probed = False
+
+    def _ensure_access_probed(self) -> ProviderAssetAccess:
+        """Probe access once (lazily) and cache it; refresh the badge from the cached result."""
+        if not self._access_probed:
+            return self._refresh_access()
+        self._apply_access_badge(self._access)
+        return self._access  # type: ignore[return-value]
 
     def _refresh_access(self) -> ProviderAssetAccess:
-        """Re-probe provider-asset access, update the badge, and cache/return the result.
+        """Probe provider-asset access, cache it, refresh the badge, and return the result.
 
-        Never raises: a probe failure is reported as INDETERMINATE and surfaced as a badge
-        rather than breaking node construction. Only a confirmed denial (403) shows the
-        error/Foundry badge; an indeterminate probe shows a non-blocking warning.
+        Never raises: a probe failure is reported as INDETERMINATE and surfaced as a badge rather
+        than propagating. Only a confirmed denial (403) shows the error/Foundry badge; an
+        indeterminate probe shows a non-blocking warning.
         """
         access = ProviderAssetAccess(
             outcome=ProviderAssetAccessOutcome.INDETERMINATE,
@@ -156,20 +162,31 @@ class SeedanceHumanReferenceAsset(DataNode):
         with suppress(Exception):
             access = check_provider_asset_access()
         self._access = access
-
-        kind_param = self.get_parameter_by_name("asset_kind")
-        if kind_param is not None:
-            if access.outcome is ProviderAssetAccessOutcome.GRANTED:
-                kind_param.clear_badge()
-            elif access.outcome is ProviderAssetAccessOutcome.DENIED:
-                kind_param.set_badge(variant="error", title=_ACCESS_BADGE_TITLE, message=access.detail)
-            else:
-                # Indeterminate: real but non-entitlement cause — warn, don't assert no-access.
-                kind_param.set_badge(variant="warning", title="Provider-asset access unverified", message=access.detail)
+        self._access_probed = True
+        self._apply_access_badge(access)
         return access
+
+    def _apply_access_badge(self, access: ProviderAssetAccess | None) -> None:
+        """Reflect the access result as a badge on asset_kind (no-op until a probe has run)."""
+        if access is None:
+            return
+        kind_param = self.get_parameter_by_name("asset_kind")
+        if kind_param is None:
+            return
+        if access.outcome is ProviderAssetAccessOutcome.GRANTED:
+            kind_param.clear_badge()
+        elif access.outcome is ProviderAssetAccessOutcome.DENIED:
+            kind_param.set_badge(variant="error", title=_ACCESS_BADGE_TITLE, message=access.detail)
+        else:
+            # Indeterminate: real but non-entitlement cause — warn, don't assert no-access.
+            kind_param.set_badge(variant="warning", title="Provider-asset access unverified", message=access.detail)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Toggle the visible media input on kind change; normalize media; publish the output."""
+        # Probe access on first interaction (cached) so the editor shows an access badge without
+        # paying for a network call at construction time.
+        self._ensure_access_probed()
+
         if parameter.name == "asset_kind":
             self._update_media_visibility()
 

--- a/tests/unit/test_provider_asset_access.py
+++ b/tests/unit/test_provider_asset_access.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import griptape_nodes_library.proxy.provider_asset_access as access_module
+from griptape_nodes_library.proxy.provider_asset_access import (
+    ProviderAssetAccessOutcome,
+    check_provider_asset_access,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+@pytest.fixture(autouse=True)
+def stub_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend a key is configured so the probe path is exercised (not the missing-key path)."""
+    monkeypatch.setattr(access_module, "resolve_proxy_api_key", lambda *_args, **_kwargs: "test-key")
+
+
+def _stub_get(monkeypatch: pytest.MonkeyPatch, response: _FakeResponse) -> None:
+    monkeypatch.setattr(access_module.httpx, "get", lambda *_args, **_kwargs: response)
+
+
+def test_access_granted_on_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, _FakeResponse(200))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.GRANTED
+    assert result.has_access is True
+
+
+def test_access_granted_on_404_with_not_found_marker(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The entitlement gate runs before the asset handler, so a 404 "provider asset not found"
+    # proves the caller passed the gate.
+    _stub_get(monkeypatch, _FakeResponse(404, '{"error":"provider asset not found."}'))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.GRANTED
+
+
+def test_404_without_marker_is_indeterminate(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, _FakeResponse(404, '{"error":"not found"}'))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.INDETERMINATE
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        '{"error":"Your organization is not entitled to use this feature."}',
+        '{"error":"This license is not permitted to perform this action."}',
+    ],
+)
+def test_403_is_denied(monkeypatch: pytest.MonkeyPatch, body: str) -> None:
+    _stub_get(monkeypatch, _FakeResponse(403, body))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.DENIED
+    assert result.is_denied is True
+    assert "request access" in result.detail.lower()
+
+
+def test_401_is_indeterminate_not_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, _FakeResponse(401, "token_not_valid"))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.INDETERMINATE
+    assert result.is_denied is False
+
+
+@pytest.mark.parametrize("status", [500, 502, 503])
+def test_server_error_is_indeterminate_not_denied(monkeypatch: pytest.MonkeyPatch, status: int) -> None:
+    # A server error must NOT be reported as "no access" — it should surface the real failure.
+    _stub_get(monkeypatch, _FakeResponse(status, "internal server error"))
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.INDETERMINATE
+    assert result.is_denied is False
+    assert str(status) in result.detail
+
+
+def test_network_error_is_indeterminate(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*_args, **_kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(access_module.httpx, "get", _raise)
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.INDETERMINATE
+    assert result.is_denied is False
+
+
+def test_missing_api_key_is_indeterminate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(access_module, "resolve_proxy_api_key", lambda *_args, **_kwargs: None)
+    result = check_provider_asset_access()
+    assert result.outcome is ProviderAssetAccessOutcome.INDETERMINATE
+    assert result.is_denied is False

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -12,7 +12,16 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from griptape_nodes.files.file import File
 
 import griptape_nodes_library.video.seedance_2_0_video_generation as seedance_2_0_module
-from griptape_nodes_library.video.seedance_2_0_video_generation import Seedance20VideoGeneration
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    create_provider_asset_reference,
+)
+from griptape_nodes_library.video.seedance_2_0_video_generation import (
+    SEEDANCE_2_0_FAST_MODEL_ID,
+    SEEDANCE_2_0_MODEL_ID,
+    Seedance20VideoGeneration,
+)
 
 
 def _set_parameter_list_values(node: Seedance20VideoGeneration, parameter_name: str, values: list[object]) -> None:
@@ -268,3 +277,208 @@ async def test_build_payload_uses_public_artifact_url_parameter_for_reference_vi
             "role": "reference_video",
         },
     ]
+
+
+# --- Private-asset reference gating (Seedance 2.0 only) -------------------------------------
+
+
+def test_supports_private_assets_only_for_seedance_2_0() -> None:
+    assert Seedance20VideoGeneration._supports_private_assets(SEEDANCE_2_0_MODEL_ID) is True
+    assert Seedance20VideoGeneration._supports_private_assets(SEEDANCE_2_0_FAST_MODEL_ID) is False
+
+
+def test_seedance_2_fast_rejects_private_asset_reference() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0 Fast")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    with pytest.raises(ValueError, match="Seedance 2.0 Fast does not support private-asset references"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_seedance_2_0_rejects_private_asset_reference_kind_mismatch() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    # An Audio-kind reference wired into a video input should be rejected.
+    node.set_parameter_value(
+        "reference_video_1",
+        create_provider_asset_reference(value="https://public.example/clip.wav", asset_kind=ASSET_KIND_AUDIO),
+    )
+
+    with pytest.raises(ValueError, match="private-asset reference is connected to a Video reference input"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_seedance_2_0_accepts_matching_private_asset_reference() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    # Matching kind on a supported model validates without raising.
+    node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.asyncio
+async def test_build_payload_registers_private_asset_reference_for_seedance_2_0(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("prompt", "Animate the reference portrait")
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    registered: list[tuple[str, str]] = []
+
+    async def fake_create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
+        registered.append((public_url, asset_kind))
+        return "generated-asset-id"
+
+    monkeypatch.setattr(Seedance20VideoGeneration, "_create_provider_asset", fake_create_provider_asset)
+    monkeypatch.setattr(Seedance20VideoGeneration, "_validate_api_key", lambda self: "test-key")
+
+    payload = await node._build_payload()
+
+    assert registered == [("https://public.example/portrait.png", ASSET_KIND_IMAGE)]
+    assert payload["content"] == [
+        {"type": "text", "text": "Animate the reference portrait"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "asset://generated-asset-id"},
+            "role": "reference_image",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_payload_does_not_register_assets_for_seedance_2_fast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0 Fast")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("prompt", "Use the reference video motion")
+    node.set_parameter_value("reference_video_1", VideoUrlArtifact("https://public.example/reference.mp4"))
+
+    def fail_if_called(self, *args, **kwargs):
+        raise AssertionError("Seedance 2.0 Fast must not register private assets")
+
+    monkeypatch.setattr(Seedance20VideoGeneration, "_create_provider_asset", fail_if_called)
+
+    payload = await node._build_payload()
+
+    # Normal media on Fast still flows through the standard (non-asset) path unchanged.
+    assert payload["content"] == [
+        {"type": "text", "text": "Use the reference video motion"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "https://public.example/reference.mp4"},
+            "role": "reference_video",
+        },
+    ]
+
+
+# --- Private-asset reference gating (Griptape auth only, not BYOK) --------------------------
+
+
+def test_private_assets_inactive_when_byok_enabled() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+
+    # Griptape auth (default): active on Seedance 2.0.
+    assert node._private_assets_active(SEEDANCE_2_0_MODEL_ID) is True
+
+    # BYOK (customer key): inactive even on Seedance 2.0.
+    node.set_parameter_value("api_key_provider", True)
+    assert node._is_byok_enabled() is True
+    assert node._private_assets_active(SEEDANCE_2_0_MODEL_ID) is False
+
+
+def test_byok_rejects_private_asset_reference() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("api_key_provider", True)
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    with pytest.raises(ValueError, match="require Griptape authentication"):
+        node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.asyncio
+async def test_build_payload_does_not_register_assets_when_byok_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("api_key_provider", True)
+    node.set_parameter_value("prompt", "Use the reference video motion")
+    node.set_parameter_value("reference_video_1", VideoUrlArtifact("https://public.example/reference.mp4"))
+
+    def fail_if_called(self, *args, **kwargs):
+        raise AssertionError("BYOK must not register private assets")
+
+    monkeypatch.setattr(Seedance20VideoGeneration, "_create_provider_asset", fail_if_called)
+
+    payload = await node._build_payload()
+
+    # Normal media under BYOK still flows through the standard (non-asset) path unchanged.
+    assert payload["content"] == [
+        {"type": "text", "text": "Use the reference video motion"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "https://public.example/reference.mp4"},
+            "role": "reference_video",
+        },
+    ]
+
+
+def test_scratch_upload_parameters_are_removed_after_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Registering an asset whose media needs uploading creates a uniquely-named scratch
+    # parameter. The cleanup must remove it so parameters don't accumulate across runs.
+    node = Seedance20VideoGeneration(name="Seedance20")
+
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter,
+        "get_public_url_for_parameter",
+        lambda self: "https://public.example/uploaded.png",
+    )
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: None)
+
+    # A non-public (data URI) value forces the upload path that mints a scratch parameter.
+    public_url = node._resolve_public_url_for_asset(
+        create_provider_asset_reference(value="data:image/png;base64,AAAA", asset_kind=ASSET_KIND_IMAGE),
+        asset_kind=ASSET_KIND_IMAGE,
+    )
+    assert public_url == "https://public.example/uploaded.png"
+
+    scratch_names = [name for _, name in node._pending_asset_uploads]
+    assert scratch_names, "expected a scratch upload parameter to be created"
+    assert all(node.get_parameter_by_name(name) is not None for name in scratch_names)
+
+    # Run the cleanup the way _process_generation's finally block does.
+    for helper, scratch_name in node._pending_asset_uploads:
+        helper.delete_uploaded_artifact()
+        node.remove_parameter_element_by_name(scratch_name)
+
+    assert all(node.get_parameter_by_name(name) is None for name in scratch_names)

--- a/tests/unit/video/test_seedance_human_reference_asset.py
+++ b/tests/unit/video/test_seedance_human_reference_asset.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+import griptape_nodes_library.video.seedance_human_reference_asset as asset_module
+from griptape_nodes_library.proxy.provider_asset_access import ProviderAssetAccess, ProviderAssetAccessOutcome
+from griptape_nodes_library.video.seedance_human_reference_asset import SeedanceHumanReferenceAsset
+
+
+@pytest.fixture
+def granted(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
+    """Stub the access probe to GRANTED and count how many times it is called."""
+    calls = {"n": 0}
+
+    def _probe() -> ProviderAssetAccess:
+        calls["n"] += 1
+        return ProviderAssetAccess(outcome=ProviderAssetAccessOutcome.GRANTED, detail="ok")
+
+    monkeypatch.setattr(asset_module, "check_provider_asset_access", _probe)
+    return calls
+
+
+def test_access_not_probed_during_construction(granted: dict[str, int]) -> None:
+    node = SeedanceHumanReferenceAsset(name="HRA")
+    assert granted["n"] == 0, "construction must not perform the access probe (no network I/O on load)"
+    assert node._access is None
+    assert node._access_probed is False
+
+
+def test_access_probed_lazily_on_first_interaction_then_cached(granted: dict[str, int]) -> None:
+    node = SeedanceHumanReferenceAsset(name="HRA")
+
+    node.set_parameter_value("asset_kind", "Image")
+    assert granted["n"] == 1, "first interaction should probe access once"
+
+    node.set_parameter_value("asset_kind", "Video")
+    assert granted["n"] == 1, "subsequent interactions should use the cached result"
+
+
+def test_validate_before_run_blocks_on_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        asset_module,
+        "check_provider_asset_access",
+        lambda: ProviderAssetAccess(outcome=ProviderAssetAccessOutcome.DENIED, detail="request access from Foundry"),
+    )
+    node = SeedanceHumanReferenceAsset(name="HRA")
+
+    exceptions = node.validate_before_node_run()
+    assert exceptions, "a denied org must block the run"
+    assert "request access from Foundry" in str(exceptions[0])
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [ProviderAssetAccessOutcome.GRANTED, ProviderAssetAccessOutcome.INDETERMINATE],
+)
+def test_validate_before_run_does_not_block_unless_denied(
+    monkeypatch: pytest.MonkeyPatch, outcome: ProviderAssetAccessOutcome
+) -> None:
+    monkeypatch.setattr(
+        asset_module,
+        "check_provider_asset_access",
+        lambda: ProviderAssetAccess(outcome=outcome, detail="..."),
+    )
+    node = SeedanceHumanReferenceAsset(name="HRA")
+    assert node.validate_before_node_run() is None


### PR DESCRIPTION
## Summary

Adds support for registering media as provider private assets for the **Seedance 2.0** node, ported from the byteplus-proxy library.

- **New node `SeedanceHumanReferenceAsset`** (`video/seedance` category): packages an image, video, or audio as a provider-asset reference for Seedance 2.0 human-reference inputs.
- **`Seedance20VideoGeneration`** now accepts those references on its reference inputs and registers them as private assets at generation time (`asset://{id}`).

Closes https://github.com/griptape-ai/griptape-nodes-library-byteplus-proxy/issues/2

## Gating

Private-asset functionality is active **only** when:
- the model is **Seedance 2.0** (not 2.0 Fast), and
- the node uses **Griptape auth** (not BYOK) — provider assets are registered through the Griptape Cloud proxy on the org's behalf.

Connecting a reference when either condition is unmet raises a clear, specific validation error. Normal (non-asset) media paths are unchanged.

## Access check

The asset node checks org entitlement by probing `GET proxy/v2/assets/<id>` and classifies the result:
- **Granted** (reached the handler) → no error.
- **Denied** (HTTP 403 entitlement gate) → error asking an admin to request access from Foundry; blocks the run.
- **Indeterminate** (401 / 5xx / network) → surfaces the real cause; does **not** claim no-access or block.

## Tests

New unit coverage for the model/BYOK gating and the access-check classification (granted / denied / indeterminate). Existing behavior preserved.

<img width="994" height="693" alt="provider_access_required" src="https://github.com/user-attachments/assets/22851bce-e20d-4b18-b927-7847581b0a60" />

<img width="1054" height="693" alt="seedance_human_references" src="https://github.com/user-attachments/assets/79672e06-399e-444b-9eaa-57213169abcc" />


