### PR TITLE
fix: remove unused _DISABLED_NODE_PROVIDER_CONFIGS

### DIFF
--- a/griptape_nodes_library/proxy/__init__.py
+++ b/griptape_nodes_library/proxy/__init__.py
@@ -4,7 +4,6 @@ from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.proxy.proxy_api_key_providers import (
     ProxyApiKeyProviderConfig,
     get_proxy_api_key_provider_config,
-    is_proxy_api_key_provider_disabled,
 )
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
 
@@ -13,5 +12,4 @@ __all__ = [
     "ProxyApiKeyProviderConfig",
     "ProxyAuthProviderParameter",
     "get_proxy_api_key_provider_config",
-    "is_proxy_api_key_provider_disabled",
 ]

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 __all__ = [
     "ProxyApiKeyProviderConfig",
     "get_proxy_api_key_provider_config",
-    "is_proxy_api_key_provider_disabled",
 ]
 
 
@@ -155,15 +154,6 @@ _NODE_PROVIDER_CONFIGS = {
     "WorldLabsWorldGeneration": WORLD_LABS,
 }
 
-_DISABLED_NODE_PROVIDER_CONFIGS: set[str] = {
-    "GoogleImageGeneration",
-    "Veo3VideoGeneration",
-}
-
 
 def get_proxy_api_key_provider_config(node_class_name: str) -> ProxyApiKeyProviderConfig | None:
     return _NODE_PROVIDER_CONFIGS.get(node_class_name)
-
-
-def is_proxy_api_key_provider_disabled(node_class_name: str) -> bool:
-    return node_class_name in _DISABLED_NODE_PROVIDER_CONFIGS

--- a/tests/unit/test_griptape_proxy_node_byok.py
+++ b/tests/unit/test_griptape_proxy_node_byok.py
@@ -13,10 +13,7 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 )
 
 from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
-from griptape_nodes_library.proxy import (
-    get_proxy_api_key_provider_config,
-    is_proxy_api_key_provider_disabled,
-)
+from griptape_nodes_library.proxy import get_proxy_api_key_provider_config
 
 
 def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
@@ -47,13 +44,6 @@ def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-@pytest.mark.parametrize(("class_name", "_module_name"), PROXY_NODE_CLASSES)
-def test_every_proxy_node_explicitly_declares_byok_support_state(class_name: str, _module_name: str) -> None:
-    provider_config = get_proxy_api_key_provider_config(class_name)
-    is_disabled = is_proxy_api_key_provider_disabled(class_name)
-    assert (provider_config is not None) != is_disabled
-
-
 @pytest.mark.parametrize(("class_name", "module_name"), PROXY_NODE_CLASSES)
 def test_every_proxy_node_exposes_shared_byok_ui(class_name: str, module_name: str) -> None:
     provider_config = get_proxy_api_key_provider_config(class_name)
@@ -65,12 +55,6 @@ def test_every_proxy_node_exposes_shared_byok_ui(class_name: str, module_name: s
         (parameter for parameter in node.parameters if parameter.name == "api_key_provider"), None
     )
     api_key_provider_message = node.get_message_by_name_or_element_id("api_key_provider_message")
-
-    if is_proxy_api_key_provider_disabled(class_name):
-        assert provider_config is None
-        assert api_key_provider_parameter is None
-        assert api_key_provider_message is None
-        return
 
     assert provider_config is not None
     assert api_key_provider_parameter is not None


### PR DESCRIPTION
Part of #409. Addressing failure in `test_griptape_proxy_node_byok.py`.

PR #144 "BYOK Node UI" (7acffbd) introduced an `is_proxy_api_key_provider_disabled()`, which has never been used in this repo, nor seemingly any other across the Griptape GitHub org.

The test `test_every_proxy_node_explicitly_declares_byok_support_state` failed because GoogleImageGeneration and Veo3VideoGeneration appeared in both `_NODE_PROVIDER_CONFIGS` and `_DISABLED_NODE_PROVIDER_CONFIGS`.

The disabling of GoogleImageGeneration and Veo3VideoGeneration appears to be part of squash commit. The original disabling appears to originate in 3808ae3 with a cryptic comment "Disable Google nodes bc SA json".

However, `_DISABLED_NODE_PROVIDER_CONFIGS` (via
`is_proxy_api_key_provider_disabled()`) is never used, so those nodes have never been disabled in practice.

So assuming the status quo is the intended behaviour, remove `_DISABLED_NODE_PROVIDER_CONFIGS` and related code.