### PR TITLE
fix: use native OllamaPromptDriver for Ollama providers (tool calling)

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -24,6 +24,7 @@ from griptape.events import (
 from griptape.memory.structure import ConversationMemory, Run
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
+from griptape_nodes.drivers.cloud_models import ProviderID
 from griptape_nodes.exe_types.core_types import (
     NodeMessageResult,
     Parameter,
@@ -1011,7 +1012,7 @@ class Agent(ControlNode):
             # Wrappers from older versions lack "type"; those fall through to the OpenAI-compat driver.
             if incoming_provider:
                 incoming_base_url = incoming_provider.get("base_url", "")
-                if incoming_provider.get("type") == "ollama":
+                if incoming_provider.get("type") == ProviderID.OLLAMA:
                     rebuilt_driver = GtOllamaPromptDriver(
                         model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
                         host=ollama_host_from_base_url(incoming_base_url),
@@ -1048,7 +1049,7 @@ class Agent(ControlNode):
                 provider_config = next((p for p in providers if p.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
                 base_url = provider_config.base_url or ""
                 api_key = self._resolve_provider_api_key(provider_config)
-                if provider_config.type == "ollama":
+                if provider_config.type == ProviderID.OLLAMA:
                     prompt_driver = GtOllamaPromptDriver(
                         model=model_input,
                         host=ollama_host_from_base_url(base_url),

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -1021,6 +1021,11 @@ class Agent(ControlNode):
                 incoming_base_url = incoming_provider.get("base_url", "")
                 model = agent.tasks[0].prompt_driver.model
                 if incoming_provider.get("type") == ProviderID.OLLAMA:
+                    # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
+                    # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
+                    # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
+                    # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
+                    #   https://github.com/griptape-ai/griptape/issues/2238
                     rebuilt_driver = GtOllamaPromptDriver(
                         model=model,
                         host=ollama_host_from_base_url(incoming_base_url),
@@ -1058,6 +1063,11 @@ class Agent(ControlNode):
                 base_url = provider_config.base_url or ""
                 api_key = self._resolve_provider_api_key(provider_config)
                 if provider_config.type == ProviderID.OLLAMA:
+                    # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
+                    # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
+                    # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
+                    # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
+                    #   https://github.com/griptape-ai/griptape/issues/2238
                     prompt_driver = GtOllamaPromptDriver(
                         model=model_input,
                         host=ollama_host_from_base_url(base_url),

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -12,8 +12,6 @@ from typing import TYPE_CHECKING, Any, cast  # cast used for handle_request narr
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
-from griptape.drivers.prompt.ollama import OllamaPromptDriver as GtOllamaPromptDriver
-from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape.events import (
     ActionChunkEvent,
     FinishActionsSubtaskEvent,
@@ -24,7 +22,6 @@ from griptape.events import (
 from griptape.memory.structure import ConversationMemory, Run
 from griptape.structures import Structure
 from griptape.tasks import PromptTask
-from griptape_nodes.drivers.cloud_models import ProviderID
 from griptape_nodes.exe_types.core_types import (
     NodeMessageResult,
     Parameter,
@@ -51,9 +48,9 @@ from griptape_nodes_library.config.prompt.cloud_models import (
     MODEL_CHOICES_ARGS,
 )
 from griptape_nodes_library.utils.agent_utils import (
+    build_prompt_driver,
     build_rulesets_from_configs,
     build_tools,
-    ollama_host_from_base_url,
     ruleset_to_config,
     unwrap_agent,
     wrap_agent,
@@ -1018,27 +1015,12 @@ class Agent(ControlNode):
             # Rebuild the prompt driver for non-GTC providers — griptape strips api_key during serialization.
             # Wrappers from older versions lack "type"; those fall through to the OpenAI-compat driver.
             if incoming_provider:
-                incoming_base_url = incoming_provider.get("base_url", "")
-                model = agent.tasks[0].prompt_driver.model
-                if incoming_provider.get("type") == ProviderID.OLLAMA:
-                    # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
-                    # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
-                    # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
-                    # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
-                    #   https://github.com/griptape-ai/griptape/issues/2238
-                    rebuilt_driver = GtOllamaPromptDriver(
-                        model=model,
-                        host=ollama_host_from_base_url(incoming_base_url),
-                        stream=True,
-                    )
-                else:
-                    rebuilt_driver = GtOpenAiChatPromptDriver(
-                        model=model,
-                        base_url=incoming_base_url,
-                        api_key=incoming_provider.get("api_key") or "not-needed",
-                        stream=True,
-                    )
-                cast(PromptTask, agent.tasks[0]).prompt_driver = rebuilt_driver
+                cast(PromptTask, agent.tasks[0]).prompt_driver = build_prompt_driver(
+                    provider_type=incoming_provider.get("type"),
+                    model=agent.tasks[0].prompt_driver.model,
+                    base_url=incoming_provider.get("base_url", ""),
+                    api_key=incoming_provider.get("api_key"),
+                )
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
         elif isinstance(model_input, str):
@@ -1062,24 +1044,12 @@ class Agent(ControlNode):
                 provider_config = next((p for p in providers if p.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
                 base_url = provider_config.base_url or ""
                 api_key = self._resolve_provider_api_key(provider_config)
-                if provider_config.type == ProviderID.OLLAMA:
-                    # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
-                    # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
-                    # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
-                    # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
-                    #   https://github.com/griptape-ai/griptape/issues/2238
-                    prompt_driver = GtOllamaPromptDriver(
-                        model=model_input,
-                        host=ollama_host_from_base_url(base_url),
-                        stream=True,
-                    )
-                else:
-                    prompt_driver = GtOpenAiChatPromptDriver(
-                        model=model_input,
-                        base_url=base_url,
-                        api_key=api_key,
-                        stream=True,
-                    )
+                prompt_driver = build_prompt_driver(
+                    provider_type=provider_config.type,
+                    model=model_input,
+                    base_url=base_url,
+                    api_key=api_key,
+                )
             agent = GtAgent(prompt_driver=prompt_driver, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
 
         if agent is None:

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast  # cast used for handle_request narr
 from griptape.artifacts import BaseArtifact, ModelArtifact, TextArtifact
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
+from griptape.drivers.prompt.ollama import OllamaPromptDriver as GtOllamaPromptDriver
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape.events import (
     ActionChunkEvent,
@@ -441,6 +442,19 @@ class Agent(ControlNode):
         return None
 
     # --- Helper Methods ---
+
+    @staticmethod
+    def _ollama_host_from_base_url(base_url: str) -> str | None:
+        """Convert an OpenAI-compat Ollama base_url to the host expected by OllamaPromptDriver.
+
+        Provider configs store the OpenAI-compat URL (e.g. http://localhost:11434/v1).
+        OllamaPromptDriver uses the native Ollama client, which expects just the host
+        without any path suffix (e.g. http://localhost:11434).
+        """
+        host = base_url.rstrip("/")
+        if host.endswith("/v1"):
+            host = host[:-3]
+        return host or None
 
     def _find_runs_in_data(self, data: Any) -> list[dict[str, Any]]:
         """Recursively find 'runs' array in data structure.
@@ -1007,12 +1021,20 @@ class Agent(ControlNode):
                 agent.tasks[0].output_schema = pydantic_schema
             # Rebuild the prompt driver for non-GTC providers — griptape strips api_key during serialization.
             if incoming_provider:
-                rebuilt_driver = GtOpenAiChatPromptDriver(
-                    model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
-                    base_url=incoming_provider.get("base_url", ""),
-                    api_key=incoming_provider.get("api_key") or "not-needed",
-                    stream=True,
-                )
+                incoming_base_url = incoming_provider.get("base_url", "")
+                if incoming_provider.get("type") == "ollama":
+                    rebuilt_driver = GtOllamaPromptDriver(
+                        model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
+                        host=self._ollama_host_from_base_url(incoming_base_url),
+                        stream=True,
+                    )
+                else:
+                    rebuilt_driver = GtOpenAiChatPromptDriver(
+                        model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
+                        base_url=incoming_base_url,
+                        api_key=incoming_provider.get("api_key") or "not-needed",
+                        stream=True,
+                    )
                 cast(PromptTask, agent.tasks[0]).prompt_driver = rebuilt_driver
         elif isinstance(model_input, BasePromptDriver):
             agent = GtAgent(prompt_driver=model_input, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
@@ -1029,7 +1051,7 @@ class Agent(ControlNode):
                     **args,
                 )
             else:
-                # Non-Griptape-Cloud provider: resolve config and use the OpenAI-compatible driver.
+                # Non-Griptape-Cloud provider: resolve config and pick the right driver.
                 if not _AGENT_PROVIDERS_AVAILABLE:
                     msg = f"Provider '{provider_name}' requires agent provider support which is not available in this engine version."
                     raise RuntimeError(msg)
@@ -1037,12 +1059,19 @@ class Agent(ControlNode):
                 provider_config = next((p for p in providers if p.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
                 base_url = provider_config.base_url or ""
                 api_key = self._resolve_provider_api_key(provider_config)
-                prompt_driver = GtOpenAiChatPromptDriver(
-                    model=model_input,
-                    base_url=base_url,
-                    api_key=api_key,
-                    stream=True,
-                )
+                if provider_config.type == "ollama":
+                    prompt_driver = GtOllamaPromptDriver(
+                        model=model_input,
+                        host=self._ollama_host_from_base_url(base_url),
+                        stream=True,
+                    )
+                else:
+                    prompt_driver = GtOpenAiChatPromptDriver(
+                        model=model_input,
+                        base_url=base_url,
+                        api_key=api_key,
+                        stream=True,
+                    )
             agent = GtAgent(prompt_driver=prompt_driver, tools=tools, rulesets=rulesets, output_schema=pydantic_schema)
 
         if agent is None:
@@ -1084,6 +1113,7 @@ class Agent(ControlNode):
             p = next((x for x in providers if x.name == provider_name), _GRIPTAPE_CLOUD_PROVIDER)
             wrapper["provider"] = {
                 "name": provider_name,
+                "type": p.type,
                 "base_url": p.base_url or "",
                 "api_key": self._resolve_provider_api_key(p),
             }

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -1005,6 +1005,13 @@ class Agent(ControlNode):
             agent._rulesets = build_rulesets_from_configs(ruleset_configs)
             # make sure the agent is using a PromptTask — replace rather than add to avoid two tasks
             if not isinstance(agent.tasks[0], PromptTask):
+                if incoming_provider:
+                    msg = (
+                        f"Incoming agent has a {type(agent.tasks[0]).__name__} as its first task, "
+                        "not a PromptTask. Cannot apply a non-GTC provider driver to this agent. "
+                        "Check your chain topology."
+                    )
+                    raise RuntimeError(msg)
                 agent.tasks[0] = PromptTask(prompt_driver=default_prompt_driver, output_schema=pydantic_schema)
             else:
                 agent.tasks[0].output_schema = pydantic_schema
@@ -1012,15 +1019,16 @@ class Agent(ControlNode):
             # Wrappers from older versions lack "type"; those fall through to the OpenAI-compat driver.
             if incoming_provider:
                 incoming_base_url = incoming_provider.get("base_url", "")
+                model = agent.tasks[0].prompt_driver.model
                 if incoming_provider.get("type") == ProviderID.OLLAMA:
                     rebuilt_driver = GtOllamaPromptDriver(
-                        model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
+                        model=model,
                         host=ollama_host_from_base_url(incoming_base_url),
                         stream=True,
                     )
                 else:
                     rebuilt_driver = GtOpenAiChatPromptDriver(
-                        model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
+                        model=model,
                         base_url=incoming_base_url,
                         api_key=incoming_provider.get("api_key") or "not-needed",
                         stream=True,

--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -52,6 +52,7 @@ from griptape_nodes_library.config.prompt.cloud_models import (
 from griptape_nodes_library.utils.agent_utils import (
     build_rulesets_from_configs,
     build_tools,
+    ollama_host_from_base_url,
     ruleset_to_config,
     unwrap_agent,
     wrap_agent,
@@ -442,19 +443,6 @@ class Agent(ControlNode):
         return None
 
     # --- Helper Methods ---
-
-    @staticmethod
-    def _ollama_host_from_base_url(base_url: str) -> str | None:
-        """Convert an OpenAI-compat Ollama base_url to the host expected by OllamaPromptDriver.
-
-        Provider configs store the OpenAI-compat URL (e.g. http://localhost:11434/v1).
-        OllamaPromptDriver uses the native Ollama client, which expects just the host
-        without any path suffix (e.g. http://localhost:11434).
-        """
-        host = base_url.rstrip("/")
-        if host.endswith("/v1"):
-            host = host[:-3]
-        return host or None
 
     def _find_runs_in_data(self, data: Any) -> list[dict[str, Any]]:
         """Recursively find 'runs' array in data structure.
@@ -1020,12 +1008,13 @@ class Agent(ControlNode):
             else:
                 agent.tasks[0].output_schema = pydantic_schema
             # Rebuild the prompt driver for non-GTC providers — griptape strips api_key during serialization.
+            # Wrappers from older versions lack "type"; those fall through to the OpenAI-compat driver.
             if incoming_provider:
                 incoming_base_url = incoming_provider.get("base_url", "")
                 if incoming_provider.get("type") == "ollama":
                     rebuilt_driver = GtOllamaPromptDriver(
                         model=cast(PromptTask, agent.tasks[0]).prompt_driver.model,
-                        host=self._ollama_host_from_base_url(incoming_base_url),
+                        host=ollama_host_from_base_url(incoming_base_url),
                         stream=True,
                     )
                 else:
@@ -1062,7 +1051,7 @@ class Agent(ControlNode):
                 if provider_config.type == "ollama":
                     prompt_driver = GtOllamaPromptDriver(
                         model=model_input,
-                        host=self._ollama_host_from_base_url(base_url),
+                        host=ollama_host_from_base_url(base_url),
                         stream=True,
                     )
                 else:

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -107,6 +107,11 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     base_url = provider.get("base_url", "")
 
     if provider.get("type") == ProviderID.OLLAMA:
+        # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
+        # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
+        # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
+        # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
+        #   https://github.com/griptape-ai/griptape/issues/2238
         rebuilt = OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=True)
     else:
         rebuilt = OpenAiChatPromptDriver(

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -5,6 +5,7 @@ wire and rebuilt fresh at the point of use.  Every node that produces or
 consumes an Agent value imports from here so the logic lives in one place.
 """
 
+import logging
 from typing import cast
 
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
@@ -47,6 +48,7 @@ def _patch_exa_driver() -> None:
 
 _patch_exa_driver()
 
+logger = logging.getLogger("griptape_nodes")
 
 # ---------------------------------------------------------------------------
 # Wrap / unwrap
@@ -137,8 +139,15 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     if not isinstance(task, PromptTask):
         return
 
+    provider_type = provider.get("type")
+    if provider_type is None:
+        logger.warning(
+            "Saved agent wrapper has no provider 'type' — falling back to the OpenAI-compat driver. "
+            "If this is an Ollama provider, tool calls may silently fail. "
+            "Re-run the upstream Agent node to write the correct driver type into the wrapper."
+        )
     cast(PromptTask, task).prompt_driver = build_prompt_driver(
-        provider_type=provider.get("type"),
+        provider_type=provider_type,
         model=task.prompt_driver.model,
         base_url=provider.get("base_url", ""),
         api_key=provider.get("api_key"),

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -67,7 +67,7 @@ def unwrap_agent(value: dict) -> tuple[dict, list, list]:
     return value, [], []
 
 
-def ollama_host_from_base_url(base_url: str) -> str | None:
+def _ollama_host_from_base_url(base_url: str) -> str | None:
     """Convert an OpenAI-compat Ollama base_url to the host expected by OllamaPromptDriver.
 
     Provider configs store the OpenAI-compat URL (e.g. http://localhost:11434/v1).
@@ -102,7 +102,10 @@ def build_prompt_driver(
       https://github.com/griptape-ai/griptape/issues/2238
     """
     if provider_type == ProviderID.OLLAMA:
-        return OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=stream)
+        # Ollama's OpenAI-compat /v1 endpoint drops tool_calls from streamed responses
+        # (ollama/ollama#9084). The native /api/chat endpoint handles tool-call streaming
+        # correctly, so we use OllamaPromptDriver instead of the OpenAI-compat driver.
+        return OllamaPromptDriver(model=model, host=_ollama_host_from_base_url(base_url), stream=stream)
     return OpenAiChatPromptDriver(
         model=model,
         base_url=base_url,

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -7,6 +7,7 @@ consumes an Agent value imports from here so the logic lives in one place.
 
 from typing import cast
 
+from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape.drivers.prompt.ollama import OllamaPromptDriver
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
 from griptape.rules import Rule, Ruleset
@@ -80,6 +81,36 @@ def ollama_host_from_base_url(base_url: str) -> str | None:
     return host or None
 
 
+def build_prompt_driver(
+    *,
+    provider_type: str | None,
+    model: str,
+    base_url: str,
+    api_key: str | None = None,
+    stream: bool = True,
+) -> BasePromptDriver:
+    """Build the correct prompt driver for a provider config.
+
+    Uses the native OllamaPromptDriver for Ollama providers (required for tool
+    calling — the OpenAI-compat path produces blank output). Falls through to
+    OpenAiChatPromptDriver for all other provider types, including unknown/missing.
+
+    Note: ollama.Client accepts no api_key, so api_key is silently ignored for
+    Ollama providers. Ollama instances behind an auth reverse proxy should use a
+    non-ollama provider type to have credentials forwarded.
+    TODO: remove caveat once griptape exposes headers/api_key on OllamaPromptDriver
+      https://github.com/griptape-ai/griptape/issues/2238
+    """
+    if provider_type == ProviderID.OLLAMA:
+        return OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=stream)
+    return OpenAiChatPromptDriver(
+        model=model,
+        base_url=base_url,
+        api_key=api_key or "not-needed",
+        stream=stream,
+    )
+
+
 def restore_provider_driver(agent: object, wrapper: dict) -> None:
     """Rebuild the prompt driver from provider config stored in the wrapper.
 
@@ -103,24 +134,12 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     if not isinstance(task, PromptTask):
         return
 
-    model = task.prompt_driver.model
-    base_url = provider.get("base_url", "")
-
-    if provider.get("type") == ProviderID.OLLAMA:
-        # Native Ollama driver is required for tool calling; the OpenAI-compat path produces blank output.
-        # Trade-off: ollama.Client accepts no api_key, so Ollama instances behind an auth reverse proxy
-        # cannot have their credentials forwarded here. Use a non-ollama provider type for that setup.
-        # TODO: remove once griptape exposes headers/api_key on OllamaPromptDriver
-        #   https://github.com/griptape-ai/griptape/issues/2238
-        rebuilt = OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=True)
-    else:
-        rebuilt = OpenAiChatPromptDriver(
-            model=model,
-            base_url=base_url,
-            api_key=provider.get("api_key") or "not-needed",
-            stream=True,
-        )
-    cast(PromptTask, task).prompt_driver = rebuilt
+    cast(PromptTask, task).prompt_driver = build_prompt_driver(
+        provider_type=provider.get("type"),
+        model=task.prompt_driver.model,
+        base_url=provider.get("base_url", ""),
+        api_key=provider.get("api_key"),
+    )
 
 
 def wrap_agent(agent_dict: dict, tool_configs: list, ruleset_configs: list, *, provider: dict | None = None) -> dict:

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -5,7 +5,12 @@ wire and rebuilt fresh at the point of use.  Every node that produces or
 consumes an Agent value imports from here so the logic lives in one place.
 """
 
+from typing import cast
+
+from griptape.drivers.prompt.ollama import OllamaPromptDriver
+from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
 from griptape.rules import Rule, Ruleset
+from griptape.tasks import PromptTask
 
 
 # ---------------------------------------------------------------------------
@@ -65,15 +70,11 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
 
     When a non-GTC agent is serialized via to_dict(), griptape strips the api_key.
     Callers that deserialize via from_dict() must call this immediately after to
-    restore the correct driver for OpenAI-compatible providers.
+    restore the correct driver for the provider (Ollama native or OpenAI-compatible).
     """
     provider = wrapper.get("provider") if isinstance(wrapper, dict) else None
     if not provider:
         return
-    from typing import cast
-
-    from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
-    from griptape.tasks import PromptTask
 
     tasks = getattr(agent, "tasks", None)
     if not tasks:
@@ -81,13 +82,22 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     task = tasks[0]
     if not isinstance(task, PromptTask):
         return
+
     model = task.prompt_driver.model
-    rebuilt = OpenAiChatPromptDriver(
-        model=model,
-        base_url=provider.get("base_url", ""),
-        api_key=provider.get("api_key") or "not-needed",
-        stream=True,
-    )
+    base_url = provider.get("base_url", "")
+
+    if provider.get("type") == "ollama":
+        host = base_url.rstrip("/")
+        if host.endswith("/v1"):
+            host = host[:-3]
+        rebuilt = OllamaPromptDriver(model=model, host=host or None, stream=True)
+    else:
+        rebuilt = OpenAiChatPromptDriver(
+            model=model,
+            base_url=base_url,
+            api_key=provider.get("api_key") or "not-needed",
+            stream=True,
+        )
     cast(PromptTask, task).prompt_driver = rebuilt
 
 

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -65,12 +65,31 @@ def unwrap_agent(value: dict) -> tuple[dict, list, list]:
     return value, [], []
 
 
+def ollama_host_from_base_url(base_url: str) -> str | None:
+    """Convert an OpenAI-compat Ollama base_url to the host expected by OllamaPromptDriver.
+
+    Provider configs store the OpenAI-compat URL (e.g. http://localhost:11434/v1).
+    OllamaPromptDriver uses the native Ollama client, which takes just the host
+    without any path suffix (e.g. http://localhost:11434). Passing None is valid
+    and causes ollama.Client to default to http://localhost:11434.
+    """
+    host = base_url.rstrip("/")
+    if host.endswith("/v1"):
+        host = host[:-3]
+    return host or None
+
+
 def restore_provider_driver(agent: object, wrapper: dict) -> None:
     """Rebuild the prompt driver from provider config stored in the wrapper.
 
     When a non-GTC agent is serialized via to_dict(), griptape strips the api_key.
     Callers that deserialize via from_dict() must call this immediately after to
     restore the correct driver for the provider (Ollama native or OpenAI-compatible).
+
+    Note: wrappers produced before the "type" key was added to the provider dict
+    (i.e. saved workflows from older versions) will have no "type" entry and fall
+    through to the OpenAI-compat driver. This is a known gap — those workflows
+    will need to be re-run once to pick up the correct driver.
     """
     provider = wrapper.get("provider") if isinstance(wrapper, dict) else None
     if not provider:
@@ -87,10 +106,7 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     base_url = provider.get("base_url", "")
 
     if provider.get("type") == "ollama":
-        host = base_url.rstrip("/")
-        if host.endswith("/v1"):
-            host = host[:-3]
-        rebuilt = OllamaPromptDriver(model=model, host=host or None, stream=True)
+        rebuilt = OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=True)
     else:
         rebuilt = OpenAiChatPromptDriver(
             model=model,

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -11,6 +11,7 @@ from griptape.drivers.prompt.ollama import OllamaPromptDriver
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
 from griptape.rules import Rule, Ruleset
 from griptape.tasks import PromptTask
+from griptape_nodes.drivers.cloud_models import ProviderID
 
 
 # ---------------------------------------------------------------------------
@@ -105,7 +106,7 @@ def restore_provider_driver(agent: object, wrapper: dict) -> None:
     model = task.prompt_driver.model
     base_url = provider.get("base_url", "")
 
-    if provider.get("type") == "ollama":
+    if provider.get("type") == ProviderID.OLLAMA:
         rebuilt = OllamaPromptDriver(model=model, host=ollama_host_from_base_url(base_url), stream=True)
     else:
         rebuilt = OpenAiChatPromptDriver(

--- a/tests/unit/utils/test_build_prompt_driver.py
+++ b/tests/unit/utils/test_build_prompt_driver.py
@@ -1,0 +1,58 @@
+"""Tests for build_prompt_driver host-conversion logic."""
+
+import pytest
+from griptape.drivers.prompt.ollama import OllamaPromptDriver
+from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
+
+from griptape_nodes.drivers.cloud_models import ProviderID
+from griptape_nodes_library.utils.agent_utils import build_prompt_driver
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_host"),
+    [
+        ("http://localhost:11434/v1", "http://localhost:11434"),
+        ("http://localhost:11434/v1/", "http://localhost:11434"),
+        ("http://localhost:11434/", "http://localhost:11434"),
+        ("http://localhost:11434", "http://localhost:11434"),
+        ("", None),
+    ],
+)
+def test_ollama_host_from_base_url(base_url: str, expected_host: str | None) -> None:
+    driver = build_prompt_driver(
+        provider_type=ProviderID.OLLAMA,
+        model="llama3",
+        base_url=base_url,
+    )
+    assert isinstance(driver, OllamaPromptDriver)
+    assert driver.host == expected_host
+
+
+def test_non_ollama_type_returns_openai_compat_driver() -> None:
+    driver = build_prompt_driver(
+        provider_type="some_other_provider",
+        model="gpt-4o",
+        base_url="http://example.com/v1",
+        api_key="sk-test",
+    )
+    assert isinstance(driver, OpenAiChatPromptDriver)
+
+
+def test_missing_type_falls_through_to_openai_compat() -> None:
+    driver = build_prompt_driver(
+        provider_type=None,
+        model="gpt-4o",
+        base_url="http://example.com/v1",
+    )
+    assert isinstance(driver, OpenAiChatPromptDriver)
+
+
+def test_openai_compat_uses_not_needed_fallback_when_no_api_key() -> None:
+    driver = build_prompt_driver(
+        provider_type=None,
+        model="gpt-4o",
+        base_url="http://example.com/v1",
+        api_key=None,
+    )
+    assert isinstance(driver, OpenAiChatPromptDriver)
+    assert driver.api_key == "not-needed"

--- a/tests/unit/utils/test_build_prompt_driver.py
+++ b/tests/unit/utils/test_build_prompt_driver.py
@@ -3,8 +3,8 @@
 import pytest
 from griptape.drivers.prompt.ollama import OllamaPromptDriver
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver
-
 from griptape_nodes.drivers.cloud_models import ProviderID
+
 from griptape_nodes_library.utils.agent_utils import build_prompt_driver
 
 


### PR DESCRIPTION
Closes #443

## Summary

- When the Ollama provider is selected, the Agent node now uses `OllamaPromptDriver` (native Ollama client) instead of `OpenAiChatPromptDriver` (OpenAI-compatible endpoint). Ollama's OpenAI-compat endpoint does not correctly handle streaming tool calls (https://github.com/ollama/ollama/issues/9092), causing silent blank output whenever tools are connected.
- The same fix is applied in `restore_provider_driver` in `agent_utils.py`, so all other nodes that accept an agent as input (`mcp_task`, `summarize_agent_memory`, `create_image`) are covered by the same change.
- The provider wrapper dict now includes `"type"` so downstream nodes in a chain can identify the provider and rebuild the correct driver.
- Older agent wires without `"type"` fall back to the OpenAI-compat driver, preserving backwards compatibility with saved workflows.

<img width="1129" height="862" alt="image" src="https://github.com/user-attachments/assets/96a9b6e9-a78b-416e-8f2c-db902c0c0cb9" />

## Test plan

- [ ] Agent node with Ollama provider + DateTime (or other) tool connected → agent responds and tool is called
- [ ] Agent chained through multiple Agent nodes with Ollama + tool → tool calls work end-to-end
- [ ] Agent node with LM Studio / other non-Ollama provider + tool → still works (OpenAI-compat path unchanged)
- [ ] Agent node with Griptape Cloud provider → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)