### PR TITLE
fix: warn instead of failing on undeclared proxy model

### DIFF
--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -20,7 +20,6 @@ from griptape_nodes.node_library.library_registry import get_declared_models
 from griptape_nodes.retained_mode.events.base_events import ResultPayload
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
-    DeclareModelInvocationResultFailure,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -638,12 +637,13 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         """
         model_id = self._resolve_catalog_model_id(api_model_id)
         if model_id is None:
-            return DeclareModelInvocationResultFailure(
-                result_details=(
-                    f"{self.name}: '{api_model_id}' is not a declared catalog model for this node, "
-                    f"so the invocation cannot be declared."
-                )
+            logger.warning(
+                "%s: '%s' is not a declared catalog model for this node; "
+                "declaring the invocation with the provider model id for now.",
+                self.name,
+                api_model_id,
             )
+            model_id = api_model_id
         return await GriptapeNodes.ahandle_request(
             DeclareModelInvocationRequest(model_id=model_id, node_name=self.name)
         )


### PR DESCRIPTION
When a proxy node's selected provider model id doesn't resolve to one of the node's declared catalog keys, `_declare_model_invocation` returned a `DeclareModelInvocationResultFailure` and aborted before any network call. That hard-fails legitimate invocations for models that are reachable through the proxy but simply haven't been declared in the node's catalog yet.

For now this logs a warning and falls back to declaring the invocation with the provider model id so the call can proceed. This is a stopgap while the catalog gap is closed, not the permanent behavior, hence the "for now" wording in the log.