### PR TITLE
feat: add ResolveMacroPath node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -6038,8 +6038,23 @@
       "file_path": "griptape_nodes_library/files/resolve_macro_path.py",
       "metadata": {
         "category": "files",
-        "description": "Resolve one or more macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths.",
+        "description": "Resolve a macro path (e.g. {inputs}/file.txt) to an absolute filesystem path.",
         "display_name": "Resolve Macro Path",
+        "icon": "FolderSearch",
+        "tags": [
+          "file",
+          "macro",
+          "path"
+        ]
+      }
+    },
+    {
+      "class_name": "ResolveMacroPaths",
+      "file_path": "griptape_nodes_library/files/resolve_macro_paths.py",
+      "metadata": {
+        "category": "files",
+        "description": "Resolve a list of macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths.",
+        "display_name": "Resolve Macro Paths",
         "icon": "FolderSearch",
         "tags": [
           "file",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -6038,7 +6038,7 @@
       "file_path": "griptape_nodes_library/files/resolve_macro_path.py",
       "metadata": {
         "category": "files",
-        "description": "Resolve a macro path (e.g. {inputs}/file.txt) to an absolute filesystem path.",
+        "description": "Resolve a macro path to an absolute filesystem path (e.g. {inputs}/file.txt → /home/user/project/inputs/file.txt).",
         "display_name": "Resolve Macro Path",
         "icon": "FolderSearch",
         "tags": [
@@ -6053,8 +6053,8 @@
       "file_path": "griptape_nodes_library/files/resolve_macro_paths.py",
       "metadata": {
         "category": "files",
-        "description": "Resolve a list of macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths.",
-        "display_name": "Resolve Macro Paths",
+        "description": "Resolve a list of macro paths to absolute filesystem paths (e.g. [{inputs}/file.txt, {outputs}/image.png] → [/home/user/project/inputs/file.txt, /home/user/project/outputs/image.png]).",
+        "display_name": "Resolve Macro Path List",
         "icon": "FolderSearch",
         "tags": [
           "file",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -6034,6 +6034,21 @@
       }
     },
     {
+      "class_name": "ResolveMacroPath",
+      "file_path": "griptape_nodes_library/files/resolve_macro_path.py",
+      "metadata": {
+        "category": "files",
+        "description": "Resolve one or more macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths.",
+        "display_name": "Resolve Macro Path",
+        "icon": "FolderSearch",
+        "tags": [
+          "file",
+          "macro",
+          "path"
+        ]
+      }
+    },
+    {
       "class_name": "FilePathComponents",
       "file_path": "griptape_nodes_library/files/path.py",
       "metadata": {

--- a/griptape_nodes_library/files/resolve_macro_path.py
+++ b/griptape_nodes_library/files/resolve_macro_path.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+from griptape.artifacts import UrlArtifact
+from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
+from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class ResolveMacroPath(DataNode):
+    """Resolve one or more macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.paths_input = ParameterList(
+            name="paths",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            input_types=["any"],
+            default_value=[],
+            ui_options={"hide_property": True},
+            tooltip="One or more macro paths to resolve. Accepts a single path or a list of paths.",
+        )
+        self.add_parameter(self.paths_input)
+
+        self.add_parameter(
+            ParameterString(
+                name="resolved_path",
+                allow_input=False,
+                allow_property=False,
+                default_value="",
+                tooltip="The first resolved absolute path. Convenient when only one path is provided.",
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="resolved_paths",
+                type="list",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=[],
+                tooltip="All resolved absolute paths, in the same order as the inputs.",
+            )
+        )
+
+    def _extract_path_string(self, value: Any) -> str | None:
+        """Extract a plain string from a str, UrlArtifact, or artifact-like object."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            raw = value
+        elif isinstance(value, UrlArtifact):
+            raw = str(value.value)
+        elif hasattr(value, "value"):
+            raw = str(value.value)
+        else:
+            raw = str(value)
+        cleaned = GriptapeNodes.OSManager().sanitize_path_string(raw)
+        return cleaned if cleaned else None
+
+    def _resolve_one(self, path_str: str) -> str:
+        """Resolve a single macro path to an absolute path, returning the input as-is on failure."""
+        try:
+            result = GriptapeNodes.handle_request(
+                GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
+            )
+            if isinstance(result, GetPathForMacroResultSuccess):
+                return str(result.resolved_path)
+        except MacroSyntaxError:
+            pass
+        return path_str
+
+    def process(self) -> None:
+        raw_values = self.get_parameter_list_value(self.paths_input.name)
+
+        resolved: list[str] = []
+        for raw in raw_values:
+            path_str = self._extract_path_string(raw)
+            if path_str:
+                resolved.append(self._resolve_one(path_str))
+
+        first = resolved[0] if resolved else ""
+
+        self.parameter_output_values["resolved_path"] = first
+        self.parameter_output_values["resolved_paths"] = resolved
+        self.publish_update_to_parameter("resolved_path", first)
+        self.publish_update_to_parameter("resolved_paths", resolved)

--- a/griptape_nodes_library/files/resolve_macro_path.py
+++ b/griptape_nodes_library/files/resolve_macro_path.py
@@ -1,18 +1,19 @@
 from typing import Any
 
 from griptape.artifacts import UrlArtifact
-from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
+from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
-from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.project_events import (
     GetPathForMacroRequest,
+    GetPathForMacroResultFailure,
     GetPathForMacroResultSuccess,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
-class ResolveMacroPath(DataNode):
+class ResolveMacroPath(SuccessFailureNode):
     """Resolve one or more macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths."""
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
@@ -48,6 +49,37 @@ class ResolveMacroPath(DataNode):
             )
         )
 
+        self._create_status_parameters(
+            result_details_tooltip="Details about the macro path resolution.",
+            result_details_placeholder="Results will appear here after the node runs.",
+        )
+
+    def process(self) -> None:
+        self._clear_execution_status()
+        try:
+            raw_values = self.get_parameter_list_value(self.paths_input.name)
+
+            resolved: list[str] = []
+            for raw in raw_values:
+                path_str = self._extract_path_string(raw)
+                if path_str:
+                    resolved.append(self._resolve_one(path_str))
+
+            first = resolved[0] if resolved else ""
+
+            self.parameter_output_values["resolved_path"] = first
+            self.parameter_output_values["resolved_paths"] = resolved
+
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"Resolved {len(resolved)} path(s).",
+            )
+        except Exception as exc:
+            self._set_status_results(was_successful=False, result_details=str(exc))
+            self.parameter_output_values["resolved_path"] = ""
+            self.parameter_output_values["resolved_paths"] = []
+            self._handle_failure_exception(exc)
+
     def _extract_path_string(self, value: Any) -> str | None:
         """Extract a plain string from a str, UrlArtifact, or artifact-like object."""
         if value is None:
@@ -64,29 +96,14 @@ class ResolveMacroPath(DataNode):
         return cleaned if cleaned else None
 
     def _resolve_one(self, path_str: str) -> str:
-        """Resolve a single macro path to an absolute path, returning the input as-is on failure."""
-        try:
-            result = GriptapeNodes.handle_request(
-                GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
-            )
-            if isinstance(result, GetPathForMacroResultSuccess):
-                return str(result.resolved_path)
-        except MacroSyntaxError:
-            pass
-        return path_str
-
-    def process(self) -> None:
-        raw_values = self.get_parameter_list_value(self.paths_input.name)
-
-        resolved: list[str] = []
-        for raw in raw_values:
-            path_str = self._extract_path_string(raw)
-            if path_str:
-                resolved.append(self._resolve_one(path_str))
-
-        first = resolved[0] if resolved else ""
-
-        self.parameter_output_values["resolved_path"] = first
-        self.parameter_output_values["resolved_paths"] = resolved
-        self.publish_update_to_parameter("resolved_path", first)
-        self.publish_update_to_parameter("resolved_paths", resolved)
+        """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
+        result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
+        )
+        if isinstance(result, GetPathForMacroResultSuccess):
+            return str(result.resolved_path)
+        if isinstance(result, GetPathForMacroResultFailure):
+            msg = f"Could not resolve macro path '{path_str}': {result.failure_reason.value}"
+            raise ValueError(msg)
+        msg = f"Unexpected result resolving macro path '{path_str}'"
+        raise ValueError(msg)

--- a/griptape_nodes_library/files/resolve_macro_path.py
+++ b/griptape_nodes_library/files/resolve_macro_path.py
@@ -97,9 +97,7 @@ class ResolveMacroPath(SuccessFailureNode):
 
     def _resolve_one(self, path_str: str) -> str:
         """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
-        result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
-        )
+        result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={}))
         if isinstance(result, GetPathForMacroResultSuccess):
             return str(result.resolved_path)
         if isinstance(result, GetPathForMacroResultFailure):

--- a/griptape_nodes_library/files/resolve_macro_path.py
+++ b/griptape_nodes_library/files/resolve_macro_path.py
@@ -1,33 +1,26 @@
 from typing import Any
 
-from griptape.artifacts import UrlArtifact
-from griptape_nodes.common.macro_parser import ParsedMacro
-from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
-from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.retained_mode.events.project_events import (
-    GetPathForMacroRequest,
-    GetPathForMacroResultFailure,
-    GetPathForMacroResultSuccess,
-)
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+from griptape_nodes_library.files.resolve_macro_path_base import BaseResolveMacroPath
 
 
-class ResolveMacroPath(SuccessFailureNode):
-    """Resolve one or more macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths."""
+class ResolveMacroPath(BaseResolveMacroPath):
+    """Resolve a macro path (e.g. {inputs}/file.txt) to an absolute filesystem path."""
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
 
-        self.paths_input = ParameterList(
-            name="paths",
-            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-            input_types=["any"],
-            default_value=[],
-            ui_options={"hide_property": True},
-            tooltip="One or more macro paths to resolve. Accepts a single path or a list of paths.",
+        self.add_parameter(
+            ParameterString(
+                name="path",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value="",
+                tooltip="Macro path to resolve. Accepts any artifact type.",
+                placeholder_text="Example: {inputs}/my_file.png",
+            )
         )
-        self.add_parameter(self.paths_input)
 
         self.add_parameter(
             ParameterString(
@@ -35,17 +28,8 @@ class ResolveMacroPath(SuccessFailureNode):
                 allow_input=False,
                 allow_property=False,
                 default_value="",
-                tooltip="The first resolved absolute path. Convenient when only one path is provided.",
-            )
-        )
-
-        self.add_parameter(
-            Parameter(
-                name="resolved_paths",
-                type="list",
-                allowed_modes={ParameterMode.OUTPUT},
-                default_value=[],
-                tooltip="All resolved absolute paths, in the same order as the inputs.",
+                tooltip="The resolved absolute path.",
+                placeholder_text="Example: /Users/me/project/inputs/my_file.png",
             )
         )
 
@@ -57,51 +41,13 @@ class ResolveMacroPath(SuccessFailureNode):
     def process(self) -> None:
         self._clear_execution_status()
         try:
-            raw_values = self.get_parameter_list_value(self.paths_input.name)
+            raw = self.get_parameter_value("path")
+            path_str = self._extract_path_string(raw)
+            resolved = self._resolve_one(path_str) if path_str else ""
 
-            resolved: list[str] = []
-            for raw in raw_values:
-                path_str = self._extract_path_string(raw)
-                if path_str:
-                    resolved.append(self._resolve_one(path_str))
-
-            first = resolved[0] if resolved else ""
-
-            self.parameter_output_values["resolved_path"] = first
-            self.parameter_output_values["resolved_paths"] = resolved
-
-            self._set_status_results(
-                was_successful=True,
-                result_details=f"Resolved {len(resolved)} path(s).",
-            )
+            self.parameter_output_values["resolved_path"] = resolved
+            self._set_status_results(was_successful=True, result_details=f"Resolved: {resolved}")
         except Exception as exc:
             self._set_status_results(was_successful=False, result_details=str(exc))
             self.parameter_output_values["resolved_path"] = ""
-            self.parameter_output_values["resolved_paths"] = []
             self._handle_failure_exception(exc)
-
-    def _extract_path_string(self, value: Any) -> str | None:
-        """Extract a plain string from a str, UrlArtifact, or artifact-like object."""
-        if value is None:
-            return None
-        if isinstance(value, str):
-            raw = value
-        elif isinstance(value, UrlArtifact):
-            raw = str(value.value)
-        elif hasattr(value, "value"):
-            raw = str(value.value)
-        else:
-            raw = str(value)
-        cleaned = GriptapeNodes.OSManager().sanitize_path_string(raw)
-        return cleaned if cleaned else None
-
-    def _resolve_one(self, path_str: str) -> str:
-        """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
-        result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={}))
-        if isinstance(result, GetPathForMacroResultSuccess):
-            return str(result.resolved_path)
-        if isinstance(result, GetPathForMacroResultFailure):
-            msg = f"Could not resolve macro path '{path_str}': {result.failure_reason.value}"
-            raise ValueError(msg)
-        msg = f"Unexpected result resolving macro path '{path_str}'"
-        raise ValueError(msg)

--- a/griptape_nodes_library/files/resolve_macro_path_base.py
+++ b/griptape_nodes_library/files/resolve_macro_path_base.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from griptape.artifacts import UrlArtifact
+from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultFailure,
+    GetPathForMacroResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class BaseResolveMacroPath(SuccessFailureNode):
+    """Shared helpers for macro-path resolution nodes."""
+
+    def _extract_path_string(self, value: Any) -> str | None:
+        """Extract a plain string from a str, UrlArtifact, or artifact-like object."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            raw = value
+        elif isinstance(value, UrlArtifact):
+            raw = str(value.value)
+        elif hasattr(value, "value"):
+            raw = str(value.value)
+        else:
+            raw = str(value)
+        cleaned = GriptapeNodes.OSManager().sanitize_path_string(raw)
+        return cleaned if cleaned else None
+
+    def _resolve_one(self, path_str: str) -> str:
+        """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
+        result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
+        )
+        if isinstance(result, GetPathForMacroResultSuccess):
+            return str(result.resolved_path)
+        if isinstance(result, GetPathForMacroResultFailure):
+            msg = f"Could not resolve macro path '{path_str}': {result.failure_reason.value}"
+            raise ValueError(msg)
+        msg = f"Unexpected result resolving macro path '{path_str}'"
+        raise ValueError(msg)

--- a/griptape_nodes_library/files/resolve_macro_path_base.py
+++ b/griptape_nodes_library/files/resolve_macro_path_base.py
@@ -31,9 +31,7 @@ class BaseResolveMacroPath(SuccessFailureNode):
 
     def _resolve_one(self, path_str: str) -> str:
         """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
-        result = GriptapeNodes.handle_request(
-            GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={})
-        )
+        result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={}))
         if isinstance(result, GetPathForMacroResultSuccess):
             return str(result.resolved_path)
         if isinstance(result, GetPathForMacroResultFailure):

--- a/griptape_nodes_library/files/resolve_macro_paths.py
+++ b/griptape_nodes_library/files/resolve_macro_paths.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode
+
+from griptape_nodes_library.files.resolve_macro_path_base import BaseResolveMacroPath
+
+
+class ResolveMacroPaths(BaseResolveMacroPath):
+    """Resolve a list of macro paths (e.g. {inputs}/file.txt) to absolute filesystem paths."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata)
+
+        self.add_parameter(
+            ParameterList(
+                name="paths",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                input_types=["any"],
+                default_value=[],
+                ui_options={"hide_property": True},
+                tooltip="One or more macro paths to resolve. Accepts any artifact type.",
+            )
+        )
+
+        self.add_parameter(
+            Parameter(
+                name="resolved_paths",
+                type="list",
+                allowed_modes={ParameterMode.OUTPUT},
+                default_value=[],
+                tooltip="All resolved absolute paths, in the same order as the inputs.",
+            )
+        )
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the macro path resolution.",
+            result_details_placeholder="Results will appear here after the node runs.",
+        )
+
+    def process(self) -> None:
+        self._clear_execution_status()
+        try:
+            raw_values = self.get_parameter_list_value("paths")
+
+            resolved: list[str] = []
+            for raw in raw_values:
+                path_str = self._extract_path_string(raw)
+                if path_str:
+                    resolved.append(self._resolve_one(path_str))
+
+            self.parameter_output_values["resolved_paths"] = resolved
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"Resolved {len(resolved)} path(s).",
+            )
+        except Exception as exc:
+            self._set_status_results(was_successful=False, result_details=str(exc))
+            self.parameter_output_values["resolved_paths"] = []
+            self._handle_failure_exception(exc)


### PR DESCRIPTION
## Summary

- Adds `BaseResolveMacroPath` with shared `_extract_path_string` and `_resolve_one` helpers
- Adds `ResolveMacroPath`: single path input (`ParameterString`) → single `resolved_path` output
- Adds `ResolveMacroPaths`: `ParameterList` input → `resolved_paths` list output
- Both are `SuccessFailureNode` — malformed or unresolvable macros surface as a routable failure rather than a silent passthrough
- Accepts any artifact type (plain strings, `UrlArtifact`, `ImageUrlArtifact`, etc.)

Closes #286

## Test plan

- [ ] Wire `Select From Project` → `ResolveMacroPath` and confirm the output is an absolute path
- [ ] Wire an `ImageUrlArtifact` source → `ResolveMacroPath` and confirm it resolves correctly
- [ ] Pass a malformed macro (e.g. `{unclosed`) and confirm the failure edge fires with a useful message
- [ ] Wire multiple paths into `ResolveMacroPaths` and confirm `resolved_paths` contains all of them in order
- [ ] Pass a plain absolute path and confirm it passes through unchanged
- [ ] Confirm both nodes appear in the palette under the **files** category

🤖 Generated with [Claude Code](https://claude.com/claude-code)