### PR TITLE
feat: add catalog entries and model_usage for remaining model-selection nodes

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -295,6 +295,12 @@
                 "provider_model_id": "gpt-image-1",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               },
+              "gtc_gpt_image_1_mini": {
+                "display_name": "GPT Image 1 Mini",
+                "family": "GPT Image",
+                "provider_model_id": "gpt-image-1-mini",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
               "gtc_gpt_image_1_5": {
                 "display_name": "GPT Image 1.5",
                 "family": "GPT Image",
@@ -324,6 +330,18 @@
                 "family": "Whisper",
                 "provider_model_id": "whisper-1",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "openai_dall_e_3": {
+                "display_name": "DALL-E 3",
+                "family": "DALL-E",
+                "provider_model_id": "dall-e-3",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "openai_dall_e_2": {
+                "display_name": "DALL-E 2",
+                "family": "DALL-E",
+                "provider_model_id": "dall-e-2",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
               }
             }
           },
@@ -465,6 +483,42 @@
                 "family": "Grok Imagine",
                 "provider_model_id": "grok-imagine-video",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "xai_grok_2_image_1212": {
+                "display_name": "Grok 2 Image",
+                "family": "Grok Image",
+                "provider_model_id": "grok-2-image-1212",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "xai_grok_3_beta": {
+                "display_name": "Grok 3 Beta",
+                "family": "Grok 3",
+                "provider_model_id": "grok-3-beta",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "xai_grok_3_fast_beta": {
+                "display_name": "Grok 3 Fast Beta",
+                "family": "Grok 3",
+                "provider_model_id": "grok-3-fast-beta",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "xai_grok_3_mini_beta": {
+                "display_name": "Grok 3 Mini Beta",
+                "family": "Grok 3",
+                "provider_model_id": "grok-3-mini-beta",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "xai_grok_3_mini_fast_beta": {
+                "display_name": "Grok 3 Mini Fast Beta",
+                "family": "Grok 3",
+                "provider_model_id": "grok-3-mini-fast-beta",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "xai_grok_2_vision_1212": {
+                "display_name": "Grok 2 Vision",
+                "family": "Grok 2",
+                "provider_model_id": "grok-2-vision-1212",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
               }
             }
           },
@@ -882,6 +936,179 @@
                 "family": "ElevenLabs",
                 "provider_model_id": "eleven_v3",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              }
+            }
+          },
+          "cohere": {
+            "display_name": "Cohere",
+            "models": {
+              "cohere_command_r_plus": {
+                "display_name": "Command R+",
+                "family": "Command R",
+                "provider_model_id": "command-r-plus",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              }
+            }
+          },
+          "groq": {
+            "display_name": "Groq",
+            "notes": "Groq is a serving platform, not a model vendor; the models below (Llama, Gemma, DeepSeek, etc.) are served through Groq's infrastructure under Groq's own model ids. Using the serving platform as the provider key here is provisional pending the platform-as-provider convention discussion in issue #429 (Amazon Bedrock).",
+            "models": {
+              "groq_gemma2_9b_it": {
+                "display_name": "Gemma 2 9B IT",
+                "family": "Gemma 2",
+                "provider_model_id": "gemma2-9b-it",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama_guard_4_12b": {
+                "display_name": "Llama Guard 4 12B",
+                "family": "Llama Guard",
+                "provider_model_id": "meta-llama/llama-guard-4-12b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama_3_3_70b_versatile": {
+                "display_name": "Llama 3.3 70B Versatile",
+                "family": "Llama 3",
+                "provider_model_id": "llama-3.3-70b-versatile",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama_3_1_8b_instant": {
+                "display_name": "Llama 3.1 8B Instant",
+                "family": "Llama 3",
+                "provider_model_id": "llama-3.1-8b-instant",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama3_70b_8192": {
+                "display_name": "Llama 3 70B 8192",
+                "family": "Llama 3",
+                "provider_model_id": "llama3-70b-8192",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama3_8b_8192": {
+                "display_name": "Llama 3 8B 8192",
+                "family": "Llama 3",
+                "provider_model_id": "llama3-8b-8192",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_allam_2_7b": {
+                "display_name": "Allam 2 7B",
+                "family": "Allam",
+                "provider_model_id": "allam-2-7b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_deepseek_r1_distill_llama_70b": {
+                "display_name": "DeepSeek R1 Distill Llama 70B",
+                "family": "DeepSeek R1",
+                "provider_model_id": "deepseek-r1-distill-llama-70b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama_4_scout_17b_16e_instruct": {
+                "display_name": "Llama 4 Scout 17B 16E Instruct",
+                "family": "Llama 4",
+                "provider_model_id": "meta-llama/llama-4-scout-17b-16e-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "groq_llama_4_maverick_17b_128e_instruct": {
+                "display_name": "Llama 4 Maverick 17B 128E Instruct",
+                "family": "Llama 4",
+                "provider_model_id": "meta-llama/llama-4-maverick-17b-128e-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              }
+            }
+          },
+          "nvidia_nim": {
+            "display_name": "NVIDIA NIM",
+            "notes": "NVIDIA NIM is a serving platform, not a model vendor; the models below (Llama, Gemma, DeepSeek, Mistral, etc.) are served through NVIDIA's infrastructure under NVIDIA's own model ids. Using the serving platform as the provider key here is provisional pending the platform-as-provider convention discussion in issue #429 (Amazon Bedrock).",
+            "models": {
+              "nim_deepseek_v3_1": {
+                "display_name": "DeepSeek V3.1",
+                "family": "DeepSeek V3",
+                "provider_model_id": "deepseek-ai/deepseek-v3.1",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_gemma_3_1b_it": {
+                "display_name": "Gemma 3 1B IT",
+                "family": "Gemma 3",
+                "provider_model_id": "google/gemma-3-1b-it",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_4_maverick_17b_128e_instruct": {
+                "display_name": "Llama 4 Maverick 17B 128E Instruct",
+                "family": "Llama 4",
+                "provider_model_id": "meta/llama-4-maverick-17b-128e-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_4_scout_17b_16e_instruct": {
+                "display_name": "Llama 4 Scout 17B 16E Instruct",
+                "family": "Llama 4",
+                "provider_model_id": "meta/llama-4-scout-17b-16e-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_3_2_11b_vision_instruct": {
+                "display_name": "Llama 3.2 11B Vision Instruct",
+                "family": "Llama 3",
+                "provider_model_id": "meta/llama-3.2-11b-vision-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_3_2_90b_vision_instruct": {
+                "display_name": "Llama 3.2 90B Vision Instruct",
+                "family": "Llama 3",
+                "provider_model_id": "meta/llama-3.2-90b-vision-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama3_8b_instruct": {
+                "display_name": "Llama 3 8B Instruct",
+                "family": "Llama 3",
+                "provider_model_id": "meta/llama3-8b-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_3_3_nemotron_super_49b_v1_5": {
+                "display_name": "Llama 3.3 Nemotron Super 49B v1.5",
+                "family": "Nemotron",
+                "provider_model_id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_llama_3_1_nemotron_nano_vl_8b_v1": {
+                "display_name": "Llama 3.1 Nemotron Nano VL 8B v1",
+                "family": "Nemotron",
+                "provider_model_id": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_nemotron_nano_9b_v2": {
+                "display_name": "Nemotron Nano 9B v2",
+                "family": "Nemotron",
+                "provider_model_id": "nvidia/nvidia-nemotron-nano-9b-v2",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_gpt_oss_20b": {
+                "display_name": "GPT-OSS 20B",
+                "family": "GPT-OSS",
+                "provider_model_id": "openai/gpt-oss-20b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_gpt_oss_120b": {
+                "display_name": "GPT-OSS 120B",
+                "family": "GPT-OSS",
+                "provider_model_id": "openai/gpt-oss-120b",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_teuken_7b_instruct_commercial_v0_4": {
+                "display_name": "Teuken 7B Instruct Commercial v0.4",
+                "family": "Teuken",
+                "provider_model_id": "opengpt-x/teuken-7b-instruct-commercial-v0.4",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_kimi_k2_instruct": {
+                "display_name": "Kimi K2 Instruct",
+                "family": "Kimi",
+                "provider_model_id": "moonshotai/kimi-k2-instruct",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "nim_magistral_small_2506": {
+                "display_name": "Magistral Small 2506",
+                "family": "Magistral",
+                "provider_model_id": "mistralai/magistral-small-2506",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
               }
             }
           }
@@ -3706,6 +3933,15 @@
           "driver",
           "config",
           "griptape"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_image_1_mini",
+              "gtc_gpt_image_1_5"
+            ]
+          }
         ]
       }
     },
@@ -3728,6 +3964,14 @@
           "config",
           "grok",
           "xai"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "xai_grok_2_image_1212"
+            ]
+          }
         ]
       }
     },
@@ -3749,6 +3993,16 @@
           "driver",
           "config",
           "openai"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_image_1",
+              "openai_dall_e_3",
+              "openai_dall_e_2"
+            ]
+          }
         ]
       }
     },
@@ -3810,6 +4064,14 @@
           "config",
           "cohere",
           "llm"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "cohere_command_r_plus"
+            ]
+          }
         ]
       }
     },
@@ -3888,6 +4150,18 @@
           "grok",
           "xai",
           "llm"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "xai_grok_3_beta",
+              "xai_grok_3_fast_beta",
+              "xai_grok_3_mini_beta",
+              "xai_grok_3_mini_fast_beta",
+              "xai_grok_2_vision_1212"
+            ]
+          }
         ]
       }
     },
@@ -3909,6 +4183,23 @@
           "config",
           "groq",
           "llm"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "groq_gemma2_9b_it",
+              "groq_llama_guard_4_12b",
+              "groq_llama_3_3_70b_versatile",
+              "groq_llama_3_1_8b_instant",
+              "groq_llama3_70b_8192",
+              "groq_llama3_8b_8192",
+              "groq_allam_2_7b",
+              "groq_deepseek_r1_distill_llama_70b",
+              "groq_llama_4_scout_17b_16e_instruct",
+              "groq_llama_4_maverick_17b_128e_instruct"
+            ]
+          }
         ]
       }
     },
@@ -3927,6 +4218,28 @@
           "nvidia",
           "nim",
           "llm"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "nim_deepseek_v3_1",
+              "nim_gemma_3_1b_it",
+              "nim_llama_4_maverick_17b_128e_instruct",
+              "nim_llama_4_scout_17b_16e_instruct",
+              "nim_llama_3_2_11b_vision_instruct",
+              "nim_llama_3_2_90b_vision_instruct",
+              "nim_llama3_8b_instruct",
+              "nim_llama_3_3_nemotron_super_49b_v1_5",
+              "nim_llama_3_1_nemotron_nano_vl_8b_v1",
+              "nim_nemotron_nano_9b_v2",
+              "nim_gpt_oss_20b",
+              "nim_gpt_oss_120b",
+              "nim_teuken_7b_instruct_commercial_v0_4",
+              "nim_kimi_k2_instruct",
+              "nim_magistral_small_2506"
+            ]
+          }
         ]
       }
     },
@@ -4081,6 +4394,15 @@
           "image",
           "generation",
           "ai"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_image_1_mini",
+              "gtc_gpt_image_1_5"
+            ]
+          }
         ]
       }
     },

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -17,7 +17,17 @@ from typing import Any
 
 import pytest
 
+from griptape_nodes_library.config.image.griptape_cloud_image_driver import (
+    MODEL_CHOICES as GRIPTAPE_CLOUD_IMAGE_MODEL_CHOICES,
+)
+from griptape_nodes_library.config.image.grok_image_driver import MODEL_CHOICES as GROK_IMAGE_MODEL_CHOICES
+from griptape_nodes_library.config.image.openai_image_driver import MODEL_CHOICES as OPENAI_IMAGE_MODEL_CHOICES
 from griptape_nodes_library.config.prompt.cloud_models import MODEL_CHOICES_ARGS
+from griptape_nodes_library.config.prompt.cohere_prompt import MODEL_CHOICES as COHERE_PROMPT_MODEL_CHOICES
+from griptape_nodes_library.config.prompt.grok_prompt import MODEL_CHOICES as GROK_PROMPT_MODEL_CHOICES
+from griptape_nodes_library.config.prompt.groq_prompt import MODEL_CHOICES as GROQ_PROMPT_MODEL_CHOICES
+from griptape_nodes_library.config.prompt.nim_prompt import MODEL_CHOICES as NIM_PROMPT_MODEL_CHOICES
+from griptape_nodes_library.image.create_image import MODEL_CHOICES as GENERATE_IMAGE_MODEL_CHOICES
 
 LIBRARY_JSON = Path(__file__).parents[2] / "griptape_nodes_library.json"
 
@@ -66,6 +76,36 @@ def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
     served = [model["name"] for model in MODEL_CHOICES_ARGS]
 
     assert declared == served
+
+
+@pytest.mark.parametrize(
+    ("class_name", "expected_provider_model_ids"),
+    [
+        ("GenerateImage", GENERATE_IMAGE_MODEL_CHOICES),
+        ("GriptapeCloudImage", GRIPTAPE_CLOUD_IMAGE_MODEL_CHOICES),
+        ("OpenAiImage", OPENAI_IMAGE_MODEL_CHOICES),
+        ("GrokImage", GROK_IMAGE_MODEL_CHOICES),
+        ("GrokPrompt", GROK_PROMPT_MODEL_CHOICES),
+        ("CoherePrompt", COHERE_PROMPT_MODEL_CHOICES),
+        ("GroqPrompt", GROQ_PROMPT_MODEL_CHOICES),
+        ("NimPrompt", NIM_PROMPT_MODEL_CHOICES),
+    ],
+)
+def test_model_selection_node_usage_matches_static_choices(
+    class_name: str, expected_provider_model_ids: list[str]
+) -> None:
+    """The model list in Python and the models the node declares must agree.
+
+    Each node's `model_usage` ids resolve (through the catalog) to the same
+    ordered provider model ids the node's `MODEL_CHOICES` constant serves. A
+    mismatch means the manifest and the code drifted and one side needs updating.
+    """
+    library = _load_library()
+    provider_model_id_by_catalog_id = _provider_model_id_by_catalog_id(library)
+
+    declared = [provider_model_id_by_catalog_id[model_id] for model_id in _model_usage_ids(library, class_name)]
+
+    assert declared == expected_provider_model_ids
 
 
 def test_declared_models_resolve_uniquely_per_node() -> None:


### PR DESCRIPTION
Closes #428.

Purely additive: 35 catalog models (3 under `openai`, 6 under `xai`, new `cohere`, `groq`, and `nvidia_nim` providers) and `model_usage` on the eight model-selection nodes that had none (`GenerateImage`, `GriptapeCloudImage`, `OpenAiImage`, `GrokImage`, `GrokPrompt`, `CoherePrompt`, `GroqPrompt`, `NimPrompt`). No existing entries change. A consistency test guards each node's declared ids against its Python model list.

Key support follows routing: `gtc_gpt_image_1_mini` mirrors its Griptape-Cloud sibling, everything else is `REQUIRES_CUSTOMER_KEY` since those drivers pull vendor keys straight from secrets with no Griptape path.

Groq and NIM serve other vendors' models, which strains the vendor-keyed provider convention from #353 the same way Bedrock does. They are keyed by serving platform here, with literal wire ids as `provider_model_id` and a provisional note on each provider, pending the convention discussion in #429.