### PR TITLE
feat(access): DescribeImage + TranscribeAudio adopt ModelAccessParameter helper

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -3962,6 +3962,28 @@
           "text",
           "ai",
           "vision"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_5_2",
+              "gtc_gpt_5_1",
+              "gtc_gpt_5",
+              "gtc_gpt_5_mini",
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_4o",
+              "gtc_o4_mini",
+              "gtc_o3",
+              "gtc_claude_opus_4_7",
+              "gtc_claude_sonnet_4_6",
+              "gtc_claude_sonnet_4_5",
+              "gtc_gemini_3_1_pro",
+              "gtc_gemini_2_5_pro"
+            ]
+          }
         ]
       }
     },

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -897,22 +897,22 @@
     {
       "name": "SplatViewer",
       "path": "griptape_nodes_library/splat/widgets/SplatViewer.js",
-      "description": "Inline Gaussian splat viewer — auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
+      "description": "Inline Gaussian splat viewer \u2014 auto-renders the highest-fidelity wired splat using OrbitControls, matching the vsl-gui SplatComponent appearance."
     },
     {
       "name": "CropImageEditor",
       "path": "widgets/CropImageEditor/CropImageEditor.js",
-      "description": "Interactive crop editor — drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
+      "description": "Interactive crop editor \u2014 drag to move/resize the crop rectangle, draw a new crop area, with rule-of-thirds guides and live coordinate readout."
     },
     {
       "name": "CropVideoEditor",
       "path": "widgets/CropVideoEditor/CropVideoEditor.js",
-      "description": "Interactive video crop editor — drag handles on a live video frame with frame scrubber, aspect ratio, resolution, and position presets."
+      "description": "Interactive video crop editor \u2014 drag handles on a live video frame with frame scrubber, aspect ratio, resolution, and position presets."
     },
     {
       "name": "SelectFromGrid",
       "path": "widgets/SelectFromGrid/SelectFromGrid.js",
-      "description": "Interactive grid selector — displays list items as thumbnails (images, video, audio, text) and lets the user click to select one or more."
+      "description": "Interactive grid selector \u2014 displays list items as thumbnails (images, video, audio, text) and lets the user click to select one or more."
     }
   ],
   "categories": [
@@ -6076,7 +6076,7 @@
       "file_path": "griptape_nodes_library/files/resolve_macro_path.py",
       "metadata": {
         "category": "files",
-        "description": "Resolve a macro path to an absolute filesystem path (e.g. {inputs}/file.txt → /home/user/project/inputs/file.txt).",
+        "description": "Resolve a macro path to an absolute filesystem path (e.g. {inputs}/file.txt \u2192 /home/user/project/inputs/file.txt).",
         "display_name": "Resolve Macro Path",
         "icon": "FolderSearch",
         "tags": [
@@ -6091,7 +6091,7 @@
       "file_path": "griptape_nodes_library/files/resolve_macro_paths.py",
       "metadata": {
         "category": "files",
-        "description": "Resolve a list of macro paths to absolute filesystem paths (e.g. [{inputs}/file.txt, {outputs}/image.png] → [/home/user/project/inputs/file.txt, /home/user/project/outputs/image.png]).",
+        "description": "Resolve a list of macro paths to absolute filesystem paths (e.g. [{inputs}/file.txt, {outputs}/image.png] \u2192 [/home/user/project/inputs/file.txt, /home/user/project/outputs/image.png]).",
         "display_name": "Resolve Macro Path List",
         "icon": "FolderSearch",
         "tags": [

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -7,7 +7,7 @@ from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
-from griptape_nodes.exe_types.param_components.model_access_parameter import ModelAccessParameter
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
@@ -72,15 +72,6 @@ class TranscribeAudio(GriptapeProxyNode):
         self.category = "audio"
         self.description = "Transcribe audio to text using OpenAI models via Griptape Cloud proxy"
 
-        # License-policy helper for the "model" dropdown. Owns the model list,
-        # installs the Options + refresh Button traits, applies per-row
-        # decoration + badge, exposes pick_permitted_default / query_for_denial.
-        self._model_access = ModelAccessParameter(
-            node=self,
-            model_choices=MODEL_CHOICES,
-            default_model=DEFAULT_MODEL,
-        )
-
         # --- INPUT PARAMETERS ---
         self.add_parameter(
             Parameter(
@@ -105,13 +96,21 @@ class TranscribeAudio(GriptapeProxyNode):
 
         model_param = ParameterString(
             name="model",
-            default_value=self._model_access.pick_permitted_default() or DEFAULT_MODEL,
+            default_value=DEFAULT_MODEL,
             tooltip="Transcription model to use",
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             ui_options={"display_name": "audio transcription model"},
         )
         self.add_parameter(model_param)
-        self._model_access.install(model_param)
+        # License-policy helper: adds Options + refresh Button traits, applies per-row
+        # decoration + badge, exposes query_for_denial, and relocates the stored value
+        # to a permitted alternative if DEFAULT_MODEL is denied.
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
+        )
 
         self.add_node_element(
             ParameterMessage(

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -7,6 +7,7 @@ from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.param_components.model_access_parameter import ModelAccessParameter
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
@@ -71,6 +72,15 @@ class TranscribeAudio(GriptapeProxyNode):
         self.category = "audio"
         self.description = "Transcribe audio to text using OpenAI models via Griptape Cloud proxy"
 
+        # License-policy helper for the "model" dropdown. Owns the model list,
+        # installs the Options + refresh Button traits, applies per-row
+        # decoration + badge, exposes pick_permitted_default / query_for_denial.
+        self._model_access = ModelAccessParameter(
+            node=self,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
+        )
+
         # --- INPUT PARAMETERS ---
         self.add_parameter(
             Parameter(
@@ -93,16 +103,15 @@ class TranscribeAudio(GriptapeProxyNode):
             )
         )
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Transcription model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_CHOICES)},
-                ui_options={"display_name": "audio transcription model"},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=self._model_access.pick_permitted_default() or DEFAULT_MODEL,
+            tooltip="Transcription model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "audio transcription model"},
         )
+        self.add_parameter(model_param)
+        self._model_access.install(model_param)
 
         self.add_node_element(
             ParameterMessage(
@@ -242,6 +251,8 @@ class TranscribeAudio(GriptapeProxyNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
         if parameter.name == "response_format":
             if value == "verbose_json":
                 self.show_parameter_by_name("segments")
@@ -308,6 +319,18 @@ class TranscribeAudio(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for OpenAI audio transcription."""
+        # License-policy runtime gate. SuccessFailure idiom: route the denial
+        # through _set_status_results and return an empty payload so the outer
+        # proxy pipeline sees was_successful=False rather than an exception.
+        # Runs BEFORE the proxy's own INVOKE_MODEL gate so a denied model fails
+        # immediately instead of after payload construction.
+        model_value = self.get_parameter_value("model")
+        denial = self._model_access.query_for_denial(model_value)
+        if denial is not None:
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details=denial.reason())
+            return {}
+
         audio_value = self.get_parameter_value("audio")
         if audio_value is None:
             msg = "No audio provided. Please connect an audio source."

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -8,6 +8,7 @@ from griptape.structures import Structure
 from griptape.tasks import PromptTask
 from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode, ParameterType
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
+from griptape_nodes.exe_types.param_components.model_access_parameter import ModelAccessParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -54,6 +55,16 @@ class DescribeImage(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
+        # License-policy helper for the "model" dropdown. Owns the model list,
+        # installs the Options + refresh Button traits, applies per-row
+        # decoration + badge, exposes pick_permitted_default / query_for_denial /
+        # raise_if_denied.
+        self._model_access = ModelAccessParameter(
+            node=self,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
+        )
+
         self.add_parameter(
             Parameter(
                 name="agent",
@@ -64,19 +75,18 @@ class DescribeImage(ControlNode):
                 allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                input_types=["str", "Prompt Model Config"],
-                type="str",
-                output_type="str",
-                default_value=DEFAULT_MODEL,
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                tooltip="Choose a model, or connect a Prompt Model Configuration or an Agent",
-                traits={Options(choices=MODEL_CHOICES)},
-                ui_options={"display_name": "prompt model"},
-            )
+        model_param = Parameter(
+            name="model",
+            input_types=["str", "Prompt Model Config"],
+            type="str",
+            output_type="str",
+            default_value=self._model_access.pick_permitted_default() or DEFAULT_MODEL,
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            tooltip="Choose a model, or connect a Prompt Model Configuration or an Agent",
+            ui_options={"display_name": "prompt model"},
         )
+        self.add_parameter(model_param)
+        self._model_access.install(model_param)
         self.add_parameter(
             ParameterList(
                 name="images",
@@ -284,20 +294,35 @@ class DescribeImage(ControlNode):
             # Enable PROPERTY so the user can set it
             target_parameter.allowed_modes = {ParameterMode.INPUT, ParameterMode.PROPERTY}
 
-            target_parameter.add_trait(Options(choices=MODEL_CHOICES))
-            target_parameter.set_default_value(DEFAULT_MODEL)
-            target_parameter.default_value = DEFAULT_MODEL
+            default_model = self._model_access.pick_permitted_default() or DEFAULT_MODEL
+            target_parameter.set_default_value(default_model)
+            target_parameter.default_value = default_model
             ui_options = target_parameter.ui_options
             ui_options["display_name"] = "prompt model"
             target_parameter.ui_options = ui_options
-            self.set_parameter_value("model", DEFAULT_MODEL)
+            self.set_parameter_value("model", default_model)
+            # Helper reinstalls its Options trait + decoration + badge on the freshly-uncovered
+            # parameter (the incoming-connection handler stripped Options when the driver connected).
+            self._model_access.reinstall_options()
 
         return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        super().after_value_set(parameter, value)
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
 
     def process(self) -> AsyncResult[Structure]:  # noqa: C901, PLR0915, PLR0912
         # Get the parameters from the node
         params = self.parameter_values
         model_input = self.get_parameter_value("model")
+
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied, which propagates as an error toast in the workflow.
+        # Bypasses non-string values (e.g. a connected Prompt Model Config driver
+        # carries its own model identity that the helper isn't aware of).
+        self._model_access.raise_if_denied(model_input)
+
         agent = None
 
         default_prompt_driver = GriptapeCloudPromptDriver(
@@ -369,7 +394,7 @@ class DescribeImage(ControlNode):
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, output_schema=pydantic_schema)
         elif isinstance(model_input, str):
-            if model_input not in MODEL_CHOICES:
+            if model_input not in self._model_access.model_choices:
                 model_input = DEFAULT_MODEL
             prompt_driver = GriptapeCloudPromptDriver(
                 model=model_input,

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -8,7 +8,7 @@ from griptape.structures import Structure
 from griptape.tasks import PromptTask
 from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode, ParameterType
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
-from griptape_nodes.exe_types.param_components.model_access_parameter import ModelAccessParameter
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -55,16 +55,6 @@ class DescribeImage(ControlNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        # License-policy helper for the "model" dropdown. Owns the model list,
-        # installs the Options + refresh Button traits, applies per-row
-        # decoration + badge, exposes pick_permitted_default / query_for_denial /
-        # raise_if_denied.
-        self._model_access = ModelAccessParameter(
-            node=self,
-            model_choices=MODEL_CHOICES,
-            default_model=DEFAULT_MODEL,
-        )
-
         self.add_parameter(
             Parameter(
                 name="agent",
@@ -80,13 +70,21 @@ class DescribeImage(ControlNode):
             input_types=["str", "Prompt Model Config"],
             type="str",
             output_type="str",
-            default_value=self._model_access.pick_permitted_default() or DEFAULT_MODEL,
+            default_value=DEFAULT_MODEL,
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             tooltip="Choose a model, or connect a Prompt Model Configuration or an Agent",
             ui_options={"display_name": "prompt model"},
         )
         self.add_parameter(model_param)
-        self._model_access.install(model_param)
+        # License-policy helper: adds Options + refresh Button traits, applies per-row
+        # decoration + badge, exposes query_for_denial / raise_if_denied, and
+        # relocates the stored value to a permitted alternative if DEFAULT_MODEL is denied.
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
+        )
         self.add_parameter(
             ParameterList(
                 name="images",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.90.0",
+  "griptape-nodes-engine>=0.92.0",
   "lxml>=5.0.0",
 ]
 
@@ -54,7 +54,13 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [dependency-groups]
-dev = ["pyright>=1.1.396", "pytest-asyncio>=0.21.0", "ruff>=0.8.0", "pytest", "lxml-stubs>=0.5.1"]
+dev = [
+  "pyright>=1.1.396",
+  "pytest-asyncio>=0.21.0",
+  "ruff>=0.8.0",
+  "pytest",
+  "lxml-stubs>=0.5.1",
+]
 
 [tool.pyright]
 venvPath = "."

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.89.0"
+version = "0.90.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/21/a5b13929a22a44f4c92b695fcb6ad6d8a07aeb9e7d156fdc94299d7d8f9e/griptape_nodes_engine-0.89.0.tar.gz", hash = "sha256:c0a6202681d7ccaa639c54c2e9d2f57299a5f26a260b4e187e9e1b3a6e53955c", size = 981672, upload-time = "2026-06-30T22:08:25.405Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/78/1090a534483bfb8e932563bab419b3a80aaeb75b4b93a44fc4c4de482e10/griptape_nodes_engine-0.90.0.tar.gz", hash = "sha256:d9b90af3e49b02ae1a359b15ebaa928eaa3dfc871956864c62890661eb4638bc", size = 1008976, upload-time = "2026-07-02T21:39:21.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/e0/a77da498845566ccd011477379bad1b391c0ca789a3ba3bb88fb0ffecf4d/griptape_nodes_engine-0.89.0-py3-none-any.whl", hash = "sha256:291178e9308b4862b0cbebf14e38bf52fe5af38085f423aa28f39b289865b4c8", size = 1219385, upload-time = "2026-06-30T22:08:23.906Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/f2e5bf0b4c95130408b6a57313ab1fabd84deaf759f201b85215c1ebdf6d/griptape_nodes_engine-0.90.0-py3-none-any.whl", hash = "sha256:a2925ea7800a6d47af265d5efd7cf458f96a57f1c9d52cc6b0250180c3d303e5", size = 1247926, upload-time = "2026-07-02T21:39:20.321Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.89.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.90.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.91.0"
+version = "0.92.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/67/559a6ae3a98be6c3bc5a35eb5c3821f60ac86d18865822ce65169f952ad3/griptape_nodes_engine-0.91.0.tar.gz", hash = "sha256:733cd598e3deea3a16269a709342ada9b82867622aad8695e71648abd00c4e47", size = 1010943, upload-time = "2026-07-06T19:09:32.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/e6/43fd2d8fe8c76357d9304f9ce8ba0397cc37b6336048b263f6256bd0a2ca/griptape_nodes_engine-0.92.0.tar.gz", hash = "sha256:00bbf73eb8f4f3ef100d8f924b92fe4d0cd54bdd7f4bf6b383ff696e469bdfff", size = 1040297, upload-time = "2026-07-08T20:30:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/4b/4108a3f1e209661bda8f8771cffa66f931fe2994e65a45cefa5bddc130fd/griptape_nodes_engine-0.91.0-py3-none-any.whl", hash = "sha256:e9937b1d7d8311af626c993198976ee209d0491f5b4a2a1848aad23de68e2534", size = 1249740, upload-time = "2026-07-06T19:09:30.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/80/5999f71e074a8b067f5600b736ed26be0842b14050799885c932ad026f73/griptape_nodes_engine-0.92.0-py3-none-any.whl", hash = "sha256:04d6c0f7586cf6546697ce4da236b64e5e8dd9a01c6ace62053b7d9f8ead0640", size = 1280258, upload-time = "2026-07-08T20:30:03.953Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.90.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.92.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
**This PR imports `ModelAccessComponent` from a module (`griptape_nodes.exe_types.param_components.model_access_component`) that does not exist in ANY currently-published `griptape-nodes-engine` release.** Merging this before engine #5040 ships in a tagged engine release WILL BREAK EVERY INSTALL of the standard library. The library's `make check` currently fails with `reportMissingImports` for exactly this reason.

### Merge order (mandatory)

1. Engine PR [#5040](https://github.com/griptape-ai/griptape-nodes-engine/pull/5040) is reviewed and merged.
2. A new `griptape-nodes-engine` release is cut that includes it.
3. This library PR's `pyproject.toml` dependency line is bumped: `"griptape-nodes-engine>=<new-version>"`.
4. Library `make check` passes (all `reportMissingImports` errors clear).
5. **Then and only then** may this PR be marked ready for review and merged.

---

## Summary

Supersedes draft [#368](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/368) — will close that PR once this one is merged (or vice versa). Addresses [@collindutter's feedback](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/368#issuecomment-4869277014) on #368: "Functionally it looks great but I'm a little worried by the amount of boilerplate introduced. Every node will need to implement this?"

The copy-pasted `~150 lines per node` from #368 is replaced with the engine-side `ModelAccessComponent` helper (see engine PR #5040). Per-node glue drops from `~150 lines` to `~8 lines`. Same UX as the initial pilot — dropdown decoration, badge on denied selection, inline refresh button, runtime denial gate.

## Changes

### `griptape_nodes_library/image/describe_image.py` (ControlNode idiom)

- Constructs the `model` Parameter first (name / type / input_types / tooltip / ui_options unchanged from today; no `Options` trait — the component adds it), then instantiates `self._model_access = ModelAccessComponent(node=self, parameter=model_param, ...)` in one step. All install work (Options + Button traits, dropdown decoration, initial badge, stored-value relocation off a denied default) happens in the component's `__init__`.
- `after_value_set` forwards to `helper.on_value_changed()`.
- `after_incoming_connection_removed` calls `helper.reinstall_options()` in the driver-disconnect branch.
- `process()` calls `helper.raise_if_denied(model_input)` at the top; raises `RuntimeError` on denial which propagates as a workflow error.
- `process()`'s validation branch reads `helper.model_choices` instead of module-level `MODEL_CHOICES` (single source of truth).

### `griptape_nodes_library/audio/transcribe_audio.py` (SuccessFailureNode idiom via GriptapeProxyNode)

- Same `__init__` + `after_value_set` shape as DescribeImage.
- `_build_payload()` calls `helper.query_for_denial(model_value)` at the top. On denial, routes through `_set_safe_defaults()` + `_set_status_results(was_successful=False, result_details=denial.reason())` + `return {}` — matches the SuccessFailure contract instead of raising.
- Existing `model_deprecation_notice` `ParameterMessage` unchanged.

Both idioms exercise the same helper. Together they validate the design for the 4 `ControlNode` candidates AND the 27 `SuccessFailureNode`-family candidates identified in the standard-library survey.

### `griptape_nodes_library.json`

Adds a `model_usage` declaration to `DescribeImage` (15 `gtc_*` catalog ids matching its `MODEL_CHOICES` list). `TranscribeAudio`'s existing `gtc_whisper_1` declaration is unchanged.

### `pyproject.toml`

Still pinned at `griptape-nodes-engine>=0.90.0`. **Must be bumped before merge** — see the merge order above.

### `uv.lock`

Routine `uv sync` pickup of the already-pinned engine 0.90.0. Not a substantive change.

## Diff size

`+100 / -30` across 4 files (was `+373 / -16` for #368). Removed everything in the "copy-paste plumbing" bucket; kept only the ~8 lines of per-node glue.

## Fail modes handled (from engine PR #5040)

- **Engine can't resolve the node's access** (unregistered class, missing `model_usage` declaration): dropdown renders without decoration (permissive UI so the artist can still open the workflow), but every runtime query returns a synthesized `CheckpointDenial("License policy could not be evaluated for node 'X'... verify manifest declares model_usage.")`. A warning also logs.
- **Constructor misuse**: raises `ValueError` if the Parameter isn't attached to the node, already carries `Options`, or already carries `Button`. A second `ModelAccessComponent` against the same Parameter trips the pre-existing-Options precondition.
- **Backwards compat**: the Parameter's name / type / input_types / stored value are byte-identical to today. Saved workflows load unchanged. See engine PR for the full compat argument.

## Reviewer testing (after engine ships)

Once the engine dep is bumped and this becomes reviewable:

1. Register a deny stub via `GriptapeNodes.EventManager().add_authorization_hook(...)` that returns a `CheckpointDenial` for one or two `gtc_*` catalog ids (sample code in engine #5040's PR description).
2. **DescribeImage smoke test**: drop the node → open dropdown → confirm denied entries show `shield-off` + "Not permitted by your license". Select a denied model → confirm error badge. Click refresh → confirm re-query. Run the node → confirm `RuntimeError` propagates.
3. **TranscribeAudio smoke test**: same UX flow. Run the node with `whisper-1` denied — confirm the **failure branch** of the SuccessFailure routing fires (was_successful=False), NOT an unhandled exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)