### PR TITLE
fix(load-text): resolve path to macro form when within the workspace

### DIFF
--- a/griptape_nodes_library/text/load_text.py
+++ b/griptape_nodes_library/text/load_text.py
@@ -70,6 +70,7 @@ class LoadText(ControlNode):
         # Get the selected file
         text_path = self.get_parameter_value("path")
 
+        # Wire-connected paths bypass after_value_set, so resolve here too
         macro_result = resolve_to_macro_path(text_path)
         if not macro_result.is_external:
             text_path = macro_result.resolved_path

--- a/griptape_nodes_library/text/load_text.py
+++ b/griptape_nodes_library/text/load_text.py
@@ -8,6 +8,7 @@ from griptape_nodes.files.file import File
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
 
 from griptape_nodes_library.utils.file_utils import SUPPORTED_TEXT_EXTENSIONS
+from griptape_nodes_library.utils.macro_path_utils import resolve_to_macro_path
 
 
 class LoadText(ControlNode):
@@ -49,6 +50,13 @@ class LoadText(ControlNode):
             )
         )
 
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter == self.path and value:
+            result = resolve_to_macro_path(value)
+            if not result.is_external and result.resolved_path != value:
+                self.set_parameter_value("path", result.resolved_path)
+        return super().after_value_set(parameter, value)
+
     def get_node_dependencies(self) -> NodeDependencies | None:
         deps = super().get_node_dependencies()
         if deps is None:
@@ -61,6 +69,10 @@ class LoadText(ControlNode):
     def process(self) -> None:
         # Get the selected file
         text_path = self.get_parameter_value("path")
+
+        macro_result = resolve_to_macro_path(text_path)
+        if not macro_result.is_external:
+            text_path = macro_result.resolved_path
 
         # Load file content based on extension
         ext = os.path.splitext(text_path)[1]  # noqa: PTH122

--- a/griptape_nodes_library/text/load_text.py
+++ b/griptape_nodes_library/text/load_text.py
@@ -75,5 +75,4 @@ class LoadText(ControlNode):
         self.parameter_output_values["output"] = output_text
 
         # Also set in parameter_values for get_value compatibility
-        self.parameter_values["path"] = text_path
         self.parameter_values["output"] = output_text


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/449

## Summary

- `LoadText` now calls `resolve_to_macro_path` in `after_value_set` so that when a user picks a file inside the workspace, the absolute path is immediately rewritten to its macro form (e.g. `{workspace_dir}/...`)
- The same resolution runs at the start of `process()` to handle paths set via a wire connection, ensuring the `path` output also emits the macro form

This mirrors the existing behaviour in `LoadImage`, `LoadAudio`, and `LoadVideo`.

## Test plan

- [ ] Pick a file inside the workspace — verify `path` shows a macro path, not an absolute path
- [ ] Pick a file outside the workspace — verify `path` is left as-is (external)
- [ ] Connect a string path from another node — verify `process()` output uses the macro form

🤖 Generated with [Claude Code](https://claude.com/claude-code)