### PR TITLE
fix(agent): re-add Options trait to model param on disconnect

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -712,8 +712,11 @@ class Agent(ControlNode):
             self.hide_parameter_by_name(params_to_toggle)
 
         if target_parameter.name == "model" and source_parameter.name == "prompt_model_config":
-            # Remove the options trait
-            target_parameter.remove_trait(trait_type=target_parameter.find_elements_by_type(Options)[0])
+            # Remove the options trait. Defensive guard so this stays idempotent instead
+            # of raising IndexError.
+            options_traits = target_parameter.find_elements_by_type(Options)
+            if options_traits:
+                target_parameter.remove_trait(trait_type=options_traits[0])
 
             # Check and see if the incoming connection is from a prompt model config or an agent.
             target_parameter.type = source_parameter.type
@@ -774,6 +777,10 @@ class Agent(ControlNode):
             # Restore choices for the currently selected provider.
             current_provider = self.get_parameter_value("model_provider") or "griptape_cloud"
             restored_models = self._fetch_models_for_provider(current_provider)
+            # The connect hook stripped the Options trait; reinstall it before updating
+            # choices, otherwise _update_option_choices raises "No Options trait found".
+            if not target_parameter.find_elements_by_type(Options):
+                target_parameter.add_trait(Options(choices=restored_models))
             self._update_option_choices(param="model", choices=restored_models, default=DEFAULT_MODEL)
 
             # Change the display name to be appropriate

--- a/tests/unit/agents/conftest.py
+++ b/tests/unit/agents/conftest.py
@@ -1,0 +1,12 @@
+"""Shared fixtures for Agent node unit tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes_library.agents.agent import Agent
+
+
+@pytest.fixture
+def agent_node() -> Agent:
+    return Agent(name="Agent")

--- a/tests/unit/agents/test_agent_connections.py
+++ b/tests/unit/agents/test_agent_connections.py
@@ -1,0 +1,85 @@
+"""Tests for the Agent node's connection hooks."""
+
+from __future__ import annotations
+
+import pytest
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.agents.agent import Agent
+
+
+def test_connect_disconnect_reconnect_prompt_model_config_round_trip(
+    agent_node: Agent, prompt_model_config_source: DataNode
+) -> None:
+    """Grouping reroutes the connection: connect -> disconnect -> reconnect.
+
+    The full round-trip must not raise, and the ``model`` parameter must end back
+    in the connected state (no ``Options`` trait, type mirroring the source).
+    """
+    model_param = agent_node.get_parameter_by_name("model")
+    assert model_param is not None
+    # A fresh model parameter carries an Options dropdown.
+    assert model_param.find_elements_by_type(Options)
+
+    source_param = prompt_model_config_source.get_parameter_by_name("prompt_model_config")
+    assert source_param is not None
+
+    # 1) Connect: the Agent strips the Options trait so the param acts as a pure input.
+    agent_node.after_incoming_connection(prompt_model_config_source, source_param, model_param)
+    assert not model_param.find_elements_by_type(Options)
+    assert model_param.type == "Prompt Model Config"
+
+    # 2) Disconnect (first half of the group reroute): must restore the dropdown.
+    agent_node.after_incoming_connection_removed(prompt_model_config_source, source_param, model_param)
+    assert model_param.find_elements_by_type(Options)
+    assert model_param.type == "str"
+
+    # 3) Reconnect through the group proxy (second half of the reroute).
+    agent_node.after_incoming_connection(prompt_model_config_source, source_param, model_param)
+    assert not model_param.find_elements_by_type(Options)
+    assert model_param.type == "Prompt Model Config"
+
+
+def test_connect_when_options_trait_already_absent_does_not_raise(
+    agent_node: Agent, prompt_model_config_source: DataNode
+) -> None:
+    """Defensive: after_incoming_connection must tolerate a model param with no
+    Options trait instead of doing find_elements_by_type(Options)[0] and raising
+    IndexError. Simulates the trait having been removed by some other/future path.
+    """
+    model_param = agent_node.get_parameter_by_name("model")
+    assert model_param is not None
+    source_param = prompt_model_config_source.get_parameter_by_name("prompt_model_config")
+    assert source_param is not None
+
+    # Put the param in the (unexpected) state where its Options trait is already gone.
+    model_param.remove_trait(model_param.find_elements_by_type(Options)[0])
+    assert not model_param.find_elements_by_type(Options)
+
+    # Connecting must be a safe no-op on the missing trait, not an IndexError.
+    agent_node.after_incoming_connection(prompt_model_config_source, source_param, model_param)
+    assert not model_param.find_elements_by_type(Options)
+    assert model_param.type == "Prompt Model Config"
+
+
+@pytest.fixture
+def prompt_model_config_source() -> DataNode:
+    """A stand-in prompt driver node exposing a ``prompt_model_config`` output.
+
+    The Agent's ``model`` connection hooks never read the source node itself, so a
+    lightweight ``DataNode`` avoids the network calls a real prompt-driver node
+    makes in ``__init__``.
+    """
+    source_node = DataNode(name="Griptape Cloud Prompt")
+    source_node.add_parameter(
+        Parameter(
+            name="prompt_model_config",
+            type="Prompt Model Config",
+            output_type="Prompt Model Config",
+            allowed_modes={ParameterMode.OUTPUT},
+            tooltip="Prompt model configuration output.",
+        )
+    )
+    return source_node

--- a/tests/unit/agents/test_agent_validation.py
+++ b/tests/unit/agents/test_agent_validation.py
@@ -6,11 +6,6 @@ from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 from griptape_nodes_library.agents.agent import API_KEY_ENV_VAR, Agent
 
 
-@pytest.fixture
-def agent_node() -> Agent:
-    return Agent(name="Agent")
-
-
 def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
     """Make the engine's SecretsManager return *value* for any secret lookup."""
     import griptape_nodes_library.agents.agent as agent_module


### PR DESCRIPTION
Closes #455.

A connect -> disconnect -> connect of the Agent node's "model" parameter would cause ValueError followed by IndexError as the Option trait is removed on connect and wasn't reinstated on disconnect.

So reinstate the Options trait on the "model" parameter on disconnect.

Also add a defensive guard on connect to make the hook idempotent (not strictly necessary to fix the bug).