### PR TITLE
fix: opt in to collect_deleted_paths in DeleteFile node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -30,7 +30,7 @@
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
     "library_version": "0.82.0",
-    "engine_version": "0.92.0",
+    "engine_version": "0.93.0",
     "tags": [
       "Griptape",
       "AI"

--- a/griptape_nodes_library/files/delete_file.py
+++ b/griptape_nodes_library/files/delete_file.py
@@ -586,7 +586,7 @@ class DeleteFile(SuccessFailureNode):
 
         for target in deletion_order:
             # Create and send delete request
-            request = DeleteFileRequest(path=target.path, workspace_only=False)
+            request = DeleteFileRequest(path=target.path, workspace_only=False, collect_deleted_paths=True)
             result = GriptapeNodes.handle_request(request)
 
             if isinstance(result, DeleteFileResultFailure):


### PR DESCRIPTION
The engine is changing `DeleteFileRequest` so that a deleted directory no longer expands into every descendant path by default (griptape-ai/griptape-nodes-engine#5098, griptape-ai/griptape-nodes-engine#5099), since that list reached multiple megabytes and got broadcast over the websocket. The recursive enumeration is now gated behind a `collect_deleted_paths` flag.

The `DeleteFile` node surfaces `deleted_paths` as an output and deletes explicitly-requested directories as single targets that rely on the engine's recursion, so it needs the full descendant list. It now sets `collect_deleted_paths=True` to preserve that output.

This depends on the engine flag, so the required `engine_version` and the `griptape-nodes-engine` pin are bumped to 0.93.0. That version is not on PyPI yet, so lockfile resolution and CI will fail until the engine change ships. Merging is blocked on the engine release.