### PR TITLE
feat: refreshable variable dropdowns + auto-name for CreateVariable

### DIFF
--- a/.claude/skills/hide-show-parameter/SKILL.md
+++ b/.claude/skills/hide-show-parameter/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: hide-show-parameter
+description: Hide or show node parameters by name at runtime — in __init__ for initial state, or in after_value_set to toggle visibility based on another parameter's value.
+argument-hint: <parameter-name> <condition-parameter-name>
+allowed-tools: Read Edit Grep Glob
+disable-model-invocation: false
+---
+
+# Hide and Show Parameters
+
+Use `hide_parameter_by_name` / `show_parameter_by_name` to control parameter visibility at runtime. Both accept a single name string or a list of names.
+
+```python
+self.hide_parameter_by_name("my_param")
+self.show_parameter_by_name("my_param")
+
+# Multiple at once
+self.hide_parameter_by_name(["param_a", "param_b"])
+self.show_parameter_by_name(["param_a", "param_b"])
+```
+
+---
+
+## Pattern 1 — Hidden by default, shown conditionally
+
+Hide in `__init__` right after `add_parameter`, then toggle in `after_value_set` when the controlling parameter changes.
+
+```python
+def __init__(self, **kwargs) -> None:
+    super().__init__(**kwargs)
+
+    self.enable_param = Parameter(
+        name="enable_thing",
+        type="bool",
+        default_value=False,
+        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        tooltip="Enable the thing",
+    )
+    self.add_parameter(self.enable_param)
+
+    self.thing_options_param = Parameter(
+        name="thing_options",
+        type="str",
+        default_value="default",
+        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        tooltip="Options for the thing (only relevant when enable_thing is on)",
+    )
+    self.add_parameter(self.thing_options_param)
+    self.hide_parameter_by_name(self.thing_options_param.name)   # hidden until needed
+
+def after_value_set(self, parameter: Parameter, value: Any) -> None:
+    if parameter is self.enable_param:
+        if value:
+            self.show_parameter_by_name(self.thing_options_param.name)
+        else:
+            self.hide_parameter_by_name(self.thing_options_param.name)
+    super().after_value_set(parameter, value)
+```
+
+---
+
+## Pattern 2 — Shown by default, hidden conditionally
+
+Start visible, hide when the controlling value makes it irrelevant.
+
+```python
+self.add_parameter(self.detail_param)
+# No hide call — visible by default
+
+def after_value_set(self, parameter: Parameter, value: Any) -> None:
+    if parameter is self.mode_param:
+        if value == "simple":
+            self.hide_parameter_by_name(self.detail_param.name)
+        else:
+            self.show_parameter_by_name(self.detail_param.name)
+    super().after_value_set(parameter, value)
+```
+
+---
+
+## Pattern 3 — Hide a group of related parameters together
+
+```python
+ADVANCED_PARAMS = ["threshold", "iterations", "seed"]
+
+# In __init__, after adding all of them:
+self.hide_parameter_by_name(ADVANCED_PARAMS)
+
+# In after_value_set:
+if parameter is self.show_advanced_param:
+    if value:
+        self.show_parameter_by_name(ADVANCED_PARAMS)
+    else:
+        self.hide_parameter_by_name(ADVANCED_PARAMS)
+```
+
+---
+
+## Notes
+
+- Always call `add_parameter` **before** `hide_parameter_by_name` — you can't hide a parameter that hasn't been added yet.
+- Use `parameter is self.foo_param` (identity) in `after_value_set`, not `parameter.name == "foo"` — it's faster and avoids string bugs.
+- Always call `super().after_value_set(parameter, value)` at the end of the method.
+- Hidden parameters still exist and hold their value — hiding is purely visual. The value is preserved and can still be read/written programmatically.
+- If you need to hide a `ParameterMessage` (not a regular parameter), use `hide_message_by_name` / `show_message_by_name` instead.
+
+---
+
+## Real example in this repo
+
+`griptape_nodes_library/variables/create_variable.py` — `auto_name_case` is hidden on init and shown/hidden in `after_value_set` when `auto_name` toggles.

--- a/.claude/skills/refreshable-options-param/SKILL.md
+++ b/.claude/skills/refreshable-options-param/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: refreshable-options-param
+description: Add a ParameterString with an Options dropdown and a Button that refreshes the choices at runtime (e.g. querying a live API for available models, voices, etc.).
+argument-hint: <parameter-name> <what-the-list-contains>
+allowed-tools: Read Edit Grep Glob
+disable-model-invocation: false
+---
+
+# Refreshable Options Parameter
+
+A pattern for a dropdown (`Options`) whose choices are fetched at runtime, with a refresh button the user can click to re-query the source.
+
+The canonical example is the Ollama model picker in
+`griptape_nodes_library/config/prompt/ollama_prompt_driver.py`.
+
+---
+
+## Imports
+
+```python
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
+```
+
+---
+
+## Core Pattern
+
+### 1. Fetch the initial list before creating the parameter
+
+Call your data-source function inside `__init__`, before creating the parameter, so the dropdown is pre-populated on first render.
+
+```python
+available_items = self._get_available_items()   # may return empty list or error sentinel
+
+if not available_items:
+    available_items = ["⚠️ No items found"]
+```
+
+### 2. Create the parameter with both traits
+
+Pass `Options` and `Button` together in the `traits` set.  The `Button` wires the refresh callback via `on_click`.
+
+```python
+self.items_param = ParameterString(
+    name="item",
+    default_value=available_items[0],
+    tooltip="Select an item from the list.",
+    traits={
+        Options(choices=available_items),
+        Button(
+            icon="list-restart",   # Lucide icon name
+            size="icon",
+            variant="secondary",
+            on_click=self._refresh_items,
+        ),
+    },
+)
+self.add_parameter(self.items_param)
+```
+
+Common icon choices: `"list-restart"` (refresh list), `"refresh-cw"` (generic refresh), `"search"` (fetch/search).
+
+---
+
+## Fetching Choices
+
+### Low-level fetch (raises on error)
+
+```python
+def _get_items(self, *, raise_on_error: bool = True) -> list[str]:
+    try:
+        items = _query_your_source()   # replace with real call
+        if items:
+            items.sort()
+            return items
+        return []
+    except Exception as e:
+        if raise_on_error:
+            raise
+        return []
+```
+
+### User-facing wrapper (returns sentinel on failure)
+
+```python
+WARNING_EMOJI = "⚠️"
+
+def _get_available_items(self) -> list[str]:
+    try:
+        return self._get_items(raise_on_error=True)
+    except Exception as e:
+        return [f"{WARNING_EMOJI} Could not load items: {e}"]
+```
+
+---
+
+## Refresh Callback
+
+`on_click` receives the `Button` instance and a `ButtonDetailsMessagePayload`.  The return value is `NodeMessageResult | None`; return `None` unless you need to send a message back to the UI.
+
+```python
+def _refresh_items(
+    self,
+    button: Button,
+    button_details: ButtonDetailsMessagePayload,
+) -> NodeMessageResult | None:  # noqa: ARG002
+    try:
+        fresh_items = self._get_items(raise_on_error=False)
+
+        if not fresh_items:
+            fresh_items = [f"{WARNING_EMOJI} No items found"]
+
+        current_value = self.get_parameter_value("item")
+
+        self._update_option_choices(
+            param="item",
+            choices=fresh_items,
+            default=fresh_items[0],
+        )
+
+        # Preserve the user's current selection if it is still valid
+        if current_value and current_value in fresh_items:
+            self.set_parameter_value("item", current_value)
+        else:
+            # Pick the first real (non-sentinel) value
+            first_real = next(
+                (v for v in fresh_items if not v.startswith(WARNING_EMOJI)),
+                None,
+            )
+            self.set_parameter_value("item", first_real or fresh_items[0])
+
+    except Exception:
+        fallback = [f"{WARNING_EMOJI} No items found"]
+        self._update_option_choices(param="item", choices=fallback, default=fallback[0])
+        self.set_parameter_value("item", fallback[0])
+
+    return None
+```
+
+Key helper: `self._update_option_choices(param, choices, default)` — replaces the `Options` trait's choices list in-place and updates the parameter's default.
+
+---
+
+## Auto-refresh on Related Parameter Changes
+
+If the list depends on another parameter (e.g. a server URL), re-fetch whenever that parameter changes:
+
+```python
+def after_value_set(self, parameter: Parameter, value: Any) -> None:
+    if parameter.name in ("server_url", "port"):
+        self._refresh_item_list()   # internal helper, not the button callback
+    return super().after_value_set(parameter, value)
+```
+
+Internal helper (same logic as the button callback, but called programmatically):
+
+```python
+def _refresh_item_list(self) -> None:
+    fresh_items = self._get_items(raise_on_error=False) or [f"{WARNING_EMOJI} No items found"]
+    current_value = self.get_parameter_value("item")
+    self._update_option_choices(param="item", choices=fresh_items, default=fresh_items[0])
+    if current_value and current_value in fresh_items:
+        self.set_parameter_value("item", current_value)
+    else:
+        first_real = next((v for v in fresh_items if not v.startswith(WARNING_EMOJI)), None)
+        self.set_parameter_value("item", first_real or fresh_items[0])
+```
+
+---
+
+## Validation
+
+Skip validation when the selected value is an error sentinel, then check the real values:
+
+```python
+def validate_before_node_run(self) -> list[Exception] | None:
+    exceptions = []
+    selected = self.get_parameter_value("item")
+
+    if not selected:
+        exceptions.append(ValueError("No item selected"))
+        return exceptions
+
+    # Don't validate sentinel values — they are UI state, not real selections
+    if selected.startswith(WARNING_EMOJI):
+        return None
+
+    available = self._get_items(raise_on_error=False)
+    if not available:
+        exceptions.append(ValueError("No items available — check your connection"))
+    elif selected not in available:
+        exceptions.append(ValueError(f"'{selected}' is no longer available"))
+
+    return exceptions or None
+```
+
+---
+
+## Optional: Status Messages
+
+Show/hide a `ParameterMessage` based on whether the source is reachable (see Ollama pattern):
+
+```python
+from griptape_nodes.exe_types.core_types import ParameterMessage
+
+self.error_message = ParameterMessage(
+    name="source_error_message",
+    title="Source Unavailable",
+    value="Cannot reach the item source. Check your connection settings.",
+    variant="warning",
+)
+self.add_node_element(self.error_message)
+self.move_element_to_position(self.error_message.name, "first")
+self.hide_message_by_name("source_error_message")   # hidden by default
+
+# Then show/hide after each fetch attempt:
+def _update_message_visibility(self) -> None:
+    try:
+        items = self._get_items(raise_on_error=True)
+        self.hide_message_by_name("source_error_message")
+    except Exception:
+        self.show_message_by_name("source_error_message")
+```
+
+Call `_update_message_visibility()` at the end of `__init__`, and again at the end of `_refresh_items` / `_refresh_item_list`.
+
+---
+
+## Complete Minimal Example
+
+```python
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
+
+WARNING_EMOJI = "⚠️"
+
+
+class MyNode(BaseNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        available = self._get_available_items()
+        if not available:
+            available = [f"{WARNING_EMOJI} No items found"]
+
+        self.items_param = ParameterString(
+            name="item",
+            default_value=available[0],
+            tooltip="Choose an item.",
+            traits={
+                Options(choices=available),
+                Button(icon="list-restart", size="icon", variant="secondary", on_click=self._refresh_items),
+            },
+        )
+        self.add_parameter(self.items_param)
+
+    def _get_items(self, *, raise_on_error: bool = True) -> list[str]:
+        # Replace with real query
+        return sorted(["alpha", "beta", "gamma"])
+
+    def _get_available_items(self) -> list[str]:
+        try:
+            return self._get_items(raise_on_error=True)
+        except Exception as e:
+            return [f"{WARNING_EMOJI} Error: {e}"]
+
+    def _refresh_items(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+        fresh = self._get_items(raise_on_error=False) or [f"{WARNING_EMOJI} No items found"]
+        current = self.get_parameter_value("item")
+        self._update_option_choices(param="item", choices=fresh, default=fresh[0])
+        if current and current in fresh:
+            self.set_parameter_value("item", current)
+        else:
+            first_real = next((v for v in fresh if not v.startswith(WARNING_EMOJI)), None)
+            self.set_parameter_value("item", first_real or fresh[0])
+        return None
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        selected = self.get_parameter_value("item")
+        if not selected or selected.startswith(WARNING_EMOJI):
+            return [ValueError("No valid item selected")] if not selected else None
+        available = self._get_items(raise_on_error=False)
+        if available and selected not in available:
+            return [ValueError(f"'{selected}' is no longer available")]
+        return None
+
+    def process(self) -> None:
+        item = self.get_parameter_value("item")
+        # use item ...
+```
+
+---
+
+## Real Example
+
+`griptape_nodes_library/config/prompt/ollama_prompt_driver.py` — full working implementation with:
+- Live Ollama model list via the `ollama` Python package
+- Connection-settings group (`base_url`, `port`) that trigger auto-refresh via `after_value_set`
+- Two conditional `ParameterMessage` widgets (server not running / no models installed)
+- `validate_before_node_run` that checks model availability before execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,28 @@ if case_style == CaseStyle.SNAKE:
 ```
 
 Use `StrEnum` (not plain `Enum`) so values compare equal to their string equivalents — parameter values coming back from the UI are plain strings, and `StrEnum` members match them without explicit `.value` lookups.
+
+### Use `match`/`case` instead of `if`/`elif` chains
+
+Whenever you're branching on a single value across three or more cases — whether it's a `StrEnum`, a string, an int, or a type tag — use `match`/`case` instead of a chain of `if` comparisons. Always end with a wildcard `case _:` that raises `ValueError`; this surfaces unhandled values immediately rather than silently falling through to a wrong default.
+
+```python
+# BAD — if/elif chain
+if case_style == CaseStyle.SNAKE:
+    return "_".join(w.lower() for w in words)
+elif case_style == CaseStyle.CAMEL:
+    return words[0].lower() + "".join(w.capitalize() for w in words[1:])
+# ... six more elifs, then a silent default or nothing
+
+# GOOD
+match case_style:
+    case CaseStyle.SNAKE:
+        return "_".join(w.lower() for w in words)
+    case CaseStyle.CAMEL:
+        return words[0].lower() + "".join(w.capitalize() for w in words[1:])
+    case _:
+        msg = f"Unknown case style: {case_style!r}"
+        raise ValueError(msg)
+```
+
+The wildcard `case _: raise ValueError(...)` is not optional — it ensures that adding a new enum member (or passing an unexpected value) is caught immediately rather than producing a silent wrong result.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Griptape Nodes Library — Standard
+
+## Python conventions
+
+### Hoist imports to the top level unless they cause circular imports
+
+Keep all imports at the top of the file. Only use lazy (function-level) imports when necessary to break a circular dependency — in that case add a `# avoid circular import` comment so the reason is clear.
+
+```python
+# BAD — lazy import with no circular-import justification
+def _my_method(self) -> None:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    GriptapeNodes.handle_request(...)
+
+# GOOD
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+def _my_method(self) -> None:
+    GriptapeNodes.handle_request(...)
+
+# ACCEPTABLE — circular import that can't be avoided
+def process(self) -> None:
+    from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest  # avoid circular import
+    ...
+```
+
+### Use `StrEnum` for string option sets
+
+When a parameter has a fixed set of string choices (e.g. a dropdown), declare them as a `StrEnum` rather than bare module-level constants. This keeps the options co-located, makes comparisons type-safe, and lets you pass `list(MyEnum)` directly to `Options(choices=...)`.
+
+```python
+from enum import StrEnum
+
+class CaseStyle(StrEnum):
+    SNAKE = "snake_case"
+    CAMEL = "camelCase"
+    PASCAL = "PascalCase"
+
+# In __init__:
+param.add_trait(Options(choices=list(CaseStyle)))
+
+# In logic:
+if case_style == CaseStyle.SNAKE:
+    ...
+```
+
+Use `StrEnum` (not plain `Enum`) so values compare equal to their string equivalents — parameter values coming back from the UI are plain strings, and `StrEnum` members match them without explicit `.value` lookups.

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -9,9 +9,17 @@ from griptape_nodes.exe_types.node_types import (
     BaseNode,
     ControlNode,
     NodeDependencies,
+    NodeResolutionState,
     VariableAccess,
     VariableReference,
 )
+from griptape_nodes.retained_mode.events.connection_events import (
+    DeleteConnectionRequest,
+    DeleteConnectionResultSuccess,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.variable_types import VariableScope
 from griptape_nodes.traits.options import Options
 
@@ -132,14 +140,6 @@ class CreateVariable(ControlNode):
 
     def _delete_incoming_connections_to_parameter(self, parameter_name: str) -> None:
         """Helper to delete all incoming connections to a specific parameter."""
-        from griptape_nodes.retained_mode.events.connection_events import (
-            DeleteConnectionRequest,
-            DeleteConnectionResultSuccess,
-            ListConnectionsForNodeRequest,
-            ListConnectionsForNodeResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         connections_request = ListConnectionsForNodeRequest(node_name=self.name)
         connections_result = GriptapeNodes.handle_request(connections_request)
 
@@ -162,14 +162,6 @@ class CreateVariable(ControlNode):
 
     def _cleanup_incompatible_value_connections(self) -> None:
         """Remove all connections to/from value parameter that are incompatible with its current type."""
-        from griptape_nodes.retained_mode.events.connection_events import (
-            DeleteConnectionRequest,
-            DeleteConnectionResultSuccess,
-            ListConnectionsForNodeRequest,
-            ListConnectionsForNodeResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         connections_request = ListConnectionsForNodeRequest(node_name=self.name)
         connections_result = GriptapeNodes.handle_request(connections_request)
 
@@ -251,12 +243,6 @@ class CreateVariable(ControlNode):
 
     def _get_value_source_node_name(self) -> str | None:
         """Return the name of the node wired into the value parameter, or None."""
-        from griptape_nodes.retained_mode.events.connection_events import (
-            ListConnectionsForNodeRequest,
-            ListConnectionsForNodeResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         try:
             result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
             if isinstance(result, ListConnectionsForNodeResultSuccess):
@@ -540,8 +526,6 @@ class CreateVariable(ControlNode):
 
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Variable nodes have side effects and need to execute every workflow run."""
-        from griptape_nodes.exe_types.node_types import NodeResolutionState
-
         self.make_node_unresolved(
             current_states_to_trigger_change_event={NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
         )
@@ -549,8 +533,6 @@ class CreateVariable(ControlNode):
 
     def validate_before_node_run(self) -> list[Exception] | None:
         """Variable nodes have side effects and need to execute every time they run."""
-        from griptape_nodes.exe_types.node_types import NodeResolutionState
-
         self.make_node_unresolved(
             current_states_to_trigger_change_event={NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
         )

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -312,20 +312,24 @@ class CreateVariable(ControlNode):
     @staticmethod
     def _apply_case(words: list[str], case_style: str) -> str:
         """Join tokens using the requested case convention."""
-        if case_style == CaseStyle.UPPER:
-            return " ".join(w.upper() for w in words)
-        if case_style == CaseStyle.UPPER_SNAKE:
-            return "_".join(w.upper() for w in words)
-        if case_style == CaseStyle.TITLE:
-            return " ".join(w.capitalize() for w in words)
-        if case_style == CaseStyle.KEBAB:
-            return "-".join(w.lower() for w in words)
-        if case_style == CaseStyle.PASCAL:
-            return "".join(w.capitalize() for w in words)
-        if case_style == CaseStyle.CAMEL:
-            return words[0].lower() + "".join(w.capitalize() for w in words[1:])
-        # Default: snake_case
-        return "_".join(w.lower() for w in words)
+        match case_style:
+            case CaseStyle.UPPER:
+                return " ".join(w.upper() for w in words)
+            case CaseStyle.UPPER_SNAKE:
+                return "_".join(w.upper() for w in words)
+            case CaseStyle.TITLE:
+                return " ".join(w.capitalize() for w in words)
+            case CaseStyle.SNAKE:
+                return "_".join(w.lower() for w in words)
+            case CaseStyle.KEBAB:
+                return "-".join(w.lower() for w in words)
+            case CaseStyle.PASCAL:
+                return "".join(w.capitalize() for w in words)
+            case CaseStyle.CAMEL:
+                return words[0].lower() + "".join(w.capitalize() for w in words[1:])
+            case _:
+                msg = f"Unknown case style: {case_style!r}"
+                raise ValueError(msg)
 
     @staticmethod
     def _strip_version_suffix(stem: str) -> str:

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -1,7 +1,10 @@
 import logging
+import os
+import re
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.traits.options import Options
 from griptape_nodes.exe_types.node_types import (
     BaseNode,
     ControlNode,
@@ -12,6 +15,16 @@ from griptape_nodes.exe_types.node_types import (
 from griptape_nodes.retained_mode.variable_types import VariableScope
 
 logger = logging.getLogger("griptape_nodes")
+
+CASE_UPPER = "UPPER CASE"
+CASE_UPPER_SNAKE = "UPPER_SNAKE_CASE"
+CASE_TITLE = "Title Case"
+CASE_SNAKE = "snake_case"
+CASE_KEBAB = "kebab-case"
+CASE_PASCAL = "PascalCase"
+CASE_CAMEL = "camelCase"
+CASE_AS_IS = "as is"
+CASE_OPTIONS = [CASE_UPPER, CASE_UPPER_SNAKE, CASE_TITLE, CASE_SNAKE, CASE_KEBAB, CASE_PASCAL, CASE_CAMEL, CASE_AS_IS]
 
 
 class CreateVariable(ControlNode):
@@ -29,6 +42,26 @@ class CreateVariable(ControlNode):
             tooltip="The name of the variable to create",
         )
         self.add_parameter(self.variable_name_param)
+
+        self.auto_name_param = Parameter(
+            name="auto_name",
+            type="bool",
+            default_value=False,
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            tooltip="Automatically derive the variable name from the connected value (file basename, artifact name, or source node name)",
+        )
+        self.add_parameter(self.auto_name_param)
+
+        self.auto_name_case_param = Parameter(
+            name="auto_name_case",
+            type="str",
+            default_value=CASE_SNAKE,
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            tooltip="Case style used when auto_name is on",
+        )
+        self.auto_name_case_param.add_trait(Options(choices=CASE_OPTIONS))
+        self.add_parameter(self.auto_name_case_param)
+        self.hide_parameter_by_name(self.auto_name_case_param.name)
 
         self.variable_type_param = Parameter(
             name="variable_type",
@@ -52,12 +85,19 @@ class CreateVariable(ControlNode):
 
     def after_incoming_connection(
         self,
-        source_node: BaseNode,  # noqa: ARG002
+        source_node: BaseNode,
         source_parameter: Parameter,
         target_parameter: Parameter,
     ) -> None:
         """Handle incoming connections, especially to the value parameter for auto-type detection."""
         if target_parameter.name == self.value_param.name:
+            # Auto-name: set immediately from source node name; after_value_set will refine
+            # once the actual value propagates.
+            if self.get_parameter_value(self.auto_name_param.name):
+                derived = self._derive_variable_name(None, source_node.name)
+                if derived:
+                    self.set_parameter_value(self.variable_name_param.name, derived)
+
             detected_type = source_parameter.output_type
 
             # Lock down the variable_type parameter since it's now controlled by the incoming connection
@@ -191,6 +231,134 @@ class CreateVariable(ControlNode):
                                 f"Failed to delete incompatible outgoing connection: {delete_result.result_details}"
                             )
                             raise TypeError(error_msg)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter is self.auto_name_param:
+            if value:
+                self.show_parameter_by_name(self.auto_name_case_param.name)
+            else:
+                self.hide_parameter_by_name(self.auto_name_case_param.name)
+
+        if parameter is self.value_param and self.get_parameter_value(self.auto_name_param.name):
+            source_node_name = self._get_value_source_node_name()
+            derived = self._derive_variable_name(value, source_node_name)
+            if derived:
+                self.set_parameter_value(self.variable_name_param.name, derived)
+
+        super().after_value_set(parameter, value)
+
+    def _get_value_source_node_name(self) -> str | None:
+        """Return the name of the node wired into the value parameter, or None."""
+        from griptape_nodes.retained_mode.events.connection_events import (
+            ListConnectionsForNodeRequest,
+            ListConnectionsForNodeResultSuccess,
+        )
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        try:
+            result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self.name))
+            if isinstance(result, ListConnectionsForNodeResultSuccess):
+                for conn in result.incoming_connections:
+                    if conn.target_parameter_name == self.value_param.name:
+                        return conn.source_node_name
+        except Exception:
+            pass
+        return None
+
+    def _derive_variable_name(self, value: Any, source_node_name: str | None) -> str | None:
+        """Derive a variable name from a value and/or source node name, styled per auto_name_case."""
+        raw = self._get_raw_name(value, source_node_name)
+        if not raw:
+            return None
+        case_style = self.get_parameter_value(self.auto_name_case_param.name) or CASE_SNAKE
+        if case_style == CASE_AS_IS:
+            return raw
+        words = self._tokenize(raw)
+        if not words:
+            return None
+        return self._apply_case(words, case_style)
+
+    def _get_raw_name(self, value: Any, source_node_name: str | None) -> str | None:
+        """Extract an unstyled base name from a value or source node name.
+
+        Priority:
+        1. Artifact with a filename (ImageArtifact, AudioArtifact, VideoArtifact, BlobArtifact)
+        2. String that looks like a file path → basename without extension
+        3. Source node name (engine _N suffix stripped)
+        """
+        # Any artifact type: try .name first (filename-bearing artifacts like ImageArtifact),
+        # then .value (URL-bearing artifacts like ImageUrlArtifact). Guards on class name so we
+        # don't accidentally match plain dicts or strings that happen to have a .name attr.
+        if "Artifact" in type(value).__name__:
+            artifact_name = getattr(value, "name", None)
+            if artifact_name and self._has_file_extension(str(artifact_name)):
+                return self._strip_version_suffix(os.path.splitext(str(artifact_name))[0])
+
+            artifact_value = getattr(value, "value", None)
+            if isinstance(artifact_value, str):
+                basename = os.path.basename(artifact_value.rstrip("/").split("?")[0])
+                stem = os.path.splitext(basename)[0]
+                if stem and self._has_file_extension(basename):
+                    return self._strip_version_suffix(stem)
+
+        # String that looks like a file path
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped and ("/" in stripped or "\\" in stripped or self._has_file_extension(stripped)):
+                return self._strip_version_suffix(os.path.splitext(os.path.basename(stripped))[0])
+
+        # Fall back to source node name (strip engine _N suffix)
+        if source_node_name:
+            return re.sub(r"_\d+$", "", source_node_name)
+
+        return None
+
+    @staticmethod
+    def _tokenize(name: str) -> list[str]:
+        """Split a name into word tokens, handling snake_case, kebab-case, and CamelCase."""
+        # Split CamelCase/PascalCase boundaries before any other splitting
+        name = re.sub(r"([a-z])([A-Z])", r"\1 \2", name)
+        tokens = re.split(r"[\s_\-\.]+", name)
+        return [t for t in tokens if t]
+
+    @staticmethod
+    def _apply_case(words: list[str], case_style: str) -> str:
+        """Join tokens using the requested case convention."""
+        if case_style == CASE_UPPER:
+            return " ".join(w.upper() for w in words)
+        if case_style == CASE_UPPER_SNAKE:
+            return "_".join(w.upper() for w in words)
+        if case_style == CASE_TITLE:
+            return " ".join(w.capitalize() for w in words)
+        if case_style == CASE_KEBAB:
+            return "-".join(w.lower() for w in words)
+        if case_style == CASE_PASCAL:
+            return "".join(w.capitalize() for w in words)
+        if case_style == CASE_CAMEL:
+            return words[0].lower() + "".join(w.capitalize() for w in words[1:])
+        # Default: snake_case
+        return "_".join(w.lower() for w in words)
+
+    @staticmethod
+    def _strip_version_suffix(stem: str) -> str:
+        """Strip VFX-convention version/frame suffixes from a filename stem.
+
+        character_v001 → character, yellow_house_v001 → yellow_house,
+        yellow_house_001 → yellow_house. Single trailing digits (texture2d) are left alone.
+        """
+        stem = re.sub(r"[_\-]v\d+$", "", stem, flags=re.IGNORECASE)
+        stem = re.sub(r"[_\-]\d{2,}$", "", stem)
+        return stem
+
+    @staticmethod
+    def _has_file_extension(s: str) -> bool:
+        _EXTENSIONS = {
+            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
+            ".mp4", ".mov", ".avi", ".mp3", ".wav", ".ogg",
+            ".json", ".txt", ".csv", ".pdf",
+        }
+        _, ext = os.path.splitext(s)
+        return ext.lower() in _EXTENSIONS
 
     def before_value_set(self, parameter: Parameter, value: Any) -> Any:
         """Handle changes to the variable_type parameter."""

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from enum import StrEnum
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
@@ -16,15 +17,16 @@ from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
 
-CASE_UPPER = "UPPER CASE"
-CASE_UPPER_SNAKE = "UPPER_SNAKE_CASE"
-CASE_TITLE = "Title Case"
-CASE_SNAKE = "snake_case"
-CASE_KEBAB = "kebab-case"
-CASE_PASCAL = "PascalCase"
-CASE_CAMEL = "camelCase"
-CASE_AS_IS = "as is"
-CASE_OPTIONS = [CASE_UPPER, CASE_UPPER_SNAKE, CASE_TITLE, CASE_SNAKE, CASE_KEBAB, CASE_PASCAL, CASE_CAMEL, CASE_AS_IS]
+
+class CaseStyle(StrEnum):
+    UPPER = "UPPER CASE"
+    UPPER_SNAKE = "UPPER_SNAKE_CASE"
+    TITLE = "Title Case"
+    SNAKE = "snake_case"
+    KEBAB = "kebab-case"
+    PASCAL = "PascalCase"
+    CAMEL = "camelCase"
+    AS_IS = "as is"
 
 
 class CreateVariable(ControlNode):
@@ -55,11 +57,11 @@ class CreateVariable(ControlNode):
         self.auto_name_case_param = Parameter(
             name="auto_name_case",
             type="str",
-            default_value=CASE_SNAKE,
+            default_value=CaseStyle.SNAKE,
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             tooltip="Case style used when auto_name is on",
         )
-        self.auto_name_case_param.add_trait(Options(choices=CASE_OPTIONS))
+        self.auto_name_case_param.add_trait(Options(choices=list(CaseStyle)))
         self.add_parameter(self.auto_name_case_param)
         self.hide_parameter_by_name(self.auto_name_case_param.name)
 
@@ -270,8 +272,8 @@ class CreateVariable(ControlNode):
         raw = self._get_raw_name(value, source_node_name)
         if not raw:
             return None
-        case_style = self.get_parameter_value(self.auto_name_case_param.name) or CASE_SNAKE
-        if case_style == CASE_AS_IS:
+        case_style = self.get_parameter_value(self.auto_name_case_param.name) or CaseStyle.SNAKE
+        if case_style == CaseStyle.AS_IS:
             return raw
         words = self._tokenize(raw)
         if not words:
@@ -324,17 +326,17 @@ class CreateVariable(ControlNode):
     @staticmethod
     def _apply_case(words: list[str], case_style: str) -> str:
         """Join tokens using the requested case convention."""
-        if case_style == CASE_UPPER:
+        if case_style == CaseStyle.UPPER:
             return " ".join(w.upper() for w in words)
-        if case_style == CASE_UPPER_SNAKE:
+        if case_style == CaseStyle.UPPER_SNAKE:
             return "_".join(w.upper() for w in words)
-        if case_style == CASE_TITLE:
+        if case_style == CaseStyle.TITLE:
             return " ".join(w.capitalize() for w in words)
-        if case_style == CASE_KEBAB:
+        if case_style == CaseStyle.KEBAB:
             return "-".join(w.lower() for w in words)
-        if case_style == CASE_PASCAL:
+        if case_style == CaseStyle.PASCAL:
             return "".join(w.capitalize() for w in words)
-        if case_style == CASE_CAMEL:
+        if case_style == CaseStyle.CAMEL:
             return words[0].lower() + "".join(w.capitalize() for w in words[1:])
         # Default: snake_case
         return "_".join(w.lower() for w in words)

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -353,9 +353,22 @@ class CreateVariable(ControlNode):
     @staticmethod
     def _has_file_extension(s: str) -> bool:
         _EXTENSIONS = {
-            ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp",
-            ".mp4", ".mov", ".avi", ".mp3", ".wav", ".ogg",
-            ".json", ".txt", ".csv", ".pdf",
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".webp",
+            ".bmp",
+            ".mp4",
+            ".mov",
+            ".avi",
+            ".mp3",
+            ".wav",
+            ".ogg",
+            ".json",
+            ".txt",
+            ".csv",
+            ".pdf",
         }
         _, ext = os.path.splitext(s)
         return ext.lower() in _EXTENSIONS

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -344,26 +344,7 @@ class CreateVariable(ControlNode):
 
     @staticmethod
     def _has_file_extension(s: str) -> bool:
-        _EXTENSIONS = {
-            ".png",
-            ".jpg",
-            ".jpeg",
-            ".gif",
-            ".webp",
-            ".bmp",
-            ".mp4",
-            ".mov",
-            ".avi",
-            ".mp3",
-            ".wav",
-            ".ogg",
-            ".json",
-            ".txt",
-            ".csv",
-            ".pdf",
-        }
-        _, ext = os.path.splitext(s)
-        return ext.lower() in _EXTENSIONS
+        return bool(re.search(r"\.[a-zA-Z0-9]{2,5}$", s))
 
     def before_value_set(self, parameter: Parameter, value: Any) -> Any:
         """Handle changes to the variable_type parameter."""

--- a/griptape_nodes_library/variables/create_variable.py
+++ b/griptape_nodes_library/variables/create_variable.py
@@ -4,7 +4,6 @@ import re
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
-from griptape_nodes.traits.options import Options
 from griptape_nodes.exe_types.node_types import (
     BaseNode,
     ControlNode,
@@ -13,6 +12,7 @@ from griptape_nodes.exe_types.node_types import (
     VariableReference,
 )
 from griptape_nodes.retained_mode.variable_types import VariableScope
+from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/variables/get_variable.py
+++ b/griptape_nodes_library/variables/get_variable.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import (
     ControlNode,
     NodeDependencies,
@@ -9,10 +9,13 @@ from griptape_nodes.exe_types.node_types import (
     VariableReference,
 )
 from griptape_nodes.retained_mode.variable_types import VariableScope
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.variables.variable_utils import (
     create_advanced_parameter_group,
     get_variable,
+    list_variables,
     scope_string_to_variable_scope,
 )
 
@@ -31,6 +34,16 @@ class GetVariable(ControlNode):
             allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT, ParameterMode.PROPERTY},
             tooltip="Name of the variable to retrieve",
         )
+        available_names = self._get_variable_names()
+        self.variable_name_param.add_trait(Options(choices=available_names))
+        self.variable_name_param.add_trait(
+            Button(
+                icon="list-restart",
+                size="icon",
+                variant="secondary",
+                on_click=self._refresh_variable_names,
+            )
+        )
         self.add_parameter(self.variable_name_param)
 
         self.value_param = Parameter(
@@ -45,6 +58,19 @@ class GetVariable(ControlNode):
         advanced = create_advanced_parameter_group()
         self.scope_param = advanced.scope_param
         self.add_node_element(advanced.parameter_group)
+
+    def _get_variable_names(self) -> list[str]:
+        scope_str = self.get_parameter_value("scope")
+        scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
+        return list_variables(node_name=self.name, scope=scope)
+
+    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+        names = self._get_variable_names()
+        current = self.get_parameter_value("variable_name")
+        self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")
+        if current and current in names:
+            self.set_parameter_value("variable_name", current)
+        return None
 
     def process(self) -> None:
         variable_name = self.get_parameter_value(self.variable_name_param.name)

--- a/griptape_nodes_library/variables/get_variable.py
+++ b/griptape_nodes_library/variables/get_variable.py
@@ -64,7 +64,9 @@ class GetVariable(ControlNode):
         scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
         return list_variables(node_name=self.name, scope=scope)
 
-    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+    def _refresh_variable_names(
+        self, button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:  # noqa: ARG002
         names = self._get_variable_names()
         current = self.get_parameter_value("variable_name")
         self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")

--- a/griptape_nodes_library/variables/has_variable.py
+++ b/griptape_nodes_library/variables/has_variable.py
@@ -65,7 +65,9 @@ class HasVariable(ControlNode):
         scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
         return list_variables(node_name=self.name, scope=scope)
 
-    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+    def _refresh_variable_names(
+        self, button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:  # noqa: ARG002
         names = self._get_variable_names()
         current = self.get_parameter_value("variable_name")
         self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")

--- a/griptape_nodes_library/variables/has_variable.py
+++ b/griptape_nodes_library/variables/has_variable.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import (
     ControlNode,
     NodeDependencies,
@@ -9,10 +9,13 @@ from griptape_nodes.exe_types.node_types import (
     VariableReference,
 )
 from griptape_nodes.retained_mode.variable_types import VariableScope
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.variables.variable_utils import (
     create_advanced_parameter_group,
     has_variable,
+    list_variables,
     scope_string_to_variable_scope,
 )
 
@@ -31,6 +34,16 @@ class HasVariable(ControlNode):
             allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT, ParameterMode.PROPERTY},
             tooltip="Name of the variable to check for existence",
         )
+        available_names = self._get_variable_names()
+        self.variable_name_param.add_trait(Options(choices=available_names))
+        self.variable_name_param.add_trait(
+            Button(
+                icon="list-restart",
+                size="icon",
+                variant="secondary",
+                on_click=self._refresh_variable_names,
+            )
+        )
         self.add_parameter(self.variable_name_param)
 
         self.exists_param = Parameter(
@@ -46,6 +59,19 @@ class HasVariable(ControlNode):
         advanced = create_advanced_parameter_group()
         self.scope_param = advanced.scope_param
         self.add_node_element(advanced.parameter_group)
+
+    def _get_variable_names(self) -> list[str]:
+        scope_str = self.get_parameter_value("scope")
+        scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
+        return list_variables(node_name=self.name, scope=scope)
+
+    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+        names = self._get_variable_names()
+        current = self.get_parameter_value("variable_name")
+        self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")
+        if current and current in names:
+            self.set_parameter_value("variable_name", current)
+        return None
 
     def process(self) -> None:
         variable_name = self.get_parameter_value(self.variable_name_param.name)

--- a/griptape_nodes_library/variables/set_variable.py
+++ b/griptape_nodes_library/variables/set_variable.py
@@ -85,7 +85,9 @@ class SetVariable(ControlNode):
         scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
         return list_variables(node_name=self.name, scope=scope)
 
-    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+    def _refresh_variable_names(
+        self, button: Button, button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:  # noqa: ARG002
         names = self._get_variable_names()
         current = self.get_parameter_value("variable_name")
         self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")

--- a/griptape_nodes_library/variables/set_variable.py
+++ b/griptape_nodes_library/variables/set_variable.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import (
     BaseNode,
     ControlNode,
@@ -26,12 +26,15 @@ from griptape_nodes.retained_mode.events.variable_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.variable_types import VariableScope
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.variables.variable_utils import (
     _get_flow_for_node,
     create_advanced_parameter_group,
     get_variable,
     has_variable,
+    list_variables,
     scope_string_to_variable_scope,
 )
 
@@ -52,6 +55,16 @@ class SetVariable(ControlNode):
             allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT, ParameterMode.PROPERTY},
             tooltip="Name of the variable to set. The variable is created if it does not exist.",
         )
+        available_names = self._get_variable_names()
+        self.variable_name_param.add_trait(Options(choices=available_names))
+        self.variable_name_param.add_trait(
+            Button(
+                icon="list-restart",
+                size="icon",
+                variant="secondary",
+                on_click=self._refresh_variable_names,
+            )
+        )
         self.add_parameter(self.variable_name_param)
 
         self.value_param = Parameter(
@@ -66,6 +79,19 @@ class SetVariable(ControlNode):
         advanced = create_advanced_parameter_group()
         self.scope_param = advanced.scope_param
         self.add_node_element(advanced.parameter_group)
+
+    def _get_variable_names(self) -> list[str]:
+        scope_str = self.get_parameter_value("scope")
+        scope = scope_string_to_variable_scope(scope_str) if scope_str else VariableScope.HIERARCHICAL
+        return list_variables(node_name=self.name, scope=scope)
+
+    def _refresh_variable_names(self, button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult | None:  # noqa: ARG002
+        names = self._get_variable_names()
+        current = self.get_parameter_value("variable_name")
+        self._update_option_choices(param="variable_name", choices=names, default=names[0] if names else "")
+        if current and current in names:
+            self.set_parameter_value("variable_name", current)
+        return None
 
     def after_incoming_connection(
         self,

--- a/griptape_nodes_library/variables/variable_utils.py
+++ b/griptape_nodes_library/variables/variable_utils.py
@@ -104,6 +104,37 @@ def get_variable(node_name: str, variable_name: str, scope: "VariableScope") -> 
     return result.variable
 
 
+def list_variables(node_name: str, scope: "VariableScope") -> list[str]:
+    """Return the names of all variables visible from this node at the given scope.
+
+    Args:
+        node_name: The name of the node making the request
+        scope: The scope to search for variables within
+
+    Returns:
+        Sorted list of variable names, or empty list on failure.
+    """
+    from griptape_nodes.retained_mode.events.variable_events import (
+        ListVariablesRequest,
+        ListVariablesResultSuccess,
+    )
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+    # Try to resolve via the node's registered flow; fall back to the Context Manager's
+    # active flow (starting_flow=None) so the list populates during node creation before
+    # the node has been added to a flow.
+    try:
+        current_flow_name = _get_flow_for_node(node_name)
+    except RuntimeError:
+        current_flow_name = None
+
+    request = ListVariablesRequest(lookup_scope=scope, starting_flow=current_flow_name)
+    result = GriptapeNodes.handle_request(request)
+    if not isinstance(result, ListVariablesResultSuccess):
+        return []
+    return [v.name for v in result.variables]
+
+
 def has_variable(node_name: str, variable_name: str, scope: "VariableScope") -> bool:
     """Attempts to check if a variable exists at the specified scope.
 


### PR DESCRIPTION
Closes #206

## Summary

- **GetVariable, SetVariable, HasVariable** — `variable_name` is now a dropdown populated via `ListVariablesRequest` at node creation, with a refresh button (↺) to re-query at any time. The list respects the current scope setting and pre-populates immediately when a node is dropped onto the canvas.

- **CreateVariable** — new `auto_name` boolean that automatically derives the variable name from whatever is connected to `value`:
  - Artifacts (any `*Artifact` type): tries `.name` first, then `.value` for URL artifacts — extracts basename and strips VFX version suffixes (`_v001`, `_001`, etc.)
  - Strings that look like file paths: basename without extension, version suffix stripped
  - Anything else: falls back to source node name (engine `_N` suffix stripped)
  - `auto_name_case` dropdown (hidden until `auto_name` is on): `UPPER CASE`, `UPPER_SNAKE_CASE`, `Title Case`, `snake_case`, `kebab-case`, `PascalCase`, `camelCase`, `as is`

### Create Variable Node

<img width="1250" height="652" alt="image" src="https://github.com/user-attachments/assets/9704d21d-985a-4e85-a035-8f2ee82a3124" />

### Get Variable Node

<img width="1123" height="510" alt="image" src="https://github.com/user-attachments/assets/22baf233-48c9-450d-8d67-d7ec62eaddc0" />

## Test plan

- [ ] Drop a `GetVariable` / `SetVariable` / `HasVariable` node into a flow that has existing variables — dropdown should pre-populate
- [ ] Click the ↺ button after adding a new variable elsewhere — list should refresh
- [ ] Change scope in Advanced group, click ↺ — list should reflect new scope
- [ ] On `CreateVariable`, enable `auto_name`, connect an `ImageUrlArtifact` from a generation node — variable name should derive from the image filename
- [ ] Try `character_v001.png` and `yellow_house_001.png` — names should strip to `character` / `yellow_house`
- [ ] Switch `auto_name_case` through all options and verify formatting

🤖 Generated with [Claude Code](https://claude.ai/claude-code)