### PR TITLE
feature: Allow agents to use local models by providing additional agent credentials

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -345,10 +345,10 @@ class Agent(ControlNode):
         if not _AGENT_PROVIDERS_AVAILABLE:
             return _FALLBACK
         try:
-            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())  # pyright: ignore[reportPossiblyUnbound]
-            if not isinstance(result, ListAgentProvidersResultSuccess):  # pyright: ignore[reportPossiblyUnbound]
+            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
+            if not isinstance(result, ListAgentProvidersResultSuccess):  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
                 return _FALLBACK
-            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK  # pyright: ignore[reportPossiblyUnbound]
+            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         except Exception:
             return _FALLBACK
 
@@ -381,14 +381,14 @@ class Agent(ControlNode):
             if provider_config is None:
                 return MODEL_CHOICES
             result = GriptapeNodes.handle_request(
-                ListProviderModelsRequest(  # pyright: ignore[reportPossiblyUnbound]
+                ListProviderModelsRequest(  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
                     provider=provider_config.get("type", provider_name),
                     base_url=provider_config.get("base_url", ""),
                     api_key=self._resolve_provider_api_key(provider_config),
                 )
             )
-            if isinstance(result, ListProviderModelsResultSuccess):  # pyright: ignore[reportPossiblyUnbound]
-                return cast(ListProviderModelsResultSuccess, result).models or MODEL_CHOICES  # pyright: ignore[reportPossiblyUnbound]
+            if isinstance(result, ListProviderModelsResultSuccess):  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
+                return cast(ListProviderModelsResultSuccess, result).models or MODEL_CHOICES  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         except Exception:
             pass
         return MODEL_CHOICES

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -7,7 +7,7 @@ for tools, rulesets, prompts, and streams output back to the user interface.
 """
 
 import json
-from typing import TYPE_CHECKING, Any, cast  # cast used for handle_request narrowing
+from typing import Any, cast  # cast used for handle_request narrowing
 
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
@@ -40,22 +40,13 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.events.agent_events import (  # type: ignore[import]
-        ListAgentProvidersRequest,
-        ListAgentProvidersResultSuccess,
-        ListProviderModelsRequest,
-        ListProviderModelsResultSuccess,
-    )
-
 try:
-    from griptape_nodes.retained_mode.events.agent_events import (  # type: ignore[import]
-        ListAgentProvidersRequest,
-        ListAgentProvidersResultSuccess,
-        ListProviderModelsRequest,
-        ListProviderModelsResultSuccess,
+    from griptape_nodes.retained_mode.events.agent_events import (
+        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
     )
-
     _AGENT_PROVIDERS_AVAILABLE = True
 except ImportError:
     _AGENT_PROVIDERS_AVAILABLE = False
@@ -353,10 +344,10 @@ class Agent(ControlNode):
         if not _AGENT_PROVIDERS_AVAILABLE:
             return _FALLBACK
         try:
-            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
-            if not isinstance(result, ListAgentProvidersResultSuccess):
+            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())  # pyright: ignore[reportPossiblyUnbound]
+            if not isinstance(result, ListAgentProvidersResultSuccess):  # pyright: ignore[reportPossiblyUnbound]
                 return _FALLBACK
-            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK
+            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK  # pyright: ignore[reportPossiblyUnbound]
         except Exception:
             return _FALLBACK
 
@@ -389,14 +380,14 @@ class Agent(ControlNode):
             if provider_config is None:
                 return MODEL_CHOICES
             result = GriptapeNodes.handle_request(
-                ListProviderModelsRequest(
+                ListProviderModelsRequest(  # pyright: ignore[reportPossiblyUnbound]
                     provider=provider_config.get("type", provider_name),
                     base_url=provider_config.get("base_url", ""),
                     api_key=self._resolve_provider_api_key(provider_config),
                 )
             )
-            if isinstance(result, ListProviderModelsResultSuccess):
-                return cast(ListProviderModelsResultSuccess, result).models or MODEL_CHOICES
+            if isinstance(result, ListProviderModelsResultSuccess):  # pyright: ignore[reportPossiblyUnbound]
+                return cast(ListProviderModelsResultSuccess, result).models or MODEL_CHOICES  # pyright: ignore[reportPossiblyUnbound]
         except Exception:
             pass
         return MODEL_CHOICES

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -7,7 +7,7 @@ for tools, rulesets, prompts, and streams output back to the user interface.
 """
 
 import json
-from typing import Any, cast  # cast used for handle_request narrowing
+from typing import TYPE_CHECKING, Any, cast  # cast used for handle_request narrowing
 
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
@@ -35,16 +35,29 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.retained_mode.events.agent_events import (
-    ListAgentProvidersRequest,
-    ListAgentProvidersResultSuccess,
-    ListProviderModelsRequest,
-    ListProviderModelsResultSuccess,
-)
 from griptape_nodes.retained_mode.events.connection_events import DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.agent_events import (  # type: ignore[import]
+        ListAgentProvidersRequest,
+        ListAgentProvidersResultSuccess,
+        ListProviderModelsRequest,
+        ListProviderModelsResultSuccess,
+    )
+
+try:
+    from griptape_nodes.retained_mode.events.agent_events import (  # type: ignore[import]
+        ListAgentProvidersRequest,
+        ListAgentProvidersResultSuccess,
+        ListProviderModelsRequest,
+        ListProviderModelsResultSuccess,
+    )
+    _AGENT_PROVIDERS_AVAILABLE = True
+except ImportError:
+    _AGENT_PROVIDERS_AVAILABLE = False
 from jinja2 import Template
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
 
@@ -336,6 +349,8 @@ class Agent(ControlNode):
     def _fetch_providers(self) -> list[dict]:
         """Fetch configured providers from the engine, falling back to griptape_cloud only."""
         _FALLBACK = [{"name": "griptape_cloud", "type": "griptape_cloud"}]
+        if not _AGENT_PROVIDERS_AVAILABLE:
+            return _FALLBACK
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
             if not isinstance(result, ListAgentProvidersResultSuccess):
@@ -363,6 +378,8 @@ class Agent(ControlNode):
 
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
         """Return the model list for a given provider name."""
+        if not _AGENT_PROVIDERS_AVAILABLE:
+            return MODEL_CHOICES
         try:
             providers = self._fetch_providers()
             provider_config = next((p for p in providers if p["name"] == provider_name), None)

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -46,9 +46,11 @@ try:
         ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
         ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
         ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
     )
 
     _AGENT_PROVIDERS_AVAILABLE = True
+    _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
 except ImportError:
     _AGENT_PROVIDERS_AVAILABLE = False
 from jinja2 import Template
@@ -339,11 +341,11 @@ class Agent(ControlNode):
 
     # --- Provider / Model Methods ---
 
-    def _fetch_providers(self) -> list[dict]:
+    def _fetch_providers(self) -> list[ProviderConfig]:  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         """Fetch configured providers from the engine, falling back to griptape_cloud only."""
-        _FALLBACK = [{"name": "griptape_cloud", "type": "griptape_cloud"}]
         if not _AGENT_PROVIDERS_AVAILABLE:
-            return _FALLBACK
+            return []
+        _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
             if not isinstance(result, ListAgentProvidersResultSuccess):  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
@@ -355,16 +357,16 @@ class Agent(ControlNode):
     def _fetch_provider_names(self) -> list[str]:
         """Return ordered provider names for the provider dropdown."""
         providers = self._fetch_providers()
-        return [p["name"] for p in providers] or ["griptape_cloud"]
+        return [p.name for p in providers] or ["griptape_cloud"]
 
-    def _resolve_provider_api_key(self, provider_config: dict) -> str:
+    def _resolve_provider_api_key(self, provider_config: ProviderConfig) -> str:  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         """Resolve the API key for a provider config.
 
         Provider configs carry api_key_secret_name (the name of a secret in the
         secrets manager) rather than a raw api_key value.  Fall back to
         "not-needed" for providers that don't require a key (e.g. Ollama).
         """
-        secret_name = provider_config.get("api_key_secret_name", "")
+        secret_name = provider_config.api_key_secret_name or ""
         if secret_name:
             return (
                 GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"
@@ -377,13 +379,13 @@ class Agent(ControlNode):
             return MODEL_CHOICES
         try:
             providers = self._fetch_providers()
-            provider_config = next((p for p in providers if p["name"] == provider_name), None)
+            provider_config = next((p for p in providers if p.name == provider_name), None)
             if provider_config is None:
                 return MODEL_CHOICES
             result = GriptapeNodes.handle_request(
                 ListProviderModelsRequest(  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
-                    provider=provider_config.get("type", provider_name),
-                    base_url=provider_config.get("base_url", ""),
+                    provider=provider_config.type,
+                    base_url=provider_config.base_url or "",
                     api_key=self._resolve_provider_api_key(provider_config),
                 )
             )
@@ -1017,8 +1019,8 @@ class Agent(ControlNode):
             else:
                 # Non-Griptape-Cloud provider: resolve config and use the OpenAI-compatible driver.
                 providers = self._fetch_providers()
-                provider_config = next((p for p in providers if p["name"] == provider_name), {})
-                base_url = provider_config.get("base_url", "")
+                provider_config = next((p for p in providers if p.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
+                base_url = provider_config.base_url or ""
                 api_key = self._resolve_provider_api_key(provider_config)
                 prompt_driver = GtOpenAiChatPromptDriver(
                     model=model_input,
@@ -1064,10 +1066,10 @@ class Agent(ControlNode):
         # griptape strips api_key from non-GTC drivers during to_dict() serialization.
         if provider_name != "griptape_cloud":
             providers = self._fetch_providers()
-            p = next((x for x in providers if x["name"] == provider_name), {})
+            p = next((x for x in providers if x.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
             wrapper["provider"] = {
                 "name": provider_name,
-                "base_url": p.get("base_url", ""),
+                "base_url": p.base_url or "",
                 "api_key": self._resolve_provider_api_key(p),
             }
         elif incoming_provider:

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -7,11 +7,12 @@ for tools, rulesets, prompts, and streams output back to the user interface.
 """
 
 import json
-from typing import Any, cast
+from typing import Any, cast  # cast used for handle_request narrowing
 
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
+from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape.events import (
     ActionChunkEvent,
     FinishActionsSubtaskEvent,
@@ -23,6 +24,7 @@ from griptape.memory.structure import ConversationMemory, Run
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
 from griptape_nodes.exe_types.core_types import (
+    NodeMessageResult,
     Parameter,
     ParameterGroup,
     ParameterList,
@@ -33,9 +35,15 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.agent_events import (
+    ListAgentProvidersRequest,
+    ListAgentProvidersResultSuccess,
+    ListProviderModelsRequest,
+    ListProviderModelsResultSuccess,
+)
 from griptape_nodes.retained_mode.events.connection_events import DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 from jinja2 import Template
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
@@ -128,7 +136,29 @@ class Agent(ControlNode):
             )
         )
 
-        # Selection for the Griptape Cloud model.
+        # Provider selector — populated from the engine's configured providers.
+        provider_names = self._fetch_provider_names()
+        self.add_parameter(
+            Parameter(
+                name="model_provider",
+                type="str",
+                default_value=provider_names[0] if provider_names else "griptape_cloud",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                tooltip="Choose a provider. Refresh to see all configured providers.",
+                traits={
+                    Options(choices=provider_names),
+                    Button(
+                        icon="list-restart",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._refresh_providers_button,
+                    ),
+                },
+                ui_options={"display_name": "provider"},
+            )
+        )
+
+        # Model selector — choices update when the provider changes.
         self.add_parameter(
             Parameter(
                 name="model",
@@ -136,7 +166,15 @@ class Agent(ControlNode):
                 default_value=DEFAULT_MODEL,
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 tooltip="Choose a model, or connect a Prompt Model Configuration",
-                traits={Options(choices=MODEL_CHOICES)},
+                traits={
+                    Options(choices=MODEL_CHOICES),
+                    Button(
+                        icon="list-restart",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._refresh_models_button,
+                    ),
+                },
                 ui_options={"display_name": "prompt model", "data": MODEL_CHOICES_ARGS},
             )
         )
@@ -292,6 +330,77 @@ class Agent(ControlNode):
                 lines.append(f"  Result: {result}")
         lines.append("]")
         return "\n".join(lines) + "\n\n"
+
+    # --- Provider / Model Methods ---
+
+    def _fetch_providers(self) -> list[dict]:
+        """Fetch configured providers from the engine, falling back to griptape_cloud only."""
+        _FALLBACK = [{"name": "griptape_cloud", "type": "griptape_cloud"}]
+        try:
+            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
+            if not isinstance(result, ListAgentProvidersResultSuccess):
+                return _FALLBACK
+            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK
+        except Exception:
+            return _FALLBACK
+
+    def _fetch_provider_names(self) -> list[str]:
+        """Return ordered provider names for the provider dropdown."""
+        providers = self._fetch_providers()
+        return [p["name"] for p in providers] or ["griptape_cloud"]
+
+    def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
+        """Return the model list for a given provider name."""
+        try:
+            providers = self._fetch_providers()
+            provider_config = next((p for p in providers if p["name"] == provider_name), None)
+            if provider_config is None:
+                return MODEL_CHOICES
+            result = GriptapeNodes.handle_request(
+                ListProviderModelsRequest(
+                    provider=provider_config.get("type", provider_name),
+                    base_url=provider_config.get("base_url", ""),
+                    api_key=provider_config.get("api_key", ""),
+                )
+            )
+            if isinstance(result, ListProviderModelsResultSuccess):
+                return cast(ListProviderModelsResultSuccess, result).models or MODEL_CHOICES
+        except Exception:
+            pass
+        return MODEL_CHOICES
+
+    def _update_model_choices_for_provider(self, provider_name: str) -> None:
+        """Swap the model dropdown choices for the given provider."""
+        models = self._fetch_models_for_provider(provider_name)
+        default = models[0] if models else DEFAULT_MODEL
+        self._update_option_choices(param="model", choices=models, default=default)
+        # The frontend renders the dropdown from the "data" ui_options key (not "simple_dropdown").
+        # Update it explicitly so the frontend receives the change notification.
+        param = self.get_parameter_by_name("model")
+        if param:
+            if provider_name == "griptape_cloud":
+                new_data = MODEL_CHOICES_ARGS
+            else:
+                new_data = [{"name": m, "icon": "", "args": {}} for m in models]
+            param.update_ui_options_key("data", new_data)
+
+    def _refresh_providers_button(
+        self, button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:  # noqa: ARG002
+        """Refresh the provider dropdown from the engine."""
+        provider_names = self._fetch_provider_names()
+        current = self.get_parameter_value("model_provider") or "griptape_cloud"
+        default = current if current in provider_names else (provider_names[0] if provider_names else "griptape_cloud")
+        self._update_option_choices(param="model_provider", choices=provider_names, default=default)
+        return None
+
+    def _refresh_models_button(
+        self, button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:  # noqa: ARG002
+        """Refresh the model dropdown for the currently selected provider."""
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
+        self._update_model_choices_for_provider(provider_name)
+        return None
 
     # --- Helper Methods ---
 
@@ -557,6 +666,18 @@ class Agent(ControlNode):
                     )
                 )
 
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        super().after_value_set(parameter, value)
+        if parameter.name == "model_provider":
+            provider_name = str(value)
+            models = self._fetch_models_for_provider(provider_name)
+            default = models[0] if models else DEFAULT_MODEL
+            self._update_option_choices(param="model", choices=models, default=default)
+            new_data = MODEL_CHOICES_ARGS if provider_name == "griptape_cloud" else [{"name": m, "icon": "", "args": {}} for m in models]
+            param = self.get_parameter_by_name("model")
+            if param:
+                param.update_ui_options_key("data", new_data)
+
     # --- UI Interaction Hooks ---
 
     def after_incoming_connection(
@@ -564,7 +685,7 @@ class Agent(ControlNode):
     ) -> None:
         # If an existing agent is connected, hide parameters related to creating a new one.
         if target_parameter.name == "agent":
-            params_to_toggle = ["model", "tools", "rulesets"]
+            params_to_toggle = ["model", "model_provider", "tools", "rulesets"]
             self.hide_parameter_by_name(params_to_toggle)
 
         if target_parameter.name == "model" and source_parameter.name == "prompt_model_config":
@@ -607,7 +728,7 @@ class Agent(ControlNode):
     ) -> None:
         # If the agent connection is removed, show agent creation parameters.
         if target_parameter.name == "agent":
-            params_to_toggle = ["model", "tools", "rulesets", "schema"]
+            params_to_toggle = ["model", "model_provider", "tools", "rulesets", "schema"]
             self.show_parameter_by_name(params_to_toggle)
 
         if target_parameter.name == "output_schema":
@@ -627,8 +748,10 @@ class Agent(ControlNode):
             target_parameter.default_value = DEFAULT_MODEL
             self.set_parameter_value("model", DEFAULT_MODEL)
 
-            # Add the options trait
-            target_parameter.add_trait(Options(choices=MODEL_CHOICES))
+            # Restore choices for the currently selected provider.
+            current_provider = self.get_parameter_value("model_provider") or "griptape_cloud"
+            restored_models = self._fetch_models_for_provider(current_provider)
+            self._update_option_choices(param="model", choices=restored_models, default=DEFAULT_MODEL)
 
             # Change the display name to be appropriate
             ui_options = target_parameter.ui_options
@@ -680,14 +803,18 @@ class Agent(ControlNode):
     def _uses_griptape_cloud_driver(self) -> bool:
         """Return True when the node will build the default Griptape Cloud prompt driver.
 
-        A connected agent supplies its own driver, and a connected prompt driver
-        (``model`` resolved to a ``BasePromptDriver``) supplies its own credentials;
-        in both cases the Griptape Cloud API key is not needed.
+        A connected agent supplies its own driver, a connected prompt driver
+        (``model`` resolved to a ``BasePromptDriver``) supplies its own credentials,
+        and a non-griptape_cloud provider uses an OpenAI-compatible driver — none
+        of these need the Griptape Cloud API key.
         """
         if self.get_parameter_value("agent") is not None:
             return False
         model_input = self.get_parameter_value("model")
-        return not isinstance(model_input, BasePromptDriver)
+        if isinstance(model_input, BasePromptDriver):
+            return False
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
+        return provider_name == "griptape_cloud"
 
     def _handle_additional_context(self, prompt: str, additional_context: str | int | float | dict[str, Any]) -> str:  # noqa: PYI041
         """Integrates additional context into the main prompt string.
@@ -740,6 +867,7 @@ class Agent(ControlNode):
             An AsyncResult indicating the structure being processed (the agent).
         """
         model_input = self.get_parameter_value("model")
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
         agent = None
         include_details = self.get_parameter_value("include_details")
         default_prompt_driver = GriptapeCloudPromptDriver(
@@ -815,9 +943,11 @@ class Agent(ControlNode):
         # If neither are provided, we'll create a new one with the selected model.
         # Otherwise, we'll just use the default model
         agent_input = self.get_parameter_value("agent")
+        incoming_provider: dict | None = None
         if isinstance(agent_input, dict):
             # Unwrap the new-format wrapper (or handle old raw agent dict gracefully).
             agent_core_dict, incoming_tool_configs, incoming_ruleset_configs = unwrap_agent(agent_input)
+            incoming_provider = agent_input.get("provider")  # non-GTC provider config forwarded by upstream node
             agent = GtAgent().from_dict(agent_core_dict)
             # Rebuild tools from the incoming config so the live connection is fresh.
             if incoming_tool_configs:
@@ -833,20 +963,41 @@ class Agent(ControlNode):
                 agent.tasks[0] = PromptTask(prompt_driver=default_prompt_driver, output_schema=pydantic_schema)
             else:
                 agent.tasks[0].output_schema = pydantic_schema
+            # Rebuild the prompt driver for non-GTC providers — griptape strips api_key during serialization.
+            if incoming_provider:
+                rebuilt_driver = GtOpenAiChatPromptDriver(
+                    model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
+                    base_url=incoming_provider.get("base_url", ""),
+                    api_key=incoming_provider.get("api_key") or "not-needed",
+                    stream=True,
+                )
+                cast(PromptTask, agent.tasks[0]).prompt_driver = rebuilt_driver
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
         elif isinstance(model_input, str):
-            if model_input not in MODEL_CHOICES:
-                model_input = DEFAULT_MODEL
-            # Get the appropriate args
-            args = next((model["args"] for model in MODEL_CHOICES_ARGS if model["name"] == model_input), {})
-            # Remove any None values from args
-            args = {k: v for k, v in args.items() if v is not None}
-            prompt_driver = GriptapeCloudPromptDriver(
-                model=model_input,
-                api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
-                **args,
-            )
+            if provider_name == "griptape_cloud":
+                if model_input not in MODEL_CHOICES:
+                    model_input = DEFAULT_MODEL
+                # Get the appropriate args (stream setting, structured output strategy, etc.)
+                args = next((model["args"] for model in MODEL_CHOICES_ARGS if model["name"] == model_input), {})
+                args = {k: v for k, v in args.items() if v is not None}
+                prompt_driver = GriptapeCloudPromptDriver(
+                    model=model_input,
+                    api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                    **args,
+                )
+            else:
+                # Non-Griptape-Cloud provider: resolve config and use the OpenAI-compatible driver.
+                providers = self._fetch_providers()
+                provider_config = next((p for p in providers if p["name"] == provider_name), {})
+                base_url = provider_config.get("base_url", "")
+                api_key = provider_config.get("api_key") or "not-needed"
+                prompt_driver = GtOpenAiChatPromptDriver(
+                    model=model_input,
+                    base_url=base_url,
+                    api_key=api_key,
+                    stream=True,
+                )
             agent = GtAgent(prompt_driver=prompt_driver, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
 
         if agent is None:
@@ -880,7 +1031,21 @@ class Agent(ControlNode):
         # serializable. They're rebuilt from tool_configs when the next node unwraps.
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
-        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        wrapper = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        # Forward provider credentials so downstream nodes can rebuild the driver —
+        # griptape strips api_key from non-GTC drivers during to_dict() serialization.
+        if provider_name != "griptape_cloud":
+            providers = self._fetch_providers()
+            p = next((x for x in providers if x["name"] == provider_name), {})
+            wrapper["provider"] = {
+                "name": provider_name,
+                "base_url": p.get("base_url", ""),
+                "api_key": p.get("api_key") or "not-needed",
+            }
+        elif incoming_provider:
+            # Passthrough: this node uses griptape_cloud but an upstream agent used a non-GTC provider.
+            wrapper["provider"] = incoming_provider
+        self.parameter_output_values["agent"] = wrapper
 
     def _process(self, agent: GtAgent, prompt: BaseArtifact | str) -> Structure:  # noqa: C901, PLR0912
         """Performs the synchronous, streaming interaction with the Griptape Agent.

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -47,6 +47,7 @@ try:
         ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
         ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
     )
+
     _AGENT_PROVIDERS_AVAILABLE = True
 except ImportError:
     _AGENT_PROVIDERS_AVAILABLE = False

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -673,7 +673,11 @@ class Agent(ControlNode):
             models = self._fetch_models_for_provider(provider_name)
             default = models[0] if models else DEFAULT_MODEL
             self._update_option_choices(param="model", choices=models, default=default)
-            new_data = MODEL_CHOICES_ARGS if provider_name == "griptape_cloud" else [{"name": m, "icon": "", "args": {}} for m in models]
+            new_data = (
+                MODEL_CHOICES_ARGS
+                if provider_name == "griptape_cloud"
+                else [{"name": m, "icon": "", "args": {}} for m in models]
+            )
             param = self.get_parameter_by_name("model")
             if param:
                 param.update_ui_options_key("data", new_data)

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -349,6 +349,18 @@ class Agent(ControlNode):
         providers = self._fetch_providers()
         return [p["name"] for p in providers] or ["griptape_cloud"]
 
+    def _resolve_provider_api_key(self, provider_config: dict) -> str:
+        """Resolve the API key for a provider config.
+
+        Provider configs carry api_key_secret_name (the name of a secret in the
+        secrets manager) rather than a raw api_key value.  Fall back to
+        "not-needed" for providers that don't require a key (e.g. Ollama).
+        """
+        secret_name = provider_config.get("api_key_secret_name", "")
+        if secret_name:
+            return GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"
+        return "not-needed"
+
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
         """Return the model list for a given provider name."""
         try:
@@ -360,7 +372,7 @@ class Agent(ControlNode):
                 ListProviderModelsRequest(
                     provider=provider_config.get("type", provider_name),
                     base_url=provider_config.get("base_url", ""),
-                    api_key=provider_config.get("api_key", ""),
+                    api_key=self._resolve_provider_api_key(provider_config),
                 )
             )
             if isinstance(result, ListProviderModelsResultSuccess):
@@ -995,7 +1007,7 @@ class Agent(ControlNode):
                 providers = self._fetch_providers()
                 provider_config = next((p for p in providers if p["name"] == provider_name), {})
                 base_url = provider_config.get("base_url", "")
-                api_key = provider_config.get("api_key") or "not-needed"
+                api_key = self._resolve_provider_api_key(provider_config)
                 prompt_driver = GtOpenAiChatPromptDriver(
                     model=model_input,
                     base_url=base_url,
@@ -1044,7 +1056,7 @@ class Agent(ControlNode):
             wrapper["provider"] = {
                 "name": provider_name,
                 "base_url": p.get("base_url", ""),
-                "api_key": p.get("api_key") or "not-needed",
+                "api_key": self._resolve_provider_api_key(p),
             }
         elif incoming_provider:
             # Passthrough: this node uses griptape_cloud but an upstream agent used a non-GTC provider.

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -55,6 +55,7 @@ try:
         ListProviderModelsRequest,
         ListProviderModelsResultSuccess,
     )
+
     _AGENT_PROVIDERS_AVAILABLE = True
 except ImportError:
     _AGENT_PROVIDERS_AVAILABLE = False
@@ -373,7 +374,9 @@ class Agent(ControlNode):
         """
         secret_name = provider_config.get("api_key_secret_name", "")
         if secret_name:
-            return GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"
+            return (
+                GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"
+            )
         return "not-needed"
 
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -366,7 +366,7 @@ class Agent(ControlNode):
         secrets manager) rather than a raw api_key value.  Fall back to
         "not-needed" for providers that don't require a key (e.g. Ollama).
         """
-        secret_name = provider_config.api_key_secret_name or ""
+        secret_name = provider_config.api_key_secret_name or ""  # pyright: ignore[reportPossiblyUnbound,reportPossiblyUnboundVariable]
         if secret_name:
             return (
                 GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"

--- a/griptape_nodes_library/agents/memory/clear_agent_memory.py
+++ b/griptape_nodes_library/agents/memory/clear_agent_memory.py
@@ -34,6 +34,11 @@ class ClearAgentMemory(ControlNode):
 
         agent.conversation_memory.runs = []
 
-        updated = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_value.get("provider") if isinstance(agent_value, dict) else None)
+        updated = wrap_agent(
+            agent.to_dict(),
+            tool_configs,
+            ruleset_configs,
+            provider=agent_value.get("provider") if isinstance(agent_value, dict) else None,
+        )
         self.parameter_output_values["agent"] = updated
         self.publish_update_to_parameter("agent", updated)

--- a/griptape_nodes_library/agents/memory/clear_agent_memory.py
+++ b/griptape_nodes_library/agents/memory/clear_agent_memory.py
@@ -34,6 +34,6 @@ class ClearAgentMemory(ControlNode):
 
         agent.conversation_memory.runs = []
 
-        updated = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        updated = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_value.get("provider") if isinstance(agent_value, dict) else None)
         self.parameter_output_values["agent"] = updated
         self.publish_update_to_parameter("agent", updated)

--- a/griptape_nodes_library/agents/memory/replace_item_in_agent_memory.py
+++ b/griptape_nodes_library/agents/memory/replace_item_in_agent_memory.py
@@ -274,6 +274,7 @@ class ReplaceItemInAgentMemory(ControlNode):
 
         agent_value = self.get_parameter_value("agent")
         _, tool_configs, ruleset_configs = unwrap_agent(agent_value) if isinstance(agent_value, dict) else ({}, [], [])
-        updated = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        provider = agent_value.get("provider") if isinstance(agent_value, dict) else None
+        updated = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=provider)
         self.parameter_output_values["agent"] = updated
         self.publish_update_to_parameter("agent", updated)

--- a/griptape_nodes_library/agents/memory/summarize_agent_memory.py
+++ b/griptape_nodes_library/agents/memory/summarize_agent_memory.py
@@ -8,7 +8,7 @@ from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent
-from griptape_nodes_library.utils.agent_utils import unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.agent_utils import restore_provider_driver, unwrap_agent, wrap_agent
 
 
 class SummarizeAgentMemory(ControlNode):
@@ -53,6 +53,7 @@ class SummarizeAgentMemory(ControlNode):
 
         agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_value)
         agent = GriptapeNodesAgent().from_dict(agent_core_dict)
+        restore_provider_driver(agent, agent_value)
         if agent is None or agent.conversation_memory is None:
             return None, [], []
 
@@ -64,8 +65,11 @@ class SummarizeAgentMemory(ControlNode):
         if agent is None or agent.conversation_memory is None:
             return
 
+        agent_value = self.get_parameter_value("agent")
+        provider = agent_value.get("provider") if isinstance(agent_value, dict) else None
+
         if len(agent.conversation_memory.runs) == 0:
-            updated_agent_dict = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+            updated_agent_dict = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=provider)
             self.parameter_output_values["agent"] = updated_agent_dict
             self.publish_update_to_parameter("agent", updated_agent_dict)
             return
@@ -89,6 +93,6 @@ class SummarizeAgentMemory(ControlNode):
 
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
-        updated_agent_dict = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        updated_agent_dict = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=provider)
         self.parameter_output_values["agent"] = updated_agent_dict
         self.publish_update_to_parameter("agent", updated_agent_dict)

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -375,7 +375,12 @@ class TranscribeAudio(GriptapeProxyNode):
                         ),
                     )
                 )
-            self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_input.get("provider") if isinstance(agent_input, dict) else None)
+            self.parameter_output_values["agent"] = wrap_agent(
+                agent.to_dict(),
+                tool_configs,
+                ruleset_configs,
+                provider=agent_input.get("provider") if isinstance(agent_input, dict) else None,
+            )
         except Exception as e:
             logger.warning("TranscribeAudio: failed to thread agent: %s", e)
 

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -375,7 +375,7 @@ class TranscribeAudio(GriptapeProxyNode):
                         ),
                     )
                 )
-            self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+            self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_input.get("provider") if isinstance(agent_input, dict) else None)
         except Exception as e:
             logger.warning("TranscribeAudio: failed to thread agent: %s", e)
 

--- a/griptape_nodes_library/image/create_image.py
+++ b/griptape_nodes_library/image/create_image.py
@@ -310,7 +310,9 @@ IMPORTANT: Output must be a single, raw prompt string for an image generation mo
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
         provider = agent_input.get("provider") if isinstance(agent_input, dict) else None
-        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=provider)
+        self.parameter_output_values["agent"] = wrap_agent(
+            agent.to_dict(), tool_configs, ruleset_configs, provider=provider
+        )
 
     def after_incoming_connection(
         self,

--- a/griptape_nodes_library/image/create_image.py
+++ b/griptape_nodes_library/image/create_image.py
@@ -17,7 +17,7 @@ from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
-from griptape_nodes_library.utils.agent_utils import unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.agent_utils import restore_provider_driver, unwrap_agent, wrap_agent
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -225,6 +225,7 @@ class GenerateImage(ControlNode):
         else:
             agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_input)
             agent = GtAgent.from_dict(agent_core_dict)
+            restore_provider_driver(agent, agent_input)
 
         # Add some context to the prompt based on the agent's conversation memory.
         # We use this because otherwise the agent will not have the context of the prompt.
@@ -308,7 +309,8 @@ IMPORTANT: Output must be a single, raw prompt string for an image generation mo
         # Output the agent
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
-        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        provider = agent_input.get("provider") if isinstance(agent_input, dict) else None
+        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=provider)
 
     def after_incoming_connection(
         self,

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -17,7 +17,7 @@ from griptape_nodes.traits.options import Options
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
-from griptape_nodes_library.utils.agent_utils import build_rulesets_from_configs, build_tools, unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.agent_utils import build_rulesets_from_configs, build_tools, restore_provider_driver, unwrap_agent, wrap_agent
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 
@@ -347,6 +347,7 @@ class DescribeImage(ControlNode):
         if isinstance(agent_value, dict):
             agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_value)
             agent = GtAgent().from_dict(agent_core_dict)
+            restore_provider_driver(agent, agent_value)
             # Rebuild tools and rulesets from configs so they're fresh for this run.
             if tool_configs:
                 live_tools, _ = build_tools(tool_configs)
@@ -411,4 +412,4 @@ class DescribeImage(ControlNode):
         # Clear live tools before serializing, then wrap with configs for downstream nodes.
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
-        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
+        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_value.get("provider") if isinstance(agent_value, dict) else None)

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -17,7 +17,13 @@ from griptape_nodes.traits.options import Options
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
-from griptape_nodes_library.utils.agent_utils import build_rulesets_from_configs, build_tools, restore_provider_driver, unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.agent_utils import (
+    build_rulesets_from_configs,
+    build_tools,
+    restore_provider_driver,
+    unwrap_agent,
+    wrap_agent,
+)
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 
@@ -412,4 +418,9 @@ class DescribeImage(ControlNode):
         # Clear live tools before serializing, then wrap with configs for downstream nodes.
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
-        self.parameter_output_values["agent"] = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs, provider=agent_value.get("provider") if isinstance(agent_value, dict) else None)
+        self.parameter_output_values["agent"] = wrap_agent(
+            agent.to_dict(),
+            tool_configs,
+            ruleset_configs,
+            provider=agent_value.get("provider") if isinstance(agent_value, dict) else None,
+        )

--- a/griptape_nodes_library/tasks/mcp_task.py
+++ b/griptape_nodes_library/tasks/mcp_task.py
@@ -17,7 +17,7 @@ from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent
-from griptape_nodes_library.utils.agent_utils import build_tools, unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.agent_utils import build_tools, restore_provider_driver, unwrap_agent, wrap_agent
 from griptape_nodes_library.utils.mcp_utils import (
     create_mcp_tool,
     get_available_mcp_servers,
@@ -268,10 +268,12 @@ class MCPTaskNode(SuccessFailureNode):
             tools = []
             self._tool_configs: list = []
             self._ruleset_configs: list = []
+            self._provider: dict | None = None
             agent_input = self.get_parameter_value("agent")
             if isinstance(agent_input, dict):
                 agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_input)
                 agent = GriptapeNodesAgent().from_dict(agent_core_dict)
+                restore_provider_driver(agent, agent_input)
                 task = agent.tasks[0]
                 driver = task.prompt_driver
                 if tool_configs:
@@ -282,6 +284,7 @@ class MCPTaskNode(SuccessFailureNode):
                 rulesets = task.rulesets
                 self._tool_configs = tool_configs
                 self._ruleset_configs = ruleset_configs
+                self._provider = agent_input.get("provider")
             else:
                 driver = self._create_driver()
                 agent = Agent()
@@ -382,6 +385,7 @@ class MCPTaskNode(SuccessFailureNode):
             result.to_dict(),
             getattr(self, "_tool_configs", []),
             getattr(self, "_ruleset_configs", []),
+            provider=getattr(self, "_provider", None),
         )
 
     def _set_failure_output_values(self) -> None:

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -60,7 +60,38 @@ def unwrap_agent(value: dict) -> tuple[dict, list, list]:
     return value, [], []
 
 
-def wrap_agent(agent_dict: dict, tool_configs: list, ruleset_configs: list) -> dict:
+def restore_provider_driver(agent: object, wrapper: dict) -> None:
+    """Rebuild the prompt driver from provider config stored in the wrapper.
+
+    When a non-GTC agent is serialized via to_dict(), griptape strips the api_key.
+    Callers that deserialize via from_dict() must call this immediately after to
+    restore the correct driver for OpenAI-compatible providers.
+    """
+    provider = wrapper.get("provider") if isinstance(wrapper, dict) else None
+    if not provider:
+        return
+    from typing import cast
+
+    from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
+    from griptape.tasks import PromptTask
+
+    tasks = getattr(agent, "tasks", None)
+    if not tasks:
+        return
+    task = tasks[0]
+    if not isinstance(task, PromptTask):
+        return
+    model = task.prompt_driver.model
+    rebuilt = OpenAiChatPromptDriver(
+        model=model,
+        base_url=provider.get("base_url", ""),
+        api_key=provider.get("api_key") or "not-needed",
+        stream=True,
+    )
+    cast(PromptTask, task).prompt_driver = rebuilt
+
+
+def wrap_agent(agent_dict: dict, tool_configs: list, ruleset_configs: list, *, provider: dict | None = None) -> dict:
     """Strip non-serializable fields from the agent dict and return the wrapper.
 
     Tools, rulesets, and rules are cleared from the griptape dict — they live
@@ -91,11 +122,14 @@ def wrap_agent(agent_dict: dict, tool_configs: list, ruleset_configs: list) -> d
                 "value": value,
             }
 
-    return {
+    result: dict = {
         "agent": agent_dict,
         "tools": tool_configs,
         "rulesets": ruleset_configs,
     }
+    if provider:
+        result["provider"] = provider
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +259,7 @@ def build_tool_from_config(config: dict) -> object:
         agent_wrapper = config["agent_dict"]
         agent_core_dict, incoming_tool_configs, incoming_ruleset_configs = unwrap_agent(agent_wrapper)
         agent = GriptapeNodesAgent.from_dict(agent_core_dict)
+        restore_provider_driver(agent, agent_wrapper)
         if incoming_tool_configs:
             live_tools, _ = build_tools(incoming_tool_configs)
             if live_tools and agent.tasks:


### PR DESCRIPTION
## Dependencies

> **This PR requires the following to be merged first:**
> - **Engine PR:** https://github.com/griptape-ai/griptape-nodes-engine/pull/4937
> - **GUI PR:** https://github.com/griptape-ai/griptape-vsl-gui/pull/2530
>
> If they're not merged - it works as before and ignores the use of providers

## Summary

Fixes #214

- Adds multi-provider support to the Agent node: users can select from engine-configured providers (Ollama, LM Studio, custom OpenAI-compatible endpoints) via a dropdown, with a refresh button to update the list dynamically
- Adds `restore_provider_driver` helper and updates `wrap_agent` to carry a `provider` dict through the agent wire format, so non-GTC credentials (stripped by griptape during serialization) survive node-to-node chaining
- Adds `incoming_provider` passthrough in `Agent.process()` so a node with its own provider set to `griptape_cloud` still forwards an upstream non-GTC provider to its output
- Applies `restore_provider_driver` + provider passthrough to every node that unwraps and re-wraps agents: `mcp_task`, `clear_agent_memory`, `summarize_agent_memory`, `replace_item_in_agent_memory`, `describe_image`, `create_image`, `transcribe_audio`, and the `AgentTool` branch in `agent_utils.build_tool_from_config`

## Test plan

- [ ] Create an Agent node, set provider to Ollama (or LM Studio), verify model list populates and the agent runs with the local model
- [ ] Chain Agent (Ollama) → Agent_2: confirm Agent_2 receives and uses the local provider without "Missing credentials" error
- [ ] Chain Agent (Ollama) → DescribeImage → Agent_2: confirm provider travels through the image node
- [ ] Chain Agent (Ollama) → MCPTask → Agent_2: confirm MCP task runs with local provider and forwards it downstream
- [ ] Chain Agent (Ollama) → SummarizeAgentMemory → Agent_2: confirm memory node forwards provider
- [ ] Verify AgentToTool with a local-provider agent works when that tool is used by another Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)