### PR TITLE
Add support for Seedance 2.0 mini

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -372,6 +372,12 @@
                 "provider_model_id": "dreamina-seedance-2-0-fast-260128",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               },
+              "gtc_seedance_2_0_mini": {
+                "display_name": "Seedance 2.0 Mini",
+                "family": "Seedance",
+                "provider_model_id": "dreamina-seedance-2-0-mini-260615",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
               "gtc_omnihuman_1_0": {
                 "display_name": "OmniHuman 1.0",
                 "family": "OmniHuman",
@@ -2086,7 +2092,8 @@
             "type": "model_usage",
             "model_ids": [
               "gtc_seedance_2_0",
-              "gtc_seedance_2_0_fast"
+              "gtc_seedance_2_0_fast",
+              "gtc_seedance_2_0_mini"
             ]
           }
         ]

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -4,6 +4,7 @@ import asyncio
 import json as _json
 import logging
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any, ClassVar
 from urllib.parse import urljoin
 from uuid import uuid4
@@ -49,11 +50,61 @@ INPUT_MODE_FIRST_LAST_FRAME = "First/Last Frame"
 INPUT_MODE_MULTIMODAL_REFERENCES = "Multimodal References"
 MODEL_NAME_SEEDANCE_2_0 = "Seedance 2.0"
 MODEL_NAME_SEEDANCE_2_0_FAST = "Seedance 2.0 Fast"
+MODEL_NAME_SEEDANCE_2_0_MINI = "Seedance 2.0 Mini"
 SEEDANCE_2_0_MODEL_ID = "dreamina-seedance-2-0-260128"
 SEEDANCE_2_0_FAST_MODEL_ID = "dreamina-seedance-2-0-fast-260128"
+SEEDANCE_2_0_MINI_MODEL_ID = "dreamina-seedance-2-0-mini-260615"
 
-# Provider-asset (private asset) registration via the GTC proxy. Only the Seedance 2.0 model
-# supports private-asset references; Seedance 2.0 Fast does not.
+
+@dataclass(frozen=True)
+class SeedanceModelCapabilities:
+    """Capabilities supported by a Seedance 2.0 model variant, per the BytePlus model docs.
+
+    All three variants share the same feature set; they differ only in the output resolutions
+    they support (Fast and Mini top out at 720p, standard 2.0 adds 1080p and 4k).
+    """
+
+    resolutions: tuple[str, ...]
+    supports_last_frame: bool
+    supports_private_assets: bool
+
+
+# Single source of truth for per-model capabilities, keyed by provider model id. Adding a new
+# variant is one row here. Values come straight from the BytePlus Seedance 2.0 capability matrix.
+SEEDANCE_MODEL_CAPABILITIES: dict[str, SeedanceModelCapabilities] = {
+    SEEDANCE_2_0_MODEL_ID: SeedanceModelCapabilities(
+        resolutions=("480p", "720p", "1080p", "4k"),
+        supports_last_frame=True,
+        supports_private_assets=True,
+    ),
+    SEEDANCE_2_0_FAST_MODEL_ID: SeedanceModelCapabilities(
+        resolutions=("480p", "720p"),
+        supports_last_frame=True,
+        supports_private_assets=True,
+    ),
+    SEEDANCE_2_0_MINI_MODEL_ID: SeedanceModelCapabilities(
+        resolutions=("480p", "720p"),
+        supports_last_frame=True,
+        supports_private_assets=True,
+    ),
+}
+
+# Capabilities used for an unrecognized model id: most permissive resolution-wise so we don't
+# wrongly hide options, but features that depend on backend wiring stay off until declared.
+_DEFAULT_MODEL_CAPABILITIES = SeedanceModelCapabilities(
+    resolutions=("480p", "720p"),
+    supports_last_frame=True,
+    supports_private_assets=False,
+)
+
+
+def _get_model_capabilities(model_id: str) -> SeedanceModelCapabilities:
+    """Return the capability record for a provider model id, defaulting safely if unknown."""
+    return SEEDANCE_MODEL_CAPABILITIES.get(model_id, _DEFAULT_MODEL_CAPABILITIES)
+
+
+# Provider-asset (private asset) registration via the GTC proxy. Supported by all Seedance 2.0
+# variants (see SEEDANCE_MODEL_CAPABILITIES), gated to Griptape auth (not BYOK).
 ASSET_PROVIDER = "byteplus_ark"
 ASSET_POLL_INTERVAL = 3  # seconds
 ASSET_MAX_ATTEMPTS = 60  # ~3 min cap, independent of the generation timeout
@@ -63,9 +114,44 @@ ASSET_STATUS_DELETED = "DELETED"
 # Skip provider-side moderation on private-asset ingestion (content is already moderated upstream).
 ASSET_MODERATION = {"Strategy": "Skip"}
 
+# Seedance only accepts audio data URIs whose subtype is exactly `wav` or `mp3` (per the BytePlus
+# docs). The local File/mimetypes layer emits other subtypes for the same formats (e.g. an .mp3
+# resolves to `audio/mpeg`, a .wav to `audio/x-wav`), which Seedance rejects as
+# "Invalid base64 audio_url". Map those aliases back to the accepted subtypes before sending.
+SEEDANCE_AUDIO_SUBTYPE_ALIASES = {
+    "mpeg": "mp3",
+    "mp3": "mp3",
+    "x-wav": "wav",
+    "wave": "wav",
+    "vnd.wave": "wav",
+    "wav": "wav",
+}
+
+
+def _normalize_audio_data_uri_subtype(data_uri: str) -> str:
+    """Rewrite an ``data:audio/<subtype>;base64,...`` URI to a Seedance-accepted subtype.
+
+    Returns the URI unchanged if it is not an audio data URI or the subtype has no known alias.
+    """
+    prefix = "data:audio/"
+    if not data_uri.startswith(prefix):
+        return data_uri
+    remainder = data_uri[len(prefix) :]
+    subtype, separator, rest = remainder.partition(";")
+    if not separator:
+        return data_uri
+    normalized_subtype = SEEDANCE_AUDIO_SUBTYPE_ALIASES.get(subtype.lower())
+    if normalized_subtype is None or normalized_subtype == subtype:
+        return data_uri
+    return f"{prefix}{normalized_subtype};{rest}"
+
 
 class Seedance20VideoGeneration(GriptapeProxyNode):
     """Generate a video using Seedance 2.0 models via Griptape Cloud model proxy.
+
+    Supports the Seedance 2.0, Seedance 2.0 Fast, and Seedance 2.0 Mini models. All three share
+    the same feature set; they differ in output resolution: standard 2.0 supports up to 4k, while
+    Fast and Mini top out at 720p.
 
     Supports three input modes:
     - Text Only: Pure text-to-video generation (default)
@@ -80,7 +166,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         - ratio (str): Output aspect ratio (default: adaptive)
         - duration (int): Video duration in seconds (default: 5, range: 4-15 or -1 for smart)
         - generate_audio (bool): Generate audio with video (default: False)
-        - first_frame/last_frame: Optional frame images (First/Last Frame mode only, last_frame requires Seedance 2.0)
+        - first_frame/last_frame: Optional frame images (First/Last Frame mode only)
         - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal mode only)
 
     Outputs:
@@ -93,6 +179,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
     MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
         MODEL_NAME_SEEDANCE_2_0_FAST: SEEDANCE_2_0_FAST_MODEL_ID,
+        MODEL_NAME_SEEDANCE_2_0_MINI: SEEDANCE_2_0_MINI_MODEL_ID,
         MODEL_NAME_SEEDANCE_2_0: SEEDANCE_2_0_MODEL_ID,
     }
 
@@ -114,7 +201,15 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 ui_options={"display_name": "Model", "hide": False},
-                traits={Options(choices=[MODEL_NAME_SEEDANCE_2_0, MODEL_NAME_SEEDANCE_2_0_FAST])},
+                traits={
+                    Options(
+                        choices=[
+                            MODEL_NAME_SEEDANCE_2_0,
+                            MODEL_NAME_SEEDANCE_2_0_FAST,
+                            MODEL_NAME_SEEDANCE_2_0_MINI,
+                        ]
+                    )
+                },
             )
         )
 
@@ -162,7 +257,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             ParameterImage(
                 name="last_frame",
                 default_value=None,
-                tooltip="Optional last frame image (Seedance 2.0 only)",
+                tooltip="Optional last frame image",
                 allowed_modes={ParameterMode.INPUT},
                 hide_property=True,
                 ui_options={"display_name": "Last Frame"},
@@ -175,7 +270,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 name="reference_images",
                 input_types=["ImageUrlArtifact", "ImageArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_IMAGE]],
                 default_value=[],
-                tooltip="Optional reference images (0-9 images). Connect a Seedance Human Reference Asset to register an image as a private asset (Seedance 2.0 only).",
+                tooltip="Optional reference images (0-9 images). Connect a Seedance Human Reference Asset to register an image as a private asset.",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Images", "expander": True, "hide_property": True},
                 max_items=9,
@@ -248,7 +343,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 name="reference_audio",
                 input_types=["AudioArtifact", "AudioUrlArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_AUDIO]],
                 default_value=[],
-                tooltip="Optional reference audio (0-3 audio files, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported. Connect a Seedance Human Reference Asset to register audio as a private asset (Seedance 2.0 only).",
+                tooltip="Optional reference audio (0-3 audio files, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported. Connect a Seedance Human Reference Asset to register audio as a private asset.",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Audio", "expander": True, "hide_property": True},
                 max_items=3,
@@ -435,11 +530,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         if resolution_param is None:
             return
 
-        available_resolutions = ["480p", "720p"]
-        if self._supports_1080p(model_id):
-            available_resolutions.append("1080p")
-        if self._supports_4k(model_id):
-            available_resolutions.append("4k")
+        available_resolutions = list(_get_model_capabilities(model_id).resolutions)
 
         existing_traits = resolution_param.find_elements_by_type(Options)
         if existing_traits:
@@ -571,8 +662,8 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
             if params.get("last_frame") and not self._supports_last_frame(params["model_id"]):
                 msg = (
-                    f"{self.name}: Seedance 2.0 Fast does not support last_frame. "
-                    "Use first_frame only, or switch to Seedance 2.0 for first+last frame generation."
+                    f"{self.name}: the selected model does not support a last frame. "
+                    "Use first_frame only, or switch to a model that supports first+last frame generation."
                 )
                 raise ValueError(msg)
 
@@ -618,23 +709,25 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             msg = f"{self.name}: Seedance 2.0 supports duration between 4-15 seconds or -1 for smart selection, got {duration}."
             raise ValueError(msg)
 
-        # 1080p is only supported on Seedance 2.0 (not Fast)
+        # 1080p is only supported on Seedance 2.0 (not Fast or Mini)
         if params.get("resolution") == "1080p" and not self._supports_1080p(params["model_id"]):
+            supported = ", ".join(_get_model_capabilities(params["model_id"]).resolutions)
             msg = (
-                f"{self.name}: Seedance 2.0 Fast does not support 1080p resolution. "
-                "Use 480p or 720p, or switch to Seedance 2.0 for 1080p generation."
+                f"{self.name}: the selected model does not support 1080p resolution "
+                f"(supported: {supported}). Use a supported resolution, or switch to Seedance 2.0 for 1080p generation."
             )
             raise ValueError(msg)
 
-        # 4k is only supported on Seedance 2.0 (not Fast)
+        # 4k is only supported on Seedance 2.0 (not Fast or Mini)
         if params.get("resolution") == "4k" and not self._supports_4k(params["model_id"]):
+            supported = ", ".join(_get_model_capabilities(params["model_id"]).resolutions)
             msg = (
-                f"{self.name}: Seedance 2.0 Fast does not support 4k resolution. "
-                "Use 480p or 720p, or switch to Seedance 2.0 for 4k generation."
+                f"{self.name}: the selected model does not support 4k resolution "
+                f"(supported: {supported}). Use a supported resolution, or switch to Seedance 2.0 for 4k generation."
             )
             raise ValueError(msg)
 
-        # Private-asset references require Seedance 2.0 and Griptape auth (not Fast, not BYOK).
+        # Private-asset references require a model that supports them and Griptape auth (not BYOK).
         # Gate first so the user gets a specific message before the per-kind check.
         self._validate_private_asset_model(params)
         self._validate_private_asset_auth(params)
@@ -664,8 +757,8 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         for value, _ in self._iter_reference_asset_checks(params):
             if is_provider_asset_reference(value):
                 msg = (
-                    f"{self.name}: Seedance 2.0 Fast does not support private-asset references "
-                    "(Seedance Human Reference Asset). Switch the model to Seedance 2.0, or remove the "
+                    f"{self.name}: the selected model does not support private-asset references "
+                    "(Seedance Human Reference Asset). Switch to a model that supports them, or remove the "
                     "private-asset reference inputs."
                 )
                 raise ValueError(msg)
@@ -828,7 +921,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             # Text Only mode: no media inputs
             self._log(f"{self.name} text-only mode, no media inputs")
 
-    # --- Provider private-asset registration (Seedance 2.0 only) ----------------------------
+    # --- Provider private-asset registration (Seedance 2.0 variants, Griptape auth only) -----
 
     def _proxy_headers(self) -> dict[str, str]:
         """Bearer headers for the GTC proxy (same auth as the generation requests)."""
@@ -1024,12 +1117,12 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
         if audio_url.startswith(("data:audio/", "http://", "https://", "asset://")):
             self._log(f"{self.name} {audio_label} prepared as direct audio URL/data URI")
-            return audio_url
+            return _normalize_audio_data_uri_subtype(audio_url)
 
         try:
             data_uri = await File(audio_url).aread_data_uri(fallback_mime="audio/wav")
             self._log(f"{self.name} {audio_label} loaded from file into data URI")
-            return data_uri
+            return _normalize_audio_data_uri_subtype(data_uri)
         except FileLoadError as e:
             self._log(f"{self.name} {audio_label} failed to load from {audio_url}: {e}")
             return None
@@ -1205,20 +1298,20 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
     @staticmethod
     def _supports_last_frame(model_id: str) -> bool:
-        return model_id == SEEDANCE_2_0_MODEL_ID
+        return _get_model_capabilities(model_id).supports_last_frame
 
     @staticmethod
     def _supports_1080p(model_id: str) -> bool:
-        return model_id == SEEDANCE_2_0_MODEL_ID
+        return "1080p" in _get_model_capabilities(model_id).resolutions
 
     @staticmethod
     def _supports_4k(model_id: str) -> bool:
-        return model_id == SEEDANCE_2_0_MODEL_ID
+        return "4k" in _get_model_capabilities(model_id).resolutions
 
     @staticmethod
     def _supports_private_assets(model_id: str) -> bool:
-        """Private-asset references are supported by Seedance 2.0 only (not 2.0 Fast)."""
-        return model_id == SEEDANCE_2_0_MODEL_ID
+        """Whether private-asset references (Seedance Human Reference Asset) are supported."""
+        return _get_model_capabilities(model_id).supports_private_assets
 
     def _is_byok_enabled(self) -> bool:
         """Whether the node is configured to use the customer's own key (BYOK) instead of Griptape auth."""
@@ -1227,9 +1320,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
     def _private_assets_active(self, model_id: str) -> bool:
         """Whether private-asset registration applies for this run.
 
-        Requires the Seedance 2.0 model AND Griptape auth: provider assets are registered through
-        the Griptape Cloud proxy on the org's behalf, which does not apply when the user brings
-        their own provider key (BYOK).
+        Requires a model that supports private assets AND Griptape auth: provider assets are
+        registered through the Griptape Cloud proxy on the org's behalf, which does not apply when
+        the user brings their own provider key (BYOK).
         """
         return self._supports_private_assets(model_id) and not self._is_byok_enabled()
 

--- a/tests/integration/SEEDANCE_TESTING.md
+++ b/tests/integration/SEEDANCE_TESTING.md
@@ -7,7 +7,7 @@ This directory contains integration tests for the Seedance video generation node
 1. **Local Griptape Cloud proxy running** at `http://localhost:8000`
 2. **ServiceModelConfig and ServiceModelConfigAuthDetails** configured in the local database:
    - Provider: BYTEPLUS_ARK
-   - Model IDs: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`
+   - Model IDs: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`
    - API key configured
 
 ## Test Files
@@ -73,24 +73,37 @@ python tests/integration/test_seedance_2_0_features.py --storage-backend gtc --t
 
 ### Seedance 2.0 Fast
 - ✓ Text-to-video generation
-- ✓ 480p/720p resolution
+- ✓ 480p/720p resolution (no 1080p/4k)
+- ✓ First/last frame image-to-video
+- ✓ Multimodal references (images/videos/audio)
+- ✓ Private-asset (Human Reference Asset) references
 - ✓ Duration 4-15 seconds
 - ✓ Smart duration (-1)
 - ✓ Audio generation
 - ✓ Faster inference
 
+### Seedance 2.0 Mini
+- ✓ Text-to-video generation
+- ✓ 480p/720p resolution (no 1080p/4k)
+- ✓ First/last frame image-to-video
+- ✓ Multimodal references (images/videos/audio)
+- ✓ Private-asset (Human Reference Asset) references
+- ✓ Duration 4-15 seconds
+- ✓ Smart duration (-1)
+- ✓ Audio generation
+- ✓ Best cost performance
+
 ### Feature Validation
 - ✓ Parameter visibility based on model selection
-- ✓ 2.0 models hide `camera_fixed` parameter
 - ✓ 2.0 models show video/audio inputs
-- ✓ Duration range validation (4-15 or -1 for 2.0)
-- ✓ Resolution validation (no 1080p for 2.0)
+- ✓ Duration range validation (4-15 or -1)
+- ✓ Resolution validation (1080p/4k are Seedance 2.0 standard only; Fast/Mini cap at 720p)
+- ✓ First/last frame supported on all three variants
 
 ### Future Tests (TODO)
 - [ ] Reference images (multimodal, 0-9 images)
 - [ ] Reference videos (0-3 videos)
 - [ ] Reference audio (0-3 audio files)
-- [ ] First/last frame image-to-video
 - [ ] Validation: multimodal refs cannot mix with first/last frame
 - [ ] Validation: audio requires image/video
 

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from griptape.artifacts import ImageUrlArtifact
+from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterList, ParameterMode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
@@ -20,8 +21,11 @@ from griptape_nodes_library.assets import (
 )
 from griptape_nodes_library.video.seedance_2_0_video_generation import (
     SEEDANCE_2_0_FAST_MODEL_ID,
+    SEEDANCE_2_0_MINI_MODEL_ID,
     SEEDANCE_2_0_MODEL_ID,
+    SEEDANCE_MODEL_CAPABILITIES,
     Seedance20VideoGeneration,
+    _normalize_audio_data_uri_subtype,
 )
 
 
@@ -87,13 +91,21 @@ async def test_build_payload_normalizes_local_frame_paths(monkeypatch: pytest.Mo
     assert all(str(last_frame) not in item["image_url"]["url"] for item in frame_entries)
 
 
-def test_seedance_2_fast_rejects_last_frame() -> None:
+@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
+def test_all_models_support_last_frame(model_id: str) -> None:
+    # Per the BytePlus capability matrix, first+last frame i2v is supported by all three variants.
+    assert Seedance20VideoGeneration._supports_last_frame(model_id) is True
+
+
+@pytest.mark.parametrize("model_name", ["Seedance 2.0 Fast", "Seedance 2.0 Mini"])
+def test_fast_and_mini_accept_last_frame(model_name: str) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
-    node.set_parameter_value("model_id", "Seedance 2.0 Fast")
+    node.set_parameter_value("model_id", model_name)
+    node.set_parameter_value("input_mode", "First/Last Frame")
     node.set_parameter_value("last_frame", "data:image/png;base64,AAA")
 
-    with pytest.raises(ValueError, match="does not support last_frame"):
-        node._validate_parameters(node._get_parameters())
+    # Should validate without raising now that Fast/Mini support last_frame.
+    node._validate_parameters(node._get_parameters())
 
 
 def test_multimodal_mode_rejects_first_last_frame_inputs() -> None:
@@ -235,6 +247,48 @@ async def test_build_payload_includes_multimodal_video_url_and_audio_base64() ->
     ]
 
 
+@pytest.mark.parametrize(
+    ("data_uri", "expected"),
+    [
+        # mimetypes resolves .mp3 -> audio/mpeg and .wav -> audio/x-wav; Seedance only accepts
+        # audio/mp3 and audio/wav, so these aliases must be rewritten.
+        ("data:audio/mpeg;base64,AAA", "data:audio/mp3;base64,AAA"),
+        ("data:audio/x-wav;base64,BBB", "data:audio/wav;base64,BBB"),
+        # Already-accepted subtypes pass through unchanged.
+        ("data:audio/mp3;base64,CCC", "data:audio/mp3;base64,CCC"),
+        ("data:audio/wav;base64,DDD", "data:audio/wav;base64,DDD"),
+        # Non-audio data URIs and plain URLs are left alone.
+        ("data:image/png;base64,EEE", "data:image/png;base64,EEE"),
+        ("https://public.example/clip.mp3", "https://public.example/clip.mp3"),
+    ],
+)
+def test_normalize_audio_data_uri_subtype(data_uri: str, expected: str) -> None:
+    assert _normalize_audio_data_uri_subtype(data_uri) == expected
+
+
+@pytest.mark.asyncio
+async def test_build_payload_rewrites_mp3_audio_subtype_to_seedance_accepted(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    # A connected mp3 file (e.g. ElevenLabs Music output) loads to a data:audio/mpeg URI; the node
+    # must rewrite it to data:audio/mp3 so Seedance does not reject it as "Invalid base64 audio_url".
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0 Mini")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("prompt", "Use the backing track")
+    node.set_parameter_value("reference_video_1", VideoUrlArtifact("https://public.example/reference.mp4"))
+
+    music = tmp_path / "music.mp3"
+    music.write_bytes(b"ID3fakeaudio")
+    _set_parameter_list_values(node, "reference_audio", [AudioUrlArtifact(str(music))])
+
+    payload = await node._build_payload()
+    audio_entries = [item for item in payload["content"] if item["type"] == "audio_url"]
+
+    assert len(audio_entries) == 1
+    assert audio_entries[0]["audio_url"]["url"].startswith("data:audio/mp3;base64,")
+
+
 @pytest.mark.asyncio
 async def test_build_payload_rejects_local_reference_video_path(tmp_path) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
@@ -283,9 +337,11 @@ async def test_build_payload_uses_public_artifact_url_parameter_for_reference_vi
 # --- Private-asset reference gating (Seedance 2.0 only) -------------------------------------
 
 
-def test_supports_private_assets_only_for_seedance_2_0() -> None:
-    assert Seedance20VideoGeneration._supports_private_assets(SEEDANCE_2_0_MODEL_ID) is True
-    assert Seedance20VideoGeneration._supports_private_assets(SEEDANCE_2_0_FAST_MODEL_ID) is False
+@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
+def test_all_models_support_private_assets(model_id: str) -> None:
+    # The GTC backend links provider assets for all Seedance 2.0 variant ids, so the node allows
+    # private-asset references on all three.
+    assert Seedance20VideoGeneration._supports_private_assets(model_id) is True
 
 
 # --- 4k resolution gating (Seedance 2.0 only) ----------------------------------------------
@@ -294,6 +350,23 @@ def test_supports_private_assets_only_for_seedance_2_0() -> None:
 def test_supports_4k_only_for_seedance_2_0() -> None:
     assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_MODEL_ID) is True
     assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_FAST_MODEL_ID) is False
+    assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_MINI_MODEL_ID) is False
+
+
+def test_capability_table_matches_documented_matrix() -> None:
+    # Regression guard on the single source of truth: values mirror the BytePlus capability matrix.
+    # All three variants support last_frame and private assets; only resolution ceiling differs.
+    standard = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MODEL_ID]
+    fast = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_FAST_MODEL_ID]
+    mini = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MINI_MODEL_ID]
+
+    assert standard.resolutions == ("480p", "720p", "1080p", "4k")
+    assert fast.resolutions == ("480p", "720p")
+    assert mini.resolutions == ("480p", "720p")
+
+    for caps in (standard, fast, mini):
+        assert caps.supports_last_frame is True
+        assert caps.supports_private_assets is True
 
 
 def test_seedance_2_0_offers_4k_resolution_choice() -> None:
@@ -319,22 +392,36 @@ def test_seedance_2_fast_omits_4k_resolution_choice() -> None:
     assert choices == ["480p", "720p"]
 
 
-def test_seedance_2_fast_rejects_4k_resolution() -> None:
-    # The Options trait normally prevents selecting 4k on Fast via the UI, but resolution can
+def test_seedance_2_mini_omits_4k_resolution_choice() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0 Mini")
+    node._update_resolution_options(SEEDANCE_2_0_MINI_MODEL_ID)
+
+    resolution_param = _parameter_by_name(node, "resolution")
+    choices = resolution_param.find_elements_by_type(Options)[0].choices
+    assert "4k" not in choices
+    assert "1080p" not in choices
+    assert choices == ["480p", "720p"]
+
+
+@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
+def test_seedance_2_fast_and_mini_reject_4k_resolution(model_id: str) -> None:
+    # The Options trait normally prevents selecting 4k on Fast/Mini via the UI, but resolution can
     # also arrive over an INPUT connection that bypasses the trait — _validate_parameters is the
-    # backstop, mirroring the existing 1080p-on-Fast check.
+    # backstop, mirroring the existing 1080p check.
     node = Seedance20VideoGeneration(name="Seedance20")
     params = node._get_parameters()
-    params["model_id"] = SEEDANCE_2_0_FAST_MODEL_ID
+    params["model_id"] = model_id
     params["resolution"] = "4k"
 
     with pytest.raises(ValueError, match="does not support 4k resolution"):
         node._validate_parameters(params)
 
 
-def test_seedance_2_fast_rejects_private_asset_reference() -> None:
+@pytest.mark.parametrize("model_name", ["Seedance 2.0", "Seedance 2.0 Fast", "Seedance 2.0 Mini"])
+def test_all_models_accept_private_asset_reference(model_name: str) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
-    node.set_parameter_value("model_id", "Seedance 2.0 Fast")
+    node.set_parameter_value("model_id", model_name)
     node.set_parameter_value("input_mode", "Multimodal References")
     _set_parameter_list_values(
         node,
@@ -342,8 +429,8 @@ def test_seedance_2_fast_rejects_private_asset_reference() -> None:
         [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
     )
 
-    with pytest.raises(ValueError, match="Seedance 2.0 Fast does not support private-asset references"):
-        node._validate_parameters(node._get_parameters())
+    # Matching kind on any supported model validates without raising.
+    node._validate_parameters(node._get_parameters())
 
 
 def test_seedance_2_0_rejects_private_asset_reference_kind_mismatch() -> None:
@@ -411,7 +498,7 @@ async def test_build_payload_registers_private_asset_reference_for_seedance_2_0(
 
 
 @pytest.mark.asyncio
-async def test_build_payload_does_not_register_assets_for_seedance_2_fast(
+async def test_build_payload_does_not_register_assets_for_plain_media(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
@@ -421,13 +508,13 @@ async def test_build_payload_does_not_register_assets_for_seedance_2_fast(
     node.set_parameter_value("reference_video_1", VideoUrlArtifact("https://public.example/reference.mp4"))
 
     def fail_if_called(self, *args, **kwargs):
-        raise AssertionError("Seedance 2.0 Fast must not register private assets")
+        raise AssertionError("plain (non-private-asset) media must not register a provider asset")
 
     monkeypatch.setattr(Seedance20VideoGeneration, "_create_provider_asset", fail_if_called)
 
     payload = await node._build_payload()
 
-    # Normal media on Fast still flows through the standard (non-asset) path unchanged.
+    # Plain media (not a private-asset reference) flows through the standard (non-asset) path.
     assert payload["content"] == [
         {"type": "text", "text": "Use the reference video motion"},
         {


### PR DESCRIPTION
Closes #375 
Closes https://github.com/griptape-ai/griptape-cloud/issues/2059

## What

Adds **Seedance 2.0 Mini** as a selectable model on the Seedance 2.0 video node, and — in the process of getting Mini's capabilities right — corrects the per-model capability gating and fixes a reference-audio bug that affected all three Seedance 2.0 variants.

## Changes

### 1. Seedance 2.0 Mini support
- Added the `Seedance 2.0 Mini` model (`dreamina-seedance-2-0-mini-260615`) to the model dropdown, `MODEL_NAME_MAP`, and the `griptape_nodes_library.json` model catalog + node `model_usage` declaration.
- Mini supports 480p/720p only (no 1080p/4k), matching its vendor capabilities and at-cost billing.

### 2. Correct per-model capabilities (data-driven)
The node previously gated several features to Seedance 2.0 standard only, but the [BytePlus capability matrix](https://docs.byteplus.com/en/docs/ModelArk/2291680) shows Fast and Mini support them too. Replaced the scattered `_supports_*` checks with a single `SEEDANCE_MODEL_CAPABILITIES` table as the source of truth:

| Capability | 2.0 | Fast | Mini |
|---|---|---|---|
| First + last frame i2v | ✓ | ✓ (was blocked) | ✓ |
| Private-asset / Human Reference Asset | ✓ | ✓ (was blocked) | ✓ |
| Multimodal references | ✓ | ✓ | ✓ |
| 1080p / 4k resolution | ✓ | — | — |

Private assets on Fast/Mini are backend-supported: the GTC proxy's `link_provider_assets_to_generation` already lists the fast and mini model ids, and asset registration is provider-gated (`byteplus_ark`), not model-gated. Validation messages, tooltips, and the docstring were updated to match.

### 3. Fix reference-audio MIME subtype (`Invalid base64 audio_url`)
Seedance only accepts audio data URIs with subtype exactly `audio/mp3` or `audio/wav`, but the local file layer emits the system MIME subtype (`.mp3` → `audio/mpeg`, `.wav` → `audio/x-wav`), which Seedance rejected as `Invalid base64 audio_url`. This broke connecting an audio source (e.g. ElevenLabs Music output) into Reference Audio. Added `_normalize_audio_data_uri_subtype` to rewrite those aliases to the accepted subtypes at the single point all reference audio passes through.

## Tests
- New `SEEDANCE_MODEL_CAPABILITIES` regression guard and Mini coverage (resolution gating, 4k/1080p rejection, private-asset acceptance).
- Updated the two tests that asserted the old (incorrect) Fast gating for last-frame / private assets.
- New tests for the audio MIME normalization (helper + end-to-end `_build_payload`).
- `tests/integration/SEEDANCE_TESTING.md` updated with the mini model id and Mini/Fast coverage.

## Notes

<img width="655" height="1049" alt="seedance-2-0-mini" src="https://github.com/user-attachments/assets/9f8d8234-878d-4f02-ae7f-e5cdcf9e836c" />
