### PR TITLE
feature: Add Random Number node (#373)

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -4989,6 +4989,24 @@
       }
     },
     {
+      "class_name": "RandomNumber",
+      "file_path": "griptape_nodes_library/number/random_number.py",
+      "metadata": {
+        "category": "number",
+        "description": "Generate a random integer or float within a given range, with an optional seed for reproducibility.",
+        "display_name": "Random Number",
+        "icon": "dices",
+        "group": "create",
+        "tags": [
+          "number",
+          "random",
+          "integer",
+          "float",
+          "generate"
+        ]
+      }
+    },
+    {
       "class_name": "Ruleset",
       "file_path": "griptape_nodes_library/rules/create_ruleset.py",
       "metadata": {

--- a/griptape_nodes_library/number/random_number.py
+++ b/griptape_nodes_library/number/random_number.py
@@ -1,0 +1,83 @@
+import random
+from enum import StrEnum
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import ControlNode
+from griptape_nodes.exe_types.param_components.seed_parameter import SeedParameter
+from griptape_nodes.traits.options import Options
+
+
+class NumberMode(StrEnum):
+    INTEGER = "integer"
+    FLOAT = "float"
+
+
+class RandomNumber(ControlNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                tooltip="Generate a whole integer or a decimal float.",
+                type="str",
+                default_value="integer",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=list(NumberMode))},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="minimum",
+                tooltip="Minimum value (inclusive).",
+                input_types=["int", "float"],
+                default_value=0,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="maximum",
+                tooltip="Maximum value (inclusive for integers, exclusive for floats).",
+                input_types=["int", "float"],
+                default_value=100,
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+
+        self._seed_parameter = SeedParameter(self)
+        self._seed_parameter.add_input_parameters()
+
+        self.add_parameter(
+            Parameter(
+                name="result",
+                tooltip="The generated random number.",
+                output_type="float",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=0,
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        self._seed_parameter.after_value_set(parameter, value)
+        return super().after_value_set(parameter, value)
+
+    async def aprocess(self) -> None:
+        self._seed_parameter.preprocess()
+
+        mode = self.get_parameter_value("mode") or NumberMode.INTEGER
+        minimum = self.get_parameter_value("minimum") or 0
+        maximum = self.get_parameter_value("maximum") or 100
+        seed = self._seed_parameter.get_seed()
+
+        rng = random.Random(seed)
+
+        match mode:
+            case NumberMode.INTEGER:
+                self.parameter_output_values["result"] = rng.randint(int(minimum), int(maximum))
+            case NumberMode.FLOAT:
+                self.parameter_output_values["result"] = rng.uniform(float(minimum), float(maximum))
+            case _:
+                msg = f"Unknown mode: {mode!r}"
+                raise ValueError(msg)


### PR DESCRIPTION
## Summary

- Adds a new `RandomNumber` node to `griptape_nodes_library/number/`
- Registered in `griptape_nodes_library.json` under the `number` category, `create` group

## Details

The node exposes:
- **mode** — dropdown to select `integer` or `float` output
- **minimum / maximum** — range inputs (default 0–100), accept `int` or `float`
- **randomize_seed** — when enabled, generates a fresh seed each run
- **seed** — fixed seed (default 42) for reproducible results; field becomes read-only when `randomize_seed` is on
- **result** — the generated random number

Uses `SeedParameter` for the seed/randomize pattern (same as image/video generation nodes) and `async def aprocess` so `preprocess()` is called at execution time to apply the randomized seed before generating the number.

Closes #373

## Test plan

- [ ] Add node to a workflow; run it — result appears in the `result` output
- [ ] Set `mode = integer`, verify result is a whole number in [minimum, maximum]
- [ ] Set `mode = float`, verify result is a decimal in [minimum, maximum)
- [ ] Set a fixed seed, run multiple times — same result each time
- [ ] Enable `randomize_seed`, run multiple times — different results each run; seed field becomes read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)