### PR TITLE
Add is_internal flag to test workflows

### DIFF
--- a/.claude/skills/impl-proxy-node/SKILL.md
+++ b/.claude/skills/impl-proxy-node/SKILL.md
@@ -340,7 +340,7 @@ The test should:
 5. Execute and verify a file was produced
 
 Study the existing test carefully and replicate its structure. Key patterns:
-- Script metadata header with `# /// script` block
+- Script metadata header with `# /// script` block. Set `is_private = true` in the `[tool.griptape-nodes]` table so the test workflow is hidden from the GUI workflow picker (test/internal workflows must always set this; templates and user workflows must not).
 - Library registration via `RegisterLibraryFromFileRequest`
 - Node creation via `CreateNodeRequest` with `resolution="resolved"` and `initial_setup=True`
 - Connection creation via `CreateConnectionRequest`

--- a/.claude/skills/impl-proxy-node/SKILL.md
+++ b/.claude/skills/impl-proxy-node/SKILL.md
@@ -340,7 +340,7 @@ The test should:
 5. Execute and verify a file was produced
 
 Study the existing test carefully and replicate its structure. Key patterns:
-- Script metadata header with `# /// script` block. Set `is_private = true` in the `[tool.griptape-nodes]` table so the test workflow is hidden from the GUI workflow picker (test/internal workflows must always set this; templates and user workflows must not).
+- Script metadata header with `# /// script` block. Set `is_internal = true` in the `[tool.griptape-nodes]` table so the test workflow is hidden from the GUI workflow picker (test/internal workflows must always set this; templates and user workflows must not).
 - Library registration via `RegisterLibraryFromFileRequest`
 - Node creation via `CreateNodeRequest` with `resolution="resolved"` and `initial_setup=True`
 - Connection creation via `CreateConnectionRequest`

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -110,7 +110,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2.3 Fast",
+                default_value="LTX 2 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -110,7 +110,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2 Fast",
+                default_value="LTX 2.3 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -107,7 +107,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2 Fast",
+                default_value="LTX 2.3 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -107,7 +107,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2.3 Fast",
+                default_value="LTX 2 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},

--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -2,6 +2,9 @@
 
 Produces one workflow .py file per node in tests/workflows/integration_tests/.
 Run with: python scripts/generate_test_workflows.py
+
+Each generated header sets `is_private = true` so the test workflow stays hidden
+from the GUI workflow picker. Hand-written test workflows must set it too.
 """
 
 from pathlib import Path

--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -680,6 +680,7 @@ WORKFLOW_TEMPLATE = """\
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "{NodeType}"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -837,6 +838,7 @@ def generate_advanced_workflow(cfg: dict) -> str:
             f"# node_types_used = {node_types_list}",
             "# is_griptape_provided = false",
             "# is_template = false",
+            "# is_private = true",
             "# ///",
             _IMPORTS,
             "",

--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -3,7 +3,7 @@
 Produces one workflow .py file per node in tests/workflows/integration_tests/.
 Run with: python scripts/generate_test_workflows.py
 
-Each generated header sets `is_private = true` so the test workflow stays hidden
+Each generated header sets `is_internal = true` so the test workflow stays hidden
 from the GUI workflow picker. Hand-written test workflows must set it too.
 """
 
@@ -683,7 +683,7 @@ WORKFLOW_TEMPLATE = """\
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "{NodeType}"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio
@@ -841,7 +841,7 @@ def generate_advanced_workflow(cfg: dict) -> str:
             f"# node_types_used = {node_types_list}",
             "# is_griptape_provided = false",
             "# is_template = false",
-            "# is_private = true",
+            "# is_internal = true",
             "# ///",
             _IMPORTS,
             "",

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -5,8 +5,6 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_grok_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_google_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_openai_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
-    "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
-    "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_seedream_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_qwen_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_wan_image_generation.py": {"Start Flow": {"prompt": "A red circle"}},

--- a/tests/integration/test_add_text_to_existing_image.py
+++ b/tests/integration/test_add_text_to_existing_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_add_text_to_existing_image.py
+++ b/tests/integration/test_add_text_to_existing_image.py
@@ -18,89 +18,171 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AddTextToExistingImage", specific_library_name="Griptape Nodes Library",
-        node_name="AddTextToExistingImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AddTextToExistingImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="AddTextToExistingImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="text", node_name=gen_node,
-            value="Hello", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="text", node_name=gen_node, value="Hello", initial_setup=True, is_output=False
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_add_text_to_existing_image.py
+++ b/tests/integration/test_add_text_to_existing_image.py
@@ -8,179 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AddTextToExistingImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AddTextToExistingImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="AddTextToExistingImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AddTextToExistingImage", specific_library_name="Griptape Nodes Library",
+        node_name="AddTextToExistingImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="text", node_name=gen_node, value="Hello", initial_setup=True, is_output=False
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="text", node_name=gen_node,
+            value="Hello", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_add_text_to_existing_image.py
+++ b/tests/integration/test_add_text_to_existing_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AddTextToExistingImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_adjust_image_eq.py
+++ b/tests/integration/test_adjust_image_eq.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AdjustImageEQ"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AdjustImageEQ",
-            specific_library_name="Griptape Nodes Library",
-            node_name="AdjustImageEQ",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AdjustImageEQ", specific_library_name="Griptape Nodes Library",
+        node_name="AdjustImageEQ", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_adjust_image_eq.py
+++ b/tests/integration/test_adjust_image_eq.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AdjustImageEQ"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_adjust_image_eq.py
+++ b/tests/integration/test_adjust_image_eq.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AdjustImageEQ", specific_library_name="Griptape Nodes Library",
-        node_name="AdjustImageEQ", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AdjustImageEQ",
+            specific_library_name="Griptape Nodes Library",
+            node_name="AdjustImageEQ",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_adjust_image_eq.py
+++ b/tests/integration/test_adjust_image_eq.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_adjust_image_levels.py
+++ b/tests/integration/test_adjust_image_levels.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AdjustImageLevels", specific_library_name="Griptape Nodes Library",
-        node_name="AdjustImageLevels", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AdjustImageLevels",
+            specific_library_name="Griptape Nodes Library",
+            node_name="AdjustImageLevels",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_adjust_image_levels.py
+++ b/tests/integration/test_adjust_image_levels.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AdjustImageLevels"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AdjustImageLevels",
-            specific_library_name="Griptape Nodes Library",
-            node_name="AdjustImageLevels",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AdjustImageLevels", specific_library_name="Griptape Nodes Library",
+        node_name="AdjustImageLevels", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_adjust_image_levels.py
+++ b/tests/integration/test_adjust_image_levels.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "AdjustImageLevels"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_adjust_image_levels.py
+++ b/tests/integration/test_adjust_image_levels.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_apply_mask.py
+++ b/tests/integration/test_apply_mask.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ApplyMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_apply_mask.py
+++ b/tests/integration/test_apply_mask.py
@@ -8,191 +8,102 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ApplyMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 1",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    source_node_2 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 2",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ApplyMask",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ApplyMask",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
+    )).node_name
+    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ApplyMask", specific_library_name="Griptape Nodes Library",
+        node_name="ApplyMask", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_1,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_2,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_mask",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_1, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_2, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_mask", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_apply_mask.py
+++ b/tests/integration/test_apply_mask.py
@@ -18,92 +18,183 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
-    )).node_name
-    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ApplyMask", specific_library_name="Griptape Nodes Library",
-        node_name="ApplyMask", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node_1 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 1",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    source_node_2 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 2",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ApplyMask",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ApplyMask",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_1, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_2, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_mask", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_1,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_2,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_mask",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_apply_mask.py
+++ b/tests/integration/test_apply_mask.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_bloom_effect.py
+++ b/tests/integration/test_bloom_effect.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "BloomEffect"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="BloomEffect",
-            specific_library_name="Griptape Nodes Library",
-            node_name="BloomEffect",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="BloomEffect", specific_library_name="Griptape Nodes Library",
+        node_name="BloomEffect", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_bloom_effect.py
+++ b/tests/integration/test_bloom_effect.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="BloomEffect", specific_library_name="Griptape Nodes Library",
-        node_name="BloomEffect", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="BloomEffect",
+            specific_library_name="Griptape Nodes Library",
+            node_name="BloomEffect",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_bloom_effect.py
+++ b/tests/integration/test_bloom_effect.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "BloomEffect"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_bloom_effect.py
+++ b/tests/integration/test_bloom_effect.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_color_match.py
+++ b/tests/integration/test_color_match.py
@@ -8,191 +8,102 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ColorMatch"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 1",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    source_node_2 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 2",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ColorMatch",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ColorMatch",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
+    )).node_name
+    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ColorMatch", specific_library_name="Griptape Nodes Library",
+        node_name="ColorMatch", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_1,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="reference_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_2,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="target_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_1, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="reference_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_2, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="target_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_color_match.py
+++ b/tests/integration/test_color_match.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ColorMatch"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_color_match.py
+++ b/tests/integration/test_color_match.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_color_match.py
+++ b/tests/integration/test_color_match.py
@@ -18,92 +18,183 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
-    )).node_name
-    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ColorMatch", specific_library_name="Griptape Nodes Library",
-        node_name="ColorMatch", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node_1 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 1",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    source_node_2 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 2",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ColorMatch",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ColorMatch",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_1, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="reference_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_2, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="target_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_1,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="reference_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_2,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="target_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_create_color_bars.py
+++ b/tests/integration/test_create_color_bars.py
@@ -18,78 +18,147 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="CreateColorBars", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="CreateColorBars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_create_color_bars.py
+++ b/tests/integration/test_create_color_bars.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_create_color_bars.py
+++ b/tests/integration/test_create_color_bars.py
@@ -8,155 +8,88 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="CreateColorBars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="CreateColorBars", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_create_color_bars.py
+++ b/tests/integration/test_create_color_bars.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_crop_image.py
+++ b/tests/integration/test_crop_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "CropImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_crop_image.py
+++ b/tests/integration/test_crop_image.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CropImage", specific_library_name="Griptape Nodes Library",
-        node_name="CropImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CropImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="CropImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_crop_image.py
+++ b/tests/integration/test_crop_image.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "CropImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CropImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="CropImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CropImage", specific_library_name="Griptape Nodes Library",
+        node_name="CropImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_crop_image.py
+++ b/tests/integration/test_crop_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_crop_video.py
+++ b/tests/integration/test_crop_video.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_crop_video.py
+++ b/tests/integration/test_crop_video.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "CropVideo"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_crop_video.py
+++ b/tests/integration/test_crop_video.py
@@ -8,183 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "CropVideo"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CropVideo",
-            specific_library_name="Griptape Nodes Library",
-            node_name="CropVideo",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CropVideo", specific_library_name="Griptape Nodes Library",
+        node_name="CropVideo", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_crop_video.py
+++ b/tests/integration/test_crop_video.py
@@ -18,89 +18,175 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CropVideo", specific_library_name="Griptape Nodes Library",
-        node_name="CropVideo", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CropVideo",
+            specific_library_name="Griptape Nodes Library",
+            node_name="CropVideo",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_display_channel.py
+++ b/tests/integration/test_display_channel.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "DisplayChannel"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="DisplayChannel",
-            specific_library_name="Griptape Nodes Library",
-            node_name="DisplayChannel",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="DisplayChannel", specific_library_name="Griptape Nodes Library",
+        node_name="DisplayChannel", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_display_channel.py
+++ b/tests/integration/test_display_channel.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="DisplayChannel", specific_library_name="Griptape Nodes Library",
-        node_name="DisplayChannel", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="DisplayChannel",
+            specific_library_name="Griptape Nodes Library",
+            node_name="DisplayChannel",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_display_channel.py
+++ b/tests/integration/test_display_channel.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "DisplayChannel"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_display_channel.py
+++ b/tests/integration/test_display_channel.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_display_mask.py
+++ b/tests/integration/test_display_mask.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="DisplayMask", specific_library_name="Griptape Nodes Library",
-        node_name="DisplayMask", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="DisplayMask",
+            specific_library_name="Griptape Nodes Library",
+            node_name="DisplayMask",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output_mask",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output_mask",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_display_mask.py
+++ b/tests/integration/test_display_mask.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "DisplayMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_display_mask.py
+++ b/tests/integration/test_display_mask.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "DisplayMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="DisplayMask",
-            specific_library_name="Griptape Nodes Library",
-            node_name="DisplayMask",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="DisplayMask", specific_library_name="Griptape Nodes Library",
+        node_name="DisplayMask", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output_mask",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output_mask",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_display_mask.py
+++ b/tests/integration/test_display_mask.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_elevenlabs_music_generation.py
+++ b/tests/integration/test_elevenlabs_music_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_elevenlabs_music_generation.py
+++ b/tests/integration/test_elevenlabs_music_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ElevenLabsMusicGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="ElevenLabsMusicGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ElevenLabsMusicGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ElevenLabsMusicGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="audio_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="text",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="audio_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_elevenlabs_music_generation.py
+++ b/tests/integration/test_elevenlabs_music_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsMusicGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_elevenlabs_music_generation.py
+++ b/tests/integration/test_elevenlabs_music_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsMusicGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ElevenLabsMusicGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ElevenLabsMusicGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ElevenLabsMusicGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="ElevenLabsMusicGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="text",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="audio_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="audio_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_elevenlabs_sound_effect_generation.py
+++ b/tests/integration/test_elevenlabs_sound_effect_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_elevenlabs_sound_effect_generation.py
+++ b/tests/integration/test_elevenlabs_sound_effect_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsSoundEffectGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_elevenlabs_sound_effect_generation.py
+++ b/tests/integration/test_elevenlabs_sound_effect_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ElevenLabsSoundEffectGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="ElevenLabsSoundEffectGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ElevenLabsSoundEffectGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ElevenLabsSoundEffectGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="audio_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="text",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="audio_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_elevenlabs_sound_effect_generation.py
+++ b/tests/integration/test_elevenlabs_sound_effect_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsSoundEffectGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ElevenLabsSoundEffectGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ElevenLabsSoundEffectGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ElevenLabsSoundEffectGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="ElevenLabsSoundEffectGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="text",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="audio_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="audio_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_elevenlabs_text_to_speech_generation.py
+++ b/tests/integration/test_elevenlabs_text_to_speech_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_elevenlabs_text_to_speech_generation.py
+++ b/tests/integration/test_elevenlabs_text_to_speech_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsTextToSpeechGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_elevenlabs_text_to_speech_generation.py
+++ b/tests/integration/test_elevenlabs_text_to_speech_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ElevenLabsTextToSpeechGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ElevenLabsTextToSpeechGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ElevenLabsTextToSpeechGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ElevenLabsTextToSpeechGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="ElevenLabsTextToSpeechGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="text",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="audio_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="audio_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_elevenlabs_text_to_speech_generation.py
+++ b/tests/integration/test_elevenlabs_text_to_speech_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ElevenLabsTextToSpeechGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="ElevenLabsTextToSpeechGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ElevenLabsTextToSpeechGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ElevenLabsTextToSpeechGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="text", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="audio_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="text",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="audio_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_extend_canvas.py
+++ b/tests/integration/test_extend_canvas.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ExtendCanvas", specific_library_name="Griptape Nodes Library",
-        node_name="ExtendCanvas", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ExtendCanvas",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ExtendCanvas",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="extended_image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="extended_image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_extend_canvas.py
+++ b/tests/integration/test_extend_canvas.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ExtendCanvas"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_extend_canvas.py
+++ b/tests/integration/test_extend_canvas.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_extend_canvas.py
+++ b/tests/integration/test_extend_canvas.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ExtendCanvas"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ExtendCanvas",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ExtendCanvas",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ExtendCanvas", specific_library_name="Griptape Nodes Library",
+        node_name="ExtendCanvas", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="extended_image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="extended_image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -8,183 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ExtractAudio"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ExtractAudio",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ExtractAudio",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ExtractAudio", specific_library_name="Griptape Nodes Library",
+        node_name="ExtractAudio", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="extracted_audio",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="extracted_audio",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ExtractAudio"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_extract_audio.py
+++ b/tests/integration/test_extract_audio.py
@@ -18,89 +18,175 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ExtractAudio", specific_library_name="Griptape Nodes Library",
-        node_name="ExtractAudio", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ExtractAudio",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ExtractAudio",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="extracted_audio",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="extracted_audio",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_extract_last_frame.py
+++ b/tests/integration/test_extract_last_frame.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_extract_last_frame.py
+++ b/tests/integration/test_extract_last_frame.py
@@ -18,89 +18,175 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ExtractLastFrame", specific_library_name="Griptape Nodes Library",
-        node_name="ExtractLastFrame", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ExtractLastFrame",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ExtractLastFrame",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="last_frame_image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="last_frame_image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_extract_last_frame.py
+++ b/tests/integration/test_extract_last_frame.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ExtractLastFrame"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_extract_last_frame.py
+++ b/tests/integration/test_extract_last_frame.py
@@ -8,183 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ExtractLastFrame"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ExtractLastFrame",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ExtractLastFrame",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ExtractLastFrame", specific_library_name="Griptape Nodes Library",
+        node_name="ExtractLastFrame", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="last_frame_image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="last_frame_image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_flip_image.py
+++ b/tests/integration/test_flip_image.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "FlipImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="FlipImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="FlipImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="FlipImage", specific_library_name="Griptape Nodes Library",
+        node_name="FlipImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_flip_image.py
+++ b/tests/integration/test_flip_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "FlipImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_flip_image.py
+++ b/tests/integration/test_flip_image.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="FlipImage", specific_library_name="Griptape Nodes Library",
-        node_name="FlipImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="FlipImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="FlipImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_flip_image.py
+++ b/tests/integration/test_flip_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_flux_2_image_generation.py
+++ b/tests/integration/test_flux_2_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_flux_2_image_generation.py
+++ b/tests/integration/test_flux_2_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="Flux2ImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="Flux2ImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="Flux2ImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Flux2ImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_flux_2_image_generation.py
+++ b/tests/integration/test_flux_2_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Flux2ImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="Flux2ImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Flux2ImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="Flux2ImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="Flux2ImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_flux_2_image_generation.py
+++ b/tests/integration/test_flux_2_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Flux2ImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_flux_image_generation.py
+++ b/tests/integration/test_flux_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_flux_image_generation.py
+++ b/tests/integration/test_flux_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "FluxImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_flux_image_generation.py
+++ b/tests/integration/test_flux_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="FluxImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="FluxImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="FluxImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="FluxImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_flux_image_generation.py
+++ b/tests/integration/test_flux_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "FluxImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="FluxImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="FluxImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="FluxImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="FluxImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_gaussian_blur_image.py
+++ b/tests/integration/test_gaussian_blur_image.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GaussianBlurImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GaussianBlurImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GaussianBlurImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GaussianBlurImage", specific_library_name="Griptape Nodes Library",
+        node_name="GaussianBlurImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_gaussian_blur_image.py
+++ b/tests/integration/test_gaussian_blur_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GaussianBlurImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_gaussian_blur_image.py
+++ b/tests/integration/test_gaussian_blur_image.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GaussianBlurImage", specific_library_name="Griptape Nodes Library",
-        node_name="GaussianBlurImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GaussianBlurImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GaussianBlurImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_gaussian_blur_image.py
+++ b/tests/integration/test_gaussian_blur_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_gaussian_edge_fade.py
+++ b/tests/integration/test_gaussian_edge_fade.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GaussianEdgeFade"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_gaussian_edge_fade.py
+++ b/tests/integration/test_gaussian_edge_fade.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GaussianEdgeFade", specific_library_name="Griptape Nodes Library",
-        node_name="GaussianEdgeFade", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GaussianEdgeFade",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GaussianEdgeFade",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output_image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output_image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_gaussian_edge_fade.py
+++ b/tests/integration/test_gaussian_edge_fade.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GaussianEdgeFade"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GaussianEdgeFade",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GaussianEdgeFade",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GaussianEdgeFade", specific_library_name="Griptape Nodes Library",
+        node_name="GaussianEdgeFade", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output_image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output_image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_gaussian_edge_fade.py
+++ b/tests/integration/test_gaussian_edge_fade.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_generate_image.py
+++ b/tests/integration/test_generate_image.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_generate_image.py
+++ b/tests/integration/test_generate_image.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GenerateImage", specific_library_name="Griptape Nodes Library",
-        node_name="GenerateImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GenerateImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GenerateImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_generate_image.py
+++ b/tests/integration/test_generate_image.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GenerateImage"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GenerateImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GenerateImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GenerateImage", specific_library_name="Griptape Nodes Library",
+        node_name="GenerateImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_generate_image.py
+++ b/tests/integration/test_generate_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GenerateImage"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_google_image_generation.py
+++ b/tests/integration/test_google_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_google_image_generation.py
+++ b/tests/integration/test_google_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GoogleImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_google_image_generation.py
+++ b/tests/integration/test_google_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GoogleImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="GoogleImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GoogleImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GoogleImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_google_image_generation.py
+++ b/tests/integration/test_google_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GoogleImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GoogleImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GoogleImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GoogleImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="GoogleImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_grayscale_image.py
+++ b/tests/integration/test_grayscale_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrayscaleImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_grayscale_image.py
+++ b/tests/integration/test_grayscale_image.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GrayscaleImage", specific_library_name="Griptape Nodes Library",
-        node_name="GrayscaleImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GrayscaleImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GrayscaleImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grayscale_image.py
+++ b/tests/integration/test_grayscale_image.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrayscaleImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GrayscaleImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GrayscaleImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GrayscaleImage", specific_library_name="Griptape Nodes Library",
+        node_name="GrayscaleImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grayscale_image.py
+++ b/tests/integration/test_grayscale_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_grok_image_edit.py
+++ b/tests/integration/test_grok_image_edit.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_grok_image_edit.py
+++ b/tests/integration/test_grok_image_edit.py
@@ -8,179 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokImageEdit"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GrokImageEdit",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GrokImageEdit",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GrokImageEdit", specific_library_name="Griptape Nodes Library",
+        node_name="GrokImageEdit", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="image",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt", node_name=gen_node, value="Make it blue", initial_setup=True, is_output=False
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="Make it blue", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grok_image_edit.py
+++ b/tests/integration/test_grok_image_edit.py
@@ -18,89 +18,171 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GrokImageEdit", specific_library_name="Griptape Nodes Library",
-        node_name="GrokImageEdit", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GrokImageEdit",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GrokImageEdit",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="image",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="Make it blue", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt", node_name=gen_node, value="Make it blue", initial_setup=True, is_output=False
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grok_image_edit.py
+++ b/tests/integration/test_grok_image_edit.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokImageEdit"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_grok_image_generation.py
+++ b/tests/integration/test_grok_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_grok_image_generation.py
+++ b/tests/integration/test_grok_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GrokImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GrokImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GrokImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="GrokImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_grok_image_generation.py
+++ b/tests/integration/test_grok_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_grok_image_generation.py
+++ b/tests/integration/test_grok_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GrokImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="GrokImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GrokImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GrokImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_grok_video_edit.py
+++ b/tests/integration/test_grok_video_edit.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_grok_video_edit.py
+++ b/tests/integration/test_grok_video_edit.py
@@ -18,93 +18,185 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GrokVideoEdit", specific_library_name="Griptape Nodes Library",
-        node_name="GrokVideoEdit", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GrokVideoEdit",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GrokVideoEdit",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="Make it slow motion", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=gen_node,
+                value="Make it slow motion",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grok_video_edit.py
+++ b/tests/integration/test_grok_video_edit.py
@@ -8,193 +8,103 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "GrokVideoEdit"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GrokVideoEdit",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GrokVideoEdit",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GrokVideoEdit", specific_library_name="Griptape Nodes Library",
+        node_name="GrokVideoEdit", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=gen_node,
-                value="Make it slow motion",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="Make it slow motion", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_grok_video_edit.py
+++ b/tests/integration/test_grok_video_edit.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "GrokVideoEdit"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_grok_video_generation.py
+++ b/tests/integration/test_grok_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_grok_video_generation.py
+++ b/tests/integration/test_grok_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_grok_video_generation.py
+++ b/tests/integration/test_grok_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="GrokVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="GrokVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="GrokVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="GrokVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_grok_video_generation.py
+++ b/tests/integration/test_grok_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "GrokVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="GrokVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="GrokVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="GrokVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="GrokVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_image_blend_compositor.py
+++ b/tests/integration/test_image_blend_compositor.py
@@ -18,92 +18,183 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
-    )).node_name
-    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ImageBlendCompositor", specific_library_name="Griptape Nodes Library",
-        node_name="ImageBlendCompositor", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node_1 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 1",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    source_node_2 = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars 2",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ImageBlendCompositor",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ImageBlendCompositor",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_1, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node_2, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="blend_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_1,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node_2,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="blend_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_image_blend_compositor.py
+++ b/tests/integration/test_image_blend_compositor.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ImageBlendCompositor"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_image_blend_compositor.py
+++ b/tests/integration/test_image_blend_compositor.py
@@ -8,191 +8,102 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ImageBlendCompositor"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node_1 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 1",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    source_node_2 = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars 2",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ImageBlendCompositor",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ImageBlendCompositor",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node_1 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 1", metadata={}, initial_setup=True,
+    )).node_name
+    source_node_2 = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars 2", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ImageBlendCompositor", specific_library_name="Griptape Nodes Library",
+        node_name="ImageBlendCompositor", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_1,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node_2,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="blend_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_1, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node_2, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="blend_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_image_blend_compositor.py
+++ b/tests/integration/test_image_blend_compositor.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_image_grid_splitter.py
+++ b/tests/integration/test_image_grid_splitter.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ImageGridSplitter"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_image_grid_splitter.py
+++ b/tests/integration/test_image_grid_splitter.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ImageGridSplitter", specific_library_name="Griptape Nodes Library",
-        node_name="ImageGridSplitter", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ImageGridSplitter",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ImageGridSplitter",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="preview",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="preview",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_image_grid_splitter.py
+++ b/tests/integration/test_image_grid_splitter.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "ImageGridSplitter"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ImageGridSplitter",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ImageGridSplitter",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ImageGridSplitter", specific_library_name="Griptape Nodes Library",
+        node_name="ImageGridSplitter", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="preview",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="preview",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_image_grid_splitter.py
+++ b/tests/integration/test_image_grid_splitter.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_invert_image.py
+++ b/tests/integration/test_invert_image.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "InvertImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="InvertImage",
-            specific_library_name="Griptape Nodes Library",
-            node_name="InvertImage",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="InvertImage", specific_library_name="Griptape Nodes Library",
+        node_name="InvertImage", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_invert_image.py
+++ b/tests/integration/test_invert_image.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="InvertImage", specific_library_name="Griptape Nodes Library",
-        node_name="InvertImage", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="InvertImage",
+            specific_library_name="Griptape Nodes Library",
+            node_name="InvertImage",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_invert_image.py
+++ b/tests/integration/test_invert_image.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "InvertImage"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_invert_image.py
+++ b/tests/integration/test_invert_image.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_invert_mask.py
+++ b/tests/integration/test_invert_mask.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "InvertMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_invert_mask.py
+++ b/tests/integration/test_invert_mask.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="InvertMask", specific_library_name="Griptape Nodes Library",
-        node_name="InvertMask", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="InvertMask",
+            specific_library_name="Griptape Nodes Library",
+            node_name="InvertMask",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_mask", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output_mask",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_mask",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output_mask",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_invert_mask.py
+++ b/tests/integration/test_invert_mask.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "InvertMask"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="InvertMask",
-            specific_library_name="Griptape Nodes Library",
-            node_name="InvertMask",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="InvertMask", specific_library_name="Griptape Nodes Library",
+        node_name="InvertMask", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_mask",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output_mask",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_mask", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output_mask",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_invert_mask.py
+++ b/tests/integration/test_invert_mask.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_kling_image_to_video_generation.py
+++ b/tests/integration/test_kling_image_to_video_generation.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_kling_image_to_video_generation.py
+++ b/tests/integration/test_kling_image_to_video_generation.py
@@ -18,89 +18,171 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="KlingImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="KlingImageToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="KlingImageToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="KlingImageToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="image",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="Animate this", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt", node_name=gen_node, value="Animate this", initial_setup=True, is_output=False
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_kling_image_to_video_generation.py
+++ b/tests/integration/test_kling_image_to_video_generation.py
@@ -8,179 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "KlingImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="KlingImageToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="KlingImageToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="KlingImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="KlingImageToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="image",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt", node_name=gen_node, value="Animate this", initial_setup=True, is_output=False
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="Animate this", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_kling_image_to_video_generation.py
+++ b/tests/integration/test_kling_image_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "KlingImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_kling_text_to_video_generation.py
+++ b/tests/integration/test_kling_text_to_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_kling_text_to_video_generation.py
+++ b/tests/integration/test_kling_text_to_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="KlingTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="KlingTextToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="KlingTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="KlingTextToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_kling_text_to_video_generation.py
+++ b/tests/integration/test_kling_text_to_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "KlingTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="KlingTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="KlingTextToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="KlingTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="KlingTextToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_kling_text_to_video_generation.py
+++ b/tests/integration/test_kling_text_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "KlingTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_ltx_image_to_video_generation.py
+++ b/tests/integration/test_ltx_image_to_video_generation.py
@@ -8,179 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXImageToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTXImageToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTXImageToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="image",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt", node_name=gen_node, value="Animate this", initial_setup=True, is_output=False
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="Animate this", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_ltx_image_to_video_generation.py
+++ b/tests/integration/test_ltx_image_to_video_generation.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_ltx_image_to_video_generation.py
+++ b/tests/integration/test_ltx_image_to_video_generation.py
@@ -18,89 +18,171 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTXImageToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXImageToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTXImageToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="image",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="Animate this", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt", node_name=gen_node, value="Animate this", initial_setup=True, is_output=False
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_ltx_image_to_video_generation.py
+++ b/tests/integration/test_ltx_image_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_ltx_text_to_video_generation.py
+++ b/tests/integration/test_ltx_text_to_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_ltx_text_to_video_generation.py
+++ b/tests/integration/test_ltx_text_to_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTXTextToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTXTextToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_ltx_text_to_video_generation.py
+++ b/tests/integration/test_ltx_text_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_ltx_text_to_video_generation.py
+++ b/tests/integration/test_ltx_text_to_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTXTextToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTXTextToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_ltx_video_retake.py
+++ b/tests/integration/test_ltx_video_retake.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_ltx_video_retake.py
+++ b/tests/integration/test_ltx_video_retake.py
@@ -18,93 +18,185 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXVideoRetake", specific_library_name="Griptape Nodes Library",
-        node_name="LTXVideoRetake", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXVideoRetake",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTXVideoRetake",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=gen_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_ltx_video_retake.py
+++ b/tests/integration/test_ltx_video_retake.py
@@ -8,193 +8,103 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "LTXVideoRetake"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXVideoRetake",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTXVideoRetake",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXVideoRetake", specific_library_name="Griptape Nodes Library",
+        node_name="LTXVideoRetake", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=gen_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_ltx_video_retake.py
+++ b/tests/integration/test_ltx_video_retake.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "LTXVideoRetake"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_ltx_video_to_video_hdr.py
+++ b/tests/integration/test_ltx_video_to_video_hdr.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "LTXVideoToVideoHDR"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_ltx_video_to_video_hdr.py
+++ b/tests/integration/test_ltx_video_to_video_hdr.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "LTXVideoToVideoHDR"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_minimax_hailuo_video_generation.py
+++ b/tests/integration/test_minimax_hailuo_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_minimax_hailuo_video_generation.py
+++ b/tests/integration/test_minimax_hailuo_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="MinimaxHailuoVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="MinimaxHailuoVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="MinimaxHailuoVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="MinimaxHailuoVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_minimax_hailuo_video_generation.py
+++ b/tests/integration/test_minimax_hailuo_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "MinimaxHailuoVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="MinimaxHailuoVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="MinimaxHailuoVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="MinimaxHailuoVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="MinimaxHailuoVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_minimax_hailuo_video_generation.py
+++ b/tests/integration/test_minimax_hailuo_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "MinimaxHailuoVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_openai_image_generation.py
+++ b/tests/integration/test_openai_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_openai_image_generation.py
+++ b/tests/integration/test_openai_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="OpenAiImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="OpenAiImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="OpenAiImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="OpenAiImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_openai_image_generation.py
+++ b/tests/integration/test_openai_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="OpenAiImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="OpenAiImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="OpenAiImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="OpenAiImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_openai_image_generation.py
+++ b/tests/integration/test_openai_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_openai_image_generation_tall.py
+++ b/tests/integration/test_openai_image_generation_tall.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 """Integration test for OpenAiImageGeneration at the new 1024x1792 tall aspect ratio.
 

--- a/tests/integration/test_openai_image_generation_tall.py
+++ b/tests/integration/test_openai_image_generation_tall.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 """Integration test for OpenAiImageGeneration at the new 1024x1792 tall aspect ratio.
 

--- a/tests/integration/test_openai_image_generation_wide.py
+++ b/tests/integration/test_openai_image_generation_wide.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 """Integration test for OpenAiImageGeneration at the new 1792x1024 wide aspect ratio.
 

--- a/tests/integration/test_openai_image_generation_wide.py
+++ b/tests/integration/test_openai_image_generation_wide.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "OpenAiImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 """Integration test for OpenAiImageGeneration at the new 1792x1024 wide aspect ratio.
 

--- a/tests/integration/test_qwen_image_generation.py
+++ b/tests/integration/test_qwen_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_qwen_image_generation.py
+++ b/tests/integration/test_qwen_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "QwenImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_qwen_image_generation.py
+++ b/tests/integration/test_qwen_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="QwenImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="QwenImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="QwenImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="QwenImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_qwen_image_generation.py
+++ b/tests/integration/test_qwen_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "QwenImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="QwenImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="QwenImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="QwenImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="QwenImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_resize_video.py
+++ b/tests/integration/test_resize_video.py
@@ -8,183 +8,99 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ResizeVideo"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="LTXTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="LTX Text To Video Generation",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ResizeVideo",
-            specific_library_name="Griptape Nodes Library",
-            node_name="ResizeVideo",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ResizeVideo", specific_library_name="Griptape Nodes Library",
+        node_name="ResizeVideo", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt",
-                node_name=ltx_node,
-                value="A ball bouncing",
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=ltx_node,
-            source_parameter_name="video_url",
-            target_node_name=gen_node,
-            target_parameter_name="video",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="resized_video",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=ltx_node,
+            value="A ball bouncing", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=ltx_node, source_parameter_name="video_url",
+        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="resized_video",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_resize_video.py
+++ b/tests/integration/test_resize_video.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_resize_video.py
+++ b/tests/integration/test_resize_video.py
@@ -18,89 +18,175 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    ltx_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="LTXTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="LTX Text To Video Generation", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ResizeVideo", specific_library_name="Griptape Nodes Library",
-        node_name="ResizeVideo", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    ltx_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ResizeVideo",
+            specific_library_name="Griptape Nodes Library",
+            node_name="ResizeVideo",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(ltx_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=ltx_node,
-            value="A ball bouncing", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=ltx_node, source_parameter_name="video_url",
-        target_node_name=gen_node, target_parameter_name="video", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="resized_video",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_node,
+            source_parameter_name="video_url",
+            target_node_name=gen_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="resized_video",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_resize_video.py
+++ b/tests/integration/test_resize_video.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "ResizeVideo"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_rodin2_3d_generation.py
+++ b/tests/integration/test_rodin2_3d_generation.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (

--- a/tests/integration/test_rodin2_3d_generation.py
+++ b/tests/integration/test_rodin2_3d_generation.py
@@ -18,97 +18,192 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="Rodin23DGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="Rodin23DGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
-    with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
-            default_value=[], tooltip="Optional input images for Image-to-3D generation (up to 5 images)",
-            type="ImageArtifact", input_types=['ImageArtifact', 'ImageUrlArtifact', 'str', 'list', 'list[ImageArtifact]', 'list[ImageUrlArtifact]'], output_type="ImageArtifact",
-            ui_options={}, parent_container_name="input_images",
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
             initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001", initial_setup=True))
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="Rodin23DGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Rodin23DGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(SetParameterValueRequest(
-            parameter_name="prompt", node_name=gen_node,
-            value="A simple chair", initial_setup=True, is_output=False))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="model_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
+                default_value=[],
+                tooltip="Optional input images for Image-to-3D generation (up to 5 images)",
+                type="ImageArtifact",
+                input_types=[
+                    "ImageArtifact",
+                    "ImageUrlArtifact",
+                    "str",
+                    "list",
+                    "list[ImageArtifact]",
+                    "list[ImageUrlArtifact]",
+                ],
+                output_type="ImageArtifact",
+                ui_options={},
+                parent_container_name="input_images",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
+            initial_setup=True,
+        )
+    )
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt", node_name=gen_node, value="A simple chair", initial_setup=True, is_output=False
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="model_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_rodin2_3d_generation.py
+++ b/tests/integration/test_rodin2_3d_generation.py
@@ -8,200 +8,107 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Rodin23DGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="Rodin23DGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Rodin23DGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="Rodin23DGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="Rodin23DGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
-                default_value=[],
-                tooltip="Optional input images for Image-to-3D generation (up to 5 images)",
-                type="ImageArtifact",
-                input_types=[
-                    "ImageArtifact",
-                    "ImageUrlArtifact",
-                    "str",
-                    "list",
-                    "list[ImageArtifact]",
-                    "list[ImageUrlArtifact]",
-                ],
-                output_type="ImageArtifact",
-                ui_options={},
-                parent_container_name="input_images",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001",
+            default_value=[], tooltip="Optional input images for Image-to-3D generation (up to 5 images)",
+            type="ImageArtifact", input_types=['ImageArtifact', 'ImageUrlArtifact', 'str', 'list', 'list[ImageArtifact]', 'list[ImageUrlArtifact]'], output_type="ImageArtifact",
+            ui_options={}, parent_container_name="input_images",
             initial_setup=True,
-        )
-    )
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_images_ParameterListUniqueParamID_00000000000000000000000000000001", initial_setup=True))
     with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="prompt", node_name=gen_node, value="A simple chair", initial_setup=True, is_output=False
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="model_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="prompt", node_name=gen_node,
+            value="A simple chair", initial_setup=True, is_output=False))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="model_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_rodin2_3d_generation.py
+++ b/tests/integration/test_rodin2_3d_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Rodin23DGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_seedance_2_0.py
+++ b/tests/integration/test_seedance_2_0.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance20VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 """Integration test for Seedance 2.0 model."""
 

--- a/tests/integration/test_seedance_2_0.py
+++ b/tests/integration/test_seedance_2_0.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance20VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 """Integration test for Seedance 2.0 model."""
 

--- a/tests/integration/test_seedance_2_0_fast.py
+++ b/tests/integration/test_seedance_2_0_fast.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance20VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 """Integration test for Seedance 2.0 Fast model."""
 

--- a/tests/integration/test_seedance_2_0_fast.py
+++ b/tests/integration/test_seedance_2_0_fast.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance20VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 """Integration test for Seedance 2.0 Fast model."""
 

--- a/tests/integration/test_seedream_image_generation.py
+++ b/tests/integration/test_seedream_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_seedream_image_generation.py
+++ b/tests/integration/test_seedream_image_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SeedreamImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="SeedreamImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="SeedreamImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="SeedreamImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="SeedreamImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_seedream_image_generation.py
+++ b/tests/integration/test_seedream_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="SeedreamImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="SeedreamImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="SeedreamImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="SeedreamImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_seedream_image_generation.py
+++ b/tests/integration/test_seedream_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SeedreamImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_set_color_to_transparent.py
+++ b/tests/integration/test_set_color_to_transparent.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="SetColorToTransparent", specific_library_name="Griptape Nodes Library",
-        node_name="SetColorToTransparent", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="SetColorToTransparent",
+            specific_library_name="Griptape Nodes Library",
+            node_name="SetColorToTransparent",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_set_color_to_transparent.py
+++ b/tests/integration/test_set_color_to_transparent.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SetColorToTransparent"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="SetColorToTransparent",
-            specific_library_name="Griptape Nodes Library",
-            node_name="SetColorToTransparent",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="SetColorToTransparent", specific_library_name="Griptape Nodes Library",
+        node_name="SetColorToTransparent", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_set_color_to_transparent.py
+++ b/tests/integration/test_set_color_to_transparent.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SetColorToTransparent"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_set_color_to_transparent.py
+++ b/tests/integration/test_set_color_to_transparent.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_sora_video_generation.py
+++ b/tests/integration/test_sora_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SoraVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="SoraVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="SoraVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="SoraVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="SoraVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_sora_video_generation.py
+++ b/tests/integration/test_sora_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_sora_video_generation.py
+++ b/tests/integration/test_sora_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="SoraVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="SoraVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="SoraVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="SoraVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_sora_video_generation.py
+++ b/tests/integration/test_sora_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "SoraVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_topaz_image_enhance.py
+++ b/tests/integration/test_topaz_image_enhance.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TopazImageEnhance"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="TopazImageEnhance",
-            specific_library_name="Griptape Nodes Library",
-            node_name="TopazImageEnhance",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="TopazImageEnhance", specific_library_name="Griptape Nodes Library",
+        node_name="TopazImageEnhance", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="image_input",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_output",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="image_input", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_output",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_topaz_image_enhance.py
+++ b/tests/integration/test_topaz_image_enhance.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TopazImageEnhance"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_topaz_image_enhance.py
+++ b/tests/integration/test_topaz_image_enhance.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="TopazImageEnhance", specific_library_name="Griptape Nodes Library",
-        node_name="TopazImageEnhance", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="TopazImageEnhance",
+            specific_library_name="Griptape Nodes Library",
+            node_name="TopazImageEnhance",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="image_input", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_output",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="image_input",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_output",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_topaz_image_enhance.py
+++ b/tests/integration/test_topaz_image_enhance.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_tripo_image_to_3d_generation.py
+++ b/tests/integration/test_tripo_image_to_3d_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TripoImageTo3DGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_tripo_image_to_3d_generation.py
+++ b/tests/integration/test_tripo_image_to_3d_generation.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TripoImageTo3DGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="TripoImageTo3DGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="TripoImageTo3DGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="TripoImageTo3DGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="TripoImageTo3DGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="model_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="model_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_tripo_image_to_3d_generation.py
+++ b/tests/integration/test_tripo_image_to_3d_generation.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_tripo_image_to_3d_generation.py
+++ b/tests/integration/test_tripo_image_to_3d_generation.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="TripoImageTo3DGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="TripoImageTo3DGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="TripoImageTo3DGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="TripoImageTo3DGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="model_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="model_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_tripo_text_to_3d_generation.py
+++ b/tests/integration/test_tripo_text_to_3d_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TripoTextTo3DGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="TripoTextTo3DGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="TripoTextTo3DGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="TripoTextTo3DGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="TripoTextTo3DGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="model_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="model_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_tripo_text_to_3d_generation.py
+++ b/tests/integration/test_tripo_text_to_3d_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_tripo_text_to_3d_generation.py
+++ b/tests/integration/test_tripo_text_to_3d_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "TripoTextTo3DGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_tripo_text_to_3d_generation.py
+++ b/tests/integration/test_tripo_text_to_3d_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="TripoTextTo3DGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="TripoTextTo3DGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="TripoTextTo3DGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="TripoTextTo3DGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="model_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="model_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_veo3_video_generation.py
+++ b/tests/integration/test_veo3_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_veo3_video_generation.py
+++ b/tests/integration/test_veo3_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Veo3VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="Veo3VideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Veo3VideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="Veo3VideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="Veo3VideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_veo3_video_generation.py
+++ b/tests/integration/test_veo3_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Veo3VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_veo3_video_generation.py
+++ b/tests/integration/test_veo3_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="Veo3VideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="Veo3VideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="Veo3VideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Veo3VideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_wan_image_generation.py
+++ b/tests/integration/test_wan_image_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_wan_image_generation.py
+++ b/tests/integration/test_wan_image_generation.py
@@ -3,11 +3,12 @@
 # [tool.griptape-nodes]
 # name = "test_wan_image_generation"
 # schema_version = "0.16.0"
-# engine_version_created_with = "0.78.2"
-# node_libraries_referenced = [["Griptape Nodes Library", "0.68.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="WanImageGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="WanImageGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="WanImageGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="WanImageGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="image_url_1",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="image_url_1",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_wan_image_generation.py
+++ b/tests/integration/test_wan_image_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanImageGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_wan_image_generation.py
+++ b/tests/integration/test_wan_image_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="WanImageGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="WanImageGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="WanImageGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="WanImageGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="image_url_1",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="image_url_1",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_wan_image_to_video_generation.py
+++ b/tests/integration/test_wan_image_to_video_generation.py
@@ -8,173 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="WanImageToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="WanImageToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="WanImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="WanImageToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_wan_image_to_video_generation.py
+++ b/tests/integration/test_wan_image_to_video_generation.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="WanImageToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="WanImageToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="WanImageToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="WanImageToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_wan_image_to_video_generation.py
+++ b/tests/integration/test_wan_image_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanImageToVideoGeneration"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_wan_image_to_video_generation.py
+++ b/tests/integration/test_wan_image_to_video_generation.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_wan_text_to_video_generation.py
+++ b/tests/integration/test_wan_text_to_video_generation.py
@@ -17,7 +17,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -27,7 +26,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(

--- a/tests/integration/test_wan_text_to_video_generation.py
+++ b/tests/integration/test_wan_text_to_video_generation.py
@@ -8,6 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import argparse
 import asyncio
@@ -16,182 +17,97 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="WanTextToVideoGeneration",
-            specific_library_name="Griptape Nodes Library",
-            node_name="WanTextToVideoGeneration",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    start_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="StartFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Start Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="WanTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
+        node_name="WanTextToVideoGeneration", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
+        node_name="Start Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="prompt",
-                default_value="",
-                tooltip="Prompt",
-                type="str",
-                input_types=["any"],
-                output_type="str",
-                ui_options={"display_name": "Prompt", "multiline": True},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="prompt", default_value="", tooltip="Prompt",
+            type="str", input_types=["any"], output_type="str",
+            ui_options={"display_name": "Prompt", "multiline": True},
+            parent_container_name="", initial_setup=True,
+        ))
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
 
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=start_node,
-            source_parameter_name="prompt",
-            target_node_name=gen_node,
-            target_parameter_name="prompt",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="video_url",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=start_node, source_parameter_name="prompt",
+        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="video_url",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -214,6 +130,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
-    )
+        input=flow_input, storage_backend=args.storage_backend,
+        project_file_path=args.project_file_path)
     print(workflow_output)

--- a/tests/integration/test_wan_text_to_video_generation.py
+++ b/tests/integration/test_wan_text_to_video_generation.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WanTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import argparse
 import asyncio

--- a/tests/integration/test_wan_text_to_video_generation.py
+++ b/tests/integration/test_wan_text_to_video_generation.py
@@ -20,94 +20,180 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="WanTextToVideoGeneration", specific_library_name="Griptape Nodes Library",
-        node_name="WanTextToVideoGeneration", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    start_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="StartFlow", specific_library_name="Griptape Nodes Library",
-        node_name="Start Flow", metadata={}, initial_setup=True,
-    )).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="WanTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="WanTextToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(start_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="prompt", default_value="", tooltip="Prompt",
-            type="str", input_types=["any"], output_type="str",
-            ui_options={"display_name": "Prompt", "multiline": True},
-            parent_container_name="", initial_setup=True,
-        ))
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
 
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=start_node, source_parameter_name="prompt",
-        target_node_name=gen_node, target_parameter_name="prompt", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="video_url",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
 
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output
@@ -130,6 +216,6 @@ if __name__ == "__main__":
         if args.prompt is not None:
             flow_input["Start Flow"]["prompt"] = args.prompt
     workflow_output = execute_workflow(
-        input=flow_input, storage_backend=args.storage_backend,
-        project_file_path=args.project_file_path)
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
     print(workflow_output)

--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -18,85 +18,165 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
 from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
-    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
-                      set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
-        node_name="Create Color Bars", metadata={}, initial_setup=True,
-    )).node_name
-    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="WriteImageMetadataNode", specific_library_name="Griptape Nodes Library",
-        node_name="WriteImageMetadataNode", metadata={}, initial_setup=True,
-    )).node_name
-    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="ToText", specific_library_name="Griptape Nodes Library",
-        node_name="To Text", metadata={}, initial_setup=True,
-    )).node_name
-    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
-        node_name="Assert File Exists", metadata={}, initial_setup=True,
-    )).node_name
-    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
-        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
-        node_name="End Flow", metadata={}, initial_setup=True,
-    )).node_name
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="WriteImageMetadataNode",
+            specific_library_name="Griptape Nodes Library",
+            node_name="WriteImageMetadataNode",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(AddParameterToNodeRequest(
-            parameter_name="str", default_value="", tooltip="Result",
-            type="str", input_types=["str"], output_type="str",
-            ui_options={}, parent_container_name="", initial_setup=True,
-        ))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=source_node, source_parameter_name="image",
-        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=gen_node, source_parameter_name="output_image",
-        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=to_text_node, source_parameter_name="output",
-        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
-    GriptapeNodes.handle_request(CreateConnectionRequest(
-        source_node_name=assert_node, source_parameter_name="result_details",
-        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="input_image",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="output_image",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
-    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
 
 
-async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
-        skip_library_loading=True, workflows_to_register=[__file__])
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -8,183 +8,95 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WriteImageMetadataNode"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
+# is_private = true
 # ///
 import asyncio
 import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    GetTopLevelFlowRequest,
-    GetTopLevelFlowResultSuccess,
-)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, GetTopLevelFlowRequest, GetTopLevelFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
 from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-GriptapeNodes.handle_request(
-    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
-)
+GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(
+    library_name="Griptape Nodes Library", perform_discovery_if_not_found=True))
 
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
 
 flow_name = GriptapeNodes.handle_request(
-    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1",
+                      set_as_new_context=False, metadata={})
 ).flow_name
 
 with GriptapeNodes.ContextManager().flow(flow_name):
-    source_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="CreateColorBars",
-            specific_library_name="Griptape Nodes Library",
-            node_name="Create Color Bars",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    gen_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="WriteImageMetadataNode",
-            specific_library_name="Griptape Nodes Library",
-            node_name="WriteImageMetadataNode",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    to_text_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="ToText",
-            specific_library_name="Griptape Nodes Library",
-            node_name="To Text",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    assert_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="AssertFileExists",
-            specific_library_name="Griptape Nodes Testing Library",
-            node_name="Assert File Exists",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
-    end_node = GriptapeNodes.handle_request(
-        CreateNodeRequest(
-            node_type="EndFlow",
-            specific_library_name="Griptape Nodes Library",
-            node_name="End Flow",
-            metadata={},
-            initial_setup=True,
-        )
-    ).node_name
+    source_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="CreateColorBars", specific_library_name="Griptape Nodes Library",
+        node_name="Create Color Bars", metadata={}, initial_setup=True,
+    )).node_name
+    gen_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="WriteImageMetadataNode", specific_library_name="Griptape Nodes Library",
+        node_name="WriteImageMetadataNode", metadata={}, initial_setup=True,
+    )).node_name
+    to_text_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="ToText", specific_library_name="Griptape Nodes Library",
+        node_name="To Text", metadata={}, initial_setup=True,
+    )).node_name
+    assert_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="AssertFileExists", specific_library_name="Griptape Nodes Testing Library",
+        node_name="Assert File Exists", metadata={}, initial_setup=True,
+    )).node_name
+    end_node = GriptapeNodes.handle_request(CreateNodeRequest(
+        node_type="EndFlow", specific_library_name="Griptape Nodes Library",
+        node_name="End Flow", metadata={}, initial_setup=True,
+    )).node_name
     with GriptapeNodes.ContextManager().node(end_node):
-        GriptapeNodes.handle_request(
-            AddParameterToNodeRequest(
-                parameter_name="str",
-                default_value="",
-                tooltip="Result",
-                type="str",
-                input_types=["str"],
-                output_type="str",
-                ui_options={},
-                parent_container_name="",
-                initial_setup=True,
-            )
-        )
-    with GriptapeNodes.ContextManager().node(gen_node):
-        GriptapeNodes.handle_request(
-            SetParameterValueRequest(
-                parameter_name="metadata",
-                node_name=gen_node,
-                value={"author": "griptape-nodes-tests", "description": "integration test"},
-                initial_setup=True,
-                is_output=False,
-            )
-        )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=source_node,
-            source_parameter_name="image",
-            target_node_name=gen_node,
-            target_parameter_name="input_image",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=gen_node,
-            source_parameter_name="output_image",
-            target_node_name=to_text_node,
-            target_parameter_name="from",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=to_text_node,
-            source_parameter_name="output",
-            target_node_name=assert_node,
-            target_parameter_name="file_path",
-            initial_setup=True,
-        )
-    )
-    GriptapeNodes.handle_request(
-        CreateConnectionRequest(
-            source_node_name=assert_node,
-            source_parameter_name="result_details",
-            target_node_name=end_node,
-            target_parameter_name="str",
-            initial_setup=True,
-        )
-    )
-
+        GriptapeNodes.handle_request(AddParameterToNodeRequest(
+            parameter_name="str", default_value="", tooltip="Result",
+            type="str", input_types=["str"], output_type="str",
+            ui_options={}, parent_container_name="", initial_setup=True,
+        ))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=source_node, source_parameter_name="image",
+        target_node_name=gen_node, target_parameter_name="input_image", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=gen_node, source_parameter_name="output_image",
+        target_node_name=to_text_node, target_parameter_name="from", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=to_text_node, source_parameter_name="output",
+        target_node_name=assert_node, target_parameter_name="file_path", initial_setup=True))
+    GriptapeNodes.handle_request(CreateConnectionRequest(
+        source_node_name=assert_node, source_parameter_name="result_details",
+        target_node_name=end_node, target_parameter_name="str", initial_setup=True))
 
 def _ensure_workflow_context():
     context_manager = GriptapeNodes.ContextManager()
     if not context_manager.has_current_flow():
         top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
-        if (
-            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
-            and top_level_flow_result.flow_name is not None
-        ):
+        if isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess) and top_level_flow_result.flow_name is not None:
             flow_manager = GriptapeNodes.FlowManager()
             flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
             context_manager.push_flow(flow_obj)
 
 
-def execute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
-    return asyncio.run(
-        aexecute_workflow(
-            input=input,
-            storage_backend=storage_backend,
-            project_file_path=project_file_path,
-            workflow_executor=workflow_executor,
-            pickle_control_flow_result=pickle_control_flow_result,
-        )
-    )
+def execute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
+    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))
 
 
-async def aexecute_workflow(
-    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
-):
+async def aexecute_workflow(input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False):
     _ensure_workflow_context()
     storage_backend_enum = StorageBackend(storage_backend)
     project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
     workflow_executor = workflow_executor or LocalWorkflowExecutor(
-        storage_backend=storage_backend_enum,
-        project_file_path=project_file_path_resolved,
-        skip_library_loading=True,
-        workflows_to_register=[__file__],
-    )
+        storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved,
+        skip_library_loading=True, workflows_to_register=[__file__])
     async with workflow_executor as executor:
         await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
     return executor.output

--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -8,7 +8,7 @@
 # node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "WriteImageMetadataNode"], ["Griptape Nodes Library", "ToText"]]
 # is_griptape_provided = false
 # is_template = false
-# is_private = true
+# is_internal = true
 # ///
 import asyncio
 import logging

--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
-from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
 from griptape_nodes.drivers.storage.storage_backend import StorageBackend
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
 from griptape_nodes.retained_mode.events.flow_events import (
@@ -25,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(


### PR DESCRIPTION
This will hide them from users in UI. Backwards compatible, no need to require v0.88.0 of engine/[new schema](https://github.com/griptape-ai/griptape-nodes-engine/commit/24da2ecd91faf45488845658648fc95ca82fde94)