### PR TITLE
refactor: extract declare_model_invocation into a vendorable util module

### DIFF
--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -16,16 +16,11 @@ from griptape_nodes.exe_types.node_types import SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.node_library.library_registry import get_declared_models
-from griptape_nodes.retained_mode.events.base_events import ResultPayload
-from griptape_nodes.retained_mode.events.model_events import (
-    DeclareModelInvocationRequest,
-)
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key, resolve_proxy_base
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -613,43 +608,6 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._set_status_results(was_successful=False, result_details=error_msg)
         self._handle_failure_exception(e)
 
-    def _resolve_catalog_model_id(self, api_model_id: str) -> str | None:
-        """Resolve the selected provider model id to its stable catalog key.
-
-        The lookup is scoped to this node's own declared models, so the
-        provider_model_id -> stable key mapping is unambiguous: a node does not
-        declare the same upstream model under two catalog keys. Returns None
-        when the selection is not one of the node's declared catalog models.
-        """
-        matches = [
-            resolved.model_id
-            for resolved in get_declared_models(self)
-            if resolved.model.provider_model_id == api_model_id
-        ]
-        return matches[0] if len(matches) == 1 else None
-
-    async def _declare_model_invocation(self, api_model_id: str) -> ResultPayload:
-        """Declare the impending model invocation so the permission layer can gate it.
-
-        Resolves the concrete provider model id to the stable catalog key the
-        permission system gates on, and declares that. The engine clears the
-        call by default; a registered policy can deny it, in which case the
-        result reports failure. The proxy enforces server-side as well; this
-        runs first, so a denied call fails fast and never leaves the engine.
-        """
-        model_id = self._resolve_catalog_model_id(api_model_id)
-        if model_id is None:
-            logger.warning(
-                "%s: '%s' is not a declared catalog model for this node; "
-                "declaring the invocation with the provider model id for now.",
-                self.name,
-                api_model_id,
-            )
-            model_id = api_model_id
-        return await GriptapeNodes.ahandle_request(
-            DeclareModelInvocationRequest(model_id=model_id, node_name=self.name)
-        )
-
     async def _submit_and_poll(self, headers: dict[str, str]) -> tuple[str, dict[str, Any]] | None:
         """Submit generation request and poll for completion.
 
@@ -677,7 +635,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         # the engine-side gate, so a denied invocation fails fast here. The
         # declaration matches on the bare catalog id, which may differ from the
         # URL-path id (e.g. when the latter carries an operation suffix).
-        declaration = await self._declare_model_invocation(self._get_catalog_model_id())
+        declaration = await declare_model_invocation(self, self._get_catalog_model_id())
         if declaration.failed():
             self._set_safe_defaults()
             details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")

--- a/griptape_nodes_library/utils/model_invocation.py
+++ b/griptape_nodes_library/utils/model_invocation.py
@@ -1,0 +1,65 @@
+"""Declare an impending model invocation so the permission layer can gate it.
+
+Callers dispatch `declare_model_invocation` before making any network call to
+the model provider and treat a failed result as do-not-invoke: the engine
+clears the call by default, but a registered policy can deny it, in which
+case the result reports failure and the caller must not proceed. This is a
+fail-closed contract -- if the declaration fails for any reason, the model
+must not be invoked.
+
+This file is the canonical implementation. Other node libraries cannot import
+across each other's Python packages, so any library that needs this behavior
+vendors this file verbatim rather than depending on it. Keep this module free
+of dependencies beyond the engine package (`griptape_nodes.*`) and the
+standard library so it can be copied as-is into another library's `utils/`
+directory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.node_library.library_registry import get_declared_models
+from griptape_nodes.retained_mode.events.base_events import ResultPayload
+from griptape_nodes.retained_mode.events.model_events import DeclareModelInvocationRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["declare_model_invocation", "resolve_catalog_model_id"]
+
+
+def resolve_catalog_model_id(node: BaseNode, api_model_id: str) -> str | None:
+    """Resolve the selected provider model id to its stable catalog key.
+
+    The lookup is scoped to the node's own declared models, so the
+    provider_model_id -> stable key mapping is unambiguous: a node does not
+    declare the same upstream model under two catalog keys. Returns None
+    when the selection is not one of the node's declared catalog models.
+    """
+    matches = [
+        resolved.model_id for resolved in get_declared_models(node) if resolved.model.provider_model_id == api_model_id
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+async def declare_model_invocation(node: BaseNode, api_model_id: str) -> ResultPayload:
+    """Declare the impending model invocation so the permission layer can gate it.
+
+    Resolves the concrete provider model id to the stable catalog key the
+    permission system gates on, and declares that. The engine clears the
+    call by default; a registered policy can deny it, in which case the
+    result reports failure. The proxy enforces server-side as well; this
+    runs first, so a denied call fails fast and never leaves the engine.
+    """
+    model_id = resolve_catalog_model_id(node, api_model_id)
+    if model_id is None:
+        logger.warning(
+            "%s: '%s' is not a declared catalog model for this node; "
+            "declaring the invocation with the provider model id for now.",
+            node.name,
+            api_model_id,
+        )
+        model_id = api_model_id
+    return await GriptapeNodes.ahandle_request(DeclareModelInvocationRequest(model_id=model_id, node_name=node.name))

--- a/griptape_nodes_library/utils/model_invocation.py
+++ b/griptape_nodes_library/utils/model_invocation.py
@@ -27,7 +27,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logger = logging.getLogger("griptape_nodes")
 
-__all__ = ["declare_model_invocation", "resolve_catalog_model_id"]
+__all__ = ["declare_model_invocation", "declare_model_invocation_sync", "resolve_catalog_model_id"]
 
 
 def resolve_catalog_model_id(node: BaseNode, api_model_id: str) -> str | None:
@@ -53,6 +53,21 @@ async def declare_model_invocation(node: BaseNode, api_model_id: str) -> ResultP
     result reports failure. The proxy enforces server-side as well; this
     runs first, so a denied call fails fast and never leaves the engine.
     """
+    return await GriptapeNodes.ahandle_request(_build_declaration(node, api_model_id))
+
+
+def declare_model_invocation_sync(node: BaseNode, api_model_id: str) -> ResultPayload:
+    """Synchronous twin of `declare_model_invocation` for non-async call sites.
+
+    Nodes whose model call happens outside an async context (e.g. a generator
+    `process()` that runs framework drivers synchronously) declare through
+    this variant. Identical contract: dispatch before any network call and
+    treat a failed result as do-not-invoke.
+    """
+    return GriptapeNodes.handle_request(_build_declaration(node, api_model_id))
+
+
+def _build_declaration(node: BaseNode, api_model_id: str) -> DeclareModelInvocationRequest:
     model_id = resolve_catalog_model_id(node, api_model_id)
     if model_id is None:
         logger.warning(
@@ -62,4 +77,4 @@ async def declare_model_invocation(node: BaseNode, api_model_id: str) -> ResultP
             api_model_id,
         )
         model_id = api_model_id
-    return await GriptapeNodes.ahandle_request(DeclareModelInvocationRequest(model_id=model_id, node_name=node.name))
+    return DeclareModelInvocationRequest(model_id=model_id, node_name=node.name)

--- a/tests/unit/test_griptape_proxy_node_refresh.py
+++ b/tests/unit/test_griptape_proxy_node_refresh.py
@@ -133,7 +133,7 @@ async def test_refresh_async_running_updates_status_without_parsing(monkeypatch:
 
     monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
     monkeypatch.setattr(
-        "griptape_nodes_library.proxy.griptape_proxy_node.GriptapeNodes.SecretsManager",
+        "griptape_nodes_library.proxy.provider_asset_access.GriptapeNodes.SecretsManager",
         lambda: type("S", (), {"get_secret": lambda self, _name: "fake-key"})(),
     )
 
@@ -196,7 +196,7 @@ async def test_refresh_async_completed_invokes_parse_result(monkeypatch: pytest.
 
     monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
     monkeypatch.setattr(
-        "griptape_nodes_library.proxy.griptape_proxy_node.GriptapeNodes.SecretsManager",
+        "griptape_nodes_library.proxy.provider_asset_access.GriptapeNodes.SecretsManager",
         lambda: type("S", (), {"get_secret": lambda self, _name: "fake-key"})(),
     )
 

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -73,10 +73,10 @@ def test_declared_models_resolve_uniquely_per_node() -> None:
 
     The proxy base node resolves a selected provider model id back to its
     stable catalog key by matching within the node's own declared models
-    (`GriptapeProxyNode._resolve_catalog_model_id`). That match is unambiguous
-    only when a node does not declare two catalog ids that share a
-    `provider_model_id`; a duplicate would make the runtime resolver fail
-    closed. Guard the manifest against introducing one.
+    (`griptape_nodes_library.utils.model_invocation.resolve_catalog_model_id`).
+    That match is unambiguous only when a node does not declare two catalog
+    ids that share a `provider_model_id`; a duplicate would make the runtime
+    resolver fail closed. Guard the manifest against introducing one.
     """
     library = _load_library()
     provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)


### PR DESCRIPTION
Closes #426.

Every library adopting invocation gating (griptape-ai/internal#172) needs the same resolve-and-declare logic that lived as two private methods on `GriptapeProxyNode`. This moves the logic verbatim into `utils/model_invocation.py` as the canonical file external libraries vendor, with the fail-closed contract and the vendoring rationale documented in the module docstring. `GriptapeProxyNode` delegates to it; no behavior change.

Two tests in `test_griptape_proxy_node_refresh.py` monkeypatched `GriptapeNodes.SecretsManager` through `griptape_proxy_node`'s import, which only existed for the extracted code. They now patch `provider_asset_access`, the module that actually calls it on the refresh path.