### PR TITLE
ci: run unit tests on pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run checks
         run: make check
+
+      - name: Run unit tests
+        run: make test/unit

--- a/tests/unit/audio/test_transcribe_audio.py
+++ b/tests/unit/audio/test_transcribe_audio.py
@@ -1,91 +1,19 @@
-"""Tests that ``TranscribeAudio.process`` reads bytes via ``File`` for
-``AudioUrlArtifact`` inputs (issue #215).
-
-``AudioUrlArtifact.to_bytes()`` issues an HTTP GET against ``self.value`` and
-fails when the value is a project macro path (``{outputs}/Extract Audio.mp4``)
-emitted by upstream nodes that write through ``ProjectFileParameter`` (e.g.
-``ExtractAudio``). The fix routes ``AudioUrlArtifact`` inputs through
-``File(value).read_bytes()`` so macro paths and plain filesystem paths
-resolve correctly.
-"""
+"""Tests for ``TranscribeAudio`` targeting the proxy-based architecture."""
 
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
-from griptape_nodes.files import file as file_module
+from griptape_nodes.files.file import File, FileLoadError
+from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
 
 import griptape_nodes_library.audio.transcribe_audio as transcribe_audio_module
 from griptape_nodes_library.audio.transcribe_audio import TranscribeAudio
 
-
-@pytest.fixture(autouse=True)
-def _stub_external_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace external dependencies (driver, agent, loader, task) with no-ops
-    so the test can drive ``process()`` up to the ``File`` call without
-    requiring API keys, real audio bytes, or actual transcription.
-    """
-
-    class FakeDriver:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            pass
-
-    monkeypatch.setattr(transcribe_audio_module, "OpenAiAudioTranscriptionDriver", FakeDriver)
-
-    class FakeAgent:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self.output = type("Out", (), {"value": "transcribed-text"})()
-
-        def from_dict(self, _data: dict) -> FakeAgent:
-            return self
-
-        def swap_task(self, _task: Any) -> None:
-            pass
-
-        def run(self, _tasks: list) -> None:
-            pass
-
-        def insert_false_memory(self, **_kwargs: Any) -> None:
-            pass
-
-        def restore_task(self) -> None:
-            pass
-
-        def to_dict(self) -> dict:
-            return {}
-
-    monkeypatch.setattr(transcribe_audio_module, "GtAgent", FakeAgent)
-
-    class FakeLoader:
-        def parse(self, _bytes: bytes) -> Any:
-            return type("AudioArtifact", (), {})()
-
-    monkeypatch.setattr(transcribe_audio_module, "AudioLoader", FakeLoader)
-
-    monkeypatch.setattr(
-        transcribe_audio_module,
-        "AudioTranscriptionTask",
-        lambda *_args, **_kwargs: object(),
-    )
-
-
-def _drive_process(node: TranscribeAudio) -> None:
-    """Drive ``process()`` past its single yield (the agent runner)."""
-    result = node.process()
-    if result is None:
-        return
-    try:
-        runner = next(result)
-    except StopIteration:
-        # Early return path (e.g. ``audio is None``) yields nothing.
-        return
-    runner()
-    try:
-        next(result)
-    except StopIteration:
-        pass
+DATA_URI = "data:audio/mpeg;base64,QUFB"
 
 
 def _make_node() -> TranscribeAudio:
@@ -94,119 +22,212 @@ def _make_node() -> TranscribeAudio:
     return node
 
 
-def test_audio_url_artifact_with_macro_path_reads_via_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    captured: dict[str, Any] = {"paths": []}
-    real_init = file_module.File.__init__
-
-    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
-        captured["paths"].append(path)
-        real_init(self, path, *args, **kwargs)
-
-    monkeypatch.setattr(file_module.File, "__init__", capture_init)
-    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
-
-    node = _make_node()
-    node.set_parameter_value("audio", AudioUrlArtifact("{outputs}/Extract Audio_output.mp4"))
-
-    _drive_process(node)
-
-    assert "{outputs}/Extract Audio_output.mp4" in captured["paths"]
+@pytest.fixture
+def stub_file(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    mock_cls = Mock(return_value=Mock(spec=File, aread_data_uri=AsyncMock(return_value=DATA_URI)))
+    monkeypatch.setattr(transcribe_audio_module, "File", mock_cls)
+    return mock_cls
 
 
-def test_audio_url_artifact_with_filesystem_path_reads_via_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    paths: list[str] = []
-    real_init = file_module.File.__init__
+class TestResolveAudioDataUri:
+    """Exercises ``_resolve_audio_data_uri``: the method that turns audio param values
+    into base64 data URIs via ``File.aread_data_uri``.
+    """
 
-    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
-        paths.append(path)
-        real_init(self, path, *args, **kwargs)
+    @pytest.mark.asyncio
+    async def test_audio_url_artifact_with_macro_path(self, stub_file: Mock) -> None:
+        node = _make_node()
+        artifact = AudioUrlArtifact("{outputs}/Extract Audio_output.mp4")
 
-    monkeypatch.setattr(file_module.File, "__init__", capture_init)
-    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+        result = await node._resolve_audio_data_uri(artifact)
 
-    node = _make_node()
-    node.set_parameter_value("audio", AudioUrlArtifact("/abs/path/clip.mp3"))
+        stub_file.assert_called_once_with("{outputs}/Extract Audio_output.mp4")
+        stub_file.return_value.aread_data_uri.assert_awaited_once_with(fallback_mime="audio/mpeg")
+        assert result == DATA_URI
 
-    _drive_process(node)
+    @pytest.mark.asyncio
+    async def test_audio_url_artifact_with_filesystem_path(self, stub_file: Mock) -> None:
+        node = _make_node()
+        artifact = AudioUrlArtifact("/abs/path/clip.mp3")
 
-    assert "/abs/path/clip.mp3" in paths
+        result = await node._resolve_audio_data_uri(artifact)
+
+        stub_file.assert_called_once_with("/abs/path/clip.mp3")
+        stub_file.return_value.aread_data_uri.assert_awaited_once_with(fallback_mime="audio/mpeg")
+        assert result == DATA_URI
+
+    @pytest.mark.asyncio
+    async def test_audio_url_artifact_with_http_url(self, stub_file: Mock) -> None:
+        node = _make_node()
+        artifact = AudioUrlArtifact("https://example.com/clip.mp3")
+
+        result = await node._resolve_audio_data_uri(artifact)
+
+        stub_file.assert_called_once_with("https://example.com/clip.mp3")
+        stub_file.return_value.aread_data_uri.assert_awaited_once_with(fallback_mime="audio/mpeg")
+        assert result == DATA_URI
+
+    @pytest.mark.asyncio
+    async def test_dict_serialized_audio_url_artifact(self, stub_file: Mock) -> None:
+        node = _make_node()
+        audio_dict: dict[str, Any] = {"type": "AudioUrlArtifact", "value": "{outputs}/clip.mp3"}
+
+        result = await node._resolve_audio_data_uri(audio_dict)
+
+        stub_file.assert_called_once_with("{outputs}/clip.mp3")
+        stub_file.return_value.aread_data_uri.assert_awaited_once_with(fallback_mime="audio/mpeg")
+        assert result == DATA_URI
+
+    @pytest.mark.asyncio
+    async def test_file_load_error_returns_none(self, stub_file: Mock) -> None:
+        node = _make_node()
+        artifact = AudioUrlArtifact("{outputs}/missing.mp3")
+        stub_file.return_value.aread_data_uri.side_effect = FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "missing")
+
+        result = await node._resolve_audio_data_uri(artifact)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_none_audio_returns_none(self) -> None:
+        node = _make_node()
+        result = await node._resolve_audio_data_uri(None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_string_audio_value(self, stub_file: Mock) -> None:
+        node = _make_node()
+
+        result = await node._resolve_audio_data_uri("/some/path.wav")
+
+        stub_file.assert_called_once_with("/some/path.wav")
+        stub_file.return_value.aread_data_uri.assert_awaited_once_with(fallback_mime="audio/mpeg")
+        assert result == DATA_URI
+
+    @pytest.mark.asyncio
+    async def test_empty_string_returns_none(self) -> None:
+        node = _make_node()
+        result = await node._resolve_audio_data_uri("")
+        assert result is None
 
 
-def test_audio_url_artifact_with_http_url_reads_via_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    paths: list[str] = []
-    real_init = file_module.File.__init__
+class TestBuildPayload:
+    """Exercises ``_build_payload``: constructs the request dict for the proxy."""
 
-    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
-        paths.append(path)
-        real_init(self, path, *args, **kwargs)
+    @pytest.mark.asyncio
+    async def test_none_audio_raises_value_error(self) -> None:
+        node = _make_node()
+        node.set_parameter_value("audio", None)
 
-    monkeypatch.setattr(file_module.File, "__init__", capture_init)
-    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+        with pytest.raises(ValueError, match="No audio provided"):
+            await node._build_payload()
 
-    node = _make_node()
-    node.set_parameter_value("audio", AudioUrlArtifact("https://example.com/clip.mp3"))
+    @pytest.mark.asyncio
+    async def test_failed_audio_load_raises_value_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_node()
+        node.set_parameter_value("audio", AudioUrlArtifact("{outputs}/missing.mp3"))
 
-    _drive_process(node)
+        monkeypatch.setattr(node, "_resolve_audio_data_uri", AsyncMock(return_value=None))
+        with pytest.raises(ValueError, match="Failed to load audio"):
+            await node._build_payload()
 
-    assert "https://example.com/clip.mp3" in paths
+    @pytest.mark.asyncio
+    async def test_minimal_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_node()
+        node.set_parameter_value("audio", AudioUrlArtifact("test.mp3"))
 
+        monkeypatch.setattr(node, "_resolve_audio_data_uri", AsyncMock(return_value=DATA_URI))
+        payload = await node._build_payload()
 
-def test_dict_serialized_audio_url_artifact_with_macro_path_reads_via_file(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    paths: list[str] = []
-    real_init = file_module.File.__init__
+        assert payload["file"] == DATA_URI
+        assert payload["response_format"] == "json"
+        assert "language" not in payload
+        assert "prompt" not in payload
+        assert "temperature" not in payload
 
-    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
-        paths.append(path)
-        real_init(self, path, *args, **kwargs)
+    @pytest.mark.asyncio
+    async def test_payload_with_optional_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_node()
+        node.set_parameter_value("audio", AudioUrlArtifact("test.mp3"))
+        node.set_parameter_value("language", "en")
+        node.set_parameter_value("prompt", "Meeting notes")
+        node.set_parameter_value("response_format", "verbose_json")
+        node.set_parameter_value("temperature", 0.5)
 
-    monkeypatch.setattr(file_module.File, "__init__", capture_init)
-    monkeypatch.setattr(file_module.File, "read_bytes", lambda self: b"AUDIO-BYTES")
+        monkeypatch.setattr(node, "_resolve_audio_data_uri", AsyncMock(return_value=DATA_URI))
+        payload = await node._build_payload()
 
-    node = _make_node()
-    node.set_parameter_value("audio", {"type": "AudioUrlArtifact", "value": "{outputs}/clip.mp3"})
-
-    _drive_process(node)
-
-    assert "{outputs}/clip.mp3" in paths
-
-
-def test_file_load_error_is_wrapped_as_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    from griptape_nodes.retained_mode.events.os_events import FileIOFailureReason
-
-    def fail_read(self: file_module.File) -> bytes:
-        raise file_module.FileLoadError(FileIOFailureReason.FILE_NOT_FOUND, "missing")
-
-    monkeypatch.setattr(file_module.File, "read_bytes", fail_read)
-
-    node = _make_node()
-    node.set_parameter_value("audio", AudioUrlArtifact("{outputs}/missing.mp3"))
-
-    with pytest.raises(ValueError, match="Failed to read audio from"):
-        _drive_process(node)
+        assert payload["language"] == "en"
+        assert payload["prompt"] == "Meeting notes"
+        assert payload["response_format"] == "verbose_json"
+        assert payload["temperature"] == 0.5
 
 
-def test_none_audio_returns_early_without_calling_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    paths: list[str] = []
-    real_init = file_module.File.__init__
+class TestParseResult:
+    """Exercises ``_parse_result``: extracts transcription text and verbose_json fields."""
 
-    def capture_init(self: file_module.File, path: Any, *args: Any, **kwargs: Any) -> None:
-        paths.append(path)
-        real_init(self, path, *args, **kwargs)
+    @pytest.mark.asyncio
+    async def test_basic_text_output(self) -> None:
+        node = _make_node()
+        await node._parse_result({"text": "Hello world"}, generation_id="gen-1")
 
-    monkeypatch.setattr(file_module.File, "__init__", capture_init)
+        assert node.parameter_output_values["output"] == "Hello world"
 
-    node = _make_node()
-    node.set_parameter_value("audio", None)
+    @pytest.mark.asyncio
+    async def test_verbose_json_fields(self) -> None:
+        node = _make_node()
+        result_json = {
+            "text": "Hello",
+            "words": [{"word": "Hello", "start": 0.0, "end": 0.5}],
+            "segments": [{"id": 0, "text": "Hello"}],
+            "language": "en",
+            "duration": 1.5,
+        }
 
-    _drive_process(node)
+        await node._parse_result(result_json, generation_id="gen-2")
 
-    assert paths == []
-    assert node.parameter_output_values.get("output") == "No audio provided"
+        assert node.parameter_output_values["output"] == "Hello"
+        assert node.parameter_output_values["words"] == [{"word": "Hello", "start": 0.0, "end": 0.5}]
+        assert node.parameter_output_values["segments"] == [{"id": 0, "text": "Hello"}]
+        assert node.parameter_output_values["detected_language"] == "en"
+        assert node.parameter_output_values["duration"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_missing_text_sets_safe_defaults(self) -> None:
+        node = _make_node()
+        node.parameter_output_values["output"] = "stale"
+        node.parameter_output_values["agent"] = "stale"
+        node.parameter_output_values["words"] = [{"word": "stale"}]
+        node.parameter_output_values["segments"] = [{"id": 0}]
+        node.parameter_output_values["detected_language"] = "en"
+        node.parameter_output_values["duration"] = 99.0
+
+        await node._parse_result({}, generation_id="gen-3")
+
+        assert node.parameter_output_values["output"] is None
+        assert node.parameter_output_values["agent"] is None
+        assert node.parameter_output_values["words"] is None
+        assert node.parameter_output_values["segments"] is None
+        assert node.parameter_output_values["detected_language"] is None
+        assert node.parameter_output_values["duration"] is None
+
+
+class TestSetSafeDefaults:
+    """Exercises ``_set_safe_defaults``: clears all output parameters."""
+
+    def test_clears_all_outputs(self) -> None:
+        node = _make_node()
+        node.parameter_output_values["output"] = "stale"
+        node.parameter_output_values["words"] = [{"word": "stale"}]
+        node.parameter_output_values["segments"] = [{"id": 0}]
+        node.parameter_output_values["detected_language"] = "en"
+        node.parameter_output_values["duration"] = 99.0
+
+        node._set_safe_defaults()
+
+        assert node.parameter_output_values["output"] is None
+        assert node.parameter_output_values["words"] is None
+        assert node.parameter_output_values["segments"] is None
+        assert node.parameter_output_values["detected_language"] is None
+        assert node.parameter_output_values["duration"] is None
+        assert node.parameter_output_values["agent"] is None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,47 +1,84 @@
 """Shared fixtures and setup for library unit tests."""
 
+import contextlib
 import json
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 import pytest
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.metaclasses import SingletonMeta
 
 
-def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
-    """Register library before test collection to install pip dependencies and extend sys.path.
+@pytest.fixture(autouse=True, scope="session")
+def load_library_in_isolated_env() -> Generator[None, None, None]:
+    """Register library in an isolated env.
 
     Mirrors what the engine does at runtime: installs the library's pip dependencies
     into the library's own .venv and adds that venv's site-packages to sys.path.
     Must run before collection so that library dependency imports succeed.
-    """
-    from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 
-    library_json = str(Path(__file__).parents[2] / "griptape_nodes_library.json")
-    GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=library_json))
+    Use an isolated config environment so that ``SecretsManager.__init__``
+    does not load real secrets from ``~/.config/griptape_nodes/.env`` into
+    ``os.environ`` during library loading.
+    """
+
+    with _isolated_env():
+        library_json = str(Path(__file__).parents[2] / "griptape_nodes_library.json")
+        GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=library_json))
+
+        yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def run_test_in_isolated_env() -> Generator[None, None, None]:
+    """Run each test in a fresh config/secrets environment so that tests do
+    not pollute each other.
+    """
+
+    with _isolated_env():
+        yield
 
 
 @pytest.fixture(autouse=True)
-def isolate_user_config() -> Generator[Path, None, None]:
-    """Isolate the user config file during tests to prevent pollution of the real config."""
-    import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
-    from griptape_nodes.utils.metaclasses import SingletonMeta
-
-    SingletonMeta._instances.clear()
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_config_path = Path(temp_dir) / "griptape_nodes_config.json"
-        temp_config_path.write_text(json.dumps({}, indent=2))
-
-        with patch.object(config_manager_module, "USER_CONFIG_PATH", temp_config_path):
-            yield temp_config_path
-
-            SingletonMeta._instances.clear()
+def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prevent PublicArtifactUrlParameter from making HTTP calls to list buckets."""
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
+    )
 
 
 @pytest.fixture
 def griptape_nodes() -> GriptapeNodes:
     """Provide a properly initialized GriptapeNodes instance for testing."""
     return GriptapeNodes()
+
+
+@contextlib.contextmanager
+def _isolated_env():
+    """Patch config and secrets paths to temp files and clear singletons."""
+    SingletonMeta._instances.clear()
+
+    try:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_config_path = Path(temp_dir) / "griptape_nodes_config.json"
+            temp_config_path.write_text(json.dumps({}, indent=2))
+            temp_env_path = Path(temp_dir) / ".env"
+            temp_env_path.write_text("")
+
+            with (
+                patch.object(config_manager_module, "USER_CONFIG_PATH", temp_config_path),
+                patch.object(secrets_manager_module, "ENV_VAR_PATH", temp_env_path),
+            ):
+                yield
+
+    finally:
+        SingletonMeta._instances.clear()

--- a/tests/unit/image/test_openai_image_generation.py
+++ b/tests/unit/image/test_openai_image_generation.py
@@ -23,10 +23,10 @@ def _is_param_hidden(node: OpenAiImageGeneration, name: str) -> bool:
     return bool(parameter.ui_options.get("hide", False))
 
 
-def _is_message_hidden(node: OpenAiImageGeneration, name: str) -> bool:
-    message = node.get_message_by_name_or_element_id(name)
-    assert message is not None
-    return bool(message.ui_options.get("hide", False))
+def _has_size_badge(node: OpenAiImageGeneration) -> bool:
+    size_param = node.get_parameter_by_name("size")
+    assert size_param is not None
+    return size_param.get_badge() is not None
 
 
 @pytest.fixture
@@ -329,7 +329,7 @@ def test_size_choices_omit_custom_for_legacy_models(node: OpenAiImageGeneration)
 def test_custom_size_params_hidden_by_default(node: OpenAiImageGeneration) -> None:
     assert _is_param_hidden(node, "custom_width")
     assert _is_param_hidden(node, "custom_height")
-    assert _is_message_hidden(node, "custom_size_help")
+    assert not _has_size_badge(node)
 
 
 def test_selecting_custom_size_reveals_dimension_inputs(node: OpenAiImageGeneration) -> None:
@@ -337,7 +337,7 @@ def test_selecting_custom_size_reveals_dimension_inputs(node: OpenAiImageGenerat
 
     assert not _is_param_hidden(node, "custom_width")
     assert not _is_param_hidden(node, "custom_height")
-    assert not _is_message_hidden(node, "custom_size_help")
+    assert _has_size_badge(node)
 
 
 def test_switching_off_custom_size_hides_dimension_inputs(node: OpenAiImageGeneration) -> None:
@@ -346,7 +346,7 @@ def test_switching_off_custom_size_hides_dimension_inputs(node: OpenAiImageGener
 
     assert _is_param_hidden(node, "custom_width")
     assert _is_param_hidden(node, "custom_height")
-    assert _is_message_hidden(node, "custom_size_help")
+    assert not _has_size_badge(node)
 
 
 def test_switching_to_legacy_model_hides_custom_size_inputs(node: OpenAiImageGeneration) -> None:
@@ -355,7 +355,7 @@ def test_switching_to_legacy_model_hides_custom_size_inputs(node: OpenAiImageGen
 
     assert _is_param_hidden(node, "custom_width")
     assert _is_param_hidden(node, "custom_height")
-    assert _is_message_hidden(node, "custom_size_help")
+    assert not _has_size_badge(node)
 
 
 @pytest.mark.parametrize(
@@ -428,7 +428,7 @@ def test_initial_setup_sync_restores_custom_size_visibility(
 
     assert not _is_param_hidden(fresh_node, "custom_width")
     assert not _is_param_hidden(fresh_node, "custom_height")
-    assert not _is_message_hidden(fresh_node, "custom_size_help")
+    assert _has_size_badge(fresh_node)
 
 
 def test_initial_setup_does_not_snap_custom_dimensions(
@@ -444,8 +444,12 @@ def test_initial_setup_does_not_snap_custom_dimensions(
     assert fresh_node.get_parameter_value("custom_width") == 1000
 
 
-def test_custom_size_help_message_uses_markdown(node: OpenAiImageGeneration) -> None:
-    message = node.get_message_by_name_or_element_id("custom_size_help")
-
-    assert message is not None
-    assert message.ui_options.get("markdown") is True
+def test_custom_size_badge_contains_constraint_rules(node: OpenAiImageGeneration) -> None:
+    node.set_parameter_value("size", "custom")
+    size_param = node.get_parameter_by_name("size")
+    assert size_param is not None
+    badge = size_param.get_badge()
+    assert badge is not None
+    assert badge.variant == "help"
+    assert "Multiples of" in badge.message
+    assert "Aspect ratio" in badge.message

--- a/tests/unit/test_griptape_proxy_node_byok.py
+++ b/tests/unit/test_griptape_proxy_node_byok.py
@@ -8,9 +8,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
-    PublicArtifactUrlParameter,
-)
 
 from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
 from griptape_nodes_library.proxy import get_proxy_api_key_provider_config
@@ -35,13 +32,6 @@ def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
 
 
 PROXY_NODE_CLASSES = tuple(_iter_proxy_node_classes())
-
-
-@pytest.fixture(autouse=True)
-def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
-    )
 
 
 @pytest.mark.parametrize(("class_name", "module_name"), PROXY_NODE_CLASSES)

--- a/tests/unit/test_griptape_proxy_node_polling.py
+++ b/tests/unit/test_griptape_proxy_node_polling.py
@@ -8,9 +8,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
-    PublicArtifactUrlParameter,
-)
 
 from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
 
@@ -30,13 +27,6 @@ def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
 
 
 PROXY_NODE_CLASSES = tuple(_iter_proxy_node_classes())
-
-
-@pytest.fixture(autouse=True)
-def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
-    )
 
 
 @pytest.mark.parametrize(("class_name", "module_name"), PROXY_NODE_CLASSES)

--- a/tests/unit/test_griptape_proxy_node_refresh.py
+++ b/tests/unit/test_griptape_proxy_node_refresh.py
@@ -4,9 +4,6 @@ from typing import Any
 
 import pytest
 from griptape_nodes.exe_types.core_types import ParameterMode
-from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
-    PublicArtifactUrlParameter,
-)
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 
@@ -17,13 +14,6 @@ from griptape_nodes_library.proxy.griptape_proxy_node import (
     STATUS_RUNNING,
     STATUS_TIMED_OUT,
 )
-
-
-@pytest.fixture(autouse=True)
-def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
-    )
 
 
 def _find_status_group_children(node: Any) -> dict[str, Any]:

--- a/tests/unit/variables/test_set_variable.py
+++ b/tests/unit/variables/test_set_variable.py
@@ -6,9 +6,9 @@ sets ``variable_name`` and falls back to create-or-update during ``process()``.
 """
 
 from collections.abc import Generator
+from typing import cast
 
 import pytest
-from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
     CreateFlowResultSuccess,
@@ -25,6 +25,8 @@ from griptape_nodes.retained_mode.events.variable_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.variable_types import VariableScope
+
+from griptape_nodes_library.variables.set_variable import CREATE_NEW_SENTINEL, SetVariable
 
 FLOW_NAME = "canvas"
 
@@ -44,18 +46,13 @@ def flow(griptape_nodes: GriptapeNodes) -> Generator[str, None, None]:  # noqa: 
 
 
 @pytest.fixture
-def set_variable_node(flow: str) -> BaseNode:
-    """Create a SetVariable node inside the test flow and return the instance.
-
-    Returns the node as ``BaseNode`` because library nodes are loaded via a dynamic module,
-    so the imported ``SetVariable`` class and the instantiated class are different class
-    objects even though they share a name.
-    """
+def set_variable_node(flow: str) -> SetVariable:
+    """Create a SetVariable node inside the test flow and return the instance."""
     result = GriptapeNodes.handle_request(CreateNodeRequest(node_type="SetVariable", override_parent_flow_name=flow))
     assert isinstance(result, CreateNodeResultSuccess)
     node = GriptapeNodes.NodeManager().get_node_by_name(result.node_name)
     assert type(node).__name__ == "SetVariable"
-    return node
+    return node  # type: ignore[return-value]
 
 
 def _has_variable(name: str, flow_name: str) -> bool:
@@ -74,12 +71,28 @@ def _get_variable_value(name: str, flow_name: str) -> object:
     return result.variable.value
 
 
+def _add_to_dropdown(node: SetVariable, name: str, flow_name: str) -> None:
+    """Ensure *name* exists as an engine variable and appears in the dropdown.
+
+    Creates the variable via ``CreateVariableRequest`` (a no-op when it already exists)
+    then invokes the node's own ``_refresh_variable_names`` — the same code path the
+    real UI refresh button traverses.
+    """
+    if not _has_variable(name, flow_name):
+        result = GriptapeNodes.handle_request(
+            CreateVariableRequest(name=name, type="str", is_global=False, value="", owning_flow=flow_name)
+        )
+        assert isinstance(result, CreateVariableResultSuccess)
+    node._refresh_variable_names(button=None, button_details=None)  # type: ignore[arg-type]
+
+
 class TestSetVariableProcess:
     """Exercises the rewritten ``aprocess()``: create-if-missing, else update."""
 
     @pytest.mark.asyncio
-    async def test_creates_variable_when_missing(self, set_variable_node: BaseNode, flow: str) -> None:
-        set_variable_node.set_parameter_value("variable_name", "my_var")
+    async def test_creates_variable_when_missing(self, set_variable_node: SetVariable, flow: str) -> None:
+        set_variable_node.set_parameter_value("variable_name", CREATE_NEW_SENTINEL)
+        set_variable_node.set_parameter_value("new_variable_name", "my_var")
         set_variable_node.set_parameter_value("value", "hello")
 
         await set_variable_node.aprocess()
@@ -88,12 +101,13 @@ class TestSetVariableProcess:
         assert _get_variable_value("my_var", flow) == "hello"
 
     @pytest.mark.asyncio
-    async def test_updates_existing_variable(self, set_variable_node: BaseNode, flow: str) -> None:
+    async def test_updates_existing_variable(self, set_variable_node: SetVariable, flow: str) -> None:
         create_result = GriptapeNodes.handle_request(
             CreateVariableRequest(name="existing", type="str", is_global=False, value="old", owning_flow=flow)
         )
         assert isinstance(create_result, CreateVariableResultSuccess)
 
+        _add_to_dropdown(set_variable_node, "existing", flow)
         set_variable_node.set_parameter_value("variable_name", "existing")
         set_variable_node.set_parameter_value("value", "new")
 
@@ -102,8 +116,9 @@ class TestSetVariableProcess:
         assert _get_variable_value("existing", flow) == "new"
 
     @pytest.mark.asyncio
-    async def test_empty_variable_name_raises(self, set_variable_node: BaseNode) -> None:
-        set_variable_node.set_parameter_value("variable_name", "")
+    async def test_empty_variable_name_raises(self, set_variable_node: SetVariable) -> None:
+        set_variable_node.set_parameter_value("variable_name", CREATE_NEW_SENTINEL)
+        set_variable_node.set_parameter_value("new_variable_name", "")
         set_variable_node.set_parameter_value("value", "anything")
 
         with pytest.raises(ValueError, match="requires a non-empty variable_name"):
@@ -111,16 +126,17 @@ class TestSetVariableProcess:
 
 
 class TestSetVariableEagerRegistration:
-    """Exercises ``before_value_set``: variables register the moment the user enters a name."""
+    """Exercises ``before_value_set``: variables register the moment the user selects a name."""
 
-    def test_entering_name_registers_variable(self, set_variable_node: BaseNode, flow: str) -> None:
+    def test_entering_name_registers_variable(self, set_variable_node: SetVariable, flow: str) -> None:
         assert not _has_variable("eager", flow)
 
+        _add_to_dropdown(set_variable_node, "eager", flow)
         set_variable_node.set_parameter_value("variable_name", "eager")
 
         assert _has_variable("eager", flow)
 
-    def test_changing_name_registers_new_and_leaves_old_alone(self, set_variable_node: BaseNode, flow: str) -> None:
+    def test_changing_name_registers_new_and_leaves_old_alone(self, set_variable_node: SetVariable, flow: str) -> None:
         """Editing ``variable_name`` always means 'point this node at a different variable'.
 
         We intentionally do not rename the prior variable — there is no UI signal to
@@ -128,45 +144,51 @@ class TestSetVariableEagerRegistration:
         was pointing at the old name. Leftover variables get filtered out at save time
         by ``NodeDependencies``-driven serialization.
         """
+        _add_to_dropdown(set_variable_node, "first", flow)
         set_variable_node.set_parameter_value("variable_name", "first")
         assert _has_variable("first", flow)
 
+        _add_to_dropdown(set_variable_node, "second", flow)
         set_variable_node.set_parameter_value("variable_name", "second")
 
         assert _has_variable("first", flow)
         assert _has_variable("second", flow)
 
-    def test_clearing_name_leaves_variable_alone(self, set_variable_node: BaseNode, flow: str) -> None:
+    def test_clearing_name_leaves_variable_alone(self, set_variable_node: SetVariable, flow: str) -> None:
+        _add_to_dropdown(set_variable_node, "sticky", flow)
         set_variable_node.set_parameter_value("variable_name", "sticky")
         assert _has_variable("sticky", flow)
 
-        set_variable_node.set_parameter_value("variable_name", "")
+        set_variable_node.set_parameter_value("variable_name", CREATE_NEW_SENTINEL)
 
-        # Clearing is a no-op: the engine-side variable persists.
+        # Switching to the sentinel is a no-op for existing variables.
         assert _has_variable("sticky", flow)
 
-    def test_repointing_to_existing_name_does_not_clobber(self, set_variable_node: BaseNode, flow: str) -> None:
+    def test_repointing_to_existing_name_does_not_clobber(self, set_variable_node: SetVariable, flow: str) -> None:
         collision_result = GriptapeNodes.handle_request(
             CreateVariableRequest(name="taken", type="str", is_global=False, value="reserved", owning_flow=flow)
         )
         assert isinstance(collision_result, CreateVariableResultSuccess)
 
+        _add_to_dropdown(set_variable_node, "mine", flow)
         set_variable_node.set_parameter_value("variable_name", "mine")
         assert _has_variable("mine", flow)
 
         # Pointing this node at an existing name must not raise, and must not clobber
         # the existing variable's value.
+        _add_to_dropdown(set_variable_node, "taken", flow)
         set_variable_node.set_parameter_value("variable_name", "taken")
 
         assert _has_variable("taken", flow)
         assert _get_variable_value("taken", flow) == "reserved"
 
-    def test_duplicate_name_adopts_existing(self, set_variable_node: BaseNode, flow: str) -> None:
+    def test_duplicate_name_adopts_existing(self, set_variable_node: SetVariable, flow: str) -> None:
         pre_existing_result = GriptapeNodes.handle_request(
             CreateVariableRequest(name="shared", type="str", is_global=False, value="keep", owning_flow=flow)
         )
         assert isinstance(pre_existing_result, CreateVariableResultSuccess)
 
+        _add_to_dropdown(set_variable_node, "shared", flow)
         set_variable_node.set_parameter_value("variable_name", "shared")
 
         # Entering an existing name must not clobber its value.
@@ -192,18 +214,22 @@ class TestSetVariableEagerRegistration:
         assert isinstance(create_b, CreateNodeResultSuccess)
         assert isinstance(create_c, CreateNodeResultSuccess)
 
-        node_a = GriptapeNodes.NodeManager().get_node_by_name(create_a.node_name)
-        node_b = GriptapeNodes.NodeManager().get_node_by_name(create_b.node_name)
-        node_c = GriptapeNodes.NodeManager().get_node_by_name(create_c.node_name)
+        node_a = cast(SetVariable, GriptapeNodes.NodeManager().get_node_by_name(create_a.node_name))
+        node_b = cast(SetVariable, GriptapeNodes.NodeManager().get_node_by_name(create_b.node_name))
+        node_c = cast(SetVariable, GriptapeNodes.NodeManager().get_node_by_name(create_c.node_name))
 
+        _add_to_dropdown(node_a, "X", flow)
         node_a.set_parameter_value("variable_name", "X")
+        _add_to_dropdown(node_b, "Y", flow)
         node_b.set_parameter_value("variable_name", "Y")
+        _add_to_dropdown(node_c, "X", flow)
         node_c.set_parameter_value("variable_name", "X")  # silently adopts existing X
 
         assert _has_variable("X", flow)
         assert _has_variable("Y", flow)
 
         # Re-point C to a brand-new name. X must remain so that A still resolves.
+        _add_to_dropdown(node_c, "Z", flow)
         node_c.set_parameter_value("variable_name", "Z")
 
         assert _has_variable("X", flow), "Node A's variable was orphaned by Node C's edit"

--- a/tests/unit/video/test_kling_video_mode_options.py
+++ b/tests/unit/video/test_kling_video_mode_options.py
@@ -25,17 +25,18 @@ def test_kling_text_v3_adds_4k_mode_choice() -> None:
     node.set_parameter_value("mode", "4k")
     node.set_parameter_value("model_name", "Kling v2.6")
 
-    assert _mode_choices(node) == ["pro"]
-    assert node.get_parameter_value("mode") == "pro"
-
-
-def test_kling_text_non_v3_models_do_not_accept_4k_mode() -> None:
-    node = KlingTextToVideoGeneration(name="KlingText")
-    node.set_parameter_value("model_name", "Kling v2 Master")
-    node.set_parameter_value("mode", "4k")
-
     assert _mode_choices(node) == ["std", "pro"]
     assert node.get_parameter_value("mode") == "std"
+
+
+def test_kling_text_v2_master_hides_mode_selector_and_forces_pro() -> None:
+    node = KlingTextToVideoGeneration(name="KlingText")
+    node.set_parameter_value("mode", "4k")
+
+    node.set_parameter_value("model_name", "Kling v2 Master")
+
+    assert _parameter_by_name(node, "mode").hide is True
+    assert node.get_parameter_value("mode") == "pro"
 
 
 def test_kling_image_v3_adds_4k_mode_choice() -> None:
@@ -46,7 +47,7 @@ def test_kling_image_v3_adds_4k_mode_choice() -> None:
     node.set_parameter_value("mode", "4k")
     node.set_parameter_value("model_name", "Kling v2.6")
 
-    assert _mode_choices(node) == ["pro"]
+    assert _mode_choices(node) == ["std", "pro"]
     assert node.get_parameter_value("mode") == "pro"
 
 

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -10,10 +10,10 @@ from griptape_nodes.exe_types.core_types import ParameterList, ParameterMode
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.exe_types.param_types import parameter_image
 from griptape_nodes.files.file import File
 from griptape_nodes.traits.options import Options
 
-import griptape_nodes_library.video.seedance_2_0_video_generation as seedance_2_0_module
 from griptape_nodes_library.assets import (
     ASSET_KIND_AUDIO,
     ASSET_KIND_IMAGE,
@@ -67,9 +67,10 @@ async def test_build_payload_normalizes_local_frame_paths(monkeypatch: pytest.Mo
             return ImageUrlArtifact(f"https://example.com/{Path(value).name}")
         return value
 
-    monkeypatch.setattr(seedance_2_0_module, "normalize_artifact_input", fake_normalize_artifact_input)
+    monkeypatch.setattr(parameter_image, "normalize_artifact_input", fake_normalize_artifact_input)
 
     node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "First/Last Frame")
     node.set_parameter_value("prompt", "A fox runs through a forest")
     node.set_parameter_value("first_frame", str(first_frame))
     node.set_parameter_value("last_frame", str(last_frame))
@@ -165,6 +166,7 @@ def test_multimodal_reference_video_inputs_require_contiguous_order() -> None:
 async def test_build_payload_accepts_serialized_image_artifact_dict(monkeypatch: pytest.MonkeyPatch) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
     node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "First/Last Frame")
     node.set_parameter_value("prompt", "A fox runs through a forest")
     node.set_parameter_value(
         "first_frame",
@@ -197,6 +199,7 @@ async def test_build_payload_accepts_image_url_artifact_with_file_path_value(
     frame_path.write_bytes(b"frame")
 
     node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", "First/Last Frame")
     node.set_parameter_value("prompt", "A fox runs through a forest")
     node.set_parameter_value("first_frame", ImageUrlArtifact(str(frame_path)))
 

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -45,13 +45,6 @@ def _parameter_by_name(node: Seedance20VideoGeneration, parameter_name: str):
     return next(parameter for parameter in node.parameters if parameter.name == parameter_name)
 
 
-@pytest.fixture(autouse=True)
-def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
-    )
-
-
 @pytest.mark.asyncio
 async def test_build_payload_normalizes_local_frame_paths(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")

--- a/tests/unit/video/test_wan_animate_generation.py
+++ b/tests/unit/video/test_wan_animate_generation.py
@@ -1,19 +1,9 @@
 from __future__ import annotations
 
 import pytest
-from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
-    PublicArtifactUrlParameter,
-)
 
 import griptape_nodes_library.video.wan_animate_generation as wan_animate_module
 from griptape_nodes_library.video.wan_animate_generation import WanAnimateGeneration
-
-
-@pytest.fixture(autouse=True)
-def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        PublicArtifactUrlParameter, "_get_bucket_id", staticmethod(lambda *_args, **_kwargs: "test-bucket")
-    )
 
 
 def _stub_video_duration(monkeypatch: pytest.MonkeyPatch, seconds: float = 4.0) -> None:


### PR DESCRIPTION
Part of #409.

Fix failing unit tests, where failures are only due to out of date tests.

Run tests on CI after linter checks have run.

Note that failing tests that pointed to genuine bugs have been split out as #422, #423 and #424 and these must be merged and this PR rebased before unit tests will pass.