### PR TITLE
fix(save-image): output saved file path on success instead of input passthrough

### DIFF
--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -173,7 +173,12 @@ class SaveImage(SuccessFailureNode):
             self._handle_error_with_graceful_exit(error_details, e, input_info)
             return
 
-        # Success case
+        # Success case — override the image output with the real saved path so
+        # downstream nodes (and Nuke, via the End node) receive the on-disk file
+        # rather than the transient localhost static-file URL that the input
+        # artifact carries after ParameterImage normalization.
+        # Mirrors the convention in CreateColorBars and FluxImageGeneration.
+        self.parameter_output_values["image"] = ImageUrlArtifact(value=saved_path)
         success_details = "Image saved successfully"
         self._handle_execution_result(
             status=SaveImageStatus.SUCCESS,


### PR DESCRIPTION
## Summary

- After a successful save, `SaveImage`'s `image` output is now `ImageUrlArtifact(saved_path)` where `saved_path` is the real absolute on-disk path — instead of the input artifact passthrough
- Failure and warning paths retain the existing input passthrough (no behavior change when no file is written)
- Matches the convention already used by `CreateColorBars` and `FluxImageGeneration`. Before, SaveImage's image output was displaying the macro path for the file that was put in as an input. 

## Problem

`SaveImage.process()` was copying its input artifact straight to the `image` output at the top of `process()`. The input artifact had been normalized by `ParameterImage`'s converter, which uploads any local file path to static storage and returns a `http://localhost:8124/.../staticfiles/...?t=...` signed URL, or the input path from the image that was passed through. 
The real saved file path (`saved.location`, an absolute filesystem path) was only used in the status `result_details` string — never exposed as a connectable output.

## Fix

In the success path only (after `saved_path = saved.location`), override the output:

```python
self.parameter_output_values["image"] = ImageUrlArtifact(value=saved_path)
```