### PR TITLE
fix(tests): restore flow inputs and metadata preset for integration workflows

### DIFF
--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -159,6 +159,8 @@ ADVANCED_CONFIGS = [
         "image_in": "input_image",
         "output_param": "output_image",
         "suffix": "write_image_metadata",
+        # WriteImageMetadataNode rejects empty metadata, so the workflow must set it.
+        "set_params": {"metadata": {"author": "griptape-nodes-tests", "description": "integration test"}},
     },
     # single_image — API proxy nodes
     {
@@ -427,6 +429,12 @@ _SET_PARAM = """\
             parameter_name="{param}", node_name={node_var},
             value="{value}", initial_setup=True, is_output=False))"""
 
+_SET_PARAM_VALUE = """\
+    with GriptapeNodes.ContextManager().node({node_var}):
+        GriptapeNodes.handle_request(SetParameterValueRequest(
+            parameter_name="{param}", node_name={node_var},
+            value={value}, initial_setup=True, is_output=False))"""
+
 _TAIL_CONNECTIONS = """\
     GriptapeNodes.handle_request(CreateConnectionRequest(
         source_node_name=gen_node, source_parameter_name="{output_param}",
@@ -463,6 +471,13 @@ def _tail_connections(output_param: str) -> str:
 
 def _set_param(node_var: str, param: str, value: str) -> str:
     return _SET_PARAM.format(node_var=node_var, param=param, value=value)
+
+
+def _set_params(node_var: str, params: dict) -> str:
+    """Emit SetParameterValueRequest calls for parameter presets from a config's set_params."""
+    return "\n".join(
+        _SET_PARAM_VALUE.format(node_var=node_var, param=param, value=repr(value)) for param, value in params.items()
+    )
 
 
 def _add_param_list_child(
@@ -516,8 +531,10 @@ def _body_single_image(cfg: dict) -> str:
         _create_node("gen_node", node_type, node_type),
         _common_utility_nodes(),
         _connect("source_node", "image", "gen_node", image_in),
-        _tail_connections(output_param),
     ]
+    if cfg.get("set_params"):
+        parts.append(_set_params("gen_node", cfg["set_params"]))
+    parts.append(_tail_connections(output_param))
     return "\n".join(parts)
 
 
@@ -859,6 +876,8 @@ def generate_advanced_workflow(cfg: dict) -> str:
 MANUAL_FLOW_INPUTS: dict[str, dict] = {
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
+    "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }
 
 

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -22,4 +22,6 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_elevenlabs_music_generation.py": {"Start Flow": {"prompt": "Upbeat jazz"}},
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
+    "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }

--- a/tests/integration/test_write_image_metadata.py
+++ b/tests/integration/test_write_image_metadata.py
@@ -24,7 +24,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 GriptapeNodes.handle_request(
@@ -108,6 +108,16 @@ with GriptapeNodes.ContextManager().flow(flow_name):
             initial_setup=True,
         )
     )
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="metadata",
+                node_name=gen_node,
+                value={"author": "griptape-nodes-tests", "description": "integration test"},
+                initial_setup=True,
+                is_output=False,
+            )
+        )
     GriptapeNodes.handle_request(
         CreateConnectionRequest(
             source_node_name=gen_node,


### PR DESCRIPTION
The Workflow Tests job on main has been failing 3 tests for repo-side reasons (the other 3 Tripo failures were upstream credit exhaustion, since resolved):

- `test_openai_image_generation_wide` / `test_openai_image_generation_tall` were added in #220 as hand-written workflows but never registered in `FLOW_INPUTS`, so they ran with an empty flow input and `OpenAiImageGeneration` rejected the empty prompt.
- `test_write_image_metadata` was fixed by hand in #251 to set the required `metadata` parameter, but that edit lived in a generated file and was silently clobbered when #345 reran `scripts/generate_test_workflows.py`.

Both fixes now live in the generator so they survive regeneration: the wide/tall entries go through `MANUAL_FLOW_INPUTS`, and the `single_image` template gains a `set_params` config key that emits `SetParameterValueRequest` calls (used to preset `metadata` on `WriteImageMetadataNode`). The touched workflow files are regenerated output.

Verified locally: all three previously failing tests pass (`write_image_metadata` runs fully local, the two OpenAI ones against the live proxy).

Fixes integration test portion of #409