### PR TITLE
feat(video): enforce codec permissions on reads

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.82.0",
-    "engine_version": "0.90.0",
+    "engine_version": "0.92.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/video/base_video_processor.py
+++ b/griptape_nodes_library/video/base_video_processor.py
@@ -14,6 +14,11 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
+from griptape_nodes.retained_mode.events.artifact_events import (
+    CheckArtifactReadPermissionRequest,
+    CheckArtifactReadPermissionResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.utils.file_utils import generate_filename
@@ -390,6 +395,11 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
             # Validate URL before using in subprocess
             self._validate_url_safety(input_url)
 
+            # Gate the read against the codec-permission policy before spawning ffmpeg.
+            # A denial or failed permission check raises here so we never build or run
+            # the ffmpeg command without a positive result from the engine.
+            self._check_read_codec_permission(input_url)
+
             # Get FFmpeg paths
             _ffmpeg_path, ffprobe_path = self._get_ffmpeg_paths()
 
@@ -406,6 +416,25 @@ class BaseVideoProcessor(SuccessFailureNode, ABC):
             error_msg = f"Error during video processing: {e!s}"
             self.append_value_to_parameter("logs", f"ERROR: {error_msg}\n")
             raise ValueError(error_msg) from e
+
+    def _check_read_codec_permission(self, input_url: str) -> None:
+        """Ask the engine whether reading this input is permitted.
+
+        Sends a ``CheckArtifactReadPermissionRequest`` so the decision is
+        made by whichever provider owns the file's format (video, audio, etc.)
+        without the node needing to know which provider that is. Raises
+        ``ValueError`` unless the engine returns a recognized successful result
+        with no denial, so the surrounding exception handler on ``_process_video``
+        funnels the message through the node's standard error reporting.
+        """
+        result = GriptapeNodes.handle_request(CheckArtifactReadPermissionRequest(source_path=input_url))
+        file_name = Path(input_url).name
+        if not isinstance(result, CheckArtifactReadPermissionResultSuccess):
+            msg = f"Cannot load '{file_name}': the video codec permission check failed. {result.result_details}"
+            raise ValueError(msg)
+        if result.denial is not None:
+            msg = f"Cannot load '{file_name}': {result.denial.reason()}"
+            raise ValueError(msg)
 
     def _process(self, input_url: str, detected_format: str, **kwargs) -> None:
         """Common processing wrapper."""

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -6,7 +6,11 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
-from griptape_nodes.retained_mode.griptape_nodes import logger
+from griptape_nodes.retained_mode.events.artifact_events import (
+    CheckArtifactReadPermissionRequest,
+    CheckArtifactReadPermissionResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 
 from griptape_nodes_library.utils.situation_utils import (
     add_situation_parameter,
@@ -82,6 +86,18 @@ class SaveVideo(SuccessFailureNode):
         if is_video_url_artifact(raw_input):
             url = extract_url_from_video_object(raw_input)
             if url:
+                # Ask the engine whether this file may be read before loading its bytes.
+                # A denial raises here so the URL is never fetched. The write side (final
+                # File.write_bytes on aprocess/process) is still checked independently by
+                # the engine's OSManager -- this call is a UX shortcut so denials surface
+                # before the bytes are pulled over the network.
+                result = GriptapeNodes.handle_request(CheckArtifactReadPermissionRequest(source_path=url))
+                if not isinstance(result, CheckArtifactReadPermissionResultSuccess):
+                    msg = f"Cannot load '{url}': the video codec permission check failed. {result.result_details}"
+                    raise ValueError(msg)
+                if result.denial is not None:
+                    msg = f"Cannot load '{url}': {result.denial.reason()}"
+                    raise ValueError(msg)
                 video_bytes = File(url).read_bytes()
                 return VideoInput(data=video_bytes, source_url=url)
 

--- a/griptape_nodes_library/video/save_video.py
+++ b/griptape_nodes_library/video/save_video.py
@@ -86,19 +86,28 @@ class SaveVideo(SuccessFailureNode):
         if is_video_url_artifact(raw_input):
             url = extract_url_from_video_object(raw_input)
             if url:
+                # Resolve macro paths (e.g. "{inputs}/videos/clip.mp4") to a concrete
+                # path before the permission check. The engine ffprobes source_path
+                # as-is, and an unresolved macro is not a probeable file, so passing
+                # the raw macro fails the check closed even for permitted codecs.
+                # Plain paths and remote URLs pass through resolve() unchanged. This
+                # mirrors BaseVideoProcessor, which resolves in _get_video_input_data
+                # before its own read-permission check.
+                source_file = File(url)
+                resolved_path = source_file.resolve()
                 # Ask the engine whether this file may be read before loading its bytes.
                 # A denial raises here so the URL is never fetched. The write side (final
                 # File.write_bytes on aprocess/process) is still checked independently by
                 # the engine's OSManager -- this call is a UX shortcut so denials surface
                 # before the bytes are pulled over the network.
-                result = GriptapeNodes.handle_request(CheckArtifactReadPermissionRequest(source_path=url))
+                result = GriptapeNodes.handle_request(CheckArtifactReadPermissionRequest(source_path=resolved_path))
                 if not isinstance(result, CheckArtifactReadPermissionResultSuccess):
                     msg = f"Cannot load '{url}': the video codec permission check failed. {result.result_details}"
                     raise ValueError(msg)
                 if result.denial is not None:
                     msg = f"Cannot load '{url}': {result.denial.reason()}"
                     raise ValueError(msg)
-                video_bytes = File(url).read_bytes()
+                video_bytes = source_file.read_bytes()
                 return VideoInput(data=video_bytes, source_url=url)
 
         # Handle all other cases - try to extract bytes

--- a/tests/unit/video/test_base_video_processor.py
+++ b/tests/unit/video/test_base_video_processor.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+from griptape_nodes.retained_mode.events.artifact_events import (
+    CheckArtifactReadPermissionRequest,
+    CheckArtifactReadPermissionResultFailure,
+    CheckArtifactReadPermissionResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+from griptape_nodes_library.video.base_video_processor import BaseVideoProcessor
+
+
+class _StubVideoProcessor(BaseVideoProcessor):
+    """Minimal concrete subclass so the base class's read-permission gate can be tested without a real ffmpeg pipeline."""
+
+    def _setup_custom_parameters(self) -> None:
+        pass
+
+    def _get_processing_description(self) -> str:
+        return "stub processing"
+
+    def _build_ffmpeg_command(self, input_url: str, output_path: str, input_frame_rate: float, **kwargs) -> list[str]:  # noqa: ARG002
+        return []
+
+
+def _stub_handle_request(monkeypatch: pytest.MonkeyPatch, result: object) -> list[CheckArtifactReadPermissionRequest]:
+    """Replace ``GriptapeNodes.handle_request`` and capture the requests it was sent."""
+    sent: list[CheckArtifactReadPermissionRequest] = []
+
+    def fake_handle_request(request: CheckArtifactReadPermissionRequest) -> object:
+        sent.append(request)
+        return result
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", staticmethod(fake_handle_request))
+    return sent
+
+
+def test_check_read_codec_permission_allows_when_no_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent = _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultSuccess(denial=None, result_details="Read allowed for 'input.mp4'."),
+    )
+    node = _StubVideoProcessor(name="Stub")
+
+    node._check_read_codec_permission("/tmp/input.mp4")
+
+    assert sent == [CheckArtifactReadPermissionRequest(source_path="/tmp/input.mp4")]
+
+
+def test_check_read_codec_permission_raises_on_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    denial = CheckpointDenial(failures=(CheckpointFailure(detail="Codec not permitted by license policy."),))
+    _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultSuccess(denial=denial, result_details="Read denied."),
+    )
+    node = _StubVideoProcessor(name="Stub")
+
+    with pytest.raises(ValueError, match="Codec not permitted by license policy"):
+        node._check_read_codec_permission("/tmp/input.mp4")
+
+
+def test_check_read_codec_permission_raises_when_permission_check_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultFailure(result_details="Attempted to check read permission. Failed."),
+    )
+    node = _StubVideoProcessor(name="Stub")
+
+    with pytest.raises(ValueError, match="video codec permission check failed"):
+        node._check_read_codec_permission("/tmp/input.mp4")

--- a/tests/unit/video/test_save_video.py
+++ b/tests/unit/video/test_save_video.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.retained_mode.events.artifact_events import (
+    CheckArtifactReadPermissionRequest,
+    CheckArtifactReadPermissionResultFailure,
+    CheckArtifactReadPermissionResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+import griptape_nodes_library.video.save_video as save_video_module
+from griptape_nodes_library.video.save_video import SaveVideo
+
+
+def _stub_handle_request(monkeypatch: pytest.MonkeyPatch, result: object) -> list[CheckArtifactReadPermissionRequest]:
+    """Replace ``GriptapeNodes.handle_request`` and capture the requests it was sent."""
+    sent: list[CheckArtifactReadPermissionRequest] = []
+
+    def fake_handle_request(request: CheckArtifactReadPermissionRequest) -> object:
+        sent.append(request)
+        return result
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", staticmethod(fake_handle_request))
+    return sent
+
+
+def _stub_file_read_bytes(monkeypatch: pytest.MonkeyPatch, data: bytes = b"fake video bytes") -> list[str]:
+    """Replace ``File`` with a fake that records the URL it was asked to read."""
+    read_urls: list[str] = []
+
+    class _FakeFile:
+        def __init__(self, url: str) -> None:
+            read_urls.append(url)
+
+        def read_bytes(self) -> bytes:
+            return data
+
+    monkeypatch.setattr(save_video_module, "File", _FakeFile)
+    return read_urls
+
+
+def test_normalize_input_loads_bytes_when_read_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = SaveVideo(name="Save")
+    sent = _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultSuccess(denial=None, result_details="Read allowed."),
+    )
+    read_urls = _stub_file_read_bytes(monkeypatch, data=b"video-bytes")
+
+    video_input = node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
+
+    assert video_input.data == b"video-bytes"
+    assert video_input.source_url == "https://example.com/input.mp4"
+    assert sent == [CheckArtifactReadPermissionRequest(source_path="https://example.com/input.mp4")]
+    assert read_urls == ["https://example.com/input.mp4"]
+
+
+def test_normalize_input_raises_on_denial_without_reading_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = SaveVideo(name="Save")
+    denial = CheckpointDenial(failures=(CheckpointFailure(detail="Codec not permitted by license policy."),))
+    _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultSuccess(denial=denial, result_details="Read denied."),
+    )
+    read_urls = _stub_file_read_bytes(monkeypatch)
+
+    with pytest.raises(ValueError, match="Codec not permitted by license policy"):
+        node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
+
+    assert read_urls == []
+
+
+def test_normalize_input_raises_when_permission_check_fails_without_reading_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = SaveVideo(name="Save")
+    _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultFailure(result_details="Attempted to check read permission. Failed."),
+    )
+    read_urls = _stub_file_read_bytes(monkeypatch, data=b"video-bytes")
+
+    with pytest.raises(ValueError, match="video codec permission check failed"):
+        node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
+
+    assert read_urls == []

--- a/tests/unit/video/test_save_video.py
+++ b/tests/unit/video/test_save_video.py
@@ -26,19 +26,45 @@ def _stub_handle_request(monkeypatch: pytest.MonkeyPatch, result: object) -> lis
     return sent
 
 
-def _stub_file_read_bytes(monkeypatch: pytest.MonkeyPatch, data: bytes = b"fake video bytes") -> list[str]:
-    """Replace ``File`` with a fake that records the URL it was asked to read."""
-    read_urls: list[str] = []
+class _FileCalls:
+    """Records how the stubbed ``File`` was exercised."""
+
+    def __init__(self) -> None:
+        self.constructed: list[str] = []
+        self.resolved: list[str] = []
+        self.read: list[str] = []
+
+
+def _stub_file(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    data: bytes = b"fake video bytes",
+    resolved_path: str | None = None,
+) -> _FileCalls:
+    """Replace ``File`` with a fake that records construction, resolve, and read.
+
+    ``resolve()`` returns ``resolved_path`` when provided -- simulating a macro
+    path (e.g. ``{inputs}/videos/clip.mp4``) resolving to an absolute path --
+    otherwise it echoes the constructor argument, matching how the real
+    ``File.resolve()`` passes plain paths and URLs through unchanged.
+    """
+    calls = _FileCalls()
 
     class _FakeFile:
         def __init__(self, url: str) -> None:
-            read_urls.append(url)
+            self._url = url
+            calls.constructed.append(url)
+
+        def resolve(self) -> str:
+            calls.resolved.append(self._url)
+            return resolved_path if resolved_path is not None else self._url
 
         def read_bytes(self) -> bytes:
+            calls.read.append(self._url)
             return data
 
     monkeypatch.setattr(save_video_module, "File", _FakeFile)
-    return read_urls
+    return calls
 
 
 def test_normalize_input_loads_bytes_when_read_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,14 +73,40 @@ def test_normalize_input_loads_bytes_when_read_allowed(monkeypatch: pytest.Monke
         monkeypatch,
         CheckArtifactReadPermissionResultSuccess(denial=None, result_details="Read allowed."),
     )
-    read_urls = _stub_file_read_bytes(monkeypatch, data=b"video-bytes")
+    calls = _stub_file(monkeypatch, data=b"video-bytes")
 
     video_input = node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
 
     assert video_input.data == b"video-bytes"
     assert video_input.source_url == "https://example.com/input.mp4"
     assert sent == [CheckArtifactReadPermissionRequest(source_path="https://example.com/input.mp4")]
-    assert read_urls == ["https://example.com/input.mp4"]
+    assert calls.read == ["https://example.com/input.mp4"]
+
+
+def test_normalize_input_checks_resolved_macro_path_not_the_macro(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The read check must receive the resolved absolute path, not the raw macro.
+
+    A workspace artifact carries a macro value like ``{inputs}/videos/clip.mp4``.
+    The engine ffprobes ``source_path`` directly, so the macro has to be resolved
+    first or the probe fails and the check denies even permitted codecs.
+    """
+    node = SaveVideo(name="Save")
+    sent = _stub_handle_request(
+        monkeypatch,
+        CheckArtifactReadPermissionResultSuccess(denial=None, result_details="Read allowed."),
+    )
+    calls = _stub_file(
+        monkeypatch,
+        data=b"video-bytes",
+        resolved_path="/abs/workspace/inputs/videos/clip.mp4",
+    )
+
+    video_input = node._normalize_input(VideoUrlArtifact(value="{inputs}/videos/clip.mp4"))
+
+    assert sent == [CheckArtifactReadPermissionRequest(source_path="/abs/workspace/inputs/videos/clip.mp4")]
+    assert calls.read == ["{inputs}/videos/clip.mp4"]
+    # The human-facing source_url keeps the portable macro form.
+    assert video_input.source_url == "{inputs}/videos/clip.mp4"
 
 
 def test_normalize_input_raises_on_denial_without_reading_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,12 +116,12 @@ def test_normalize_input_raises_on_denial_without_reading_bytes(monkeypatch: pyt
         monkeypatch,
         CheckArtifactReadPermissionResultSuccess(denial=denial, result_details="Read denied."),
     )
-    read_urls = _stub_file_read_bytes(monkeypatch)
+    calls = _stub_file(monkeypatch)
 
     with pytest.raises(ValueError, match="Codec not permitted by license policy"):
         node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
 
-    assert read_urls == []
+    assert calls.read == []
 
 
 def test_normalize_input_raises_when_permission_check_fails_without_reading_bytes(
@@ -80,9 +132,9 @@ def test_normalize_input_raises_when_permission_check_fails_without_reading_byte
         monkeypatch,
         CheckArtifactReadPermissionResultFailure(result_details="Attempted to check read permission. Failed."),
     )
-    read_urls = _stub_file_read_bytes(monkeypatch, data=b"video-bytes")
+    calls = _stub_file(monkeypatch, data=b"video-bytes")
 
     with pytest.raises(ValueError, match="video codec permission check failed"):
         node._normalize_input(VideoUrlArtifact(value="https://example.com/input.mp4"))
 
-    assert read_urls == []
+    assert calls.read == []


### PR DESCRIPTION
Engine 0.92 now owns codec probing and write-side enforcement, but reading an existing video remains an operation-specific decision because the engine cannot assume every file read is media consumption. Standard video processors and Save Video therefore need to consult the engine before invoking ffmpeg or fetching source bytes.

The check fails closed when the engine cannot produce a permission result, matching the legal guardrail's treatment of unverified codecs. This PR now targets the released engine contract and is no longer blocked on the engine release.

Tracks [griptape-ai/internal#131](https://github.com/griptape-ai/internal/issues/131) and complements [griptape-ai/griptape-nodes-engine#5037](https://github.com/griptape-ai/griptape-nodes-engine/pull/5037).

> [!NOTE]
> Beep boop. This PR description was written by AI.
