### PR TITLE
fix: resolve audio file path in CreateVideoFromFrames

### DIFF
--- a/griptape_nodes_library/video/create_video_from_frames.py
+++ b/griptape_nodes_library/video/create_video_from_frames.py
@@ -23,6 +23,7 @@ from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.files.file import File
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import _resolve_file_path
@@ -633,8 +634,11 @@ class CreateVideoFromFrames(SuccessFailureNode):
         if not audio_url:
             return None
 
-        resolved = _resolve_file_path(audio_url)
-        return str(resolved) if resolved else audio_url
+        try:
+            return File(audio_url).resolve()
+        except Exception:
+            resolved = _resolve_file_path(audio_url)
+            return str(resolved) if resolved else audio_url
 
     def _build_ffmpeg_command(
         self,


### PR DESCRIPTION
## Summary

- `_extract_audio_url` in `CreateVideoFromFrames` was using `_resolve_file_path`, which cannot expand `{outputs}` template placeholders in stored file paths
- This caused FFmpeg to receive the raw unresolved path (e.g. `GriptapeNodes/{outputs}/audio/file.mp3`), resulting in a "No such file or directory" error
- Fixed by using `File(audio_url).resolve()` — the same resolution mechanism `BaseVideoProcessor` uses for video inputs — with `_resolve_file_path` as a fallback

Resolves griptape-ai/griptape-nodes-engine#5069

🤖 Generated with [Claude Code](https://claude.com/claude-code)