### PR TITLE
feat: declare arbitrary Python execution on ExecutePython node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1360,6 +1360,12 @@
           "python",
           "logic",
           "data"
+        ],
+        "declarations": [
+          {
+            "type": "arbitrary_python_execution",
+            "executes_arbitrary_python": true
+          }
         ]
       }
     },


### PR DESCRIPTION
The engine schema gained an `arbitrary_python_execution` node declaration so consumers can identify nodes that run author-unvetted Python and warn before they execute. `ExecutePython` is the only node in this library that runs runtime-supplied code, passing it straight to `RunArbitraryPythonStringRequest`, yet it carried no such declaration, leaving that security-relevant fact invisible to the UI and to permission gating.

Declaring it makes the node honest about what it does. The subflow nodes are left undeclared since they execute registered workflows rather than arbitrary code supplied at runtime.