### PR TITLE
feat(describe-image): provider selection + list image input

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -352,6 +352,8 @@ class Agent(ControlNode):
         return "\n".join(lines) + "\n\n"
 
     # --- Provider / Model Methods ---
+    # TODO: extract into ProviderSelectionComponent shared with DescribeImage
+    # https://github.com/griptape-ai/griptape-nodes-library-standard/issues/442
 
     def _fetch_providers(self) -> "list[ProviderConfig]":
         """Fetch configured providers from the engine, falling back to griptape_cloud only."""

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -7,7 +7,7 @@ for tools, rulesets, prompts, and streams output back to the user interface.
 """
 
 import json
-from typing import TYPE_CHECKING, Any, cast  # cast used for handle_request narrowing
+from typing import Any, cast  # cast used for handle_request narrowing
 
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
@@ -57,31 +57,15 @@ from griptape_nodes_library.utils.agent_utils import (
 )
 from griptape_nodes_library.utils.error_utils import try_throw_error
 
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.events.agent_events import (
-        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
-    )
+from griptape_nodes.retained_mode.events.agent_events import (
+    ListAgentProvidersRequest,
+    ListAgentProvidersResultSuccess,
+    ListProviderModelsRequest,
+    ListProviderModelsResultSuccess,
+    ProviderConfig,
+)
 
-_AGENT_PROVIDERS_AVAILABLE: bool = False
-_GRIPTAPE_CLOUD_PROVIDER: "ProviderConfig" = cast("ProviderConfig", None)
-
-try:
-    from griptape_nodes.retained_mode.events.agent_events import (
-        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
-    )
-
-    _AGENT_PROVIDERS_AVAILABLE = True
-    _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
-except ImportError:
-    pass
+_GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
 
 # --- Constants ---
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -357,8 +341,6 @@ class Agent(ControlNode):
 
     def _fetch_providers(self) -> "list[ProviderConfig]":
         """Fetch configured providers from the engine, falling back to griptape_cloud only."""
-        if not _AGENT_PROVIDERS_AVAILABLE:
-            return []
         _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
@@ -389,8 +371,6 @@ class Agent(ControlNode):
 
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
         """Return the model list for a given provider name."""
-        if not _AGENT_PROVIDERS_AVAILABLE:
-            return MODEL_CHOICES
         try:
             providers = self._fetch_providers()
             provider_config = next((p for p in providers if p.name == provider_name), None)
@@ -1039,9 +1019,6 @@ class Agent(ControlNode):
                 )
             else:
                 # Non-Griptape-Cloud provider: resolve config and pick the right driver.
-                if not _AGENT_PROVIDERS_AVAILABLE:
-                    msg = f"Provider '{provider_name}' requires agent provider support which is not available in this engine version."
-                    raise RuntimeError(msg)
                 providers = self._fetch_providers()
                 provider_config = next((p for p in providers if p.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
                 base_url = provider_config.base_url or ""
@@ -1088,7 +1065,7 @@ class Agent(ControlNode):
         wrapper = wrap_agent(agent.to_dict(), tool_configs, ruleset_configs)
         # Forward provider credentials so downstream nodes can rebuild the driver —
         # griptape strips api_key from non-GTC drivers during to_dict() serialization.
-        if provider_name != "griptape_cloud" and _AGENT_PROVIDERS_AVAILABLE:
+        if provider_name != "griptape_cloud":
             providers = self._fetch_providers()
             p = next((x for x in providers if x.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
             wrapper["provider"] = {

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -34,6 +34,13 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.agent_events import (
+    ListAgentProvidersRequest,
+    ListAgentProvidersResultSuccess,
+    ListProviderModelsRequest,
+    ListProviderModelsResultSuccess,
+    ProviderConfig,
+)
 from griptape_nodes.retained_mode.events.connection_events import DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -56,14 +63,6 @@ from griptape_nodes_library.utils.agent_utils import (
     wrap_agent,
 )
 from griptape_nodes_library.utils.error_utils import try_throw_error
-
-from griptape_nodes.retained_mode.events.agent_events import (
-    ListAgentProvidersRequest,
-    ListAgentProvidersResultSuccess,
-    ListProviderModelsRequest,
-    ListProviderModelsResultSuccess,
-    ProviderConfig,
-)
 
 _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
 

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -241,7 +241,8 @@ class DescribeImage(ControlNode):
         if provider_name == "griptape_cloud":
             # Use a curated vision-only subset rather than the full GTC model list.
             models = GTC_VISION_MODEL_CHOICES
-            new_data = MODEL_CHOICES_ARGS
+            vision_names = set(GTC_VISION_MODEL_CHOICES)
+            new_data = [entry for entry in MODEL_CHOICES_ARGS if entry["name"] in vision_names]
         else:
             models = self._fetch_models_for_provider(provider_name)
             new_data = [{"name": m, "icon": "", "args": {}} for m in models]

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -19,6 +19,13 @@ from griptape_nodes.exe_types.param_components.model_access_component import Mod
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.retained_mode.events.agent_events import (
+    ListAgentProvidersRequest,
+    ListAgentProvidersResultSuccess,
+    ListProviderModelsRequest,
+    ListProviderModelsResultSuccess,
+    ProviderConfig,
+)
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
@@ -36,14 +43,6 @@ from griptape_nodes_library.utils.agent_utils import (
 )
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
-
-from griptape_nodes.retained_mode.events.agent_events import (
-    ListAgentProvidersRequest,
-    ListAgentProvidersResultSuccess,
-    ListProviderModelsRequest,
-    ListProviderModelsResultSuccess,
-    ProviderConfig,
-)
 
 _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
 

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -1,12 +1,19 @@
 import json
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from griptape.artifacts import ImageUrlArtifact, ModelArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud_prompt_driver import GriptapeCloudPromptDriver
+from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
-from griptape_nodes.exe_types.core_types import Parameter, ParameterList, ParameterMode, ParameterType
+from griptape_nodes.exe_types.core_types import (
+    NodeMessageResult,
+    Parameter,
+    ParameterList,
+    ParameterMode,
+    ParameterType,
+)
 from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode, ControlNode
 from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
@@ -14,10 +21,12 @@ from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, DeleteConnectionRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 from json_schema_to_pydantic import create_model  # pyright: ignore[reportMissingImports]
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
+from griptape_nodes_library.config.prompt.cloud_models import MODEL_CHOICES_ARGS
 from griptape_nodes_library.utils.agent_utils import (
     build_rulesets_from_configs,
     build_tools,
@@ -28,10 +37,38 @@ from griptape_nodes_library.utils.agent_utils import (
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.agent_events import (
+        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+_AGENT_PROVIDERS_AVAILABLE: bool = False
+_GRIPTAPE_CLOUD_PROVIDER: "ProviderConfig" = cast("ProviderConfig", None)
+
+try:
+    from griptape_nodes.retained_mode.events.agent_events import (
+        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
+        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
+        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
+    )
+
+    _AGENT_PROVIDERS_AVAILABLE = True
+    _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
+except ImportError:
+    pass
+
 SERVICE = "Griptape"
 API_KEY_URL = "https://cloud.griptape.ai/configuration/api-keys"
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
-MODEL_CHOICES = [
+
+# Vision-capable models available on Griptape Cloud.
+GTC_VISION_MODEL_CHOICES = [
     "gpt-5.2",
     "gpt-5.1",
     "gpt-5",
@@ -48,7 +85,7 @@ MODEL_CHOICES = [
     "gemini-3.1-pro",
     "gemini-2.5-pro",
 ]
-DEFAULT_MODEL = MODEL_CHOICES[0]
+DEFAULT_MODEL = GTC_VISION_MODEL_CHOICES[0]
 
 
 class DescribeImage(ControlNode):
@@ -65,6 +102,29 @@ class DescribeImage(ControlNode):
                 allowed_modes={ParameterMode.INPUT, ParameterMode.OUTPUT},
             )
         )
+
+        # Provider selector — populated from the engine's configured providers.
+        provider_names = self._fetch_provider_names()
+        self.add_parameter(
+            Parameter(
+                name="model_provider",
+                type="str",
+                default_value=provider_names[0] if provider_names else "griptape_cloud",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                tooltip="Choose a provider. Refresh to see all configured providers.",
+                traits={
+                    Options(choices=provider_names),
+                    Button(
+                        icon="list-restart",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._refresh_providers_button,
+                    ),
+                },
+                ui_options={"display_name": "provider"},
+            )
+        )
+
         model_param = Parameter(
             name="model",
             input_types=["str", "Prompt Model Config"],
@@ -82,7 +142,7 @@ class DescribeImage(ControlNode):
         self._model_access = ModelAccessComponent(
             node=self,
             parameter=model_param,
-            model_choices=MODEL_CHOICES,
+            model_choices=GTC_VISION_MODEL_CHOICES,
             default_model=DEFAULT_MODEL,
         )
         self.add_parameter(
@@ -147,6 +207,94 @@ class DescribeImage(ControlNode):
                 hide=True,
             )
         )
+
+    # --- Provider / model helpers (mirrors agent.py) ---
+
+    def _fetch_providers(self) -> "list[ProviderConfig]":
+        _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]
+        try:
+            result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
+            if not isinstance(result, ListAgentProvidersResultSuccess):
+                return _FALLBACK
+            return cast(ListAgentProvidersResultSuccess, result).providers or _FALLBACK
+        except Exception:
+            return _FALLBACK
+
+    def _fetch_provider_names(self) -> list[str]:
+        providers = self._fetch_providers()
+        return [p.name for p in providers] or ["griptape_cloud"]
+
+    def _resolve_provider_api_key(self, provider_config: "ProviderConfig") -> str:
+        secret_name = provider_config.api_key_secret_name or ""
+        if secret_name:
+            return (
+                GriptapeNodes.SecretsManager().get_secret(secret_name, should_error_on_not_found=False) or "not-needed"
+            )
+        return "not-needed"
+
+    def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
+        if not _AGENT_PROVIDERS_AVAILABLE:
+            return GTC_VISION_MODEL_CHOICES
+        try:
+            providers = self._fetch_providers()
+            provider_config = next((p for p in providers if p.name == provider_name), None)
+            if provider_config is None:
+                return GTC_VISION_MODEL_CHOICES
+            result = GriptapeNodes.handle_request(
+                ListProviderModelsRequest(
+                    provider=provider_config.type,
+                    base_url=provider_config.base_url or "",
+                    api_key=self._resolve_provider_api_key(provider_config),
+                )
+            )
+            if isinstance(result, ListProviderModelsResultSuccess):
+                return cast(ListProviderModelsResultSuccess, result).models or GTC_VISION_MODEL_CHOICES
+        except Exception:
+            pass
+        return GTC_VISION_MODEL_CHOICES
+
+    def _update_model_choices_for_provider(self, provider_name: str) -> None:
+        if provider_name == "griptape_cloud":
+            models = GTC_VISION_MODEL_CHOICES
+            new_data = MODEL_CHOICES_ARGS
+        else:
+            models = self._fetch_models_for_provider(provider_name)
+            new_data = [{"name": m, "icon": "", "args": {}} for m in models]
+        default = models[0] if models else DEFAULT_MODEL
+        self._update_option_choices(param="model", choices=models, default=default)
+        param = self.get_parameter_by_name("model")
+        if param:
+            param.update_ui_options_key("data", new_data)
+
+    def _refresh_providers_button(
+        self,
+        button: Button,
+        button_details: ButtonDetailsMessagePayload,  # noqa: ARG002
+    ) -> NodeMessageResult | None:
+        provider_names = self._fetch_provider_names()
+        current = self.get_parameter_value("model_provider") or "griptape_cloud"
+        default = current if current in provider_names else (provider_names[0] if provider_names else "griptape_cloud")
+        self._update_option_choices(param="model_provider", choices=provider_names, default=default)
+        return None
+
+    def _refresh_models_button(
+        self,
+        button: Button,
+        button_details: ButtonDetailsMessagePayload,  # noqa: ARG002
+    ) -> NodeMessageResult | None:
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
+        self._update_model_choices_for_provider(provider_name)
+        return None
+
+    def _uses_griptape_cloud_driver(self) -> bool:
+        if self.get_parameter_value("agent") is not None:
+            return False
+        if isinstance(self.get_parameter_value("model"), BasePromptDriver):
+            return False
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
+        return provider_name == "griptape_cloud"
+
+    # --- Connection / UI helpers ---
 
     def _update_output_type_and_validate_connections(self, new_output_type: str) -> None:
         output_param = self.get_parameter_by_name("output")
@@ -238,12 +386,10 @@ class DescribeImage(ControlNode):
         )
 
     def validate_before_workflow_run(self) -> list[Exception] | None:
-        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/871
         exceptions = []
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
-        # No need for the api key. These exceptions caught on other nodes.
-        if self.parameter_values.get("agent", None) and self.parameter_values.get("driver", None):
+        if not self._uses_griptape_cloud_driver():
             return None
+        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{API_KEY_ENV_VAR} is not defined"
             exceptions.append(KeyError(msg))
@@ -258,6 +404,7 @@ class DescribeImage(ControlNode):
     ) -> None:
         if target_parameter.name == "agent":
             self.hide_parameter_by_name("model")
+            self.hide_parameter_by_name("model_provider")
 
         if target_parameter.name == "output_schema":
             self._update_output_type_and_validate_connections("json")
@@ -283,6 +430,7 @@ class DescribeImage(ControlNode):
     ) -> None:
         if target_parameter.name == "agent":
             self.show_parameter_by_name("model")
+            self.show_parameter_by_name("model_provider")
         if target_parameter.name == "output_schema":
             self.set_parameter_value("output_schema", None)
             self._update_output_type_and_validate_connections("str")
@@ -309,17 +457,18 @@ class DescribeImage(ControlNode):
         super().after_value_set(parameter, value)
         if parameter.name == "model":
             self._model_access.on_value_changed(value)
+        elif parameter.name == "model_provider":
+            self._update_model_choices_for_provider(str(value))
 
     def process(self) -> AsyncResult[Structure]:  # noqa: C901, PLR0915, PLR0912
         # Get the parameters from the node
         params = self.parameter_values
         model_input = self.get_parameter_value("model")
+        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
 
-        # License-policy runtime gate. Raises RuntimeError if the currently-selected
-        # model is denied, which propagates as an error toast in the workflow.
-        # Bypasses non-string values (e.g. a connected Prompt Model Config driver
-        # carries its own model identity that the helper isn't aware of).
-        self._model_access.raise_if_denied(model_input)
+        # License-policy runtime gate — only enforced for Griptape Cloud models.
+        if provider_name == "griptape_cloud":
+            self._model_access.raise_if_denied(model_input)
 
         agent = None
 
@@ -366,18 +515,14 @@ class DescribeImage(ControlNode):
                     logger.error(msg)
                     raise
 
-        # If an agent is provided, we'll use and ensure it's using a PromptTask
-        # If a prompt_driver is provided, we'll use that
-        # If neither are provided, we'll create a new one with the selected model.
-        # Otherwise, we'll just use the default model
         tool_configs: list = []
         ruleset_configs: list = []
+        non_gtc_provider_config = None
         agent_value = self.get_parameter_value("agent")
         if isinstance(agent_value, dict):
             agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_value)
             agent = GtAgent().from_dict(agent_core_dict)
             restore_provider_driver(agent, agent_value)
-            # Rebuild tools and rulesets from configs so they're fresh for this run.
             if tool_configs:
                 live_tools, _ = build_tools(tool_configs)
                 if live_tools and agent.tasks:
@@ -391,6 +536,19 @@ class DescribeImage(ControlNode):
                 agent.tasks[0].output_schema = pydantic_schema
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, output_schema=pydantic_schema)
+        elif provider_name != "griptape_cloud":
+            providers = self._fetch_providers()
+            non_gtc_provider_config = next((p for p in providers if p.name == provider_name), None)
+            if non_gtc_provider_config is not None:
+                prompt_driver = GtOpenAiChatPromptDriver(
+                    model=model_input if isinstance(model_input, str) else DEFAULT_MODEL,
+                    base_url=non_gtc_provider_config.base_url or "",
+                    api_key=self._resolve_provider_api_key(non_gtc_provider_config),
+                    stream=True,
+                )
+            else:
+                prompt_driver = default_prompt_driver
+            agent = GtAgent(prompt_driver=prompt_driver, output_schema=pydantic_schema)
         elif isinstance(model_input, str):
             if model_input not in self._model_access.model_choices:
                 model_input = DEFAULT_MODEL
@@ -401,7 +559,6 @@ class DescribeImage(ControlNode):
             )
             agent = GtAgent(prompt_driver=prompt_driver, output_schema=pydantic_schema)
         else:
-            # If the agent is not provided, we'll create a new one with a default prompt driver
             agent = GtAgent(prompt_driver=default_prompt_driver, output_schema=pydantic_schema)
 
         prompt = params.get("prompt", "")
@@ -412,17 +569,32 @@ class DescribeImage(ControlNode):
         if get_description_only:
             prompt += "\n\nOutput image description only."
 
-        image_artifacts = [
-            load_image_from_url_artifact(img) if isinstance(img, ImageUrlArtifact) else img
-            for img in (self.get_parameter_value("images") or [])
-            if img is not None
-        ]
+        # Flatten nested lists — a ParameterList child may receive a list of artifacts
+        # when connected to an output that produces List[ImageUrlArtifact].
+        raw_images = self.get_parameter_value("images") or []
+        flat_images: list = []
+        for img in raw_images:
+            if isinstance(img, list):
+                flat_images.extend(img)
+            else:
+                flat_images.append(img)
+
+        image_artifacts = []
+        for img in flat_images:
+            if img is None:
+                continue
+            if isinstance(img, ImageUrlArtifact):
+                image_artifacts.append(load_image_from_url_artifact(img))
+            elif isinstance(img, str) and img.strip():
+                # String path or URL — load as image bytes rather than passing as text.
+                image_artifacts.append(load_image_from_url_artifact(ImageUrlArtifact(img)))
+            else:
+                image_artifacts.append(img)
 
         if not image_artifacts:
             self.parameter_output_values["output"] = "No image provided"
             return
 
-        # Run the agent
         yield lambda: agent.run([prompt, *image_artifacts])
         agent_output = agent.output
         output_value = agent_output.value
@@ -431,7 +603,8 @@ class DescribeImage(ControlNode):
 
         self.parameter_output_values["output"] = output_value
 
-        # Insert a false memory to prevent the base64
+        # Replace the run's image bytes with text — without this, those bytes get serialized
+        # into conversation history and resent on every downstream API call.
         memory_output = output_value
         if isinstance(memory_output, (dict, list)):
             memory_output = json.dumps(memory_output, ensure_ascii=False)
@@ -441,9 +614,20 @@ class DescribeImage(ControlNode):
         # Clear live tools before serializing, then wrap with configs for downstream nodes.
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
+
+        # For non-GTC providers, include provider info so downstream nodes can restore the driver.
+        incoming_provider = agent_value.get("provider") if isinstance(agent_value, dict) else None
+        provider_info = None
+        if non_gtc_provider_config is not None:
+            provider_info = {
+                "name": provider_name,
+                "base_url": non_gtc_provider_config.base_url or "",
+                "api_key": self._resolve_provider_api_key(non_gtc_provider_config),
+            }
+
         self.parameter_output_values["agent"] = wrap_agent(
             agent.to_dict(),
             tool_configs,
             ruleset_configs,
-            provider=agent_value.get("provider") if isinstance(agent_value, dict) else None,
+            provider=provider_info or incoming_provider,
         )

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -214,7 +214,7 @@ class DescribeImage(ControlNode):
 
     def _fetch_providers(self) -> "list[ProviderConfig]":
         if not _AGENT_PROVIDERS_AVAILABLE:
-            return ["griptape_cloud"]  # type: ignore[return-value]
+            return []  # _fetch_provider_names falls back to ["griptape_cloud"] via `or`
         _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
@@ -238,7 +238,7 @@ class DescribeImage(ControlNode):
 
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
         if not _AGENT_PROVIDERS_AVAILABLE:
-            return GTC_VISION_MODEL_CHOICES
+            return GTC_VISION_MODEL_CHOICES if provider_name == "griptape_cloud" else []
         try:
             providers = self._fetch_providers()
             provider_config = next((p for p in providers if p.name == provider_name), None)
@@ -259,6 +259,7 @@ class DescribeImage(ControlNode):
 
     def _update_model_choices_for_provider(self, provider_name: str) -> None:
         if provider_name == "griptape_cloud":
+            # Use a curated vision-only subset rather than the full GTC model list.
             models = GTC_VISION_MODEL_CHOICES
             new_data = MODEL_CHOICES_ARGS
         else:
@@ -532,6 +533,9 @@ class DescribeImage(ControlNode):
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, output_schema=pydantic_schema)
         elif provider_name != "griptape_cloud":
+            if not _AGENT_PROVIDERS_AVAILABLE:
+                msg = f"DescribeImage '{self.name}': provider '{provider_name}' requires agent provider support which is not available in this engine version."
+                raise RuntimeError(msg)
             providers = self._fetch_providers()
             non_gtc_provider_config = next((p for p in providers if p.name == provider_name), None)
             if non_gtc_provider_config is None:
@@ -579,7 +583,7 @@ class DescribeImage(ControlNode):
 
         image_artifacts = []
         for img in flat_images:
-            if img is None:
+            if img is None or img == "":
                 continue
             if isinstance(img, ImageUrlArtifact):
                 image_artifacts.append(load_image_from_url_artifact(img))

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -209,6 +209,8 @@ class DescribeImage(ControlNode):
         )
 
     # --- Provider / model helpers (mirrors agent.py) ---
+    # TODO: extract into ProviderSelectionComponent shared with Agent
+    # https://github.com/griptape-ai/griptape-nodes-library-standard/issues/442
 
     def _fetch_providers(self) -> "list[ProviderConfig]":
         if not _AGENT_PROVIDERS_AVAILABLE:

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from griptape.artifacts import ImageUrlArtifact, ModelArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
@@ -37,31 +37,15 @@ from griptape_nodes_library.utils.agent_utils import (
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.events.agent_events import (
-        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
-    )
+from griptape_nodes.retained_mode.events.agent_events import (
+    ListAgentProvidersRequest,
+    ListAgentProvidersResultSuccess,
+    ListProviderModelsRequest,
+    ListProviderModelsResultSuccess,
+    ProviderConfig,
+)
 
-_AGENT_PROVIDERS_AVAILABLE: bool = False
-_GRIPTAPE_CLOUD_PROVIDER: "ProviderConfig" = cast("ProviderConfig", None)
-
-try:
-    from griptape_nodes.retained_mode.events.agent_events import (
-        ListAgentProvidersRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListAgentProvidersResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsRequest,  # pyright: ignore[reportAttributeAccessIssue]
-        ListProviderModelsResultSuccess,  # pyright: ignore[reportAttributeAccessIssue]
-        ProviderConfig,  # pyright: ignore[reportAttributeAccessIssue]
-    )
-
-    _AGENT_PROVIDERS_AVAILABLE = True
-    _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
-except ImportError:
-    pass
+_GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_cloud", model="")
 
 SERVICE = "Griptape"
 API_KEY_URL = "https://cloud.griptape.ai/configuration/api-keys"
@@ -212,9 +196,7 @@ class DescribeImage(ControlNode):
     # TODO: extract into ProviderSelectionComponent shared with Agent
     # https://github.com/griptape-ai/griptape-nodes-library-standard/issues/442
 
-    def _fetch_providers(self) -> "list[ProviderConfig]":
-        if not _AGENT_PROVIDERS_AVAILABLE:
-            return []  # _fetch_provider_names falls back to ["griptape_cloud"] via `or`
+    def _fetch_providers(self) -> list[ProviderConfig]:
         _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
@@ -237,8 +219,6 @@ class DescribeImage(ControlNode):
         return "not-needed"
 
     def _fetch_models_for_provider(self, provider_name: str) -> list[str]:
-        if not _AGENT_PROVIDERS_AVAILABLE:
-            return GTC_VISION_MODEL_CHOICES if provider_name == "griptape_cloud" else []
         try:
             providers = self._fetch_providers()
             provider_config = next((p for p in providers if p.name == provider_name), None)
@@ -533,9 +513,6 @@ class DescribeImage(ControlNode):
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, output_schema=pydantic_schema)
         elif provider_name != "griptape_cloud":
-            if not _AGENT_PROVIDERS_AVAILABLE:
-                msg = f"DescribeImage '{self.name}': provider '{provider_name}' requires agent provider support which is not available in this engine version."
-                raise RuntimeError(msg)
             providers = self._fetch_providers()
             non_gtc_provider_config = next((p for p in providers if p.name == provider_name), None)
             if non_gtc_provider_config is None:

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -211,6 +211,8 @@ class DescribeImage(ControlNode):
     # --- Provider / model helpers (mirrors agent.py) ---
 
     def _fetch_providers(self) -> "list[ProviderConfig]":
+        if not _AGENT_PROVIDERS_AVAILABLE:
+            return ["griptape_cloud"]  # type: ignore[return-value]
         _FALLBACK = [_GRIPTAPE_CLOUD_PROVIDER]
         try:
             result = GriptapeNodes.handle_request(ListAgentProvidersRequest())
@@ -275,15 +277,6 @@ class DescribeImage(ControlNode):
         current = self.get_parameter_value("model_provider") or "griptape_cloud"
         default = current if current in provider_names else (provider_names[0] if provider_names else "griptape_cloud")
         self._update_option_choices(param="model_provider", choices=provider_names, default=default)
-        return None
-
-    def _refresh_models_button(
-        self,
-        button: Button,
-        button_details: ButtonDetailsMessagePayload,  # noqa: ARG002
-    ) -> NodeMessageResult | None:
-        provider_name = self.get_parameter_value("model_provider") or "griptape_cloud"
-        self._update_model_choices_for_provider(provider_name)
         return None
 
     def _uses_griptape_cloud_driver(self) -> bool:
@@ -517,7 +510,7 @@ class DescribeImage(ControlNode):
 
         tool_configs: list = []
         ruleset_configs: list = []
-        non_gtc_provider_config = None
+        provider_info: dict | None = None
         agent_value = self.get_parameter_value("agent")
         if isinstance(agent_value, dict):
             agent_core_dict, tool_configs, ruleset_configs = unwrap_agent(agent_value)
@@ -539,15 +532,18 @@ class DescribeImage(ControlNode):
         elif provider_name != "griptape_cloud":
             providers = self._fetch_providers()
             non_gtc_provider_config = next((p for p in providers if p.name == provider_name), None)
-            if non_gtc_provider_config is not None:
-                prompt_driver = GtOpenAiChatPromptDriver(
-                    model=model_input if isinstance(model_input, str) else DEFAULT_MODEL,
-                    base_url=non_gtc_provider_config.base_url or "",
-                    api_key=self._resolve_provider_api_key(non_gtc_provider_config),
-                    stream=True,
-                )
-            else:
-                prompt_driver = default_prompt_driver
+            if non_gtc_provider_config is None:
+                msg = f"DescribeImage '{self.name}': provider '{provider_name}' not found in configured providers."
+                raise ValueError(msg)
+            api_key = self._resolve_provider_api_key(non_gtc_provider_config)
+            base_url = non_gtc_provider_config.base_url or ""
+            prompt_driver = GtOpenAiChatPromptDriver(
+                model=model_input if isinstance(model_input, str) else DEFAULT_MODEL,
+                base_url=base_url,
+                api_key=api_key,
+                stream=True,
+            )
+            provider_info = {"name": provider_name, "base_url": base_url, "api_key": api_key}
             agent = GtAgent(prompt_driver=prompt_driver, output_schema=pydantic_schema)
         elif isinstance(model_input, str):
             if model_input not in self._model_access.model_choices:
@@ -615,15 +611,7 @@ class DescribeImage(ControlNode):
         if agent.tasks:
             cast(PromptTask, agent.tasks[0]).tools = []
 
-        # For non-GTC providers, include provider info so downstream nodes can restore the driver.
         incoming_provider = agent_value.get("provider") if isinstance(agent_value, dict) else None
-        provider_info = None
-        if non_gtc_provider_config is not None:
-            provider_info = {
-                "name": provider_name,
-                "base_url": non_gtc_provider_config.base_url or "",
-                "api_key": self._resolve_provider_api_key(non_gtc_provider_config),
-            }
 
         self.parameter_output_values["agent"] = wrap_agent(
             agent.to_dict(),


### PR DESCRIPTION
Closes #439

## Summary

- **Provider selection**: adds a `model_provider` dropdown (mirrors the Agent node pattern) with a refresh button and dynamic model list via `ListAgentProvidersRequest` / `ListProviderModelsRequest`. Non-GTC providers use `GtOpenAiChatPromptDriver` and forward provider credentials in the agent wrapper so downstream nodes can restore the driver.
- **List image input**: flattens nested lists before processing — when a `List[ImageUrlArtifact]` is connected to a `ParameterList` child it arrives as a list-inside-a-list; the node now handles that transparently.
- **String path/URL fix**: string inputs to `images` are now wrapped in `ImageUrlArtifact` and loaded as image bytes rather than passed as text to the model (previously the LLM would see the file path string instead of the image).
- **Validation fix**: replaces the broken `validate_before_workflow_run` (which checked a non-existent `driver` param) with `_uses_griptape_cloud_driver()`, matching the Agent node's approach so non-GTC runs aren't incorrectly blocked.

## Test plan

- [ ] Connect a `SelectFromGrid` (or any node producing `List[ImageUrlArtifact]`) directly to `DescribeImage.images` — node should describe all images
- [ ] Switch provider dropdown to a non-GTC provider (e.g. Ollama) — model list should update and the node should run without requiring `GT_CLOUD_API_KEY`
- [ ] Wire `DescribeImage` into an agent chain and verify the downstream agent sees the description in memory (not base64 bytes)
- [ ] Existing single-image and GTC model flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)