### PR TITLE
feat(access): surface license-gated models in DescribeImage + TranscribeAudio

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -3914,6 +3914,28 @@
           "text",
           "ai",
           "vision"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_5_2",
+              "gtc_gpt_5_1",
+              "gtc_gpt_5",
+              "gtc_gpt_5_mini",
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_4o",
+              "gtc_o4_mini",
+              "gtc_o3",
+              "gtc_claude_opus_4_7",
+              "gtc_claude_sonnet_4_6",
+              "gtc_claude_sonnet_4_5",
+              "gtc_gemini_3_1_pro",
+              "gtc_gemini_2_5_pro"
+            ]
+          }
         ]
       }
     },

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -6,13 +6,25 @@ from typing import Any
 from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import (
+    NodeMessageResult,
+    Parameter,
+    ParameterGroup,
+    ParameterMessage,
+    ParameterMode,
+)
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.button import Button
+from griptape_nodes.retained_mode.events.access_events import (
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -26,6 +38,7 @@ __all__ = ["TranscribeAudio"]
 
 MODEL_CHOICES = ["whisper-1"]
 DEFAULT_MODEL = MODEL_CHOICES[0]
+
 
 # Deprecated models and their replacements (kept for backward-compat with saved graphs)
 DEPRECATED_MODELS = {
@@ -71,6 +84,13 @@ class TranscribeAudio(GriptapeProxyNode):
         self.category = "audio"
         self.description = "Transcribe audio to text using OpenAI models via Griptape Cloud proxy"
 
+        # Cache the per-provider denial map at node-init so before_value_set
+        # can render the notice without a round-trip on every selection change.
+        # _build_payload() re-asks the engine so a hook decision that flipped
+        # between creation and run still wins.
+        self._denial_by_provider_id: dict[str, CheckpointDenial] = self._fetch_denial_map()
+        default_model = self._pick_default_model()
+
         # --- INPUT PARAMETERS ---
         self.add_parameter(
             Parameter(
@@ -96,11 +116,20 @@ class TranscribeAudio(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value=DEFAULT_MODEL,
+                default_value=default_model,
                 tooltip="Transcription model to use",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_CHOICES)},
-                ui_options={"display_name": "audio transcription model"},
+                traits={
+                    Options(choices=list(MODEL_CHOICES)),
+                    Button(
+                        icon="list-restart",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._on_refresh_access_click,
+                        tooltip="Refresh available models",
+                    ),
+                },
+                ui_options=self._model_ui_options(),
             )
         )
 
@@ -241,7 +270,38 @@ class TranscribeAudio(GriptapeProxyNode):
             parameter_group_initially_collapsed=True,
         )
 
+        # Reflect the initial selection: a node born with a denied default gets
+        # the badge immediately.
+        self._update_model_access_badge(default_model)
+
+    def _update_model_access_badge(self, value: Any) -> None:
+        """Set or clear the `model` parameter's badge based on the selected value's policy verdict.
+
+        Reads the cached ``_denial_by_provider_id`` (built at init) so this is a
+        local map lookup, not a round-trip. ``_build_payload`` re-asks the engine
+        at run-time so a hook decision that changed between node creation and
+        run is still enforced.
+        """
+        param = self.get_parameter_by_name("model")
+        if param is None:
+            return
+        if not isinstance(value, str):
+            param.clear_badge()
+            return
+        denial = self._denial_by_provider_id.get(value)
+        if denial is None:
+            param.clear_badge()
+            return
+        param.set_badge(
+            variant="error",
+            title="Model Not Permitted",
+            message=f"Model `{value}` is not permitted. Running this node will fail.\n\nReason(s): {denial.reason()}",
+            icon="shield-off",
+        )
+
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == "model":
+            self._update_model_access_badge(value)
         if parameter.name == "response_format":
             if value == "verbose_json":
                 self.show_parameter_by_name("segments")
@@ -267,6 +327,101 @@ class TranscribeAudio(GriptapeProxyNode):
         elif parameter.name == "model" and isinstance(value, str):
             self.hide_message_by_name("model_deprecation_notice")
         return super().before_value_set(parameter, value)
+
+    def _fetch_denial_map(self) -> dict[str, CheckpointDenial]:
+        """Return `{provider_model_id: CheckpointDenial}` for every denied catalog model.
+
+        Asks the engine which of the node's declared catalog models the
+        authorization hook denies, keyed by the upstream provider's name (which
+        is what the dropdown stores). Also populates ``_catalog_id_by_provider_id``
+        so the runtime check in ``_build_payload`` can translate the dropdown
+        name back to the catalog id the engine policy actually matches on.
+        Empty on engine failure -- internal errors must not silently strip the
+        dropdown.
+        """
+        self._catalog_id_by_provider_id: dict[str, str] = {}
+        result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=type(self).__name__))
+        if not isinstance(result, QueryModelAccessForNodeResultSuccess):
+            return {}
+        denials: dict[str, CheckpointDenial] = {}
+        for verdict in result.verdicts:
+            if verdict.provider_model_id is not None:
+                self._catalog_id_by_provider_id[verdict.provider_model_id] = verdict.model_id
+                if verdict.denial is not None:
+                    denials[verdict.provider_model_id] = verdict.denial
+        return denials
+
+    def _pick_default_model(self) -> str:
+        """Return `DEFAULT_MODEL` if it's allowed; otherwise the first allowed entry.
+
+        Falls back to `DEFAULT_MODEL` when every entry is denied so the dropdown
+        still has a value the user can see and the warning notice can render.
+        The existing `INSTANTIATE_NODE` gate prevents the node from being created
+        at all when its single declared model is denied, so this fallback only
+        matters if the two checkpoints disagree.
+        """
+        if DEFAULT_MODEL not in self._denial_by_provider_id:
+            return DEFAULT_MODEL
+        for choice in MODEL_CHOICES:
+            if choice not in self._denial_by_provider_id:
+                return choice
+        return DEFAULT_MODEL
+
+    def _model_ui_options(self) -> dict[str, Any]:
+        """Build the `ui_options` dict for the model parameter, including per-row decoration."""
+        data: list[dict[str, str]] = []
+        for choice in MODEL_CHOICES:
+            if choice in self._denial_by_provider_id:
+                data.append({"name": choice, "icon": "shield-off", "subtitle": "Not permitted by your license"})
+            else:
+                data.append({"name": choice})
+        return {
+            "display_name": "audio transcription model",
+            "data": data,
+            "dropdown_row_icons": True,
+            "dropdown_row_subtitles": True,
+        }
+
+    def _fetch_runtime_denial(self, model_provider_id: str) -> CheckpointDenial | None:
+        """Ask the engine whether this specific model is permitted, right now.
+
+        Translates the dropdown name (e.g. ``"whisper-1"``) to the catalog id the
+        engine policy matches on (e.g. ``"gtc_whisper_1"``) via the mapping built
+        at init time. Falls through to ``None`` on any failure -- a missing
+        mapping means the dropdown got out of sync with the manifest; an engine
+        ``Failure`` means an internal error. In neither case do we want to gate
+        user work.
+        """
+        catalog_id = self._catalog_id_by_provider_id.get(model_provider_id)
+        if catalog_id is None:
+            return None
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(
+                node_type=type(self).__name__,
+                candidate_model_ids=[catalog_id],
+            )
+        )
+        if not isinstance(result, QueryModelAccessForNodeResultSuccess) or not result.verdicts:
+            return None
+        return result.verdicts[0].denial
+
+    def _on_refresh_access_click(
+        self, _button: Button, _button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        """Re-query the engine and refresh the dropdown decoration + current-selection badge.
+
+        Fires when the user clicks the inline refresh button next to the model
+        dropdown. Useful when a license / permission state has changed under the
+        running engine (e.g. the user upgraded their plan) and the artist wants
+        the dropdown to reflect it without recreating the node or reloading the
+        workflow.
+        """
+        self._denial_by_provider_id = self._fetch_denial_map()
+        model_param = self.get_parameter_by_name("model")
+        if model_param is not None:
+            model_param.update_ui_options(self._model_ui_options())
+        self._update_model_access_badge(self.get_parameter_value("model"))
+        return None
 
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation."""
@@ -308,6 +463,16 @@ class TranscribeAudio(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for OpenAI audio transcription."""
+        # Runtime entitlement gate. Re-asks the engine rather than reading the
+        # cached _denial_by_provider_id so a hook decision that changed between
+        # node creation and run is honored.
+        model_input = self.get_parameter_value("model")
+        if isinstance(model_input, str):
+            denial = self._fetch_runtime_denial(model_input)
+            if denial is not None:
+                msg = f"Cannot run {type(self).__name__}: '{model_input}' is not permitted. {denial.reason()}"
+                raise RuntimeError(msg)
+
         audio_value = self.get_parameter_value("audio")
         if audio_value is None:
             msg = "No audio provided. Please connect an audio source."

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -6,13 +6,25 @@ from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud_prompt_driver import GriptapeCloudPromptDriver
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
-from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode, ParameterType
+from griptape_nodes.exe_types.core_types import (
+    NodeMessageResult,
+    Parameter,
+    ParameterList,
+    ParameterMode,
+    ParameterType,
+)
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.access_events import (
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
 
@@ -54,6 +66,13 @@ class DescribeImage(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
+        # Cache the per-provider denial map at node-init so after_value_set can
+        # toggle the badge without a round-trip on every selection change.
+        # process() re-asks the engine so a hook decision that flipped between
+        # creation and run still wins.
+        self._denial_by_provider_id: dict[str, CheckpointDenial] = self._fetch_denial_map()
+        default_model = self._pick_default_model()
+
         self.add_parameter(
             Parameter(
                 name="agent",
@@ -70,11 +89,20 @@ class DescribeImage(ControlNode):
                 input_types=["str", "Prompt Model Config"],
                 type="str",
                 output_type="str",
-                default_value=DEFAULT_MODEL,
+                default_value=default_model,
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 tooltip="Choose a model, or connect a Prompt Model Configuration or an Agent",
-                traits={Options(choices=MODEL_CHOICES)},
-                ui_options={"display_name": "prompt model"},
+                traits={
+                    Options(choices=list(MODEL_CHOICES)),
+                    Button(
+                        icon="list-restart",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._on_refresh_access_click,
+                        tooltip="Refresh available models",
+                    ),
+                },
+                ui_options=self._model_ui_options(),
             )
         )
         self.add_parameter(
@@ -139,6 +167,101 @@ class DescribeImage(ControlNode):
                 hide=True,
             )
         )
+
+        # Reflect the initial selection: a node born with a denied default
+        # gets the badge immediately.
+        self._update_model_access_badge(default_model)
+
+    def _fetch_denial_map(self) -> dict[str, CheckpointDenial]:
+        """Return `{provider_model_id: CheckpointDenial}` for every denied catalog model.
+
+        Asks the engine which of the node's declared catalog models the
+        authorization hook denies, keyed by the upstream provider's name (which
+        is what the dropdown stores). Also populates ``_catalog_id_by_provider_id``
+        so the runtime check in ``process()`` can translate the dropdown name back
+        to the catalog id the engine policy actually matches on. Empty on engine
+        failure -- internal errors must not silently strip the dropdown.
+        """
+        self._catalog_id_by_provider_id: dict[str, str] = {}
+        result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=type(self).__name__))
+        if not isinstance(result, QueryModelAccessForNodeResultSuccess):
+            return {}
+        denials: dict[str, CheckpointDenial] = {}
+        for verdict in result.verdicts:
+            if verdict.provider_model_id is not None:
+                self._catalog_id_by_provider_id[verdict.provider_model_id] = verdict.model_id
+                if verdict.denial is not None:
+                    denials[verdict.provider_model_id] = verdict.denial
+        return denials
+
+    def _pick_default_model(self) -> str:
+        """Return `DEFAULT_MODEL` if it's allowed; otherwise the first allowed entry.
+
+        Falls back to `DEFAULT_MODEL` when every entry is denied so the dropdown
+        still has a value the user can see and the warning notice can render.
+        """
+        if DEFAULT_MODEL not in self._denial_by_provider_id:
+            return DEFAULT_MODEL
+        for choice in MODEL_CHOICES:
+            if choice not in self._denial_by_provider_id:
+                return choice
+        return DEFAULT_MODEL
+
+    def _model_ui_options(self) -> dict[str, Any]:
+        """Build the `ui_options` dict for the model parameter, including per-row decoration."""
+        data: list[dict[str, str]] = []
+        for choice in MODEL_CHOICES:
+            if choice in self._denial_by_provider_id:
+                data.append({"name": choice, "icon": "shield-off", "subtitle": "Not permitted by your license"})
+            else:
+                data.append({"name": choice})
+        return {
+            "display_name": "prompt model",
+            "data": data,
+            "dropdown_row_icons": True,
+            "dropdown_row_subtitles": True,
+        }
+
+    def _fetch_runtime_denial(self, model_provider_id: str) -> CheckpointDenial | None:
+        """Ask the engine whether this specific model is permitted, right now.
+
+        Translates the dropdown name (e.g. ``"gpt-5.2"``) to the catalog id the
+        engine policy matches on (e.g. ``"gtc_gpt_5_2"``) via the mapping built
+        at init time. Falls through to ``None`` on any failure -- a missing
+        mapping means the dropdown got out of sync with the manifest; an engine
+        ``Failure`` means an internal error. In neither case do we want to gate
+        user work.
+        """
+        catalog_id = self._catalog_id_by_provider_id.get(model_provider_id)
+        if catalog_id is None:
+            return None
+        result = GriptapeNodes.handle_request(
+            QueryModelAccessForNodeRequest(
+                node_type=type(self).__name__,
+                candidate_model_ids=[catalog_id],
+            )
+        )
+        if not isinstance(result, QueryModelAccessForNodeResultSuccess) or not result.verdicts:
+            return None
+        return result.verdicts[0].denial
+
+    def _on_refresh_access_click(
+        self, _button: Button, _button_details: ButtonDetailsMessagePayload
+    ) -> NodeMessageResult | None:
+        """Re-query the engine and refresh the dropdown decoration + current-selection badge.
+
+        Fires when the user clicks the inline refresh button next to the model
+        dropdown. Useful when a license / permission state has changed under the
+        running engine (e.g. the user upgraded their plan) and the artist wants
+        the dropdown to reflect it without recreating the node or reloading the
+        workflow.
+        """
+        self._denial_by_provider_id = self._fetch_denial_map()
+        model_param = self.get_parameter_by_name("model")
+        if model_param is not None:
+            model_param.update_ui_options(self._model_ui_options())
+        self._update_model_access_badge(self.get_parameter_value("model"))
+        return None
 
     def _update_output_type_and_validate_connections(self, new_output_type: str) -> None:
         output_param = self.get_parameter_by_name("output")
@@ -284,20 +407,67 @@ class DescribeImage(ControlNode):
             # Enable PROPERTY so the user can set it
             target_parameter.allowed_modes = {ParameterMode.INPUT, ParameterMode.PROPERTY}
 
-            target_parameter.add_trait(Options(choices=MODEL_CHOICES))
-            target_parameter.set_default_value(DEFAULT_MODEL)
-            target_parameter.default_value = DEFAULT_MODEL
-            ui_options = target_parameter.ui_options
-            ui_options["display_name"] = "prompt model"
-            target_parameter.ui_options = ui_options
-            self.set_parameter_value("model", DEFAULT_MODEL)
+            # Refresh the cached denial map first so the reinstalled dropdown reflects
+            # the current policy, then reinstall Options with the full choice set --
+            # denied entries stay in the list with their `shield-off` decoration via
+            # _model_ui_options(), matching the parameter's original construction.
+            self._denial_by_provider_id = self._fetch_denial_map()
+            default_model = self._pick_default_model()
+            target_parameter.add_trait(Options(choices=list(MODEL_CHOICES)))
+            target_parameter.set_default_value(default_model)
+            target_parameter.default_value = default_model
+            target_parameter.update_ui_options(self._model_ui_options())
+            self.set_parameter_value("model", default_model)
 
         return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
+
+    def _update_model_access_badge(self, value: Any) -> None:
+        """Set or clear the `model` parameter's badge based on the selected value's policy verdict.
+
+        Reads the cached ``_denial_by_provider_id`` (built at init) so this is a
+        local map lookup, not a round-trip to the engine. ``process()`` re-asks
+        the engine at run-time so a hook decision that changed between node
+        creation and run is still enforced.
+        """
+        param = self.get_parameter_by_name("model")
+        if param is None:
+            return
+        if not isinstance(value, str):
+            # Driver / Agent connection in flight -- the dropdown isn't the truth.
+            param.clear_badge()
+            return
+        denial = self._denial_by_provider_id.get(value)
+        if denial is None:
+            param.clear_badge()
+            return
+        param.set_badge(
+            variant="error",
+            title="Model Not Permitted",
+            message=f"Model `{value}` is not permitted. Running this node will fail.\n\nReason(s): {denial.reason()}",
+            icon="shield-off",
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        super().after_value_set(parameter, value)
+        if parameter.name == "model":
+            self._update_model_access_badge(value)
 
     def process(self) -> AsyncResult[Structure]:  # noqa: C901, PLR0915, PLR0912
         # Get the parameters from the node
         params = self.parameter_values
         model_input = self.get_parameter_value("model")
+
+        # Runtime entitlement gate. We re-ask the engine rather than reading the
+        # cached _denial_by_provider_id so a hook decision that changed between
+        # node creation and run is honored. Only checks string-valued model
+        # selections; connected driver objects (BasePromptDriver) bypass this --
+        # they carry their own model identity that the node doesn't introspect.
+        if isinstance(model_input, str):
+            denial = self._fetch_runtime_denial(model_input)
+            if denial is not None:
+                msg = f"Cannot run {type(self).__name__}: '{model_input}' is not permitted. {denial.reason()}"
+                raise RuntimeError(msg)
+
         agent = None
 
         default_prompt_driver = GriptapeCloudPromptDriver(


### PR DESCRIPTION
Closes #367. Library half of [internal#50](https://github.com/griptape-ai/internal/issues/50). Pairs with engine PR [griptape-ai/griptape-nodes-engine#4959](https://github.com/griptape-ai/griptape-nodes-engine/pull/4959).

> **⚠️ Draft — do not merge until engine #4959 ships in a tagged release.**
>
> This PR imports `griptape_nodes.retained_mode.events.access_events` and friends from #4959. The library's `griptape-nodes-engine` dependency (in `pyproject.toml`) must be bumped to that release before `make check` will pass.

## Summary

Pilots two model-selection nodes with the engine's new `OFFER_MODEL` checkpoint:

- The dropdown **keeps every model in the list**. Denied entries get an inline `shield-off` icon + `"Not permitted by your license"` subtitle, so the artist sees that the model exists but isn't available — rather than wondering whether it was removed.
- Selecting a denied model shows an inline **error badge** on the `model` parameter with the policy's denial reason. Switching to an allowed model clears it.
- A small **refresh button** (list-restart icon) sits inside the dropdown row. Clicking it re-queries the engine, rebuilds the row decoration, and updates the badge — useful after a license / permission change.
- **Running the node with a denied selection raises `RuntimeError`** with the denial reason. `process()` (DescribeImage) / `_build_payload()` (TranscribeAudio) re-ask the engine rather than reading the init-time verdict, so a hook decision that flipped between creation and run is enforced.

### Drop-down with disallowed models:
<img width="672" height="366" alt="Screenshot 2026-06-26 at 3 50 29 PM" src="https://github.com/user-attachments/assets/72261c03-6819-40be-b012-9e2b2da1e111" />

### Badge when a disallowed model is selected:
<img width="806" height="189" alt="Screenshot 2026-06-26 at 3 50 41 PM" src="https://github.com/user-attachments/assets/ab93a09c-2b12-42a0-9459-669f608b818a" />


## Files

- `griptape_nodes_library.json` — adds a `model_usage` declaration to **DescribeImage** (15 catalog ids matching its dropdown). TranscribeAudio already declared `gtc_whisper_1`.
- `griptape_nodes_library/image/describe_image.py` + `audio/transcribe_audio.py` — wire up `QueryModelAccessForNodeRequest` at parameter init, build the `data` decoration list, install the inline `Button` trait alongside `Options`, set the badge in `after_value_set`, and gate the runtime path.

Both nodes use `type(self).__name__` for `node_type` so a class rename won't silently break the entitlement check.

## Out of scope (follow-ups)

- **Agent node** — held until [PR #4937](https://github.com/griptape-ai/griptape-nodes-engine/pull/4937) (now merged) and its sibling library PR settle. Same pattern will port over once the dust clears.
- **GriptapeCloudPrompt, per-provider prompt drivers, GenerateImage, etc.** — same pilot pattern, separate PR(s).
- **Sidebar gating** — engine-side follow-up; tracked alongside #4937.

## Reviewer testing (after engine #4959 ships)

Once the engine dep is bumped:

1. Register a deny stub via `GriptapeNodes.EventManager().add_authorization_hook(...)` that returns `CheckpointDenial` for one or two catalog ids (sample code in the engine PR description).
2. Drop a DescribeImage node onto the canvas. Open the model dropdown — denied entries show the `shield-off` icon and "Not permitted by your license".
3. Select a denied model. The parameter shows a red error badge with the denial reason.
4. Click the refresh button next to the dropdown — confirms it round-trips and rebuilds the decoration.
5. Run the node with a denied model selected — `RuntimeError` with the denial reason.
6. Drop a TranscribeAudio node — same behavior with its single `whisper-1` choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
