### PR TITLE
ci: add version-check to forbid merging without bumping the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version has been bumped
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:griptape_nodes_library.json | jq -r '.metadata.library_version')
+          JSON_VERSION=$(jq -r '.metadata.library_version' griptape_nodes_library.json)
+          TOML_VERSION=$(awk -F'"' '/^version = / {print $2}' pyproject.toml)
+          echo "Base version: $BASE_VERSION"
+          echo "JSON version: $JSON_VERSION"
+          echo "TOML version: $TOML_VERSION"
+          if [ "$BASE_VERSION" = "$JSON_VERSION" ]; then
+            echo "::error::library_version in griptape_nodes_library.json has not been bumped (still $JSON_VERSION). Run 'make version/patch' or 'make version/minor' before merging."
+            exit 1
+          fi
+          if [ "$JSON_VERSION" != "$TOML_VERSION" ]; then
+            echo "::error::Version mismatch: griptape_nodes_library.json has $JSON_VERSION but pyproject.toml has $TOML_VERSION."
+            exit 1
+          fi
+
   check:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ version/get: ## Get version.
 version/set: ## Set version. Usage: make version/set v=1.2.3
 	@jq --arg v "$(v)" '.metadata.library_version = $$v' griptape_nodes_library.json > griptape_nodes_library.json.tmp
 	@mv griptape_nodes_library.json.tmp griptape_nodes_library.json
+	@$(MAKE) --no-print-directory version/sync-toml
 	@make version/commit
+
+.PHONY: version/sync-toml
+version/sync-toml: ## Sync version from griptape_nodes_library.json to pyproject.toml.
+	@VERSION=$$($(MAKE) --no-print-directory version/get); \
+	uv version --frozen "$$VERSION"
 
 .PHONY: version/patch
 version/patch: ## Bump patch version.
@@ -18,6 +24,7 @@ version/patch: ## Bump patch version.
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' griptape_nodes_library.json > griptape_nodes_library.json.tmp; \
 	mv griptape_nodes_library.json.tmp griptape_nodes_library.json; \
 	echo "Bumped to $$NEW_VERSION"
+	@$(MAKE) --no-print-directory version/sync-toml
 	@$(MAKE) --no-print-directory version/commit
 
 .PHONY: version/minor
@@ -28,6 +35,7 @@ version/minor: ## Bump minor version.
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' griptape_nodes_library.json > griptape_nodes_library.json.tmp; \
 	mv griptape_nodes_library.json.tmp griptape_nodes_library.json; \
 	echo "Bumped to $$NEW_VERSION"
+	@$(MAKE) --no-print-directory version/sync-toml
 	@$(MAKE) --no-print-directory version/commit
 
 .PHONY: version/major
@@ -38,11 +46,12 @@ version/major: ## Bump major version.
 	jq --arg v "$$NEW_VERSION" '.metadata.library_version = $$v' griptape_nodes_library.json > griptape_nodes_library.json.tmp; \
 	mv griptape_nodes_library.json.tmp griptape_nodes_library.json; \
 	echo "Bumped to $$NEW_VERSION"
+	@$(MAKE) --no-print-directory version/sync-toml
 	@$(MAKE) --no-print-directory version/commit
 
 .PHONY: version/commit
 version/commit: ## Commit version.
-	@git add griptape_nodes_library.json
+	@git add griptape_nodes_library.json pyproject.toml
 	@git commit -m "chore: bump v$$($(MAKE) --no-print-directory version/get)"
 
 .PHONY: version/publish

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.79.0",
+    "library_version": "0.80.0",
     "engine_version": "0.87.0",
     "tags": [
       "Griptape",
@@ -885,12 +885,12 @@
     {
       "name": "SplatViewer",
       "path": "griptape_nodes_library/splat/widgets/SplatViewer.js",
-      "description": "Inline Gaussian splat viewer \u2014 auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
+      "description": "Inline Gaussian splat viewer — auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
     },
     {
       "name": "CropImageEditor",
       "path": "widgets/CropImageEditor/CropImageEditor.js",
-      "description": "Interactive crop editor \u2014 drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
+      "description": "Interactive crop editor — drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
     },
     {
       "name": "CropVideoEditor",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-library-standard"
-version = "0.67.0"
+version = "0.80.0"
 description = "Default nodes for Griptape Nodes"
 authors = [{ name = "Griptape, Inc" }]
 requires-python = ">=3.12,<3.13"


### PR DESCRIPTION
## Summary

Currently users can think they have latest version of library despite having outstanding commits for the same version.

Add a `version-check` CI job that blocks merging a PR if the library version hasn't been bumped or if the versions across the two source-of-truth files diverge.

- Fails if `metadata.library_version` in `griptape_nodes_library.json` has not changed relative to the base branch
- Fails if `metadata.library_version` in `griptape_nodes_library.json` does not match `version` in `pyproject.toml`
- Only runs on `pull_request` events (skipped on pushes to `main`)
- Error annotations surface the exact problem and the fix (`make version/patch` or `make version/minor`) directly in the GitHub checks UI

## Setup required

After merging, add `version-check` to the required status checks for the `main` branch under **Settings → Branches → Branch protection rules → Require status checks to pass before merging**, otherwise the job result won't block the merge button.

## Test plan

- [x] Open a PR without bumping the version and confirm the `version-check` job fails with the expected error annotation
- [x] Open a PR with mismatched versions between `griptape_nodes_library.json` and `pyproject.toml` and confirm the mismatch error is reported
- [x] Open a PR with both versions bumped and in sync and confirm the job passes
- [x] Confirm the `check` job is unaffected by this change
- [x] Confirm `version-check` is added to required status checks in branch protection rules
