### PR TITLE
update: moves progress bar or status message in ForLoop/ForEach start nodes

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.80.2",
+    "library_version": "0.80.1",
     "engine_version": "0.87.0",
     "tags": [
       "Griptape",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.80.1",
+    "library_version": "0.80.2",
     "engine_version": "0.87.0",
     "tags": [
       "Griptape",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.79.0",
+    "library_version": "0.80.2",
     "engine_version": "0.87.0",
     "tags": [
       "Griptape",
@@ -885,12 +885,12 @@
     {
       "name": "SplatViewer",
       "path": "griptape_nodes_library/splat/widgets/SplatViewer.js",
-      "description": "Inline Gaussian splat viewer \u2014 auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
+      "description": "Inline Gaussian splat viewer — auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
     },
     {
       "name": "CropImageEditor",
       "path": "widgets/CropImageEditor/CropImageEditor.js",
-      "description": "Interactive crop editor \u2014 drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
+      "description": "Interactive crop editor — drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
     },
     {
       "name": "CropVideoEditor",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.80.1",
-    "engine_version": "0.87.0",
+    "engine_version": "0.89.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/execution/for_each_start.py
+++ b/griptape_nodes_library/execution/for_each_start.py
@@ -83,26 +83,43 @@ class ForEachStartNode(BaseIterativeStartNode):
         self.move_element_to_position("items", position="first")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        if parameter == self.run_in_order and self.end_node:
-            # Hide or show break/skip controls based on parallel mode
-            skip_param = self.end_node.skip_control
-            break_param = self.end_node.break_control
-            if value:
-                # Show controls when running sequentially
-                if skip_param:
-                    skip_param.ui_options["hide"] = False
-                if break_param:
-                    break_param.ui_options["hide"] = False
-            else:
-                # Hide controls when running in parallel (not supported)
-                if skip_param:
-                    skip_param.ui_options["hide"] = True
-                if break_param:
-                    break_param.ui_options["hide"] = True
+        if parameter == self.run_in_order:
+            if self.end_node:
+                # Hide or show break/skip controls based on parallel mode
+                skip_param = self.end_node.skip_control
+                break_param = self.end_node.break_control
+                if value:
+                    # Show controls when running sequentially
+                    if skip_param:
+                        skip_param.hide = False
+                    if break_param:
+                        break_param.hide = False
+                else:
+                    # Hide controls when running in parallel (not supported)
+                    if skip_param:
+                        skip_param.hide = True
+                    if break_param:
+                        break_param.hide = True
+
+            # Progress indicators are only meaningful in sequential mode
+            status_message = self.get_parameter_by_name("status_message")
+            if status_message:
+                status_message.hide = not value
+            progress_bar = self.get_parameter_by_name("progress")
+            if progress_bar:
+                progress_bar.hide = not value
 
         if parameter == self.testing_mode:
             self.test_item_index.hide = not value
             self.run_in_order.hide = value
+            # Progress is hidden if testing OR if running in parallel
+            hide_progress = value or not self.get_parameter_value("run_in_order")
+            status_message = self.get_parameter_by_name("status_message")
+            if status_message:
+                status_message.hide = hide_progress
+            progress_bar = self.get_parameter_by_name("progress")
+            if progress_bar:
+                progress_bar.hide = hide_progress
 
     @classmethod
     def _get_compatible_end_classes(cls) -> set[type]:

--- a/griptape_nodes_library/execution/for_each_start.py
+++ b/griptape_nodes_library/execution/for_each_start.py
@@ -6,6 +6,8 @@ from griptape_nodes.exe_types.core_types import (
     ParameterMode,
     ParameterTypeBuiltin,
 )
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 
 
 class ForEachStartNode(BaseIterativeStartNode):
@@ -32,15 +34,35 @@ class ForEachStartNode(BaseIterativeStartNode):
         self.add_parameter(self.items_list)
 
         # Add parallel execution control parameter
-        self.run_in_order = Parameter(
+        self.run_in_order = ParameterBool(
             name="run_in_order",
             tooltip="Execute all iterations in order or concurrently",
-            type=ParameterTypeBuiltin.BOOL.value,
             allowed_modes={ParameterMode.PROPERTY},
             default_value=True,
-            ui_options={"display_name": "Run in Order"},
+            display_name="Run in Order",
         )
         self.add_parameter(self.run_in_order)
+
+        # Testing mode — run the loop body for a single chosen item
+        self.testing_mode = ParameterBool(
+            name="testing_mode",
+            tooltip="When enabled, run only one iteration using the item at the chosen index",
+            allowed_modes={ParameterMode.PROPERTY},
+            default_value=False,
+            display_name="Testing Mode",
+        )
+        self.add_parameter(self.testing_mode)
+
+        self.test_item_index = ParameterInt(
+            name="test_item_index",
+            tooltip="Index of the item to test (0-based). Clamped to the valid range at runtime.",
+            allowed_modes={ParameterMode.PROPERTY},
+            default_value=0,
+            min_val=0,
+            display_name="Test Item Index",
+            hide=True,
+        )
+        self.add_parameter(self.test_item_index)
 
         # Add current_item parameter specific to ForEach
         self.current_item = Parameter(
@@ -56,6 +78,8 @@ class ForEachStartNode(BaseIterativeStartNode):
             group.add_child(self.current_item)
 
         self.move_element_to_position("run_in_order", position="first")
+        self.move_element_to_position("test_item_index", position="first")
+        self.move_element_to_position("testing_mode", position="first")
         self.move_element_to_position("items", position="first")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
@@ -76,10 +100,14 @@ class ForEachStartNode(BaseIterativeStartNode):
                 if break_param:
                     break_param.ui_options["hide"] = True
 
+        if parameter == self.testing_mode:
+            self.test_item_index.hide = not value
+            self.run_in_order.hide = value
+
     @classmethod
     def _get_compatible_end_classes(cls) -> set[type]:
         """Return the set of End node classes that this Start node can connect to."""
-        from griptape_nodes_library.execution.for_each_end import ForEachEndNode
+        from griptape_nodes_library.execution.for_each_end import ForEachEndNode  # avoid circular import
 
         return {ForEachEndNode}
 
@@ -99,34 +127,36 @@ class ForEachStartNode(BaseIterativeStartNode):
         """Get the list of items to iterate over.
 
         Accepts either a list or dict. If dict, converts to list of {"key": k, "value": v} dicts.
+        In testing mode, returns only the single item at test_item_index.
         """
         items = self.get_parameter_value("items")
 
-        # Handle case where items parameter is not connected or has no value
         if items is None:
             self._logger.info("ForEach Start '%s': No items provided, skipping loop execution", self.name)
             return []
 
-        # Handle dict input - convert to list of {"key": k, "value": v} dicts
         if isinstance(items, dict):
             if len(items) == 0:
                 self._logger.info("ForEach Start '%s': Empty dictionary provided, skipping loop execution", self.name)
                 return []
-            return [{"key": k, "value": v} for k, v in items.items()]
-
-        # Handle list input
-        if isinstance(items, list):
+            all_items = [{"key": k, "value": v} for k, v in items.items()]
+        elif isinstance(items, list):
             if len(items) == 0:
                 self._logger.info("ForEach Start '%s': Empty list provided, skipping loop execution", self.name)
-            return items
+            all_items = items
+        else:
+            error_msg = f"ForEach Start '{self.name}' expected a list or dict but got {type(items).__name__}: {items}"
+            raise TypeError(error_msg)
 
-        # Invalid type
-        error_msg = f"ForEach Start '{self.name}' expected a list or dict but got {type(items).__name__}: {items}"
-        raise TypeError(error_msg)
+        if self.get_parameter_value("testing_mode") and all_items:
+            index = self.get_parameter_value("test_item_index") or 0
+            index = max(0, min(index, len(all_items) - 1))
+            return [all_items[index]]
+
+        return all_items
 
     def _initialize_iteration_data(self) -> None:
         """Initialize iteration-specific data and state."""
-        # Get the items list for ForEach
         self._items = self._get_iteration_items()
 
     def is_loop_finished(self) -> bool:
@@ -155,7 +185,6 @@ class ForEachStartNode(BaseIterativeStartNode):
         """Get the current iteration value."""
         if self._items and self._current_iteration_count < len(self._items):
             current_item_value = self._items[self._current_iteration_count]
-            # Set the current_item output parameter
             self.parameter_output_values["current_item"] = current_item_value
             self.publish_update_to_parameter("current_item", current_item_value)
             return current_item_value

--- a/griptape_nodes_library/execution/for_each_start.py
+++ b/griptape_nodes_library/execution/for_each_start.py
@@ -55,6 +55,9 @@ class ForEachStartNode(BaseIterativeStartNode):
         if group:
             group.add_child(self.current_item)
 
+        self.move_element_to_position("run_in_order", position="first")
+        self.move_element_to_position("items", position="first")
+
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter == self.run_in_order and self.end_node:
             # Hide or show break/skip controls based on parallel mode

--- a/griptape_nodes_library/execution/for_loop_start.py
+++ b/griptape_nodes_library/execution/for_loop_start.py
@@ -77,7 +77,13 @@ class ForLoopStartNode(BaseIterativeStartNode):
         self.move_element_to_position("For Loop", position="last")
 
         # Move the status message to the very bottom
-        self.move_element_to_position("status_message", position="last")
+        status_message = self.get_parameter_by_name("status_message")
+        if status_message:
+            self.move_element_to_position("status_message", position="last")
+
+        progress_bar = self.get_parameter_by_name("progress")
+        if progress_bar:
+            self.move_element_to_position("progress", position="last")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter == self.run_in_order and self.end_node:

--- a/griptape_nodes_library/execution/for_loop_start.py
+++ b/griptape_nodes_library/execution/for_loop_start.py
@@ -86,23 +86,32 @@ class ForLoopStartNode(BaseIterativeStartNode):
             self.move_element_to_position("progress", position="last")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        if parameter == self.run_in_order and self.end_node:
-            # Hide or show break/skip controls based on parallel mode
-            skip_param = self.end_node.get_parameter_by_name("skip_iteration")
-            break_param = self.end_node.get_parameter_by_name("break_loop")
+        if parameter == self.run_in_order:
+            if self.end_node:
+                # Hide or show break/skip controls based on parallel mode
+                skip_param = self.end_node.get_parameter_by_name("skip_iteration")
+                break_param = self.end_node.get_parameter_by_name("break_loop")
 
-            if value:
-                # Show controls when running sequentially
-                if skip_param:
-                    skip_param.allowed_modes = {ParameterMode.INPUT}
-                if break_param:
-                    break_param.allowed_modes = {ParameterMode.INPUT}
-            else:
-                # Hide controls when running in parallel (not supported)
-                if skip_param:
-                    skip_param.allowed_modes = set()
-                if break_param:
-                    break_param.allowed_modes = set()
+                if value:
+                    # Show controls when running sequentially
+                    if skip_param:
+                        skip_param.allowed_modes = {ParameterMode.INPUT}
+                    if break_param:
+                        break_param.allowed_modes = {ParameterMode.INPUT}
+                else:
+                    # Hide controls when running in parallel (not supported)
+                    if skip_param:
+                        skip_param.allowed_modes = set()
+                    if break_param:
+                        break_param.allowed_modes = set()
+
+            # Progress indicators are only meaningful in sequential mode
+            status_message = self.get_parameter_by_name("status_message")
+            if status_message:
+                status_message.hide = not value
+            progress_bar = self.get_parameter_by_name("progress")
+            if progress_bar:
+                progress_bar.hide = not value
 
     @classmethod
     def _get_compatible_end_classes(cls) -> set[type]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-library-standard"
-version = "0.80.2"
+version = "0.80.1"
 description = "Default nodes for Griptape Nodes"
 authors = [{ name = "Griptape, Inc" }]
 requires-python = ">=3.12,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-library-standard"
-version = "0.80.1"
+version = "0.80.2"
 description = "Default nodes for Griptape Nodes"
 authors = [{ name = "Griptape, Inc" }]
 requires-python = ">=3.12,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.88.0",
+  "griptape-nodes-engine>=0.89.0",
   "lxml>=5.0.0",
 ]
 


### PR DESCRIPTION
fixes: https://github.com/griptape-ai/griptape-nodes-engine/issues/4966
fixes: https://github.com/griptape-ai/griptape-nodes-engine/issues/4971

<img width="657" height="721" alt="image" src="https://github.com/user-attachments/assets/38dce2d6-3f7c-4ccd-9514-a98f031d23da" />

## Summary

- `ForLoopStartNode`: makes bottom-positioning of the status/progress element forward-compatible — checks for `status_message` first (current framework), then `progress` (once the base framework switches to `ProgressBarComponent`), moving whichever exists to the bottom
- `ForEachStartNode`: reorders `items` and `run_in_order` to appear at the top for better UX

- Adds the ability to "test" running the loop by enabling Test mode for the ForEach Start node

## Context

The base `griptape_nodes` framework is getting a separate change to replace the `ParameterMessage` status text in `BaseIterativeStartNode` with a `ProgressBarComponent`. This PR prepares the library-side nodes to work correctly with both the old and new framework versions during the transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)