### PR TITLE
fix: use RENDER_SEQUENCE_PATTERN for FileOutputSettings preview resolves

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.81.0",
-    "engine_version": "0.89.0",
+    "engine_version": "0.90.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -36,6 +36,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetSituationRequest,
     GetSituationResultSuccess,
     MacroPath,
+    UnresolvedSequenceSlotBehavior,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -291,7 +292,14 @@ class FileOutputSettings(BaseNode):
             ClassifiedPath with scenario classification, or error message string
         """
         parsed_macro = ParsedMacro(file_name_value)
-        parse_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
+        parse_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={},
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
+        )
 
         if not isinstance(parse_result, GetPathForMacroResultSuccess):
             return "Failed to parse macro"
@@ -382,8 +390,13 @@ class FileOutputSettings(BaseNode):
         variables = self._build_relative_variables(classified)
 
         parsed_macro = ParsedMacro(macro_template)
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
         resolve_result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=parsed_macro, variables=variables)
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables=variables,
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
         )
 
         if not isinstance(resolve_result, GetPathForMacroResultSuccess):
@@ -399,7 +412,14 @@ class FileOutputSettings(BaseNode):
         macro_template = classified.normalized_path
 
         parsed_macro = ParsedMacro(macro_template)
-        resolve_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
+        resolve_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={},
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
+        )
 
         if not isinstance(resolve_result, GetPathForMacroResultSuccess):
             logger.error("%s: Failed to resolve macro: %s", self.name, macro_template)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.89.0",
+  "griptape-nodes-engine>=0.90.0",
   "lxml>=5.0.0",
 ]
 


### PR DESCRIPTION
## Summary

`FileOutputSettings` calls `GetPathForMacroRequest` in three preview paths (path classification, relative-path preview, absolute-path-inside-project preview). Under the `{###}` sequence-slot syntax now on engine `main`, a required `{###}` slot with no bound value fails preview resolution with `MISSING_REQUIRED_VARIABLES` — the node logs `Failed to resolve macro` and leaves the destination field empty. This surfaced during the sequence-slot demo the moment the macro flipped from `{###?}` to `{###}`.

The engine's `GetPathForMacroRequest` gained an opt-in `unresolved_sequence_slot_behavior` flag. This PR flips the three preview call sites in `FileOutputSettings` to `UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN`, which renders the slot as its bare `###` glyphs instead of failing.

Closes #387.

## Dependencies

**Hard code dependency: engine [#4990](https://github.com/griptape-ai/griptape-nodes-engine/pull/4990) — MERGED to engine `main` (commit `f84da5f88`).** Introduced `{###}` syntax, the `SequenceFormat` type, the `UnresolvedSequenceSlotBehavior` enum, and the flag on `GetPathForMacroRequest`. All three imports this PR relies on came from there.

**Release-order dependency: engine v0.90.0 must be tagged/released before merging this PR.** `griptape_nodes_library.json` pins `engine_version: "0.90.0"`. Engine `main` is currently at `0.90.0` in code, but the latest tagged release is `v0.89.0` — v0.90.0 needs to ship before the pin resolves for consumers.

**Not a dependency: engine [#4995](https://github.com/griptape-ai/griptape-nodes-engine/pull/4995) (retire `NumericPaddingFormat` heuristic).** Complementary work — both PRs modernize `SequenceFormat` grammar — but no code coupling. The `RENDER_SEQUENCE_PATTERN` flag works regardless of whether the heuristic has been retired. Also: #4995's shipped default macros use optional `{###?}` for 4 of 5 situations (which never trip the preview-break at all), and the one required `{###}` slot (`create_versioned_workflow`) is only ever resolved through the write path, not through `FileOutputSettings` preview. This PR can release before, after, or alongside #4995.

## What changed

Three call sites in [file_output_settings.py](griptape_nodes_library/filesystem/file_output_settings.py):

- `_classify_path` — classifying user input as absolute-vs-relative
- `_handle_relative_path` — the specific site that fails in the demo
- `_handle_absolute_path_inside_project` — inside-project preview

Each site adds `unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN` and a one-line comment noting the preview intent. The result is presentation-only — the returned string may contain `###` characters and must never be handed to a filesystem I/O primitive. The actual save still runs through the engine's write path, which auto-allocates `_index` as usual.

Plus a bump to `engine_version: "0.90.0"` in `griptape_nodes_library.json` to match the engine version that introduces the flag.

## Test plan

- [ ] `uv run ruff format --check` + `uv run ruff check .` clean.
- [ ] Engine v0.90.0 tagged and released.
- [ ] With engine 0.90.0 installed, drop a `FileOutputSettings` node in a project whose `save_node_output` situation uses a required `{###}`. Destination field renders `.../render###.png` (bare hashes) with no `Failed to resolve macro` in the log.
- [ ] Confirm the actual save via a downstream node still lands at `_v001.png` on the first write and advances on collision.
- [ ] Confirm optional `{###?}` situations (the shipped default) still render with the slot omitted on preview — no `###` residue.
