### PR TITLE
fix: restore RENDER_SEQUENCE_PATTERN for FileOutputSettings preview resolves

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.81.0",
-    "engine_version": "0.89.0",
+    "engine_version": "0.90.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/filesystem/file_output_settings.py
+++ b/griptape_nodes_library/filesystem/file_output_settings.py
@@ -36,6 +36,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetSituationRequest,
     GetSituationResultSuccess,
     MacroPath,
+    UnresolvedSequenceSlotBehavior,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -291,7 +292,14 @@ class FileOutputSettings(BaseNode):
             ClassifiedPath with scenario classification, or error message string
         """
         parsed_macro = ParsedMacro(file_name_value)
-        parse_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
+        parse_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={},
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
+        )
 
         if not isinstance(parse_result, GetPathForMacroResultSuccess):
             return "Failed to parse macro"
@@ -382,8 +390,13 @@ class FileOutputSettings(BaseNode):
         variables = self._build_relative_variables(classified)
 
         parsed_macro = ParsedMacro(macro_template)
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
         resolve_result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=parsed_macro, variables=variables)
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables=variables,
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
         )
 
         if not isinstance(resolve_result, GetPathForMacroResultSuccess):
@@ -399,7 +412,14 @@ class FileOutputSettings(BaseNode):
         macro_template = classified.normalized_path
 
         parsed_macro = ParsedMacro(macro_template)
-        resolve_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed_macro, variables={}))
+        # Preview-only resolve: render an unbound `{###}` as `###` instead of failing.
+        resolve_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(
+                parsed_macro=parsed_macro,
+                variables={},
+                unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN,
+            )
+        )
 
         if not isinstance(resolve_result, GetPathForMacroResultSuccess):
             logger.error("%s: Failed to resolve macro: %s", self.name, macro_template)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.89.0",
+  "griptape-nodes-engine>=0.90.0",
   "lxml>=5.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.90.0"
+version = "0.88.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/78/1090a534483bfb8e932563bab419b3a80aaeb75b4b93a44fc4c4de482e10/griptape_nodes_engine-0.90.0.tar.gz", hash = "sha256:d9b90af3e49b02ae1a359b15ebaa928eaa3dfc871956864c62890661eb4638bc", size = 1008976, upload-time = "2026-07-02T21:39:21.9Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/92/85dcb7206cf5b725606f17e6364c8583e5f858fcef07b59039152de8d912/griptape_nodes_engine-0.88.0.tar.gz", hash = "sha256:19de433dbfe68f6f58e7ecf20d6e666dca09e221eea6b6a8d29459b855955ddd", size = 935218, upload-time = "2026-06-23T22:41:39.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/7c/f2e5bf0b4c95130408b6a57313ab1fabd84deaf759f201b85215c1ebdf6d/griptape_nodes_engine-0.90.0-py3-none-any.whl", hash = "sha256:a2925ea7800a6d47af265d5efd7cf458f96a57f1c9d52cc6b0250180c3d303e5", size = 1247926, upload-time = "2026-07-02T21:39:20.321Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/dc/cc463c97aede417956c7136cfa09c0ab665c790dba1bc7ff26e98dec9a9c/griptape_nodes_engine-0.88.0-py3-none-any.whl", hash = "sha256:cd88c1008d4fbfb4aaa4b0e44427dea5a26532f518af41c080456e8c8bb66032", size = 1170364, upload-time = "2026-06-23T22:41:38.14Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.89.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.88.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
## Summary

Re-opens the sequence-preview fix that was rolled back on 2026-07-04.

**### This needs to go out when we do a full release (app/lib/desktop) with engine 0.90**

- Re-applies [#389](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/389) (commit [`5b086dd`](https://github.com/griptape-ai/griptape-nodes-library-standard/commit/5b086ddad35cf34dda37c927ea21a40dc530d4e2)), which was reverted by [#400](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/400) (commit [`8002503`](https://github.com/griptape-ai/griptape-nodes-library-standard/commit/800250342a9bd33edc52a8c01b5f2e4ddc195ba6)).
- Passes `unresolved_sequence_slot_behavior=UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN` at the three `GetPathForMacroRequest` preview call sites in `FileOutputSettings`, so an unbound `{###}` renders as `###` instead of returning `"Failed to parse macro"`.
- Bumps `engine_version` (in `griptape_nodes_library.json`) and the `griptape-nodes-engine` dependency (in `pyproject.toml` / `uv.lock`) from `0.89.0` → `0.90.0`, since the `UnresolvedSequenceSlotBehavior.RENDER_SEQUENCE_PATTERN` sentinel and the corresponding `GetPathForMacroRequest` field ship in engine 0.90.0.

## History

The original PR was reverted for release-sequencing reasons only: the library was pinned to engine `>=0.90.0` before that engine version had been tagged, so installs against the current released engine (`0.89.0`) broke. The underlying fix is unchanged.

## Blocker

**Blocked by engine 0.90.0 release — do not merge until engine 0.90.0 is tagged and published.** After the engine release, run `uv sync` here and confirm resolution against the new engine before merging.

## Test plan

- [ ] Wait for engine 0.90.0 release, then run `uv sync` in this repo — resolves against published engine 0.90.0 cleanly.
- [ ] Run `make check` — no lint/format/type regressions.
- [ ] Load a project using `FileOutputSettings` with a sequence macro (e.g. `render_{###}.png`) — preview renders as `render_###.png` instead of surfacing "Failed to parse macro".