### PR TITLE
feat: add CompareVideos node for side-by-side video comparison

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1875,6 +1875,20 @@
       }
     },
     {
+      "class_name": "CompareVideos",
+      "file_path": "griptape_nodes_library/video/compare_videos.py",
+      "metadata": {
+        "category": "video",
+        "description": "Can be used to compare two videos",
+        "display_name": "Compare Videos",
+        "group": "display",
+        "tags": [
+          "video",
+          "compare"
+        ]
+      }
+    },
+    {
       "class_name": "ResizeVideo",
       "file_path": "griptape_nodes_library/video/resize_video.py",
       "metadata": {

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1881,6 +1881,7 @@
         "category": "video",
         "description": "Can be used to compare two videos",
         "display_name": "Compare Videos",
+        "icon": "square-split-horizontal",
         "group": "display",
         "tags": [
           "video",
@@ -3808,6 +3809,7 @@
         "category": "image",
         "description": "Can be used to compare two images",
         "display_name": "Compare Images",
+        "icon": "square-split-horizontal",
         "group": "display",
         "tags": [
           "image",

--- a/griptape_nodes_library/traits/compare_videos.py
+++ b/griptape_nodes_library/traits/compare_videos.py
@@ -1,0 +1,41 @@
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, Trait
+
+
+@dataclass(eq=False)
+class CompareVideosTrait(Trait):
+    element_id: str = field(default_factory=lambda: "CompareVideosTrait")
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @classmethod
+    def get_trait_keys(cls) -> list[str]:
+        return ["compare_videos"]
+
+    def validators_for_trait(self) -> list[Callable[[Parameter, Any], Any]]:
+        def validate_video_comparison(parameter: Parameter, value: Any) -> Any:
+            if not isinstance(value, dict):
+                msg = f"Parameter {parameter.name} value must be a dictionary, got a {type(value).__name__} instead."
+                raise TypeError(msg)
+
+            expected_keys = {"input_video_1", "input_video_2"}
+            actual_keys = set(value.keys())
+            if actual_keys != expected_keys:
+                missing = expected_keys - actual_keys
+                extra = actual_keys - expected_keys
+                details = []
+                if missing:
+                    details.append(f"missing keys: {sorted(missing)}")
+                if extra:
+                    details.append(f"unexpected keys: {sorted(extra)}")
+                detail_msg = "; ".join(details)
+                msg = f"Dictionary for Parameter '{parameter.name}' must contain exactly 'input_video_1' and 'input_video_2' keys; {detail_msg}"
+                raise ValueError(msg)
+
+            return value
+
+        return [validate_video_comparison]

--- a/griptape_nodes_library/video/compare_videos.py
+++ b/griptape_nodes_library/video/compare_videos.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+
+from griptape_nodes_library.traits.compare_videos import CompareVideosTrait
+
+
+class CompareVideos(ControlNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.add_parameter(
+            ParameterVideo(
+                name="Video_1",
+                tooltip="Video 1",
+                default_value=None,
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="Video_2",
+                tooltip="Video 2",
+                default_value=None,
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterDict(
+                name="Compare",
+                tooltip="Compare two videos",
+                default_value={"input_video_1": None, "input_video_2": None},
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={CompareVideosTrait()},
+                ui_options={"video_compare": True},
+            )
+        )
+
+    def _update_compare(self) -> None:
+        """Update the Compare parameter with current videos."""
+        video_1 = self.get_parameter_value("Video_1")
+        video_2 = self.get_parameter_value("Video_2")
+
+        result_dict = {"input_video_1": video_1, "input_video_2": video_2}
+
+        self.set_parameter_value("Compare", result_dict)
+        self.parameter_output_values["Compare"] = result_dict
+
+    def after_value_set(
+        self,
+        parameter: Parameter,
+        value: Any,
+    ) -> None:
+        if parameter.name not in {"Video_1", "Video_2"}:
+            return super().after_value_set(parameter, value)
+
+        self._update_compare()
+        return super().after_value_set(parameter, value)
+
+    def process(self) -> None:
+        """Process the node during execution."""
+        self._update_compare()


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/6babbe07-517e-487d-b52f-c246f63b24a1


- Adds `CompareVideos` node (`griptape_nodes_library/video/compare_videos.py`) mirroring the existing `CompareImages` node structure
- Adds local `CompareVideosTrait` (`griptape_nodes_library/traits/compare_videos.py`) to validate the `{input_video_1, input_video_2}` dict shape
- Registers the node in `griptape_nodes_library.json` under `category: video`, `group: display`
- Uses `ui_options: {"video_compare": True}` to trigger the frontend video-compare widget (draggable divider, frame-synced playback, currentTime drift correction)

Closes #348

> **Dependent on frontend PR:** griptape-ai/griptape-vsl-gui#2496 — the `video_compare` UI option requires the companion widget to be shipped before this node is fully functional.

## How it works

Two `ParameterVideo` inputs (`Video_1`, `Video_2`) feed into a `ParameterDict` property named `Compare`. On `after_value_set` and `process`, `_update_compare()` syncs the inputs into `{input_video_1, input_video_2}` which the frontend widget reads to render the comparison view.

## Test plan

- [ ] Connect a video to `Video_1` only — widget renders with one side populated
- [ ] Connect videos to both `Video_1` and `Video_2` — both sides display, divider is draggable
- [ ] Scrub the timeline — both videos stay frame-synced
- [ ] Expand to dialog view — independent divider position works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)