### PR TITLE
feat: add situation dropdown to all save nodes

### DIFF
--- a/.claude/skills/dropdown-row-subtitles/SKILL.md
+++ b/.claude/skills/dropdown-row-subtitles/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: dropdown-row-subtitles
+description: Add per-row subtitle text and/or icons to an Options dropdown via update_ui_options, so each choice shows a name, a secondary description line, and optionally a Lucide icon.
+argument-hint: <parameter-name> <where-descriptions-come-from>
+allowed-tools: Read Edit Grep Glob
+disable-model-invocation: false
+---
+
+# Dropdown Row Subtitles (and Icons)
+
+A pattern for enriching an `Options` dropdown so each row shows a **name**, a secondary **subtitle** (description), and/or a **Lucide icon**. These are pushed via `update_ui_options` after the parameter is registered — they are not part of the `Options` trait itself.
+
+Real examples:
+- Subtitles: `griptape_nodes_library/utils/situation_utils.py` — situation dropdown on save nodes
+- Icons + subtitles: `griptape_nodes_library/variables/set_variable.py` — variable picker with download-state icons
+- Icons + subtitles: `griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py`
+
+---
+
+## How It Works
+
+The UI renders rich rows by combining feature flags with a `"data"` list:
+
+| Flag | Effect |
+|------|--------|
+| `"dropdown_row_subtitles": True` | Shows a secondary description line under each choice |
+| `"dropdown_row_icons": True` | Shows a Lucide icon to the left of each choice |
+
+Both flags can be used together. Each entry in `"data"` is a dict with some or all of:
+
+```python
+{"name": str, "subtitle": str, "icon": str}
+# "icon" is a Lucide icon name, e.g. "check-circle", "download", "loader"
+```
+
+The `"name"` values must match the `Options(choices=[...])` list exactly — the UI pairs them by name.
+
+---
+
+## Imports
+
+```python
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.options import Options
+```
+
+No special import is needed for `update_ui_options` — it is a method on every `Parameter`.
+
+---
+
+## Core Pattern
+
+### 1. Build the data list
+
+Include whichever keys you need — all three are optional but `"name"` should always be present:
+
+```python
+def _build_row_data(
+    names: list[str],
+    descriptions: dict[str, str] | None = None,
+    icons: dict[str, str] | None = None,
+) -> list[dict[str, str]]:
+    rows = []
+    for n in names:
+        row: dict[str, str] = {"name": n}
+        if descriptions:
+            row["subtitle"] = descriptions.get(n, "")
+        if icons:
+            row["icon"] = icons.get(n, "")
+        rows.append(row)
+    return rows
+```
+
+### 2. Create the parameter with `Options`
+
+```python
+options_trait = Options(choices=names)
+
+self.my_param = ParameterString(
+    name="my_param",
+    default_value=names[0],
+    traits={options_trait},
+    settable=True,
+)
+self.add_parameter(self.my_param)
+```
+
+### 3. Push subtitle data **after** `add_parameter`
+
+`update_ui_options` must be called after the parameter is registered with the node — pushing it before has no effect.
+
+```python
+self.my_param.update_ui_options({
+    "data": _build_row_data(names, descriptions=descriptions, icons=icons),
+    "dropdown_row_subtitles": True,   # omit if no subtitles
+    "dropdown_row_icons": True,       # omit if no icons
+})
+```
+
+---
+
+## Updating Subtitles at Runtime
+
+When choices change (e.g. in a refresh callback), update both the `Options` trait **and** `ui_options`. Both are needed: the trait governs value validation; `update_ui_options` drives the rendered dropdown.
+
+```python
+def _on_refresh(self, _button, button_details):
+    fresh_names, fresh_descriptions = _fetch_names_and_descriptions()
+
+    options_trait.choices = fresh_names          # keeps validation in sync
+    self.my_param.update_ui_options({
+        "data": _build_row_data(fresh_names, descriptions=fresh_descriptions, icons=fresh_icons),
+        "dropdown_row_subtitles": True,
+        "dropdown_row_icons": True,
+    })
+```
+
+---
+
+## What NOT to Do
+
+- **Don't** put descriptions or icons inside `Options(choices=...)` — `Options` only accepts a flat `list[str]`.
+- **Don't** call `update_ui_options` before `add_parameter` — the parameter must be registered first.
+- **Don't** forget the feature flags (`"dropdown_row_subtitles": True`, `"dropdown_row_icons": True`) — without them the `"data"` key is silently ignored and rows render as plain text.
+- **Don't** skip updating `options_trait.choices` on refresh — stale choices cause validation failures when the user selects a newly-added option.
+
+---
+
+## Complete Minimal Example
+
+```python
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.options import Options
+
+
+ITEMS = {
+    "alpha": "The first option",
+    "beta":  "The second option",
+    "gamma": "The third option",
+}
+
+
+class MyNode(BaseNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        names = sorted(ITEMS.keys())
+        self._options_trait = Options(choices=names)
+
+        self.my_param = ParameterString(
+            name="my_param",
+            default_value=names[0],
+            tooltip="Choose an item.",
+            traits={self._options_trait},
+            settable=True,
+        )
+        self.add_parameter(self.my_param)
+        # Must follow add_parameter:
+        self.my_param.update_ui_options({
+            "data": [{"name": n, "subtitle": ITEMS[n]} for n in names],
+            "dropdown_row_subtitles": True,
+        })
+```
+
+---
+
+## Real Examples
+
+**Subtitles only** — `griptape_nodes_library/utils/situation_utils.py`:
+`add_situation_parameter()` and `build_situation_data()` show the full pattern including
+a refresh button that updates both the trait choices and the subtitle data in one callback.
+
+**Icons + subtitles** — `griptape_nodes_library/variables/set_variable.py`:
+Variable picker that shows a Lucide icon per row indicating download state
+(`"check-circle"`, `"download"`, `"loader"`) alongside a subtitle.

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -12,7 +12,11 @@ from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
+from griptape_nodes_library.utils.situation_utils import (
+    add_situation_parameter,
+    on_output_file_connected,
+    on_output_file_disconnected,
+)
 
 
 @dataclass

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -12,7 +12,7 @@ from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
 
 
 @dataclass
@@ -171,3 +171,11 @@ class SaveAudio(SuccessFailureNode):
 
         except Exception as e:
             self._report_error(str(e), e)
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_connected(self, target_parameter)
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_disconnected(self, target_parameter)
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -57,7 +57,7 @@ class SaveAudio(SuccessFailureNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation":
+        if parameter.name == "situation" and not kwargs.get("initial_setup"):
             self._output_file._situation_name = str(value)
         super().after_value_set(parameter, value, **kwargs)
 

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -2,17 +2,25 @@ from dataclasses import dataclass
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import (
+    Parameter,
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
+)
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
 )
 
 
@@ -40,6 +48,21 @@ class SaveAudio(SuccessFailureNode):
             )
         )
 
+        situation_names, situation_descriptions = fetch_situations_with_descriptions()
+        situation_param = ParameterString(
+            name="situation",
+            default_value=DEFAULT_SITUATION,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="File save situation — determines the output directory and naming conventions.",
+            traits={Options(choices=situation_names)},
+            settable=True,
+        )
+        self.add_parameter(situation_param)
+        situation_param.update_ui_options({
+            "data": build_situation_data(situation_names, situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
@@ -52,6 +75,11 @@ class SaveAudio(SuccessFailureNode):
             result_details_tooltip="Details about the audio save operation result",
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
+
+    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
+        if parameter.name == "situation":
+            self._output_file._situation_name = str(value)
+        super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:
         """Extract bytes from various artifact types."""

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -177,7 +177,7 @@ class SaveAudio(SuccessFailureNode):
             self._report_error(str(e), e)
 
     def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
-        on_output_file_connected(self, target_parameter)
+        on_output_file_connected(self, source_node, target_parameter)
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -15,7 +15,7 @@ from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
 
 
 @dataclass
@@ -57,8 +57,7 @@ class SaveAudio(SuccessFailureNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation" and not kwargs.get("initial_setup"):
-            self._output_file._situation_name = str(value)
+        update_file_param_situation(self._output_file, parameter, value, **kwargs)
         super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -1,10 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import (
-    Parameter,
-    ParameterMode,
-)
+from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
@@ -15,7 +12,7 @@ from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 
 @dataclass
@@ -55,10 +52,6 @@ class SaveAudio(SuccessFailureNode):
             result_details_tooltip="Details about the audio save operation result",
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
-
-    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        update_file_param_situation(self._output_file, parameter, value, **kwargs)
-        super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:
         """Extract bytes from various artifact types."""
@@ -138,6 +131,7 @@ class SaveAudio(SuccessFailureNode):
     async def aprocess(self) -> None:
         """Async process method."""
         self._clear_execution_status()
+        self._output_file._situation_name = self.get_parameter_value("situation")
 
         try:
             raw_audio = self.get_parameter_value("audio")
@@ -159,6 +153,7 @@ class SaveAudio(SuccessFailureNode):
     def process(self) -> None:
         """Sync process method."""
         self._clear_execution_status()
+        self._output_file._situation_name = self.get_parameter_value("situation")
 
         try:
             raw_audio = self.get_parameter_value("audio")

--- a/griptape_nodes_library/audio/save_audio.py
+++ b/griptape_nodes_library/audio/save_audio.py
@@ -8,20 +8,14 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
-from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.audio_utils import (
     extract_url_from_audio_object,
     is_audio_url_artifact,
 )
-from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
-    build_situation_data,
-    fetch_situations_with_descriptions,
-)
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 
 @dataclass
@@ -48,26 +42,12 @@ class SaveAudio(SuccessFailureNode):
             )
         )
 
-        situation_names, situation_descriptions = fetch_situations_with_descriptions()
-        situation_param = ParameterString(
-            name="situation",
-            default_value=DEFAULT_SITUATION,
-            allowed_modes={ParameterMode.PROPERTY},
-            tooltip="File save situation — determines the output directory and naming conventions.",
-            traits={Options(choices=situation_names)},
-            settable=True,
-        )
-        self.add_parameter(situation_param)
-        situation_param.update_ui_options({
-            "data": build_situation_data(situation_names, situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
-
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_nodes.mp3",
         )
+        add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
         # Add status parameters using the helper method

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -76,7 +76,7 @@ class SaveToProject(SuccessFailureNode):
             source_path = _extract_source_path(value)
             if source_path:
                 self._update_default_filename(source_path)
-        elif parameter.name == "situation":
+        elif parameter.name == "situation" and not kwargs.get("initial_setup"):
             self._file_param._situation_name = str(value)
         return super().after_value_set(parameter, value, **kwargs)
 

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -160,7 +160,7 @@ class SaveToProject(SuccessFailureNode):
         return UrlArtifact(str(saved_path))
 
     def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
-        on_output_file_connected(self, target_parameter)
+        on_output_file_connected(self, source_node, target_parameter)
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -15,7 +15,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -76,7 +76,6 @@ class SaveToProject(SuccessFailureNode):
             source_path = _extract_source_path(value)
             if source_path:
                 self._update_default_filename(source_path)
-        update_file_param_situation(self._file_param, parameter, value, **kwargs)
         return super().after_value_set(parameter, value, **kwargs)
 
     def validate_before_node_run(self) -> list[Exception] | None:
@@ -98,6 +97,7 @@ class SaveToProject(SuccessFailureNode):
 
     async def aprocess(self) -> None:
         self._clear_execution_status()
+        self._file_param._situation_name = self.get_parameter_value("situation")
 
         source_value = self.get_parameter_value("source")
         source_path = _extract_source_path(source_value)

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -15,7 +15,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -154,3 +154,11 @@ class SaveToProject(SuccessFailureNode):
         if isinstance(result, AttemptMapAbsolutePathToProjectResultSuccess) and result.mapped_path is not None:
             return UrlArtifact(result.mapped_path)
         return UrlArtifact(str(saved_path))
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_connected(self, target_parameter)
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_disconnected(self, target_parameter)
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -15,7 +15,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -76,8 +76,7 @@ class SaveToProject(SuccessFailureNode):
             source_path = _extract_source_path(value)
             if source_path:
                 self._update_default_filename(source_path)
-        elif parameter.name == "situation" and not kwargs.get("initial_setup"):
-            self._file_param._situation_name = str(value)
+        update_file_param_situation(self._file_param, parameter, value, **kwargs)
         return super().after_value_set(parameter, value, **kwargs)
 
     def validate_before_node_run(self) -> list[Exception] | None:

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -8,20 +8,14 @@ from griptape.artifacts import UrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.project_events import (
     AttemptMapAbsolutePathToProjectRequest,
     AttemptMapAbsolutePathToProjectResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
-    build_situation_data,
-    fetch_situations_with_descriptions,
-)
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -54,26 +48,12 @@ class SaveToProject(SuccessFailureNode):
             )
         )
 
-        situation_names, situation_descriptions = fetch_situations_with_descriptions()
-        situation_param = ParameterString(
-            name="situation",
-            default_value=DEFAULT_SITUATION,
-            allowed_modes={ParameterMode.PROPERTY},
-            tooltip="File save situation — determines the output directory and naming conventions.",
-            traits={Options(choices=situation_names)},
-            settable=True,
-        )
-        self.add_parameter(situation_param)
-        situation_param.update_ui_options({
-            "data": build_situation_data(situation_names, situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
-
         self._file_param = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="output",
         )
+        add_situation_parameter(self, self._file_param)
         self._file_param.add_parameter()
 
         self.add_parameter(
@@ -91,14 +71,14 @@ class SaveToProject(SuccessFailureNode):
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
 
-    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+    def after_value_set(self, parameter: Parameter, value: Any, **kwargs: object) -> None:
         if parameter.name == "source":
             source_path = _extract_source_path(value)
             if source_path:
                 self._update_default_filename(source_path)
         elif parameter.name == "situation":
             self._file_param._situation_name = str(value)
-        return super().after_value_set(parameter, value)
+        return super().after_value_set(parameter, value, **kwargs)
 
     def validate_before_node_run(self) -> list[Exception] | None:
         """Validate that required parameters are provided."""

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -15,7 +15,11 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
+from griptape_nodes_library.utils.situation_utils import (
+    add_situation_parameter,
+    on_output_file_connected,
+    on_output_file_disconnected,
+)
 
 logger = logging.getLogger("griptape_nodes")
 

--- a/griptape_nodes_library/files/save_to_project.py
+++ b/griptape_nodes_library/files/save_to_project.py
@@ -8,12 +8,20 @@ from griptape.artifacts import UrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.project_events import (
     AttemptMapAbsolutePathToProjectRequest,
     AttemptMapAbsolutePathToProjectResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
+)
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -46,6 +54,21 @@ class SaveToProject(SuccessFailureNode):
             )
         )
 
+        situation_names, situation_descriptions = fetch_situations_with_descriptions()
+        situation_param = ParameterString(
+            name="situation",
+            default_value=DEFAULT_SITUATION,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="File save situation — determines the output directory and naming conventions.",
+            traits={Options(choices=situation_names)},
+            settable=True,
+        )
+        self.add_parameter(situation_param)
+        situation_param.update_ui_options({
+            "data": build_situation_data(situation_names, situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
         self._file_param = ProjectFileParameter(
             node=self,
             name="output_file",
@@ -73,6 +96,8 @@ class SaveToProject(SuccessFailureNode):
             source_path = _extract_source_path(value)
             if source_path:
                 self._update_default_filename(source_path)
+        elif parameter.name == "situation":
+            self._file_param._situation_name = str(value)
         return super().after_value_set(parameter, value)
 
     def validate_before_node_run(self) -> list[Exception] | None:

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -42,9 +42,8 @@ from griptape_nodes.traits.file_system_picker import FileSystemPicker
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
     build_situation_data,
-    fetch_situations_with_descriptions,
+    fetch_situation_names,
 )
 
 logger = logging.getLogger("griptape_nodes")
@@ -101,7 +100,11 @@ class FileOutputSettings(BaseNode):
 
         self._updating_lock = False
 
-        self._available_situations, self._situation_descriptions = fetch_situations_with_descriptions()
+        # GetAllSituationsForProjectRequest is init-safe (does not trigger the
+        # reentrant-bus-in-init rule). Descriptions are not available until the
+        # user clicks refresh, which uses the slower two-request fetch.
+        self._available_situations: list[str] = fetch_situation_names()
+        self._situation_descriptions: dict[str, str] = {}
         self._create_parameters()
         self._load_project_situation()
 
@@ -149,22 +152,16 @@ class FileOutputSettings(BaseNode):
             default_value=self._available_situations[0],
             allowed_modes={ParameterMode.PROPERTY},
             tooltip="Select the file save situation template to use for path resolution",
-            traits={
-                self._situation_options_trait,
-                Button(
-                    icon="refresh-cw",
-                    size="icon",
-                    variant="secondary",
-                    on_click=self._on_refresh_situations,
-                ),
-            },
+            traits={self._situation_options_trait},
             settable=True,
         )
         self.add_parameter(self.situation)
-        self.situation.update_ui_options({
-            "data": build_situation_data(self._available_situations, self._situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
+        self.situation.update_ui_options(
+            {
+                "data": build_situation_data(self._available_situations, self._situation_descriptions),
+                "dropdown_row_subtitles": True,
+            }
+        )
 
         with ParameterGroup(name="Situation Options") as situation_group:
             self.macro = ParameterString(
@@ -508,38 +505,6 @@ class FileOutputSettings(BaseNode):
     def process(self) -> None:
         """Resolve the path and set output parameter values."""
         self._resolve_and_update_path()
-
-    def _on_refresh_situations(
-        self,
-        _button: Button,
-        button_details: ButtonDetailsMessagePayload,
-    ) -> NodeMessageResult:
-        """Refresh the situations dropdown from the current project template."""
-        names, descriptions = fetch_situations_with_descriptions()
-        if not names:
-            return NodeMessageResult(
-                success=False,
-                details="No situations available — project template could not be loaded",
-                response=button_details,
-                altered_workflow_state=False,
-            )
-        self._available_situations = names
-        self._situation_descriptions = descriptions
-        self._situation_options_trait.choices = names
-        self.situation.update_ui_options({
-            "data": build_situation_data(names, descriptions),
-            "dropdown_row_subtitles": True,
-        })
-        current = self.get_parameter_value(self.situation.name)
-        if current not in names:
-            new_val = DEFAULT_SITUATION if DEFAULT_SITUATION in names else names[0]
-            self.set_parameter_value(self.situation.name, new_val)
-        return NodeMessageResult(
-            success=True,
-            details=f"Refreshed {len(names)} situation(s)",
-            response=button_details,
-            altered_workflow_state=True,
-        )
 
     def _on_reset_situation_clicked(
         self,

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -41,7 +41,11 @@ from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.utils.situation_utils import build_situation_data, fetch_situations_with_descriptions
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
+)
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -139,12 +143,21 @@ class FileOutputSettings(BaseNode):
 
     def _create_parameters(self) -> None:
         """Create all parameters for the node."""
+        self._situation_options_trait = Options(choices=self._available_situations)
         self.situation = ParameterString(
             name="situation",
             default_value=self._available_situations[0],
             allowed_modes={ParameterMode.PROPERTY},
             tooltip="Select the file save situation template to use for path resolution",
-            traits={Options(choices=self._available_situations)},
+            traits={
+                self._situation_options_trait,
+                Button(
+                    icon="refresh-cw",
+                    size="icon",
+                    variant="secondary",
+                    on_click=self._on_refresh_situations,
+                ),
+            },
             settable=True,
         )
         self.add_parameter(self.situation)
@@ -495,6 +508,38 @@ class FileOutputSettings(BaseNode):
     def process(self) -> None:
         """Resolve the path and set output parameter values."""
         self._resolve_and_update_path()
+
+    def _on_refresh_situations(
+        self,
+        _button: Button,
+        button_details: ButtonDetailsMessagePayload,
+    ) -> NodeMessageResult:
+        """Refresh the situations dropdown from the current project template."""
+        names, descriptions = fetch_situations_with_descriptions()
+        if not names:
+            return NodeMessageResult(
+                success=False,
+                details="No situations available — project template could not be loaded",
+                response=button_details,
+                altered_workflow_state=False,
+            )
+        self._available_situations = names
+        self._situation_descriptions = descriptions
+        self._situation_options_trait.choices = names
+        self.situation.update_ui_options({
+            "data": build_situation_data(names, descriptions),
+            "dropdown_row_subtitles": True,
+        })
+        current = self.get_parameter_value(self.situation.name)
+        if current not in names:
+            new_val = DEFAULT_SITUATION if DEFAULT_SITUATION in names else names[0]
+            self.set_parameter_value(self.situation.name, new_val)
+        return NodeMessageResult(
+            success=True,
+            details=f"Refreshed {len(names)} situation(s)",
+            response=button_details,
+            altered_workflow_state=True,
+        )
 
     def _on_reset_situation_clicked(
         self,

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -43,7 +43,7 @@ from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.situation_utils import (
     build_situation_data,
-    fetch_situation_names,
+    fetch_situations,
 )
 
 logger = logging.getLogger("griptape_nodes")
@@ -100,11 +100,7 @@ class FileOutputSettings(BaseNode):
 
         self._updating_lock = False
 
-        # GetAllSituationsForProjectRequest is init-safe (does not trigger the
-        # reentrant-bus-in-init rule). Descriptions are not available until the
-        # user clicks refresh, which uses the slower two-request fetch.
-        self._available_situations: list[str] = fetch_situation_names()
-        self._situation_descriptions: dict[str, str] = {}
+        self._available_situations, self._situation_descriptions = fetch_situations()
         self._create_parameters()
         self._load_project_situation()
 

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -29,8 +29,6 @@ from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.retained_mode.events.project_events import (
     AttemptMapAbsolutePathToProjectRequest,
     AttemptMapAbsolutePathToProjectResultSuccess,
-    GetAllSituationsForProjectRequest,
-    GetAllSituationsForProjectResultSuccess,
     GetPathForMacroRequest,
     GetPathForMacroResultSuccess,
     GetSituationRequest,
@@ -42,6 +40,8 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.situation_utils import build_situation_data, fetch_situations_with_descriptions
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -97,7 +97,7 @@ class FileOutputSettings(BaseNode):
 
         self._updating_lock = False
 
-        self._available_situations = self._fetch_available_situations()
+        self._available_situations, self._situation_descriptions = fetch_situations_with_descriptions()
         self._create_parameters()
         self._load_project_situation()
 
@@ -137,17 +137,6 @@ class FileOutputSettings(BaseNode):
             coerce_extension_to_match_bytes=coerce_ext,
         )
 
-    def _fetch_available_situations(self) -> list[str]:
-        """Fetch available situations from the project manager."""
-        request = GetAllSituationsForProjectRequest()
-        result = GriptapeNodes.handle_request(request)
-
-        if not isinstance(result, GetAllSituationsForProjectResultSuccess):
-            logger.error("%s: Failed to fetch situations from project", self.name)
-            return []
-
-        return sorted(result.situations.keys())
-
     def _create_parameters(self) -> None:
         """Create all parameters for the node."""
         self.situation = ParameterString(
@@ -159,6 +148,10 @@ class FileOutputSettings(BaseNode):
             settable=True,
         )
         self.add_parameter(self.situation)
+        self.situation.update_ui_options({
+            "data": build_situation_data(self._available_situations, self._situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
 
         with ParameterGroup(name="Situation Options") as situation_group:
             self.macro = ParameterString(

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -15,14 +15,13 @@ from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
 from PIL import Image
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
-
 from griptape_nodes_library.utils.image_utils import (
     dict_to_image_url_artifact,
     image_to_bytes,
     load_image_from_url_artifact,
     validate_pil_format,
 )
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
 
 PREVIEW_LENGTH = 50
 
@@ -72,8 +71,7 @@ class SaveImage(SuccessFailureNode):
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation" and not kwargs.get("initial_setup"):
-            self._output_file._situation_name = str(value)
+        update_file_param_situation(self._output_file, parameter, value, **kwargs)
         super().after_value_set(parameter, value, **kwargs)
 
     def _get_target_pil_format(self) -> str:

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -18,7 +18,7 @@ from griptape_nodes_library.utils.image_utils import (
     load_image_from_url_artifact,
     validate_pil_format,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
 
 PREVIEW_LENGTH = 50
 
@@ -257,3 +257,11 @@ class SaveImage(SuccessFailureNode):
         )
         # Use the helper to handle exception based on connection status
         self._handle_failure_exception(RuntimeError(error_details))
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_connected(self, target_parameter)
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_disconnected(self, target_parameter)
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -72,7 +72,7 @@ class SaveImage(SuccessFailureNode):
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation":
+        if parameter.name == "situation" and not kwargs.get("initial_setup"):
             self._output_file._situation_name = str(value)
         super().after_value_set(parameter, value, **kwargs)
 

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -263,7 +263,7 @@ class SaveImage(SuccessFailureNode):
         self._handle_failure_exception(RuntimeError(error_details))
 
     def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
-        on_output_file_connected(self, target_parameter)
+        on_output_file_connected(self, source_node, target_parameter)
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -4,10 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import (
-    Parameter,
-    ParameterMode,
-)
+from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
@@ -21,7 +18,7 @@ from griptape_nodes_library.utils.image_utils import (
     load_image_from_url_artifact,
     validate_pil_format,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 PREVIEW_LENGTH = 50
 
@@ -70,10 +67,6 @@ class SaveImage(SuccessFailureNode):
         add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
-    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        update_file_param_situation(self._output_file, parameter, value, **kwargs)
-        super().after_value_set(parameter, value, **kwargs)
-
     def _get_target_pil_format(self) -> str:
         """Determine the target PIL format string from the output_file parameter."""
         param_value = self.get_parameter_value("output_file")
@@ -109,6 +102,7 @@ class SaveImage(SuccessFailureNode):
     def process(self) -> None:
         # Reset execution state and result details at the start of each run
         self._clear_execution_status()
+        self._output_file._situation_name = self.get_parameter_value("situation")
 
         image = self.get_parameter_value("image")
         self.parameter_output_values["image"] = image

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -18,7 +18,11 @@ from griptape_nodes_library.utils.image_utils import (
     load_image_from_url_artifact,
     validate_pil_format,
 )
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
+from griptape_nodes_library.utils.situation_utils import (
+    add_situation_parameter,
+    on_output_file_connected,
+    on_output_file_disconnected,
+)
 
 PREVIEW_LENGTH = 50
 

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -11,17 +11,11 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
-from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
-from griptape_nodes.traits.options import Options
 from PIL import Image
 
-from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
-    build_situation_data,
-    fetch_situations_with_descriptions,
-)
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 from griptape_nodes_library.utils.image_utils import (
     dict_to_image_url_artifact,
@@ -69,26 +63,12 @@ class SaveImage(SuccessFailureNode):
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
 
-        situation_names, situation_descriptions = fetch_situations_with_descriptions()
-        situation_param = ParameterString(
-            name="situation",
-            default_value=DEFAULT_SITUATION,
-            allowed_modes={ParameterMode.PROPERTY},
-            tooltip="File save situation — determines the output directory and naming conventions.",
-            traits={Options(choices=situation_names)},
-            settable=True,
-        )
-        self.add_parameter(situation_param)
-        situation_param.update_ui_options({
-            "data": build_situation_data(situation_names, situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
-
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_nodes.png",
         )
+        add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:

--- a/griptape_nodes_library/image/save_image.py
+++ b/griptape_nodes_library/image/save_image.py
@@ -5,14 +5,23 @@ from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import (
+    Parameter,
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
+from griptape_nodes.traits.options import Options
 from PIL import Image
+
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
+)
 
 from griptape_nodes_library.utils.image_utils import (
     dict_to_image_url_artifact,
@@ -60,12 +69,32 @@ class SaveImage(SuccessFailureNode):
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
 
+        situation_names, situation_descriptions = fetch_situations_with_descriptions()
+        situation_param = ParameterString(
+            name="situation",
+            default_value=DEFAULT_SITUATION,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="File save situation — determines the output directory and naming conventions.",
+            traits={Options(choices=situation_names)},
+            settable=True,
+        )
+        self.add_parameter(situation_param)
+        situation_param.update_ui_options({
+            "data": build_situation_data(situation_names, situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_nodes.png",
         )
         self._output_file.add_parameter()
+
+    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
+        if parameter.name == "situation":
+            self._output_file._situation_name = str(value)
+        super().after_value_set(parameter, value, **kwargs)
 
     def _get_target_pil_format(self) -> str:
         """Determine the target PIL format string from the output_file parameter."""

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -57,7 +57,7 @@ class SaveText(ControlNode):
             raise ValueError(msg) from e
 
     def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
-        on_output_file_connected(self, target_parameter)
+        on_output_file_connected(self, source_node, target_parameter)
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -6,15 +6,9 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.griptape_nodes import logger
-from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
-    build_situation_data,
-    fetch_situations_with_descriptions,
-)
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 
 class SaveText(ControlNode):
@@ -34,26 +28,12 @@ class SaveText(ControlNode):
             )
         )
 
-        situation_names, situation_descriptions = fetch_situations_with_descriptions()
-        situation_param = ParameterString(
-            name="situation",
-            default_value=DEFAULT_SITUATION,
-            allowed_modes={ParameterMode.PROPERTY},
-            tooltip="File save situation — determines the output directory and naming conventions.",
-            traits={Options(choices=situation_names)},
-            settable=True,
-        )
-        self.add_parameter(situation_param)
-        situation_param.update_ui_options({
-            "data": build_situation_data(situation_names, situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
-
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_output.txt",
         )
+        add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -37,7 +37,7 @@ class SaveText(ControlNode):
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation":
+        if parameter.name == "situation" and not kwargs.get("initial_setup"):
             self._output_file._situation_name = str(value)
         super().after_value_set(parameter, value, **kwargs)
 

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -5,7 +5,7 @@ from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
 
 
 class SaveText(ControlNode):
@@ -51,3 +51,11 @@ class SaveText(ControlNode):
             error_message = str(e)
             msg = f"Error saving file: {error_message}"
             raise ValueError(msg) from e
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_connected(self, target_parameter)
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_disconnected(self, target_parameter)
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -5,7 +5,11 @@ from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
+from griptape_nodes_library.utils.situation_utils import (
+    add_situation_parameter,
+    on_output_file_connected,
+    on_output_file_disconnected,
+)
 
 
 class SaveText(ControlNode):

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -6,7 +6,15 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.griptape_nodes import logger
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
+)
 
 
 class SaveText(ControlNode):
@@ -26,12 +34,32 @@ class SaveText(ControlNode):
             )
         )
 
+        situation_names, situation_descriptions = fetch_situations_with_descriptions()
+        situation_param = ParameterString(
+            name="situation",
+            default_value=DEFAULT_SITUATION,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="File save situation — determines the output directory and naming conventions.",
+            traits={Options(choices=situation_names)},
+            settable=True,
+        )
+        self.add_parameter(situation_param)
+        situation_param.update_ui_options({
+            "data": build_situation_data(situation_names, situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_output.txt",
         )
         self._output_file.add_parameter()
+
+    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
+        if parameter.name == "situation":
+            self._output_file._situation_name = str(value)
+        super().after_value_set(parameter, value, **kwargs)
 
     def process(self) -> None:
         """Process the node by saving text to a file."""

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -1,14 +1,11 @@
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import (
-    Parameter,
-    ParameterMode,
-)
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 
 
 class SaveText(ControlNode):
@@ -36,12 +33,9 @@ class SaveText(ControlNode):
         add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
-    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        update_file_param_situation(self._output_file, parameter, value, **kwargs)
-        super().after_value_set(parameter, value, **kwargs)
-
     def process(self) -> None:
         """Process the node by saving text to a file."""
+        self._output_file._situation_name = self.get_parameter_value("situation")
         text = self.parameter_values.get("text", "")
 
         try:

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -51,8 +51,6 @@ class SaveText(ControlNode):
             saved_path = saved.location
             logger.info("Saved file: %s", saved_path)
 
-            self.parameter_output_values["output_file"] = saved_path
-
         except Exception as e:
             error_message = str(e)
             msg = f"Error saving file: {error_message}"

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -8,7 +8,7 @@ from griptape_nodes.exe_types.node_types import ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
 
 
 class SaveText(ControlNode):
@@ -37,8 +37,7 @@ class SaveText(ControlNode):
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation" and not kwargs.get("initial_setup"):
-            self._output_file._situation_name = str(value)
+        update_file_param_situation(self._output_file, parameter, value, **kwargs)
         super().after_value_set(parameter, value, **kwargs)
 
     def process(self) -> None:

--- a/griptape_nodes_library/text/save_text.py
+++ b/griptape_nodes_library/text/save_text.py
@@ -50,6 +50,9 @@ class SaveText(ControlNode):
             saved = dest.write_bytes(text.encode("utf-8"))
             saved_path = saved.location
             logger.info("Saved file: %s", saved_path)
+            # Do NOT write saved_path back to parameter_output_values["output_file"] —
+            # that clobbers the user's filename with the resolved macro path. No other
+            # node using ProjectFileParameter does this; the path is log-only here.
 
         except Exception as e:
             error_message = str(e)

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -1,0 +1,45 @@
+"""Shared helpers for situation dropdown parameters in save nodes."""
+
+import logging
+
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.retained_mode.events.project_events import (
+    GetCurrentProjectRequest,
+    GetCurrentProjectResultSuccess,
+    GetProjectTemplateRequest,
+    GetProjectTemplateResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = logging.getLogger("griptape_nodes")
+
+DEFAULT_SITUATION = ProjectFileParameter.DEFAULT_SITUATION
+
+
+def fetch_situations_with_descriptions() -> tuple[list[str], dict[str, str]]:
+    """Return (sorted_names, {name: description}) from the current project.
+
+    Falls back to a single-entry list containing the default situation when the
+    project template is not yet loaded.
+    """
+    current = GriptapeNodes.handle_request(GetCurrentProjectRequest())
+    if not isinstance(current, GetCurrentProjectResultSuccess):
+        logger.warning("Could not fetch current project; using default situation")
+        return [DEFAULT_SITUATION], {}
+
+    template_result = GriptapeNodes.handle_request(
+        GetProjectTemplateRequest(project_id=current.project_info.project_id)
+    )
+    if not isinstance(template_result, GetProjectTemplateResultSuccess):
+        logger.warning("Could not fetch project template; using default situation")
+        return [DEFAULT_SITUATION], {}
+
+    situations = template_result.template.situations
+    names = sorted(situations.keys())
+    descriptions = {name: (sit.description or "") for name, sit in situations.items()}
+    return names, descriptions
+
+
+def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list[dict]:
+    """Build the ui_options data list for dropdown_row_subtitles display."""
+    return [{"name": n, "subtitle": descriptions.get(n, "")} for n in names]

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -1,9 +1,9 @@
 """Shared helpers for situation dropdown parameters in save nodes."""
 
 import logging
-from typing import Any
 
-from griptape_nodes.exe_types.core_types import NodeMessageResult, ParameterMode
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
@@ -50,7 +50,21 @@ def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list
     return [{"name": n, "subtitle": descriptions.get(n, "")} for n in names]
 
 
-def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None:
+def update_file_param_situation(
+    file_param: ProjectFileParameter, parameter: Parameter, value: object, **kwargs: object
+) -> None:
+    """Sync situation name to file_param when the situation parameter changes.
+
+    Centralises the single write to the private ``_situation_name`` attribute so
+    all five save nodes share one call site instead of five.  The ``initial_setup``
+    guard mirrors ``FileOutputSettings.after_value_set`` — skip internal framework
+    setup calls because ``add_situation_parameter`` already seeds the correct default.
+    """
+    if parameter.name == "situation" and not kwargs.get("initial_setup"):
+        file_param._situation_name = str(value)
+
+
+def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) -> None:
     """Add a situation dropdown and refresh button to a save node.
 
     ``file_param`` must be created (but NOT yet added via ``add_parameter()``)
@@ -116,6 +130,8 @@ def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None
         settable=True,
     )
     node.add_parameter(situation_param)
+    # update_ui_options must follow add_parameter — subtitle data is separate from
+    # the trait and must be pushed to the UI layer after the param is registered.
     situation_param.update_ui_options({
         "data": build_situation_data(names, descriptions),
         "dropdown_row_subtitles": True,

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -7,6 +7,8 @@ from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
+    GetAllSituationsForProjectRequest,
+    GetAllSituationsForProjectResultSuccess,
     GetCurrentProjectRequest,
     GetCurrentProjectResultSuccess,
     GetProjectTemplateRequest,
@@ -19,6 +21,21 @@ from griptape_nodes.traits.options import Options
 logger = logging.getLogger("griptape_nodes")
 
 DEFAULT_SITUATION = ProjectFileParameter.DEFAULT_SITUATION
+
+
+def fetch_situation_names() -> list[str]:
+    """Return sorted situation names from the current project.
+
+    Uses GetAllSituationsForProjectRequest, which is safe to call from __init__
+    (does not trigger the reentrant-bus-in-init strict-mode rule). Falls back to
+    [DEFAULT_SITUATION] when the project template is not yet loaded.
+    """
+    result = GriptapeNodes.handle_request(GetAllSituationsForProjectRequest())
+    if not isinstance(result, GetAllSituationsForProjectResultSuccess):
+        logger.warning("Could not fetch situation names; using default situation")
+        return [DEFAULT_SITUATION]
+    names = sorted(result.situations.keys())
+    return names if names else [DEFAULT_SITUATION]
 
 
 def fetch_situations_with_descriptions() -> tuple[list[str], dict[str, str]]:
@@ -69,9 +86,13 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
 
     ``file_param`` must be created (but NOT yet added via ``add_parameter()``)
     before calling this so that ``after_value_set`` can safely reference it.
+
+    Uses GetAllSituationsForProjectRequest (init-safe) for the initial list.
+    Descriptions are not available until the user clicks the refresh button,
+    which calls the slower two-request fetch that includes them.
     """
-    names, descriptions = fetch_situations_with_descriptions()
-    default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else (names[0] if names else DEFAULT_SITUATION)
+    names = fetch_situation_names()
+    default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else names[0]
 
     options_trait = Options(choices=names)
 
@@ -91,18 +112,16 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
         # drives the rich dropdown rendering. FileOutputSettings omits the trait mutation
         # because it never refreshes in-place; here we need both.
         options_trait.choices = refreshed_names
-        situation_param.update_ui_options({
-            "data": build_situation_data(refreshed_names, refreshed_descriptions),
-            "dropdown_row_subtitles": True,
-        })
+        situation_param.update_ui_options(
+            {
+                "data": build_situation_data(refreshed_names, refreshed_descriptions),
+                "dropdown_row_subtitles": True,
+            }
+        )
 
         current = node.get_parameter_value("situation")
         if current not in refreshed_names:
-            new_val = (
-                DEFAULT_SITUATION
-                if DEFAULT_SITUATION in refreshed_names
-                else refreshed_names[0]
-            )
+            new_val = DEFAULT_SITUATION if DEFAULT_SITUATION in refreshed_names else refreshed_names[0]
             node.set_parameter_value("situation", new_val)
             file_param._situation_name = new_val
 
@@ -130,10 +149,4 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
         settable=True,
     )
     node.add_parameter(situation_param)
-    # update_ui_options must follow add_parameter — subtitle data is separate from
-    # the trait and must be pushed to the UI layer after the param is registered.
-    situation_param.update_ui_options({
-        "data": build_situation_data(names, descriptions),
-        "dropdown_row_subtitles": True,
-    })
     file_param._situation_name = default

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -5,8 +5,8 @@ import logging
 from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.files.file import FileDestinationProvider
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.files.file import FileDestinationProvider
 from griptape_nodes.retained_mode.events.project_events import (
     GetAllSituationsForProjectRequest,
     GetAllSituationsForProjectResultSuccess,

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import NodeMessageResult, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -47,25 +47,19 @@ def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list
     return [{"name": n, "subtitle": descriptions.get(n, "")} for n in names]
 
 
-def update_file_param_situation(
-    file_param: ProjectFileParameter, parameter: Parameter, value: object, **kwargs: object
-) -> None:
-    """Sync situation name to file_param when the situation parameter changes.
-
-    Centralises the single write to the private ``_situation_name`` attribute so
-    all five save nodes share one call site instead of five.  The ``initial_setup``
-    guard mirrors ``FileOutputSettings.after_value_set`` — skip internal framework
-    setup calls because ``add_situation_parameter`` already seeds the correct default.
-    """
-    if parameter.name == "situation" and not kwargs.get("initial_setup"):
-        file_param._situation_name = str(value)
-
-
 def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) -> None:
     """Add a situation dropdown and refresh button to a save node.
 
-    ``file_param`` must be created (but NOT yet added via ``add_parameter()``)
-    before calling this so that ``after_value_set`` can safely reference it.
+    ``file_param`` must be created before calling this (it seeds ``_situation_name``
+    to the dropdown default). Callers must resolve the situation fresh at process time:
+    set ``file_param._situation_name = node.get_parameter_value("situation")`` at the
+    top of each process/aprocess before calling ``build_file()``. Do NOT sync via
+    ``after_value_set`` — that hook is skipped on workflow reload, causing files to
+    land in the wrong situation directory after a save/reload cycle.
+
+    TODO: remove the per-node sync lines once the engine resolves situation natively
+    in ProjectFileParameter.build_file() — see
+    https://github.com/griptape-ai/griptape-nodes-engine/issues/5105
     """
     names, descriptions = fetch_situations()
     default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else names[0]

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -5,6 +5,7 @@ import logging
 from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import FileDestinationProvider
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
     GetAllSituationsForProjectRequest,
@@ -20,9 +21,15 @@ DEFAULT_SITUATION = ProjectFileParameter.DEFAULT_SITUATION
 _OUTPUT_FILE_PARAM = "output_file"
 
 
-def on_output_file_connected(node: BaseNode, target_parameter: Parameter) -> None:
-    """Call from after_incoming_connection to hide the situation dropdown."""
-    if target_parameter.name == _OUTPUT_FILE_PARAM:
+def on_output_file_connected(node: BaseNode, source_node: BaseNode, target_parameter: Parameter) -> None:
+    """Call from after_incoming_connection to hide the situation dropdown.
+
+    Only hides when the source is a FileDestinationProvider — the same predicate
+    build_file() uses to bypass situation resolution. Plain-string connections to
+    output_file still let the situation govern the save path, so the dropdown must
+    remain visible.
+    """
+    if target_parameter.name == _OUTPUT_FILE_PARAM and isinstance(source_node, FileDestinationProvider):
         param = node.get_parameter_by_name("situation")
         if param is not None:
             param.hide = True

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -5,7 +5,6 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import NodeMessageResult, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
     GetCurrentProjectRequest,
@@ -60,29 +59,12 @@ def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None
     names, descriptions = fetch_situations_with_descriptions()
     default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else (names[0] if names else DEFAULT_SITUATION)
 
-    situation_param = ParameterString(
-        name="situation",
-        default_value=default,
-        allowed_modes={ParameterMode.PROPERTY},
-        tooltip="File save situation — determines the output directory and naming conventions.",
-        traits={Options(choices=names)},
-        settable=True,
-    )
-    node.add_parameter(situation_param)
-    situation_param.update_ui_options({
-        "data": build_situation_data(names, descriptions),
-        "dropdown_row_subtitles": True,
-    })
-    file_param._situation_name = default
+    options_trait = Options(choices=names)
 
-    def _on_refresh(button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:  # noqa: ARG001
+    def _on_refresh(_button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:
         refreshed_names, refreshed_descriptions = fetch_situations_with_descriptions()
 
-        for trait in situation_param.traits:
-            if isinstance(trait, Options):
-                trait.choices = refreshed_names
-                break
-
+        options_trait.choices = refreshed_names
         situation_param.update_ui_options({
             "data": build_situation_data(refreshed_names, refreshed_descriptions),
             "dropdown_row_subtitles": True,
@@ -105,12 +87,25 @@ def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None
             altered_workflow_state=True,
         )
 
-    node.add_node_element(
-        ParameterButton(
-            name="refresh_situations",
-            label="Refresh Situations",
-            variant="default",
-            icon="refresh-cw",
-            on_click=_on_refresh,
-        )
+    situation_param = ParameterString(
+        name="situation",
+        default_value=default,
+        allowed_modes={ParameterMode.PROPERTY},
+        tooltip="File save situation — determines the output directory and naming conventions.",
+        traits={
+            options_trait,
+            Button(
+                icon="refresh-cw",
+                size="icon",
+                variant="secondary",
+                on_click=_on_refresh,
+            ),
+        },
+        settable=True,
     )
+    node.add_parameter(situation_param)
+    situation_param.update_ui_options({
+        "data": build_situation_data(names, descriptions),
+        "dropdown_row_subtitles": True,
+    })
+    file_param._situation_name = default

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from griptape_nodes.exe_types.core_types import NodeMessageResult, ParameterMode
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -17,6 +17,23 @@ from griptape_nodes.traits.options import Options
 logger = logging.getLogger("griptape_nodes")
 
 DEFAULT_SITUATION = ProjectFileParameter.DEFAULT_SITUATION
+_OUTPUT_FILE_PARAM = "output_file"
+
+
+def on_output_file_connected(node: BaseNode, target_parameter: Parameter) -> None:
+    """Call from after_incoming_connection to hide the situation dropdown."""
+    if target_parameter.name == _OUTPUT_FILE_PARAM:
+        param = node.get_parameter_by_name("situation")
+        if param is not None:
+            param.hide = True
+
+
+def on_output_file_disconnected(node: BaseNode, target_parameter: Parameter) -> None:
+    """Call from after_incoming_connection_removed to restore the situation dropdown."""
+    if target_parameter.name == _OUTPUT_FILE_PARAM:
+        param = node.get_parameter_by_name("situation")
+        if param is not None:
+            param.hide = False
 
 
 def fetch_situations() -> tuple[list[str], dict[str, str]]:

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -80,10 +80,12 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
         # Both are needed: the trait attribute governs value validation; update_ui_options
         # drives the rich dropdown rendering.
         options_trait.choices = refreshed_names
-        situation_param.update_ui_options({
-            "data": build_situation_data(refreshed_names, refreshed_descriptions),
-            "dropdown_row_subtitles": True,
-        })
+        situation_param.update_ui_options(
+            {
+                "data": build_situation_data(refreshed_names, refreshed_descriptions),
+                "dropdown_row_subtitles": True,
+            }
+        )
 
         current = node.get_parameter_value("situation")
         if current not in refreshed_names:
@@ -117,8 +119,10 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
     node.add_parameter(situation_param)
     # update_ui_options must follow add_parameter — subtitle data is pushed to the
     # UI layer after the param is registered.
-    situation_param.update_ui_options({
-        "data": build_situation_data(names, descriptions),
-        "dropdown_row_subtitles": True,
-    })
+    situation_param.update_ui_options(
+        {
+            "data": build_situation_data(names, descriptions),
+            "dropdown_row_subtitles": True,
+        }
+    )
     file_param._situation_name = default

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -69,14 +69,6 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
     def _on_refresh(_button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:
         refreshed_names, refreshed_descriptions = fetch_situations()
 
-        if not refreshed_names:
-            return NodeMessageResult(
-                success=False,
-                details="No situations available — project template could not be loaded",
-                response=button_details,
-                altered_workflow_state=False,
-            )
-
         # Update trait choices (for validation) and ui_options (for subtitle display).
         # Both are needed: the trait attribute governs value validation; update_ui_options
         # drives the rich dropdown rendering.

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -64,6 +64,18 @@ def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None
     def _on_refresh(_button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:
         refreshed_names, refreshed_descriptions = fetch_situations_with_descriptions()
 
+        if not refreshed_names:
+            return NodeMessageResult(
+                success=False,
+                details="No situations available — project template could not be loaded",
+                response=button_details,
+                altered_workflow_state=False,
+            )
+
+        # Update trait choices (for validation) and ui_options (for subtitle display).
+        # Both are needed: the trait attribute governs value validation; update_ui_options
+        # drives the rich dropdown rendering. FileOutputSettings omits the trait mutation
+        # because it never refreshes in-place; here we need both.
         options_trait.choices = refreshed_names
         situation_param.update_ui_options({
             "data": build_situation_data(refreshed_names, refreshed_descriptions),
@@ -75,7 +87,7 @@ def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None
             new_val = (
                 DEFAULT_SITUATION
                 if DEFAULT_SITUATION in refreshed_names
-                else (refreshed_names[0] if refreshed_names else DEFAULT_SITUATION)
+                else refreshed_names[0]
             )
             node.set_parameter_value("situation", new_val)
             file_param._situation_name = new_val

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -26,7 +26,14 @@ def fetch_situations() -> tuple[list[str], dict[str, str]]:
     (does not trigger the reentrant-bus-in-init strict-mode rule). Falls back to
     ([DEFAULT_SITUATION], {}) when the project template is not yet loaded.
     """
-    result = GriptapeNodes.handle_request(GetAllSituationsForProjectRequest())
+    try:
+        # Request only the fields we need. The `fields` parameter was added in a later engine
+        # release — see https://github.com/griptape-ai/griptape-nodes-engine/pull/5047.
+        # Falls back to the unfiltered call on older engines that raise TypeError for the
+        # unknown kwarg.
+        result = GriptapeNodes.handle_request(GetAllSituationsForProjectRequest(fields=["situations", "descriptions"]))  # type: ignore[call-arg]
+    except TypeError:
+        result = GriptapeNodes.handle_request(GetAllSituationsForProjectRequest())
     if not isinstance(result, GetAllSituationsForProjectResultSuccess):
         logger.warning("Could not fetch situations; using default situation")
         return [DEFAULT_SITUATION], {}

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -1,8 +1,12 @@
 """Shared helpers for situation dropdown parameters in save nodes."""
 
 import logging
+from typing import Any
 
+from griptape_nodes.exe_types.core_types import NodeMessageResult, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
     GetCurrentProjectRequest,
     GetCurrentProjectResultSuccess,
@@ -10,6 +14,8 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetProjectTemplateResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -40,6 +46,71 @@ def fetch_situations_with_descriptions() -> tuple[list[str], dict[str, str]]:
     return names, descriptions
 
 
-def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list[dict]:
+def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list[dict[str, str]]:
     """Build the ui_options data list for dropdown_row_subtitles display."""
     return [{"name": n, "subtitle": descriptions.get(n, "")} for n in names]
+
+
+def add_situation_parameter(node: Any, file_param: ProjectFileParameter) -> None:
+    """Add a situation dropdown and refresh button to a save node.
+
+    ``file_param`` must be created (but NOT yet added via ``add_parameter()``)
+    before calling this so that ``after_value_set`` can safely reference it.
+    """
+    names, descriptions = fetch_situations_with_descriptions()
+    default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else (names[0] if names else DEFAULT_SITUATION)
+
+    situation_param = ParameterString(
+        name="situation",
+        default_value=default,
+        allowed_modes={ParameterMode.PROPERTY},
+        tooltip="File save situation — determines the output directory and naming conventions.",
+        traits={Options(choices=names)},
+        settable=True,
+    )
+    node.add_parameter(situation_param)
+    situation_param.update_ui_options({
+        "data": build_situation_data(names, descriptions),
+        "dropdown_row_subtitles": True,
+    })
+    file_param._situation_name = default
+
+    def _on_refresh(button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:  # noqa: ARG001
+        refreshed_names, refreshed_descriptions = fetch_situations_with_descriptions()
+
+        for trait in situation_param.traits:
+            if isinstance(trait, Options):
+                trait.choices = refreshed_names
+                break
+
+        situation_param.update_ui_options({
+            "data": build_situation_data(refreshed_names, refreshed_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
+        current = node.get_parameter_value("situation")
+        if current not in refreshed_names:
+            new_val = (
+                DEFAULT_SITUATION
+                if DEFAULT_SITUATION in refreshed_names
+                else (refreshed_names[0] if refreshed_names else DEFAULT_SITUATION)
+            )
+            node.set_parameter_value("situation", new_val)
+            file_param._situation_name = new_val
+
+        return NodeMessageResult(
+            success=True,
+            details=f"Refreshed {len(refreshed_names)} situation(s)",
+            response=button_details,
+            altered_workflow_state=True,
+        )
+
+    node.add_node_element(
+        ParameterButton(
+            name="refresh_situations",
+            label="Refresh Situations",
+            variant="default",
+            icon="refresh-cw",
+            on_click=_on_refresh,
+        )
+    )

--- a/griptape_nodes_library/utils/situation_utils.py
+++ b/griptape_nodes_library/utils/situation_utils.py
@@ -9,10 +9,6 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes.retained_mode.events.project_events import (
     GetAllSituationsForProjectRequest,
     GetAllSituationsForProjectResultSuccess,
-    GetCurrentProjectRequest,
-    GetCurrentProjectResultSuccess,
-    GetProjectTemplateRequest,
-    GetProjectTemplateResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -23,43 +19,20 @@ logger = logging.getLogger("griptape_nodes")
 DEFAULT_SITUATION = ProjectFileParameter.DEFAULT_SITUATION
 
 
-def fetch_situation_names() -> list[str]:
-    """Return sorted situation names from the current project.
+def fetch_situations() -> tuple[list[str], dict[str, str]]:
+    """Return (sorted_names, {name: description}) from the current project.
 
     Uses GetAllSituationsForProjectRequest, which is safe to call from __init__
     (does not trigger the reentrant-bus-in-init strict-mode rule). Falls back to
-    [DEFAULT_SITUATION] when the project template is not yet loaded.
+    ([DEFAULT_SITUATION], {}) when the project template is not yet loaded.
     """
     result = GriptapeNodes.handle_request(GetAllSituationsForProjectRequest())
     if not isinstance(result, GetAllSituationsForProjectResultSuccess):
-        logger.warning("Could not fetch situation names; using default situation")
-        return [DEFAULT_SITUATION]
+        logger.warning("Could not fetch situations; using default situation")
+        return [DEFAULT_SITUATION], {}
     names = sorted(result.situations.keys())
-    return names if names else [DEFAULT_SITUATION]
-
-
-def fetch_situations_with_descriptions() -> tuple[list[str], dict[str, str]]:
-    """Return (sorted_names, {name: description}) from the current project.
-
-    Falls back to a single-entry list containing the default situation when the
-    project template is not yet loaded.
-    """
-    current = GriptapeNodes.handle_request(GetCurrentProjectRequest())
-    if not isinstance(current, GetCurrentProjectResultSuccess):
-        logger.warning("Could not fetch current project; using default situation")
-        return [DEFAULT_SITUATION], {}
-
-    template_result = GriptapeNodes.handle_request(
-        GetProjectTemplateRequest(project_id=current.project_info.project_id)
-    )
-    if not isinstance(template_result, GetProjectTemplateResultSuccess):
-        logger.warning("Could not fetch project template; using default situation")
-        return [DEFAULT_SITUATION], {}
-
-    situations = template_result.template.situations
-    names = sorted(situations.keys())
-    descriptions = {name: (sit.description or "") for name, sit in situations.items()}
-    return names, descriptions
+    descriptions: dict[str, str] = getattr(result, "descriptions", {})
+    return (names if names else [DEFAULT_SITUATION]), descriptions
 
 
 def build_situation_data(names: list[str], descriptions: dict[str, str]) -> list[dict[str, str]]:
@@ -86,18 +59,14 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
 
     ``file_param`` must be created (but NOT yet added via ``add_parameter()``)
     before calling this so that ``after_value_set`` can safely reference it.
-
-    Uses GetAllSituationsForProjectRequest (init-safe) for the initial list.
-    Descriptions are not available until the user clicks the refresh button,
-    which calls the slower two-request fetch that includes them.
     """
-    names = fetch_situation_names()
+    names, descriptions = fetch_situations()
     default = DEFAULT_SITUATION if DEFAULT_SITUATION in names else names[0]
 
     options_trait = Options(choices=names)
 
     def _on_refresh(_button: Button, button_details: ButtonDetailsMessagePayload) -> NodeMessageResult:
-        refreshed_names, refreshed_descriptions = fetch_situations_with_descriptions()
+        refreshed_names, refreshed_descriptions = fetch_situations()
 
         if not refreshed_names:
             return NodeMessageResult(
@@ -109,15 +78,12 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
 
         # Update trait choices (for validation) and ui_options (for subtitle display).
         # Both are needed: the trait attribute governs value validation; update_ui_options
-        # drives the rich dropdown rendering. FileOutputSettings omits the trait mutation
-        # because it never refreshes in-place; here we need both.
+        # drives the rich dropdown rendering.
         options_trait.choices = refreshed_names
-        situation_param.update_ui_options(
-            {
-                "data": build_situation_data(refreshed_names, refreshed_descriptions),
-                "dropdown_row_subtitles": True,
-            }
-        )
+        situation_param.update_ui_options({
+            "data": build_situation_data(refreshed_names, refreshed_descriptions),
+            "dropdown_row_subtitles": True,
+        })
 
         current = node.get_parameter_value("situation")
         if current not in refreshed_names:
@@ -149,4 +115,10 @@ def add_situation_parameter(node: BaseNode, file_param: ProjectFileParameter) ->
         settable=True,
     )
     node.add_parameter(situation_param)
+    # update_ui_options must follow add_parameter — subtitle data is pushed to the
+    # UI layer after the param is registered.
+    situation_param.update_ui_options({
+        "data": build_situation_data(names, descriptions),
+        "dropdown_row_subtitles": True,
+    })
     file_param._situation_name = default

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -7,7 +7,6 @@ from griptape_nodes.exe_types.core_types import (
 )
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
-from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.artifact_events import (
@@ -15,13 +14,8 @@ from griptape_nodes.retained_mode.events.artifact_events import (
     CheckArtifactReadPermissionResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
-from griptape_nodes.traits.options import Options
 
-from griptape_nodes_library.utils.situation_utils import (
-    DEFAULT_SITUATION,
-    build_situation_data,
-    fetch_situations_with_descriptions,
-)
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,
@@ -52,26 +46,12 @@ class SaveVideo(SuccessFailureNode):
             )
         )
 
-        situation_names, situation_descriptions = fetch_situations_with_descriptions()
-        situation_param = ParameterString(
-            name="situation",
-            default_value=DEFAULT_SITUATION,
-            allowed_modes={ParameterMode.PROPERTY},
-            tooltip="File save situation — determines the output directory and naming conventions.",
-            traits={Options(choices=situation_names)},
-            settable=True,
-        )
-        self.add_parameter(situation_param)
-        situation_param.update_ui_options({
-            "data": build_situation_data(situation_names, situation_descriptions),
-            "dropdown_row_subtitles": True,
-        })
-
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
             default_filename="griptape_nodes.mp4",
         )
+        add_situation_parameter(self, self._output_file)
         self._output_file.add_parameter()
 
         # Add status parameters using the helper method

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -8,7 +8,7 @@ from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,
@@ -171,3 +171,11 @@ class SaveVideo(SuccessFailureNode):
 
         except Exception as e:
             self._report_error(str(e), e)
+
+    def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_connected(self, target_parameter)
+        return super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:
+        on_output_file_disconnected(self, target_parameter)
+        return super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -2,10 +2,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from griptape_nodes.exe_types.core_types import (
+    Parameter,
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.artifact_events import (
@@ -13,7 +15,13 @@ from griptape_nodes.retained_mode.events.artifact_events import (
     CheckArtifactReadPermissionResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.traits.options import Options
 
+from griptape_nodes_library.utils.situation_utils import (
+    DEFAULT_SITUATION,
+    build_situation_data,
+    fetch_situations_with_descriptions,
+)
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,
@@ -44,6 +52,21 @@ class SaveVideo(SuccessFailureNode):
             )
         )
 
+        situation_names, situation_descriptions = fetch_situations_with_descriptions()
+        situation_param = ParameterString(
+            name="situation",
+            default_value=DEFAULT_SITUATION,
+            allowed_modes={ParameterMode.PROPERTY},
+            tooltip="File save situation — determines the output directory and naming conventions.",
+            traits={Options(choices=situation_names)},
+            settable=True,
+        )
+        self.add_parameter(situation_param)
+        situation_param.update_ui_options({
+            "data": build_situation_data(situation_names, situation_descriptions),
+            "dropdown_row_subtitles": True,
+        })
+
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
@@ -56,6 +79,11 @@ class SaveVideo(SuccessFailureNode):
             result_details_tooltip="Details about the video save operation result",
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
+
+    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
+        if parameter.name == "situation":
+            self._output_file._situation_name = str(value)
+        super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:
         """Extract bytes from various artifact types."""

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -61,7 +61,7 @@ class SaveVideo(SuccessFailureNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation":
+        if parameter.name == "situation" and not kwargs.get("initial_setup"):
             self._output_file._situation_name = str(value)
         super().after_value_set(parameter, value, **kwargs)
 

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -8,7 +8,11 @@ from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, on_output_file_connected, on_output_file_disconnected
+from griptape_nodes_library.utils.situation_utils import (
+    add_situation_parameter,
+    on_output_file_connected,
+    on_output_file_disconnected,
+)
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -15,7 +15,7 @@ from griptape_nodes.retained_mode.events.artifact_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,
@@ -61,8 +61,7 @@ class SaveVideo(SuccessFailureNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        if parameter.name == "situation" and not kwargs.get("initial_setup"):
-            self._output_file._situation_name = str(value)
+        update_file_param_situation(self._output_file, parameter, value, **kwargs)
         super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -1,17 +1,14 @@
 from dataclasses import dataclass
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import (
-    Parameter,
-    ParameterMode,
-)
+from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import logger
 
-from griptape_nodes_library.utils.situation_utils import add_situation_parameter, update_file_param_situation
+from griptape_nodes_library.utils.situation_utils import add_situation_parameter
 from griptape_nodes_library.utils.video_utils import (
     extract_url_from_video_object,
     is_video_url_artifact,
@@ -55,10 +52,6 @@ class SaveVideo(SuccessFailureNode):
             result_details_tooltip="Details about the video save operation result",
             result_details_placeholder="Details on the save attempt will be presented here.",
         )
-
-    def after_value_set(self, parameter: Parameter, value: object, **kwargs: object) -> None:
-        update_file_param_situation(self._output_file, parameter, value, **kwargs)
-        super().after_value_set(parameter, value, **kwargs)
 
     def _extract_bytes_from_artifact(self, artifact: Any) -> bytes | None:
         """Extract bytes from various artifact types."""
@@ -138,6 +131,7 @@ class SaveVideo(SuccessFailureNode):
     async def aprocess(self) -> None:
         """Async process method."""
         self._clear_execution_status()
+        self._output_file._situation_name = self.get_parameter_value("situation")
 
         try:
             raw_video = self.get_parameter_value("video")
@@ -159,6 +153,7 @@ class SaveVideo(SuccessFailureNode):
     def process(self) -> None:
         """Sync process method."""
         self._clear_execution_status()
+        self._output_file._situation_name = self.get_parameter_value("situation")
 
         try:
             raw_video = self.get_parameter_value("video")

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -177,7 +177,7 @@ class SaveVideo(SuccessFailureNode):
             self._report_error(str(e), e)
 
     def after_incoming_connection(self, source_node, source_parameter, target_parameter) -> None:
-        on_output_file_connected(self, target_parameter)
+        on_output_file_connected(self, source_node, target_parameter)
         return super().after_incoming_connection(source_node, source_parameter, target_parameter)
 
     def after_incoming_connection_removed(self, source_node, source_parameter, target_parameter) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.89.0"
+version = "0.90.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/21/a5b13929a22a44f4c92b695fcb6ad6d8a07aeb9e7d156fdc94299d7d8f9e/griptape_nodes_engine-0.89.0.tar.gz", hash = "sha256:c0a6202681d7ccaa639c54c2e9d2f57299a5f26a260b4e187e9e1b3a6e53955c", size = 981672, upload-time = "2026-06-30T22:08:25.405Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/78/1090a534483bfb8e932563bab419b3a80aaeb75b4b93a44fc4c4de482e10/griptape_nodes_engine-0.90.0.tar.gz", hash = "sha256:d9b90af3e49b02ae1a359b15ebaa928eaa3dfc871956864c62890661eb4638bc", size = 1008976, upload-time = "2026-07-02T21:39:21.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/e0/a77da498845566ccd011477379bad1b391c0ca789a3ba3bb88fb0ffecf4d/griptape_nodes_engine-0.89.0-py3-none-any.whl", hash = "sha256:291178e9308b4862b0cbebf14e38bf52fe5af38085f423aa28f39b289865b4c8", size = 1219385, upload-time = "2026-06-30T22:08:23.906Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/f2e5bf0b4c95130408b6a57313ab1fabd84deaf759f201b85215c1ebdf6d/griptape_nodes_engine-0.90.0-py3-none-any.whl", hash = "sha256:a2925ea7800a6d47af265d5efd7cf458f96a57f1c9d52cc6b0250180c3d303e5", size = 1247926, upload-time = "2026-07-02T21:39:20.321Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.89.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.90.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
Closes #330

# 🔥 Waiting for https://github.com/griptape-ai/griptape-nodes-engine/pull/5047

<img width="896" height="1086" alt="image" src="https://github.com/user-attachments/assets/a9841e37-0820-4527-beca-d3d11f3141da" />

## Summary

- Adds an inline **Situation** dropdown to all five save nodes (`SaveImage`, `SaveAudio`, `SaveVideo`, `SaveText`, `SaveToProject`) — no more detour through `FileOutputSettings` just to change where files land
- Situation dropdown also added to `FileOutputSettings` itself, with descriptions shown as subtitles (engine 0.91.0+, gracefully degraded on 0.90.0 via `getattr`)
- Refresh button on save node dropdowns lets users pick up newly-added situations without reloading
- Shared logic DRY'd into `griptape_nodes_library/utils/situation_utils.py` — `add_situation_parameter()`, `fetch_situations()`, `build_situation_data()`, `update_file_param_situation()`
- Uses `GetAllSituationsForProjectRequest` (init-safe) to avoid the `reentrant-bus-in-init` strict-mode rule
- Adds `.claude/skills/dropdown-row-subtitles` skill documenting the `update_ui_options` subtitle + icon pattern

## Engine compatibility

`fetch_situations()` is written to work across three engine generations:

| Engine | `descriptions` field | `fields` param | Behavior |
|--------|---------------------|----------------|----------|
| 0.90.x | ✗ | ✗ | Names only (subtitles blank) |
| 0.91.x | ✓ (via `getattr`) | ✗ | Names + descriptions |
| 0.93.x+ | ✓ | ✓ ([#5047](https://github.com/griptape-ai/griptape-nodes-engine/pull/5047)) | Names + descriptions, filtered fetch |

The `fields=["situations", "descriptions"]` call falls back gracefully to an unfiltered request on older engines via `TypeError`.

## Test plan

- [ ] Add a Save Image / Save Audio / Save Video / Save Text / Save to Project node — situation dropdown appears pre-populated with the project's situations
- [ ] Change situation on a save node and run — output lands in the correct situation directory
- [ ] Click the refresh button after adding a new situation to the project — dropdown updates without reloading
- [ ] Open a FileOutputSettings node — situation dropdown shows names (and descriptions as subtitles on engine 0.91.0+)
- [ ] Workflow round-trip: save and reload — chosen situation is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)