### PR TITLE
refactor(proxy): declare model invocations by stable catalog key

### DIFF
--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -16,8 +16,12 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.node_library.library_registry import get_declared_models
 from griptape_nodes.retained_mode.events.base_events import ResultPayload
-from griptape_nodes.retained_mode.events.model_events import DeclareModelInvocationRequest
+from griptape_nodes.retained_mode.events.model_events import (
+    DeclareModelInvocationRequest,
+    DeclareModelInvocationResultFailure,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key, resolve_proxy_base
@@ -591,18 +595,40 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._set_status_results(was_successful=False, result_details=error_msg)
         self._handle_failure_exception(e)
 
+    def _resolve_catalog_model_id(self, api_model_id: str) -> str | None:
+        """Resolve the selected provider model id to its stable catalog key.
+
+        The lookup is scoped to this node's own declared models, so the
+        provider_model_id -> stable key mapping is unambiguous: a node does not
+        declare the same upstream model under two catalog keys. Returns None
+        when the selection is not one of the node's declared catalog models.
+        """
+        matches = [
+            resolved.model_id
+            for resolved in get_declared_models(self)
+            if resolved.model.provider_model_id == api_model_id
+        ]
+        return matches[0] if len(matches) == 1 else None
+
     async def _declare_model_invocation(self, api_model_id: str) -> ResultPayload:
         """Declare the impending model invocation so the permission layer can gate it.
 
-        Dispatches a DeclareModelInvocationRequest carrying the concrete model,
-        the provider it routes to, and this node's name. The engine clears the
+        Resolves the concrete provider model id to the stable catalog key the
+        permission system gates on, and declares that. The engine clears the
         call by default; a registered policy can deny it, in which case the
         result reports failure. The proxy enforces server-side as well; this
         runs first, so a denied call fails fast and never leaves the engine.
         """
-        provider_id = self._api_key_provider.provider_id if self._api_key_provider else None
+        model_id = self._resolve_catalog_model_id(api_model_id)
+        if model_id is None:
+            return DeclareModelInvocationResultFailure(
+                result_details=(
+                    f"{self.name}: '{api_model_id}' is not a declared catalog model for this node, "
+                    f"so the invocation cannot be declared."
+                )
+            )
         return await GriptapeNodes.ahandle_request(
-            DeclareModelInvocationRequest(model=api_model_id, provider_id=provider_id, node_name=self.name)
+            DeclareModelInvocationRequest(model_id=model_id, node_name=self.name)
         )
 
     async def _submit_and_poll(self, headers: dict[str, str]) -> tuple[str, dict[str, Any]] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.87.0",
+  "griptape-nodes-engine>=0.88.0",
   "lxml>=5.0.0",
 ]
 

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -1,11 +1,12 @@
 """Keep the `model_catalog` declarations in sync with the model lists the
 library actually serves.
 
-Nodes do not read the catalog at runtime: the catalog is the contract the
-library exposes to the platform (policy, key support, UI grouping), and the
-node Python is the implementation. This test is the guard that keeps the two
-from drifting, so the catalog stays trustworthy without any node depending on
-the library registry to decide its behavior.
+The catalog is the contract the library exposes to the platform (policy, key
+support, UI grouping). The chat nodes carry their model lists statically in
+Python, while the proxy base node resolves a runtime selection back to its
+stable catalog key from the library registry. Either way the catalog and the
+served models must agree, and these tests are the guard that keeps them from
+drifting.
 """
 
 from __future__ import annotations
@@ -41,6 +42,15 @@ def _model_usage_ids(library: dict[str, Any], class_name: str) -> list[str]:
     return usage["model_ids"]
 
 
+def _nodes_with_model_usage(library: dict[str, Any]) -> list[str]:
+    """Class names of every node that declares `model_usage`."""
+    return [
+        node["class_name"]
+        for node in library["nodes"]
+        if any(d.get("type") == "model_usage" for d in node.get("metadata", {}).get("declarations", []))
+    ]
+
+
 @pytest.mark.parametrize("class_name", ["Agent", "GriptapeCloudPrompt"])
 def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
     """The chat model list in Python and the models the node declares must agree.
@@ -56,3 +66,26 @@ def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
     served = [model["name"] for model in MODEL_CHOICES_ARGS]
 
     assert declared == served
+
+
+def test_declared_models_resolve_uniquely_per_node() -> None:
+    """Each node's declared models map one-to-one to provider model ids.
+
+    The proxy base node resolves a selected provider model id back to its
+    stable catalog key by matching within the node's own declared models
+    (`GriptapeProxyNode._resolve_catalog_model_id`). That match is unambiguous
+    only when a node does not declare two catalog ids that share a
+    `provider_model_id`; a duplicate would make the runtime resolver fail
+    closed. Guard the manifest against introducing one.
+    """
+    library = _load_library()
+    provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)
+
+    duplicates: dict[str, list[str]] = {}
+    for class_name in _nodes_with_model_usage(library):
+        wire_ids = [provider_model_id_by_catalog_id[model_id] for model_id in _model_usage_ids(library, class_name)]
+        repeated = sorted({wire_id for wire_id in wire_ids if wire_ids.count(wire_id) > 1})
+        if repeated:
+            duplicates[class_name] = repeated
+
+    assert not duplicates, f"nodes declare catalog ids that share a provider_model_id: {duplicates}"

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.87.0"
+version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/67/6ba3507209b6b12a2ecb814f15af33c3ed8db082b0122aef12b063833e6a/griptape_nodes_engine-0.87.0.tar.gz", hash = "sha256:1415f3597c6f709d87b3e81658335d636a245b830d5416f541050b4f1051cd67", size = 911352, upload-time = "2026-06-18T19:23:36.224Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/92/85dcb7206cf5b725606f17e6364c8583e5f858fcef07b59039152de8d912/griptape_nodes_engine-0.88.0.tar.gz", hash = "sha256:19de433dbfe68f6f58e7ecf20d6e666dca09e221eea6b6a8d29459b855955ddd", size = 935218, upload-time = "2026-06-23T22:41:39.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/eb/f2fc731c97bae08f67143026145da7ef7c42bb5dba0c8a25641c401b14c5/griptape_nodes_engine-0.87.0-py3-none-any.whl", hash = "sha256:04514f228e2655d215d14cf0163a9efa7a6b8fad18b77bfce0fe73bec1c11c87", size = 1141817, upload-time = "2026-06-18T19:23:37.506Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/dc/cc463c97aede417956c7136cfa09c0ab665c790dba1bc7ff26e98dec9a9c/griptape_nodes_engine-0.88.0-py3-none-any.whl", hash = "sha256:cd88c1008d4fbfb4aaa4b0e44427dea5a26532f518af41c080456e8c8bb66032", size = 1170364, upload-time = "2026-06-23T22:41:38.14Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.87.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.88.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
The proxy base node was declaring impending model invocations to the permission layer using the concrete provider model id (the wire id) plus the resolved `provider_id`. That couples the permission contract to provider-specific wire ids, which can collide or shift, and forces every declaration to also carry provider routing the engine can infer.

This routes declarations through the stable catalog key instead. `GriptapeProxyNode` resolves the selected `provider_model_id` back to the catalog `model_id` by matching within the node's own declared models, where the mapping is unambiguous because a node never declares the same upstream model under two catalog keys. An unresolved selection fails closed: it returns a `DeclareModelInvocationResultFailure` rather than silently declaring an unknown model.

`test_declared_models_resolve_uniquely_per_node` guards the manifest so no node can introduce two catalog ids sharing a `provider_model_id`, which would make the runtime resolver ambiguous and fail closed.

This depends on the `DeclareModelInvocationRequest` reshaping (`model_id`, no `provider_id`) that ships in `griptape-nodes-engine` 0.88.0, so the engine pin is bumped to match.

<img width="944" height="480" alt="image" src="https://github.com/user-attachments/assets/d54cda05-70f0-4227-9c8a-bb634244f2e7" />
