### PR TITLE
feat: add SetVariableSubstitution node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -5978,6 +5978,22 @@
       }
     },
     {
+      "class_name": "SetVariableSubstitution",
+      "file_path": "griptape_nodes_library/variables/set_variable_substitution.py",
+      "metadata": {
+        "category": "variables",
+        "description": "Enable or disable inline variable substitution ({VARIABLE_NAME} token replacement) for this workflow. The setting is scoped to the current workflow and saved with it.",
+        "display_name": "Set Variable Substitution",
+        "icon": "Replace",
+        "group": "edit",
+        "tags": [
+          "variable",
+          "workflow",
+          "substitution"
+        ]
+      }
+    },
+    {
       "class_name": "FileOutputSettings",
       "file_path": "griptape_nodes_library/filesystem/file_output_settings.py",
       "metadata": {

--- a/griptape_nodes_library/variables/set_variable_substitution.py
+++ b/griptape_nodes_library/variables/set_variable_substitution.py
@@ -51,7 +51,10 @@ class SetVariableSubstitution(SuccessFailureNode):
             if isinstance(result, SetVariableSubstitutionEnabledResultFailure):
                 msg = result.result_details or "Failed to set variable substitution state."
                 raise RuntimeError(msg)  # noqa: TRY301
-            if not isinstance(result, SetVariableSubstitutionEnabledResultSuccess | SetVariableSubstitutionEnabledResultNotAlteredSuccess):
+            if not isinstance(
+                result,
+                SetVariableSubstitutionEnabledResultSuccess | SetVariableSubstitutionEnabledResultNotAlteredSuccess,
+            ):
                 msg = f"Unexpected result type: {type(result).__name__}"
                 raise RuntimeError(msg)  # noqa: TRY301
             state = "enabled" if enabled else "disabled"

--- a/griptape_nodes_library/variables/set_variable_substitution.py
+++ b/griptape_nodes_library/variables/set_variable_substitution.py
@@ -1,0 +1,61 @@
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.retained_mode.events.workflow_events import (
+    SetVariableSubstitutionEnabledRequest,
+    SetVariableSubstitutionEnabledResultFailure,
+    SetVariableSubstitutionEnabledResultNotAlteredSuccess,
+    SetVariableSubstitutionEnabledResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class SetVariableSubstitution(SuccessFailureNode):
+    """Enable or disable inline variable substitution for the current workflow.
+
+    When enabled, {VARIABLE_NAME} tokens in parameter values are replaced with
+    the corresponding variable's value at execution time. The setting is
+    workflow-scoped and baked into the saved workflow file.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        metadata: dict[Any, Any] | None = None,
+    ) -> None:
+        super().__init__(name, metadata)
+
+        self.enabled_param = Parameter(
+            name="enabled",
+            type="bool",
+            default_value=True,
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            tooltip=(
+                "When True, {VARIABLE_NAME} tokens in parameter values are replaced with "
+                "the variable's value at execution time. Scoped to the current workflow."
+            ),
+        )
+        self.add_parameter(self.enabled_param)
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the variable substitution setting.",
+            result_details_placeholder="Results will appear here after the node runs.",
+        )
+
+    def process(self) -> None:
+        self._clear_execution_status()
+        try:
+            enabled = bool(self.get_parameter_value(self.enabled_param.name))
+            result = GriptapeNodes.handle_request(SetVariableSubstitutionEnabledRequest(enabled=enabled))
+            if isinstance(result, SetVariableSubstitutionEnabledResultFailure):
+                msg = result.result_details or "Failed to set variable substitution state."
+                raise RuntimeError(msg)  # noqa: TRY301
+            if not isinstance(result, SetVariableSubstitutionEnabledResultSuccess | SetVariableSubstitutionEnabledResultNotAlteredSuccess):
+                msg = f"Unexpected result type: {type(result).__name__}"
+                raise RuntimeError(msg)  # noqa: TRY301
+            state = "enabled" if enabled else "disabled"
+            self._set_status_results(was_successful=True, result_details=f"Variable substitution {state}.")
+        except Exception as exc:
+            self._set_status_results(was_successful=False, result_details=str(exc))
+            self._handle_failure_exception(exc)


### PR DESCRIPTION
## Summary

Closes #417.

- Adds a new **Set Variable Substitution** node (`griptape_nodes_library/variables/set_variable_substitution.py`) that enables or disables inline `{VARIABLE_NAME}` token substitution for the current workflow
- The node issues `SetVariableSubstitutionEnabledRequest(enabled=...)` under the hood, replacing the need for users to hand-wire a generic Engine Request node and know the internal request name
- Registered in `griptape_nodes_library.json` alongside the existing variable nodes (`Create Variable`, `Set Variable`, `Get Variable`, `Has Variable`)

The node is a `SuccessFailureNode` with a single boolean `enabled` parameter (default `True`). The setting is workflow-scoped and baked into the saved workflow file on save.

## Test plan

- [ ] Drop a **Set Variable Substitution** node into a workflow
- [ ] Verify it appears in the Variables category in the node palette
- [ ] Set `enabled = True`, run — confirm status shows "Variable substitution enabled."
- [ ] Set `enabled = False`, run — confirm status shows "Variable substitution disabled."
- [ ] Wire a text node with a `{MY_VAR}` token; confirm substitution is applied / suppressed based on the flag
- [ ] Confirm the failure output edge fires when run outside a valid workflow context

🤖 Generated with [Claude Code](https://claude.com/claude-code)