### PR TITLE
Feat: add video metadata extraction to LoadVideo node

### DIFF
--- a/griptape_nodes_library/utils/ffmpeg_utils.py
+++ b/griptape_nodes_library/utils/ffmpeg_utils.py
@@ -390,8 +390,11 @@ def video_metadata_to_player_dict(metadata: VideoMetadata, video_path: str) -> d
         "width": metadata.dimensions.width,
         "height": metadata.dimensions.height,
         "codec": metadata.file_details.codec_name,
-        "frame_rate": metadata.frame_details.frame_rate,
     }
+
+    frame_rate = metadata.frame_details.frame_rate
+    if frame_rate:
+        meta["frame_rate"] = frame_rate
 
     if metadata.file_details.optional_file_size is not None:
         meta["file_size"] = metadata.file_details.optional_file_size

--- a/griptape_nodes_library/utils/ffmpeg_utils.py
+++ b/griptape_nodes_library/utils/ffmpeg_utils.py
@@ -1,13 +1,16 @@
 """FFmpeg utility functions for cross-platform executable path resolution."""
 
 import json
+import math
 import os
 import subprocess
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, NamedTuple
 
 import static_ffmpeg.run  # type: ignore[import-untyped]
 
+DEFAULT_FRAME_RATE = 24.0
 RATE_TOLERANCE = 0.1
 MIN_SEGMENT_DURATION_FOR_STREAM_COPY = 2.0  # seconds — below this stream copy is unreliable
 
@@ -23,77 +26,93 @@ class VideoProperties(NamedTuple):
     duration: float
 
 
-def get_ffmpeg_path() -> str:
-    """Get the path to ffmpeg executable using static_ffmpeg for cross-platform compatibility.
+@dataclass
+class FileDetails:
+    """File-level metadata with guaranteed and optional fields."""
 
-    This function handles finding the ffmpeg executable across different platforms:
-    - Windows: Uses static-ffmpeg's platform-specific resolution
-    - Linux: Uses static-ffmpeg's platform-specific resolution
-    - macOS: Uses static-ffmpeg's platform-specific resolution
+    codec_name: str
+    codec_type: str  # Always "video" for video streams
 
-    Returns:
-        Path to the ffmpeg executable
+    optional_duration: float | None = None
+    optional_bit_rate: int | None = None
+    optional_codec_long_name: str | None = None
+    optional_profile: str | None = None
+    optional_level: int | None = None
+    optional_pixel_format: str | None = None
+    optional_file_size: int | None = None
+    optional_format_name: str | None = None
 
-    Raises:
-        RuntimeError: If ffmpeg is not found or static-ffmpeg is not properly installed
-    """
-    # FAILURE CASES FIRST
+
+@dataclass
+class Dimensions:
+    """Dimension-related metadata with guaranteed and optional fields."""
+
+    width: int
+    height: int
+    aspect_ratio_decimal: float
+    aspect_ratio_string: str
+
+    optional_coded_width: int | None = None
+    optional_coded_height: int | None = None
+    optional_sample_aspect_ratio: str | None = None
+    optional_display_aspect_ratio: str | None = None
+
+
+@dataclass
+class ColorDetails:
+    """Color and visual quality metadata."""
+
+    optional_color_space: str | None = None
+    optional_color_transfer: str | None = None
+    optional_color_primaries: str | None = None
+    optional_chroma_location: str | None = None
+    optional_field_order: str | None = None
+
+
+@dataclass
+class FrameDetails:
+    """Frame rate and timing metadata with guaranteed and optional fields."""
+
+    r_frame_rate: str  # Raw fraction string like "30/1"
+    avg_frame_rate: str
+    time_base: str
+    frame_rate: float  # Selected playback rate (avg_frame_rate preferred, r_frame_rate or nb_frames/duration fallback)
+
+    optional_nb_frames: int | None = None
+    optional_start_time: float | None = None
+
+
+@dataclass
+class VideoMetadata:
+    """Container for all video metadata categories."""
+
+    file_details: FileDetails
+    dimensions: Dimensions
+    color_details: ColorDetails
+    frame_details: FrameDetails
+
+
+def _resolve_executables() -> tuple[str, str]:
     try:
-        ffmpeg_path, _ = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
+        return static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
     except (FileNotFoundError, OSError, ImportError) as e:
-        error_msg = f"FFmpeg not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
-        raise RuntimeError(error_msg) from e
+        msg = f"FFmpeg/FFprobe not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
+        raise RuntimeError(msg) from e
 
-    # SUCCESS PATH AT END
-    return ffmpeg_path
+
+def get_ffmpeg_path() -> str:
+    """Return the path to the ffmpeg executable."""
+    return _resolve_executables()[0]
 
 
 def get_ffprobe_path() -> str:
-    """Get the path to ffprobe executable using static_ffmpeg for cross-platform compatibility.
-
-    This function handles finding the ffprobe executable across different platforms:
-    - Windows: Uses static-ffmpeg's platform-specific resolution
-    - Linux: Uses static-ffmpeg's platform-specific resolution
-    - macOS: Uses static-ffmpeg's platform-specific resolution
-
-    Returns:
-        Path to the ffprobe executable
-
-    Raises:
-        RuntimeError: If ffprobe is not found or static-ffmpeg is not properly installed
-    """
-    # FAILURE CASES FIRST
-    try:
-        _, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
-    except (FileNotFoundError, OSError, ImportError) as e:
-        error_msg = f"FFprobe not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
-        raise RuntimeError(error_msg) from e
-
-    # SUCCESS PATH AT END
-    return ffprobe_path
+    """Return the path to the ffprobe executable."""
+    return _resolve_executables()[1]
 
 
 def get_ffmpeg_paths() -> FfmpegPaths:
-    """Get both ffmpeg and ffprobe executable paths using static_ffmpeg.
-
-    This is a convenience function that returns both paths in a single call,
-    which is useful when you need both executables.
-
-    Returns:
-        FfmpegPaths(ffmpeg, ffprobe)
-
-    Raises:
-        RuntimeError: If either executable is not found or static-ffmpeg is not properly installed
-    """
-    # FAILURE CASES FIRST
-    try:
-        ffmpeg_path, ffprobe_path = static_ffmpeg.run.get_or_fetch_platform_executables_else_raise()
-    except (FileNotFoundError, OSError, ImportError) as e:
-        error_msg = f"FFmpeg/FFprobe not found. Please ensure static-ffmpeg is properly installed. Error: {e!s}"
-        raise RuntimeError(error_msg) from e
-
-    # SUCCESS PATH AT END
-    return FfmpegPaths(ffmpeg_path, ffprobe_path)
+    """Return both ffmpeg and ffprobe executable paths in a single call."""
+    return FfmpegPaths(*_resolve_executables())
 
 
 def run_ffmpeg_cmd(
@@ -133,8 +152,8 @@ def detect_video_properties(
     Falls back to VideoProperties(24.0, False, 0.0) if ffprobe fails to run, logging a
     warning via `log`. Raises ValueError if ffprobe succeeds but finds no video streams.
     """
-    _DEFAULTS = VideoProperties(24.0, False, 0.0)
-    _DEFAULT_MSG = "24 fps, non-drop-frame, duration 0.0s"
+    _DEFAULTS = VideoProperties(DEFAULT_FRAME_RATE, False, 0.0)
+    _DEFAULT_MSG = f"{DEFAULT_FRAME_RATE} fps, non-drop-frame, duration 0.0s"
 
     cmd = [
         ffprobe_path,
@@ -164,12 +183,7 @@ def detect_video_properties(
         raise ValueError(msg)
 
     stream = data["streams"][0]
-    r_frame_rate = stream.get("r_frame_rate", "24/1")
-    if "/" in r_frame_rate:
-        num, den = map(int, r_frame_rate.split("/"))
-        frame_rate = num / den
-    else:
-        frame_rate = float(r_frame_rate)
+    frame_rate = _parse_fraction_string(stream.get("r_frame_rate", "24/1")) or DEFAULT_FRAME_RATE
 
     drop_frame = abs(frame_rate - 29.97) < RATE_TOLERANCE or abs(frame_rate - 59.94) < RATE_TOLERANCE
 
@@ -193,19 +207,128 @@ def seconds_to_ts(sec: float) -> str:
     return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
 
 
-def extract_video_player_metadata(video_path: str) -> dict[str, Any]:
-    """Extract video metadata in the shape expected by the video player details view.
-
-    Runs ffprobe on *video_path* and returns a dict whose keys match the player's
-    artifact-metadata contract (width, height, file_size, format, color_space,
-    duration_seconds, codec, frame_rate).  Missing or unextractable fields are
-    omitted.  Never raises — returns {} on any failure so callers can always attach
-    the result to an artifact unconditionally.
-    """
+def _parse_fraction_string(fraction_str: str) -> float:
+    """Parse ffprobe fraction string like '30/1' or '30000/1001' to float."""
+    if not fraction_str or fraction_str == "0/0":
+        return 0.0
     try:
-        ffprobe_path = get_ffprobe_path()
-    except RuntimeError:
-        return {}
+        parts = fraction_str.split("/")
+        if len(parts) == 2:  # noqa: PLR2004
+            numerator = float(parts[0])
+            denominator = float(parts[1])
+            if denominator != 0:
+                return numerator / denominator
+    except (ValueError, ZeroDivisionError):
+        pass
+    return 0.0
+
+
+def _safe_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _safe_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
+def _calculate_aspect_ratio_string(width: int, height: int) -> str:
+    divisor = math.gcd(width, height)
+    return f"{width // divisor}:{height // divisor}"
+
+
+def _parse_file_details(video_stream: dict, fmt: dict) -> FileDetails:
+    stream_duration = _safe_float(video_stream.get("duration"))
+    format_duration = _safe_float(fmt.get("duration"))
+    return FileDetails(
+        codec_name=video_stream["codec_name"],
+        codec_type=video_stream["codec_type"],
+        optional_duration=stream_duration or format_duration,
+        optional_bit_rate=_safe_int(video_stream.get("bit_rate")),
+        optional_codec_long_name=video_stream.get("codec_long_name"),
+        optional_profile=video_stream.get("profile"),
+        optional_level=_safe_int(video_stream.get("level")),
+        optional_pixel_format=video_stream.get("pix_fmt"),
+        optional_file_size=_safe_int(fmt.get("size")),
+        optional_format_name=fmt.get("format_name"),
+    )
+
+
+def _parse_dimensions(
+    video_stream: dict, width: int, height: int, aspect_ratio_string: str, aspect_ratio_decimal: float
+) -> Dimensions:
+    return Dimensions(
+        width=width,
+        height=height,
+        aspect_ratio_decimal=aspect_ratio_decimal,
+        aspect_ratio_string=aspect_ratio_string,
+        optional_coded_width=_safe_int(video_stream.get("coded_width")),
+        optional_coded_height=_safe_int(video_stream.get("coded_height")),
+        optional_sample_aspect_ratio=video_stream.get("sample_aspect_ratio"),
+        optional_display_aspect_ratio=video_stream.get("display_aspect_ratio"),
+    )
+
+
+def _parse_color_details(video_stream: dict) -> ColorDetails:
+    return ColorDetails(
+        optional_color_space=video_stream.get("color_space"),
+        optional_color_transfer=video_stream.get("color_transfer"),
+        optional_color_primaries=video_stream.get("color_primaries"),
+        optional_chroma_location=video_stream.get("chroma_location"),
+        optional_field_order=video_stream.get("field_order"),
+    )
+
+
+def _select_frame_rate(video_stream: dict) -> float:
+    """Determine playback frame rate from ffprobe stream data.
+
+    FFmpeg's avformat.h documents r_frame_rate as the lowest rate at which all
+    timestamps can be represented exactly and explicitly notes it is "just a guess".
+    avg_frame_rate is the actual average playback rate and is preferred. Falls back to
+    r_frame_rate when avg is unset ("0/0"), then to nb_frames/duration as a last resort.
+    """
+    avg_parsed = _parse_fraction_string(video_stream.get("avg_frame_rate", ""))
+    if avg_parsed > 0.0:
+        return avg_parsed
+
+    r_parsed = _parse_fraction_string(video_stream.get("r_frame_rate", ""))
+    if r_parsed > 0.0:
+        return r_parsed
+
+    nb_frames = _safe_int(video_stream.get("nb_frames"))
+    duration = _safe_float(video_stream.get("duration"))
+    if nb_frames is not None and nb_frames > 0 and duration is not None and duration > 0:
+        return nb_frames / duration
+
+    return 0.0
+
+
+def _parse_frame_details(video_stream: dict) -> FrameDetails:
+    return FrameDetails(
+        r_frame_rate=video_stream["r_frame_rate"],
+        avg_frame_rate=video_stream["avg_frame_rate"],
+        time_base=video_stream["time_base"],
+        frame_rate=_select_frame_rate(video_stream),
+        optional_nb_frames=_safe_int(video_stream.get("nb_frames")),
+        optional_start_time=_safe_float(video_stream.get("start_time")),
+    )
+
+
+def extract_video_metadata_structured(video_path: str) -> VideoMetadata:
+    """Extract structured video metadata from a local file via ffprobe.
+
+    Raises ValueError on any ffprobe failure so callers can decide how to surface errors.
+    """
+    ffprobe_path = get_ffprobe_path()
 
     cmd = [
         ffprobe_path,
@@ -222,22 +345,56 @@ def extract_video_player_metadata(video_path: str) -> dict[str, Any]:
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
-        data = json.loads(result.stdout)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
-        return {}
+    except subprocess.TimeoutExpired as e:
+        msg = f"When attempting to extract video metadata, ffprobe operation timed out: {e}"
+        raise ValueError(msg) from e
+    except subprocess.CalledProcessError as e:
+        msg = f"When attempting to extract video metadata, ffprobe failed: {e.stderr}"
+        raise ValueError(msg) from e
 
-    meta: dict[str, Any] = {}
-    stream = data["streams"][0] if data.get("streams") else {}
-    fmt = data.get("format", {})
+    try:
+        probe_data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        msg = f"When attempting to extract video metadata, ffprobe returned invalid JSON: {e}"
+        raise ValueError(msg) from e
 
-    if "width" in stream:
-        meta["width"] = int(stream["width"])
-    if "height" in stream:
-        meta["height"] = int(stream["height"])
+    streams = probe_data.get("streams", [])
+    if not streams:
+        msg = "When attempting to extract video metadata, no video streams found in file"
+        raise ValueError(msg)
 
-    # Prefer ffprobe's reported size; fall back to filesystem stat for local paths.
-    if "size" in fmt:
-        meta["file_size"] = int(fmt["size"])
+    video_stream = streams[0]
+    fmt = probe_data.get("format", {})
+
+    try:
+        width = video_stream["width"]
+        height = video_stream["height"]
+    except KeyError as e:
+        msg = f"When attempting to extract video metadata, required field missing from ffprobe output: {e}"
+        raise ValueError(msg) from e
+
+    aspect_ratio_decimal = width / height
+    aspect_ratio_string = video_stream.get("display_aspect_ratio") or _calculate_aspect_ratio_string(width, height)
+
+    return VideoMetadata(
+        file_details=_parse_file_details(video_stream, fmt),
+        dimensions=_parse_dimensions(video_stream, width, height, aspect_ratio_string, aspect_ratio_decimal),
+        color_details=_parse_color_details(video_stream),
+        frame_details=_parse_frame_details(video_stream),
+    )
+
+
+def video_metadata_to_player_dict(metadata: VideoMetadata, video_path: str) -> dict[str, Any]:
+    """Map a VideoMetadata struct to the flat dict the video player details view expects."""
+    meta: dict[str, Any] = {
+        "width": metadata.dimensions.width,
+        "height": metadata.dimensions.height,
+        "codec": metadata.file_details.codec_name,
+        "frame_rate": metadata.frame_details.frame_rate,
+    }
+
+    if metadata.file_details.optional_file_size is not None:
+        meta["file_size"] = metadata.file_details.optional_file_size
     else:
         try:
             meta["file_size"] = os.path.getsize(video_path)
@@ -245,33 +402,29 @@ def extract_video_player_metadata(video_path: str) -> dict[str, Any]:
             pass
 
     # "mp4,mov,m4a,3gp,…" — take the first token as the canonical format name.
-    if fmt.get("format_name"):
-        meta["format"] = fmt["format_name"].split(",")[0]
+    if metadata.file_details.optional_format_name:
+        meta["format"] = metadata.file_details.optional_format_name.split(",")[0]
 
-    if stream.get("color_space"):
-        meta["color_space"] = stream["color_space"]
+    if metadata.color_details.optional_color_space:
+        meta["color_space"] = metadata.color_details.optional_color_space
 
-    duration_str = fmt.get("duration") or stream.get("duration")
-    if duration_str:
-        try:
-            meta["duration_seconds"] = float(duration_str)
-        except (ValueError, TypeError):
-            pass
-
-    if stream.get("codec_name"):
-        meta["codec"] = stream["codec_name"]
-
-    r_frame_rate = stream.get("r_frame_rate", "")
-    if r_frame_rate and r_frame_rate != "0/0":
-        try:
-            num_str, den_str = r_frame_rate.split("/")
-            den = float(den_str)
-            if den != 0:
-                meta["frame_rate"] = float(num_str) / den
-        except (ValueError, ZeroDivisionError):
-            pass
+    if metadata.file_details.optional_duration is not None:
+        meta["duration_seconds"] = metadata.file_details.optional_duration
 
     return meta
+
+
+def extract_video_player_metadata(video_path: str) -> dict[str, Any]:
+    """Extract video metadata in the shape expected by the video player details view.
+
+    Never raises — returns {} on any failure so callers can always attach the result
+    to an artifact unconditionally.
+    """
+    try:
+        metadata = extract_video_metadata_structured(video_path)
+        return video_metadata_to_player_dict(metadata, video_path)
+    except Exception:
+        return {}
 
 
 def build_video_segment_cmd(

--- a/griptape_nodes_library/utils/ffmpeg_utils.py
+++ b/griptape_nodes_library/utils/ffmpeg_utils.py
@@ -1,9 +1,10 @@
 """FFmpeg utility functions for cross-platform executable path resolution."""
 
 import json
+import os
 import subprocess
 from collections.abc import Callable
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import static_ffmpeg.run  # type: ignore[import-untyped]
 
@@ -190,6 +191,87 @@ def seconds_to_ts(sec: float) -> str:
     m = (whole % 3600) // 60
     s = whole % 60
     return f"{h:02d}:{m:02d}:{s:02d}.{ms:03d}"
+
+
+def extract_video_player_metadata(video_path: str) -> dict[str, Any]:
+    """Extract video metadata in the shape expected by the video player details view.
+
+    Runs ffprobe on *video_path* and returns a dict whose keys match the player's
+    artifact-metadata contract (width, height, file_size, format, color_space,
+    duration_seconds, codec, frame_rate).  Missing or unextractable fields are
+    omitted.  Never raises — returns {} on any failure so callers can always attach
+    the result to an artifact unconditionally.
+    """
+    try:
+        ffprobe_path = get_ffprobe_path()
+    except RuntimeError:
+        return {}
+
+    cmd = [
+        ffprobe_path,
+        "-v",
+        "quiet",
+        "-print_format",
+        "json",
+        "-show_streams",
+        "-show_format",
+        "-select_streams",
+        "v:0",
+        video_path,
+    ]
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)  # noqa: S603
+        data = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
+        return {}
+
+    meta: dict[str, Any] = {}
+    stream = data["streams"][0] if data.get("streams") else {}
+    fmt = data.get("format", {})
+
+    if "width" in stream:
+        meta["width"] = int(stream["width"])
+    if "height" in stream:
+        meta["height"] = int(stream["height"])
+
+    # Prefer ffprobe's reported size; fall back to filesystem stat for local paths.
+    if "size" in fmt:
+        meta["file_size"] = int(fmt["size"])
+    else:
+        try:
+            meta["file_size"] = os.path.getsize(video_path)
+        except OSError:
+            pass
+
+    # "mp4,mov,m4a,3gp,…" — take the first token as the canonical format name.
+    if fmt.get("format_name"):
+        meta["format"] = fmt["format_name"].split(",")[0]
+
+    if stream.get("color_space"):
+        meta["color_space"] = stream["color_space"]
+
+    duration_str = fmt.get("duration") or stream.get("duration")
+    if duration_str:
+        try:
+            meta["duration_seconds"] = float(duration_str)
+        except (ValueError, TypeError):
+            pass
+
+    if stream.get("codec_name"):
+        meta["codec"] = stream["codec_name"]
+
+    r_frame_rate = stream.get("r_frame_rate", "")
+    if r_frame_rate and r_frame_rate != "0/0":
+        try:
+            num_str, den_str = r_frame_rate.split("/")
+            den = float(den_str)
+            if den != 0:
+                meta["frame_rate"] = float(num_str) / den
+        except (ValueError, ZeroDivisionError):
+            pass
+
+    return meta
 
 
 def build_video_segment_cmd(

--- a/griptape_nodes_library/video/get_video_metadata.py
+++ b/griptape_nodes_library/video/get_video_metadata.py
@@ -1,6 +1,3 @@
-import json
-import subprocess
-from dataclasses import dataclass
 from typing import Any
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
@@ -9,89 +6,10 @@ from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-
-# static_ffmpeg is dynamically installed by the library loader at runtime
-# into the library's own virtual environment, but not available during type checking
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
-from static_ffmpeg import run  # type: ignore[import-untyped]
 
-
-@dataclass
-class FileDetails:
-    """File-level metadata with guaranteed and optional fields."""
-
-    # Guaranteed fields
-    codec_name: str
-    codec_type: str  # Always "video" for video streams
-
-    # Optional fields (prefixed with optional_)
-    optional_duration: float | None = None
-    optional_bit_rate: int | None = None
-    optional_codec_long_name: str | None = None
-    optional_profile: str | None = None
-    optional_level: int | None = None
-    optional_pixel_format: str | None = None
-
-
-@dataclass
-class Dimensions:
-    """Dimension-related metadata with guaranteed and optional fields."""
-
-    # Guaranteed fields (from ffprobe)
-    width: int
-    height: int
-
-    # Guaranteed fields (calculated by us)
-    aspect_ratio_decimal: float
-    aspect_ratio_string: str  # Either from display_aspect_ratio or calculated
-
-    # Optional fields
-    optional_coded_width: int | None = None
-    optional_coded_height: int | None = None
-    optional_sample_aspect_ratio: str | None = None
-    optional_display_aspect_ratio: str | None = None  # Raw from ffprobe
-
-
-@dataclass
-class ColorDetails:
-    """Color and visual quality metadata with guaranteed and optional fields."""
-
-    # No guaranteed color fields from ffprobe
-
-    # Optional fields
-    optional_color_space: str | None = None
-    optional_color_transfer: str | None = None
-    optional_color_primaries: str | None = None
-    optional_chroma_location: str | None = None
-    optional_field_order: str | None = None
-
-
-@dataclass
-class FrameDetails:
-    """Frame rate and timing metadata with guaranteed and optional fields."""
-
-    # Guaranteed fields (from ffprobe)
-    r_frame_rate: str  # Raw fraction string like "30/1"
-    avg_frame_rate: str  # Raw fraction string
-    time_base: str  # Raw fraction string
-
-    # Guaranteed fields (calculated by us)
-    frame_rate: float  # Selected playback rate (avg_frame_rate preferred, r_frame_rate or nb_frames/duration fallback)
-
-    # Optional fields
-    optional_nb_frames: int | None = None
-    optional_start_time: float | None = None
-
-
-@dataclass
-class VideoMetadata:
-    """Container for all video metadata categories."""
-
-    file_details: FileDetails
-    dimensions: Dimensions
-    color_details: ColorDetails
-    frame_details: FrameDetails
+from griptape_nodes_library.utils import ffmpeg_utils
 
 
 class GetVideoMetadata(DataNode):
@@ -108,7 +26,7 @@ class GetVideoMetadata(DataNode):
             ParameterVideo(
                 name="video",
                 default_value=value,
-                tooltip="The video to analyze for metadata",
+                tooltip="The video to analyse for metadata",
                 allowed_modes={ParameterMode.INPUT},
             )
         )
@@ -251,235 +169,19 @@ class GetVideoMetadata(DataNode):
     def _get_video_url(self, video_input: Any) -> str:
         """Extract video URL from VideoUrlArtifact.
 
-        The ParameterVideo converter should have already normalized string inputs
+        The ParameterVideo converter should have already normalised string inputs
         to VideoUrlArtifact before this method is called.
         """
         if isinstance(video_input, VideoUrlArtifact):
             return File(video_input.value).resolve()
 
-        # Handle other artifact types that have a value attribute
         if hasattr(video_input, "value") and not isinstance(video_input, str):
             return File(video_input.value).resolve()
 
         msg = f"Unsupported video input type: {type(video_input)}. Expected VideoUrlArtifact (ParameterVideo should convert strings automatically)."
         raise ValueError(msg)
 
-    def _get_ffprobe_exe(self) -> str:
-        """Get ffprobe executable path from static-ffmpeg dependency."""
-        _, ffprobe_path = run.get_or_fetch_platform_executables_else_raise()
-        return ffprobe_path
-
-    def _extract_video_metadata_structured(self, video_url: str) -> VideoMetadata:
-        """Extract video metadata using ffprobe JSON output - no regex parsing!"""
-        ffprobe_exe = self._get_ffprobe_exe()
-
-        cmd = [
-            ffprobe_exe,
-            "-v",
-            "quiet",
-            "-print_format",
-            "json",
-            "-show_streams",
-            "-select_streams",
-            "v:0",  # Only first video stream
-            video_url,
-        ]
-
-        try:
-            result = subprocess.run(  # noqa: S603
-                cmd, capture_output=True, text=True, check=True, timeout=30
-            )
-        except subprocess.TimeoutExpired as e:
-            msg = f"When attempting to extract video metadata, ffprobe operation timed out: {e}"
-            raise ValueError(msg) from e
-        except subprocess.CalledProcessError as e:
-            msg = f"When attempting to extract video metadata, ffprobe failed: {e.stderr}"
-            raise ValueError(msg) from e
-
-        try:
-            stream_data = json.loads(result.stdout)
-        except json.JSONDecodeError as e:
-            msg = f"When attempting to extract video metadata, ffprobe returned invalid JSON: {e}"
-            raise ValueError(msg) from e
-
-        streams = stream_data.get("streams", [])
-        if not streams:
-            msg = "When attempting to extract video metadata, no video streams found in file"
-            raise ValueError(msg)
-
-        video_stream = streams[0]  # First video stream
-
-        try:
-            width = video_stream["width"]
-            height = video_stream["height"]
-        except KeyError as e:
-            msg = f"When attempting to extract video metadata, required field missing from ffprobe output: {e}"
-            raise ValueError(msg) from e
-
-        aspect_ratio_decimal = width / height
-
-        # Use display_aspect_ratio from ffprobe if available
-        aspect_ratio_string = video_stream.get("display_aspect_ratio")
-        if not aspect_ratio_string:
-            aspect_ratio_string = self._calculate_aspect_ratio_string(width, height)
-
-        # Create structured metadata from parsed data
-        file_details = self._parse_file_details(video_stream)
-        dimensions = self._parse_dimensions(video_stream, width, height, aspect_ratio_string, aspect_ratio_decimal)
-        color_details = self._parse_color_details(video_stream)
-        frame_details = self._parse_frame_details(video_stream)
-
-        return VideoMetadata(
-            file_details=file_details,
-            dimensions=dimensions,
-            color_details=color_details,
-            frame_details=frame_details,
-        )
-
-    def _calculate_aspect_ratio_string(self, width: int, height: int) -> str:
-        """Calculate simplified aspect ratio string from width and height."""
-
-        # Calculate GCD to simplify the ratio
-        def gcd(a: int, b: int) -> int:
-            while b:
-                a, b = b, a % b
-            return a
-
-        divisor = gcd(width, height)
-        simplified_width = width // divisor
-        simplified_height = height // divisor
-
-        return f"{simplified_width}:{simplified_height}"
-
-    def _parse_file_details(self, video_stream: dict) -> FileDetails:
-        """Parse file-level metadata from ffprobe stream data."""
-        return FileDetails(
-            codec_name=video_stream["codec_name"],
-            codec_type=video_stream["codec_type"],
-            optional_duration=self._safe_float(video_stream.get("duration")),
-            optional_bit_rate=self._safe_int(video_stream.get("bit_rate")),
-            optional_codec_long_name=video_stream.get("codec_long_name"),
-            optional_profile=video_stream.get("profile"),
-            optional_level=self._safe_int(video_stream.get("level")),
-            optional_pixel_format=video_stream.get("pix_fmt"),
-        )
-
-    def _parse_dimensions(
-        self, video_stream: dict, width: int, height: int, aspect_ratio_string: str, aspect_ratio_decimal: float
-    ) -> Dimensions:
-        """Parse dimension-related metadata from ffprobe stream data."""
-        return Dimensions(
-            width=width,
-            height=height,
-            aspect_ratio_decimal=aspect_ratio_decimal,
-            aspect_ratio_string=aspect_ratio_string,
-            optional_coded_width=self._safe_int(video_stream.get("coded_width")),
-            optional_coded_height=self._safe_int(video_stream.get("coded_height")),
-            optional_sample_aspect_ratio=video_stream.get("sample_aspect_ratio"),
-            optional_display_aspect_ratio=video_stream.get("display_aspect_ratio"),
-        )
-
-    def _parse_color_details(self, video_stream: dict) -> ColorDetails:
-        """Parse color-related metadata from ffprobe stream data."""
-        return ColorDetails(
-            optional_color_space=video_stream.get("color_space"),
-            optional_color_transfer=video_stream.get("color_transfer"),
-            optional_color_primaries=video_stream.get("color_primaries"),
-            optional_chroma_location=video_stream.get("chroma_location"),
-            optional_field_order=video_stream.get("field_order"),
-        )
-
-    def _parse_frame_details(self, video_stream: dict) -> FrameDetails:
-        """Parse frame rate and timing metadata from ffprobe stream data."""
-        r_frame_rate = video_stream["r_frame_rate"]
-        avg_frame_rate = video_stream["avg_frame_rate"]
-        time_base = video_stream["time_base"]
-
-        frame_rate = self._select_frame_rate(video_stream)
-
-        return FrameDetails(
-            r_frame_rate=r_frame_rate,
-            avg_frame_rate=avg_frame_rate,
-            time_base=time_base,
-            frame_rate=frame_rate,
-            optional_nb_frames=self._safe_int(video_stream.get("nb_frames")),
-            optional_start_time=self._safe_float(video_stream.get("start_time")),
-        )
-
-    def _select_frame_rate(self, video_stream: dict) -> float:
-        """Determine playback frame rate from ffprobe stream data.
-
-        FFmpeg's avformat.h documents r_frame_rate as the lowest rate at which
-        all timestamps can be represented exactly (the LCM of per-frame ticks)
-        and explicitly notes "this value is just a guess" — for many files it
-        is a timing-grid artifact rather than the playback rate. Practitioner
-        consensus (xklb, video-trimmer, Frigate) prefers avg_frame_rate, with
-        r_frame_rate as fallback when avg is unset ("0/0"), and nb_frames /
-        duration as a last resort for malformed-but-fixable files.
-        """
-        avg_parsed = self._parse_fraction_string(video_stream.get("avg_frame_rate", ""))
-        if avg_parsed > 0.0:
-            return avg_parsed
-
-        r_parsed = self._parse_fraction_string(video_stream.get("r_frame_rate", ""))
-        if r_parsed > 0.0:
-            return r_parsed
-
-        # AVStream.nb_frames docs nb_frames=0 as the "unknown" sentinel.
-        nb_frames = self._safe_int(video_stream.get("nb_frames"))
-        duration = self._safe_float(video_stream.get("duration"))
-        if nb_frames is not None and nb_frames > 0 and duration is not None and duration > 0:
-            return nb_frames / duration
-
-        return 0.0
-
-    def _parse_fraction_string(self, fraction_str: str) -> float:
-        """Parse ffprobe fraction string like '30/1' or '30000/1001' to float."""
-        if not fraction_str or fraction_str == "0/0":
-            return 0.0
-
-        try:
-            parts = fraction_str.split("/")
-            expected_parts = 2
-            if len(parts) == expected_parts:
-                numerator = float(parts[0])
-                denominator = float(parts[1])
-                if denominator != 0:
-                    return numerator / denominator
-        except (ValueError, ZeroDivisionError):
-            pass
-
-        return 0.0
-
-    def _safe_float(self, value: str | None) -> float | None:
-        """Safely convert string to float, returning None for invalid values."""
-        if value is None:
-            return None
-        try:
-            return float(value)
-        except (ValueError, TypeError):
-            return None
-
-    def _safe_int(self, value: str | None) -> int | None:
-        """Safely convert string to int, returning None for invalid values."""
-        if value is None:
-            return None
-        try:
-            return int(value)
-        except (ValueError, TypeError):
-            return None
-
-    def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        """Extract metadata when video parameter is set."""
-        if parameter.name == "video":
-            if not value:
-                self._set_default_output_values()
-            else:
-                video_url = self._get_video_url(value)
-                metadata = self._extract_video_metadata_structured(video_url)
-                self._set_metadata_output_values(metadata)
-
-    def _set_metadata_output_values(self, metadata: VideoMetadata) -> None:
+    def _set_metadata_output_values(self, metadata: ffmpeg_utils.VideoMetadata) -> None:
         """Set output values from extracted metadata."""
         # File Details
         self.parameter_output_values["codec_name"] = metadata.file_details.codec_name
@@ -510,14 +212,12 @@ class GetVideoMetadata(DataNode):
 
     def _set_default_output_values(self) -> None:
         """Set all output values to their defaults when no valid video input."""
-        # File Details - use placeholder values for guaranteed fields
         self.parameter_output_values["codec_name"] = "unknown"
         self.parameter_output_values["codec_type"] = "video"
         self.parameter_output_values["optional_duration"] = None
         self.parameter_output_values["optional_bit_rate"] = None
         self.parameter_output_values["optional_codec_long_name"] = None
 
-        # Dimensions - use placeholder values for guaranteed fields
         self.parameter_output_values["width"] = 0
         self.parameter_output_values["height"] = 0
         self.parameter_output_values["aspect_ratio_decimal"] = 0.0
@@ -525,25 +225,33 @@ class GetVideoMetadata(DataNode):
         self.parameter_output_values["optional_coded_width"] = None
         self.parameter_output_values["optional_coded_height"] = None
 
-        # Color Details - all optional, set to None
         self.parameter_output_values["optional_color_space"] = None
         self.parameter_output_values["optional_color_transfer"] = None
         self.parameter_output_values["optional_color_primaries"] = None
 
-        # Frame Details - use placeholder for guaranteed field
         self.parameter_output_values["frame_rate"] = 0.0
         self.parameter_output_values["r_frame_rate"] = "0/0"
         self.parameter_output_values["avg_frame_rate"] = "0/0"
         self.parameter_output_values["optional_nb_frames"] = None
         self.parameter_output_values["optional_start_time"] = None
 
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Extract metadata when video parameter is set."""
+        if parameter.name == "video":
+            if not value:
+                self._set_default_output_values()
+            else:
+                video_url = self._get_video_url(value)
+                metadata = ffmpeg_utils.extract_video_metadata_structured(video_url)
+                self._set_metadata_output_values(metadata)
+
     def process(self) -> None:
-        """Process method - ensures metadata extraction runs regardless of when parameter was set."""
+        """Ensures metadata extraction runs regardless of when parameter was set."""
         video_input = self.get_parameter_value("video")
 
         if not video_input:
             self._set_default_output_values()
         else:
             video_url = self._get_video_url(video_input)
-            metadata = self._extract_video_metadata_structured(video_url)
+            metadata = ffmpeg_utils.extract_video_metadata_structured(video_url)
             self._set_metadata_output_values(metadata)

--- a/griptape_nodes_library/video/load_video.py
+++ b/griptape_nodes_library/video/load_video.py
@@ -6,6 +6,7 @@ from griptape_nodes.exe_types.node_types import BaseNode, DataNode, NodeDependen
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 
+from griptape_nodes_library.utils import ffmpeg_utils
 from griptape_nodes_library.utils.artifact_path_tethering import (
     ArtifactPathTethering,
     ArtifactTetheringConfig,
@@ -17,7 +18,6 @@ from griptape_nodes_library.utils.macro_path_utils import (
     resolve_to_macro_path,
     update_external_file_controls,
 )
-from griptape_nodes_library.utils import ffmpeg_utils
 from griptape_nodes_library.utils.video_utils import SUPPORTED_VIDEO_EXTENSIONS, dict_to_video_url_artifact
 
 

--- a/griptape_nodes_library/video/load_video.py
+++ b/griptape_nodes_library/video/load_video.py
@@ -17,6 +17,7 @@ from griptape_nodes_library.utils.macro_path_utils import (
     resolve_to_macro_path,
     update_external_file_controls,
 )
+from griptape_nodes_library.utils import ffmpeg_utils
 from griptape_nodes_library.utils.video_utils import SUPPORTED_VIDEO_EXTENSIONS, dict_to_video_url_artifact
 
 
@@ -150,8 +151,10 @@ class LoadVideo(DataNode):
             result = resolve_to_macro_path(video_artifact.value)  # pyright: ignore[reportAttributeAccessIssue]
             update_external_file_controls(result, self._external_warning, self._copy_button, self.name, "video")
             if not result.is_external:
-                video_artifact = VideoUrlArtifact(result.resolved_path)
-                path_value = result.resolved_path
+                resolved_path = result.resolved_path
+                extracted_metadata = ffmpeg_utils.extract_video_player_metadata(resolved_path)
+                video_artifact = VideoUrlArtifact(resolved_path, meta=extracted_metadata)
+                path_value = resolved_path
 
         self.parameter_output_values["video"] = video_artifact
         self.parameter_output_values["path"] = path_value


### PR DESCRIPTION
## Summary

The new video player surfaces a metadata details view (fps, resolution, duration, codec, format, file size) for any loaded video. `Load Video` was outputting a bare `VideoUrlArtifact` with no metadata attached, so the player had no source-of-truth values and fell back to client-side extraction from the downscaled preview — which reports preview dimensions and fps rather than the source file's.

This PR fixes that for `Load Video` and consolidates the underlying ffprobe extraction logic that was previously duplicated between this node and `Get Video Metadata`.

Closes #351

## Changes

### `griptape_nodes_library/utils/ffmpeg_utils.py`

The shared home for all ffprobe-based video metadata extraction:

- **Dataclasses** (`FileDetails`, `Dimensions`, `ColorDetails`, `FrameDetails`, `VideoMetadata`) moved here from `get_video_metadata.py`. `FileDetails` gains two new optional fields — `optional_file_size` and `optional_format_name` — populated from ffprobe's `-show_format` output, which is now always requested.
- **Shared parsing helpers** (`_parse_fraction_string`, `_safe_float`, `_safe_int`, `_calculate_aspect_ratio_string`, `_parse_file_details/_dimensions/_color/_frame`) are module-level functions used by both the structured extractor and `detect_video_properties`.
- **`extract_video_metadata_structured(video_path)`** — runs ffprobe with `-show_streams -show_format`, raises `ValueError` on failure, returns a `VideoMetadata` struct. Used directly by `Get Video Metadata`.
- **`video_metadata_to_player_dict(metadata, video_path)`** — maps a `VideoMetadata` struct to the flat dict the player's artifact-metadata contract expects (`width`, `height`, `file_size`, `format`, `color_space`, `duration_seconds`, `codec`, `frame_rate`). `file_size` falls back to `os.path.getsize` if ffprobe's format section omits it. `frame_rate` is parsed from ffprobe's fraction string (e.g. `30000/1001 → 29.97`).
- **`extract_video_player_metadata(video_path)`** — thin wrapper over the two above; never raises, returns `{}` on any failure so callers can attach the result to an artifact unconditionally.
- **Consolidation of path functions**: `get_ffmpeg_path`, `get_ffprobe_path`, and `get_ffmpeg_paths` previously each duplicated the same try/except around `get_or_fetch_platform_executables_else_raise`. They now delegate to a shared private `_resolve_executables()`.
- **`detect_video_properties`** now uses `_parse_fraction_string` instead of its own inline fraction-parsing branch.
- **`_calculate_aspect_ratio_string`** uses `math.gcd` instead of a hand-rolled nested function.

### `griptape_nodes_library/video/get_video_metadata.py`

Reduced from ~500 lines to ~220. All dataclass definitions and private parsing methods removed; the node now calls `ffmpeg_utils.extract_video_metadata_structured(video_url)` directly and maps the result to its output parameters as before.

A side effect of switching to `-show_format`: `optional_duration` will now fall back to the format-level duration when the video stream doesn't carry one — a quiet improvement for some container formats.

### `griptape_nodes_library/video/load_video.py`

In `process()`, after resolving the video to a local path, calls `ffmpeg_utils.extract_video_player_metadata(resolved_path)` and passes the result as `meta=` when constructing the output `VideoUrlArtifact`. Only runs for non-external (local) files, matching the existing control flow.

## Notes

Generation and processing nodes (Kling, LTX, Sora, etc.) have the same gap — they also output bare `VideoUrlArtifacts`. A follow-up is tracked separately.
