### PR TITLE
feat: add FileExists node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -6021,6 +6021,19 @@
       }
     },
     {
+      "class_name": "FileExists",
+      "file_path": "griptape_nodes_library/files/file_exists.py",
+      "metadata": {
+        "category": "files",
+        "description": "Check whether a file or directory exists at a given path. Outputs a boolean result suitable for wiring into an If/Else node.",
+        "display_name": "File Exists",
+        "icon": "FileSearch",
+        "tags": [
+          "file"
+        ]
+      }
+    },
+    {
       "class_name": "FilePathComponents",
       "file_path": "griptape_nodes_library/files/path.py",
       "metadata": {

--- a/griptape_nodes_library/files/file_exists.py
+++ b/griptape_nodes_library/files/file_exists.py
@@ -1,0 +1,71 @@
+from typing import Any
+
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.os_events import (
+    GetFileInfoRequest,
+    GetFileInfoResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.file_system_picker import FileSystemPicker
+
+
+class FileExists(DataNode):
+    """Check whether a file or directory exists at a given path."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.path_input = ParameterString(
+            name="path",
+            default_value="",
+            tooltip="Path to check for existence.",
+            placeholder_text="Example: my_folder/file.txt",
+        )
+        self.path_input.add_trait(
+            FileSystemPicker(
+                allow_files=True,
+                allow_directories=True,
+                multiple=False,
+            )
+        )
+        self.add_parameter(self.path_input)
+
+        self.add_parameter(
+            ParameterBool(
+                name="exists",
+                allow_input=False,
+                allow_property=False,
+                default_value=False,
+                tooltip="True if the path exists, False otherwise.",
+            )
+        )
+
+        self.add_parameter(
+            ParameterBool(
+                name="is_directory",
+                allow_input=False,
+                allow_property=False,
+                default_value=False,
+                tooltip="True if the path exists and is a directory.",
+            )
+        )
+
+    def process(self) -> None:
+        path_str = self.get_parameter_value("path") or ""
+        path_str = GriptapeNodes.OSManager().sanitize_path_string(str(path_str))
+
+        exists = False
+        is_directory = False
+
+        if path_str:
+            result = GriptapeNodes.handle_request(GetFileInfoRequest(path=path_str, workspace_only=False))
+            if isinstance(result, GetFileInfoResultSuccess) and result.file_entry is not None:
+                exists = True
+                is_directory = result.file_entry.is_dir
+
+        self.parameter_output_values["exists"] = exists
+        self.parameter_output_values["is_directory"] = is_directory
+        self.publish_update_to_parameter("exists", exists)
+        self.publish_update_to_parameter("is_directory", is_directory)

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ loaders-pdf = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.88.0"
+version = "0.91.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -741,9 +741,9 @@ dependencies = [
     { name = "websockets" },
     { name = "xdg-base-dirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/92/85dcb7206cf5b725606f17e6364c8583e5f858fcef07b59039152de8d912/griptape_nodes_engine-0.88.0.tar.gz", hash = "sha256:19de433dbfe68f6f58e7ecf20d6e666dca09e221eea6b6a8d29459b855955ddd", size = 935218, upload-time = "2026-06-23T22:41:39.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/67/559a6ae3a98be6c3bc5a35eb5c3821f60ac86d18865822ce65169f952ad3/griptape_nodes_engine-0.91.0.tar.gz", hash = "sha256:733cd598e3deea3a16269a709342ada9b82867622aad8695e71648abd00c4e47", size = 1010943, upload-time = "2026-07-06T19:09:32.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/dc/cc463c97aede417956c7136cfa09c0ab665c790dba1bc7ff26e98dec9a9c/griptape_nodes_engine-0.88.0-py3-none-any.whl", hash = "sha256:cd88c1008d4fbfb4aaa4b0e44427dea5a26532f518af41c080456e8c8bb66032", size = 1170364, upload-time = "2026-06-23T22:41:38.14Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4b/4108a3f1e209661bda8f8771cffa66f931fe2994e65a45cefa5bddc130fd/griptape_nodes_engine-0.91.0-py3-none-any.whl", hash = "sha256:e9937b1d7d8311af626c993198976ee209d0491f5b4a2a1848aad23de68e2534", size = 1249740, upload-time = "2026-07-06T19:09:30.802Z" },
 ]
 
 [[package]]
@@ -781,7 +781,7 @@ requires-dist = [
     { name = "asteval", specifier = ">=1.0.8" },
     { name = "color-matcher" },
     { name = "griptape", extras = ["drivers-prompt-amazon-bedrock", "drivers-prompt-anthropic", "drivers-prompt-cohere", "drivers-prompt-ollama", "drivers-web-scraper-trafilatura", "drivers-web-search-duckduckgo", "drivers-web-search-exa", "loaders-image", "loaders-pdf"], specifier = ">=1.9.4" },
-    { name = "griptape-nodes-engine", specifier = ">=0.88.0" },
+    { name = "griptape-nodes-engine", specifier = ">=0.90.0" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "json-repair", specifier = ">=0.46.1" },
     { name = "json-schema-to-pydantic", specifier = ">=0.4.6" },


### PR DESCRIPTION
## Summary

- Adds a `FileExists` node to `griptape_nodes_library/files/` that takes a path input and outputs `exists` (bool) and `is_directory` (bool)
- The `exists` output wires directly into the `evaluate` input of the existing `If/Else` node for clean conditional branching
- Uses the same `GetFileInfoRequest` / path-sanitize pattern as the other file nodes for consistent behaviour across files, directories, and macro paths

https://github.com/griptape-ai/griptape-nodes-library-standard/issues/404

<img width="1894" height="526" alt="image" src="https://github.com/user-attachments/assets/3d35d0fd-9887-4b6a-bcb0-2a11368ee358" />

Closes #404

## Test plan

- [ ] Wire a `Select From Project` → `FileExists` → `If/Else` and confirm `Then` fires when the file is present, `Else` when it isn't
- [ ] Test with a directory path — confirm `is_directory` is `True`
- [ ] Test with a nonexistent path — confirm `exists` is `False`
- [ ] Confirm the `FileExists` node appears in the node palette under the **files** category

🤖 Generated with [Claude Code](https://claude.com/claude-code)