### PR TITLE
fix(subflow): recompute workflow shape on execute

### DIFF
--- a/griptape_nodes_library/engine/subflow_workflow_node.py
+++ b/griptape_nodes_library/engine/subflow_workflow_node.py
@@ -5,7 +5,7 @@ from typing import Any
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import NodeDependencies, SuccessFailureNode
-from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.execution_events import (
     StartLocalSubflowRequest,
     StartLocalSubflowResultFailure,
@@ -264,15 +264,8 @@ class SubflowWorkflowNode(SuccessFailureNode):
             self._handle_failure_exception(RuntimeError(msg))
             return
 
-        workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
-        workflow_shape = workflow.metadata.workflow_shape
-        if workflow_shape is None:
-            msg = f"Workflow '{workflow_name}' has no shape defined."
-            self._set_status_results(was_successful=False, result_details=msg)
-            self._handle_failure_exception(RuntimeError(msg))
-            return
-
-        # Use the pre-loaded subflow if available; otherwise load it now.
+        # Use the pre-loaded subflow if available; otherwise load it now. Load it before
+        # deriving the shape so the shape reflects the live (imported) nodes.
         existing_flow_names = set(GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow).keys())
         subflow_name = self.metadata.get("subflow_name")
         if not subflow_name or subflow_name not in existing_flow_names:
@@ -283,6 +276,20 @@ class SubflowWorkflowNode(SuccessFailureNode):
                 self._set_status_results(was_successful=False, result_details=msg)
                 self._handle_failure_exception(RuntimeError(msg))
                 return
+
+        # Re-derive the shape from the freshly-imported subflow instead of
+        # trusting the shape saved with the workflow. Importing renames any node
+        # whose name collides with an existing one (e.g. 'Start Flow' -> 'Start
+        # Flow_1'), which leaves the saved shape's node-name keys pointing at
+        # nodes that no longer exist.
+        try:
+            shape = GriptapeNodes.WorkflowManager().extract_workflow_shape(workflow_name, flow_name=subflow_name)
+        except ValueError:
+            msg = f"Workflow '{workflow_name}' has no shape defined."
+            self._set_status_results(was_successful=False, result_details=msg)
+            self._handle_failure_exception(RuntimeError(msg))
+            return
+        workflow_shape = WorkflowShape(inputs=shape["input"], outputs=shape["output"])
 
         self._set_workflow_inputs(subflow_name, workflow_shape)
         result = await GriptapeNodes.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))

--- a/tests/integration/subflow_inner_echo.py
+++ b/tests/integration/subflow_inner_echo.py
@@ -1,0 +1,383 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "subflow_inner_echo"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.82.0"]]
+# node_types_used = [["Griptape Nodes Library", "DisplayText"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"]]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-14T11:05:57.883915Z
+# last_modified_date = 2026-07-14T11:07:07.546560Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"text_in\":{\"name\":\"text_in\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"text_out\":{\"name\":\"text_out\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "16e08bbb-08fa-4478-9868-d407f1d8b84c": pickle.loads(
+            b"\x80\x04\x95 \x00\x00\x00\x00\x00\x00\x00\x8c\x1cINNER_DEFAULT_NOT_FROM_OUTER\x94."
+        ),
+        "dc64b6ec-c616-41ae-9559-6433a79b0ecd": pickle.loads(
+            b"\x80\x04\x95\x1b\x00\x00\x00\x00\x00\x00\x00\x8c\x17Control Input Selection\x94."
+        ),
+        "fd117146-5b43-48ef-8fb6-8c0795bcc207": pickle.loads(b"\x80\x04\x88."),
+        "f0c0f188-8d5a-4a2d-97e4-53d57e86ee2c": pickle.loads(
+            b"\x80\x04\x957\x00\x00\x00\x00\x00\x00\x00\x8c3[SUCCEEDED]\n[SUCCEEDED]\nNo details supplied by flow\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "showaddparameter": True,
+                        "position": {"x": 0, "y": 0},
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "size": {"width": 600, "height": 196},
+                    },
+                    resolution="resolved",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="text_in",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="DisplayText",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Display Text",
+                    metadata={
+                        "position": {"x": 500, "y": 0},
+                        "library_node_metadata": {
+                            "category": "text",
+                            "description": "DisplayText node",
+                            "display_name": "Display Text",
+                            "tags": ["text", "display"],
+                            "icon": None,
+                            "color": None,
+                            "group": "display",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "DisplayText",
+                        "showaddparameter": False,
+                        "size": {"width": 600, "height": 236},
+                    },
+                    resolution="resolved",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "showaddparameter": True,
+                        "position": {"x": 1000, "y": 0},
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "size": {"width": 600, "height": 344},
+                    },
+                    resolution="resolved",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="text_out",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node1_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="text_in",
+                target_node_name=node1_name,
+                target_parameter_name="text",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node1_name,
+                source_parameter_name="text",
+                target_node_name=node2_name,
+                target_parameter_name="text_out",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_in",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["16e08bbb-08fa-4478-9868-d407f1d8b84c"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["16e08bbb-08fa-4478-9868-d407f1d8b84c"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["16e08bbb-08fa-4478-9868-d407f1d8b84c"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="exec_in",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["dc64b6ec-c616-41ae-9559-6433a79b0ecd"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["fd117146-5b43-48ef-8fb6-8c0795bcc207"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["fd117146-5b43-48ef-8fb6-8c0795bcc207"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["f0c0f188-8d5a-4a2d-97e4-53d57e86ee2c"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["f0c0f188-8d5a-4a2d-97e4-53d57e86ee2c"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["16e08bbb-08fa-4478-9868-d407f1d8b84c"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["16e08bbb-08fa-4478-9868-d407f1d8b84c"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    parser.add_argument("--text_in", dest="text_in", default=None, help="workflow input")
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+        if args.text_in is not None:
+            flow_input["Start Flow"]["text_in"] = args.text_in
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/integration/test_subflow_workflow_node.py
+++ b/tests/integration/test_subflow_workflow_node.py
@@ -1,0 +1,557 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "test_subflow_workflow_node"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.82.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"], ["Griptape Nodes Testing Library", "AssertStrings"]]
+# workflows_referenced = ["subflow_inner_echo"]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-14T11:08:14.793456Z
+# last_modified_date = 2026-07-14T11:08:59.775118Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+
+# --- ADDED FOR THE INTEGRATION TEST (not emitted by the serialiser) ---
+# Used by the inner-workflow registration block inside build_workflow() below.
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AlterParameterDetailsRequest,
+    AlterParameterGroupDetailsRequest,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    LoadWorkflowMetadata,
+    LoadWorkflowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# --- END ADDED IMPORTS ---
+
+
+# === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+async def _ensure_inner_workflow_registered() -> None:
+    """Register the co-located inner echo workflow under its bare registry key.
+
+    When a parent workflow that ALSO contains its own Start Flow / End Flow is
+    run through a Workflow node, the imported sub-workflow's Start/End nodes are
+    renamed on the name collision (e.g. "Start Flow_1"). The Workflow node
+    routes inputs/outputs by the node names captured in the sub-workflow's saved
+    `workflow_shape` ("Start Flow" / "End Flow"), so the lookups miss and both
+    input injection and output collection are silently skipped -> `text_out`
+    comes back empty.
+
+    The serialised outer workflow refers to the inner workflow purely by its
+    bare registry key "subflow_inner_echo" (see the SubflowWorkflowNode metadata
+    and the ImportWorkflowAsReferencedSubFlowRequest). At test time that inner
+    workflow is NOT in the engine workspace — it lives next to this file — so we
+    register it here. We register the bare key and the absolute file path
+    separately (WorkflowRegistry.generate_new_workflow permits a key that is not
+    derived from the file path) so the committed test stays portable: the key is
+    the stable stem the serialisation expects, and the path is resolved from
+    __file__.
+
+    Called both from build_workflow() (so the build-time import resolves) and
+    again after the executor is entered in aexecute_workflow() (entering
+    broadcasts AppInitializationComplete -> refresh_workflow_registry ->
+    clear_user_workflows(), which would otherwise drop this registration before
+    the flow runs in the standalone __main__ path).
+    """
+    if WorkflowRegistry.has_workflow_with_name("subflow_inner_echo"):
+        return
+    inner_workflow_path = Path(__file__).parent / "subflow_inner_echo.py"
+    inner_metadata_result = await GriptapeNodes.ahandle_request(
+        LoadWorkflowMetadata(file_name=str(inner_workflow_path))
+    )
+    if not isinstance(inner_metadata_result, LoadWorkflowMetadataResultSuccess):
+        msg = f"Failed to load inner workflow metadata from '{inner_workflow_path}': {inner_metadata_result.result_details}"
+        raise RuntimeError(msg)
+    WorkflowRegistry.generate_new_workflow(
+        registry_key="subflow_inner_echo",
+        metadata=inner_metadata_result.metadata,
+        file_path=str(inner_workflow_path),
+    )
+
+
+# === END ADDED SECTION ===
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(
+            library_name="Griptape Nodes Testing Library", perform_discovery_if_not_found=True
+        )
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+    # Register the co-located inner workflow before any node that references it is created
+    # (the SubflowWorkflowNode below and the ImportWorkflowAsReferencedSubFlowRequest both
+    # look it up by the bare key "subflow_inner_echo"). See _ensure_inner_workflow_registered.
+    await _ensure_inner_workflow_registered()
+    # === END ADDED SECTION ===
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "fa4f5520-01cd-4a03-9dd9-78fa15a1361b": pickle.loads(b"\x80\x04\x89."),
+        "c034888e-d70f-415c-9692-1d3b02d5db89": pickle.loads(
+            b"\x80\x04\x95\x16\x00\x00\x00\x00\x00\x00\x00\x8c\x12subflow_inner_echo\x94."
+        ),
+        "fd3a45ea-fe86-4a28-a55a-46f37528879f": pickle.loads(b"\x80\x04\x88."),
+        "26bf9e7d-a849-488e-b01e-b18ee6f21031": pickle.loads(
+            b"\x80\x04\x959\x00\x00\x00\x00\x00\x00\x00\x8c5Workflow 'subflow_inner_echo' completed successfully.\x94."
+        ),
+        "16a4e3da-7750-48a0-bf92-52c21959b7c3": pickle.loads(
+            b"\x80\x04\x95\x0e\x00\x00\x00\x00\x00\x00\x00\x8c\necho_me_42\x94."
+        ),
+        "77073b7e-4d6d-47e4-81b3-51e63c71bd22": pickle.loads(
+            b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
+        ),
+        "ac33ec68-f656-4af7-b4ed-70c43c8509e7": pickle.loads(
+            b"\x80\x04\x95\x06\x00\x00\x00\x00\x00\x00\x00\x8c\x02==\x94."
+        ),
+        "027adbaf-6932-4bff-bee4-2d27e9debf28": pickle.loads(
+            b"\x80\x04\x95(\x00\x00\x00\x00\x00\x00\x00\x8c$Assertion failed: '' == 'echo_me_42'\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "showaddparameter": True,
+                        "position": {"x": 0, "y": 0},
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "size": {"width": 600, "height": 190},
+                    },
+                    resolution="resolved",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "showaddparameter": True,
+                        "position": {"x": 1500, "y": 0},
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "size": {"width": 600, "height": 300},
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow Node",
+                    metadata={
+                        "position": {"x": 500, "y": 0},
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "showaddparameter": False,
+                        "size": {"width": 600, "height": 344},
+                        "workflow_shape_params": ["text_in", "text_out"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_2",
+                        "_subflow_workflow": "subflow_inner_echo",
+                    },
+                    resolution="resolved",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in", default_value="", tooltip="workflow input", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        node3_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="AssertStrings",
+                    specific_library_name="Griptape Nodes Testing Library",
+                    node_name="Assert Strings",
+                    metadata={
+                        "position": {"x": 1000, "y": 0},
+                        "library_node_metadata": {
+                            "category": "assert",
+                            "description": "Asserts a string comparison using a selected operator.",
+                            "display_name": "Assert Strings",
+                            "tags": None,
+                            "icon": "ShieldCheck",
+                            "color": None,
+                            "group": "assert",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                            "resolved_model_usage": [],
+                        },
+                        "library": "Griptape Nodes Testing Library",
+                        "node_type": "AssertStrings",
+                        "showaddparameter": False,
+                        "size": {"width": 600, "height": 476},
+                    },
+                    resolution="resolving",
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterGroupDetailsRequest(
+                    group_name="Status", ui_options={"collapsed": True, "display_name": "⚠️ Status"}, initial_setup=True
+                )
+            )
+        # Serialiser emits `flow1_name = (await ...).created_flow_name`; the returned name is
+        # unused here (the node reloads its own subflow at run time), so we keep only the
+        # side-effecting import to satisfy ruff (F841/B018).
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name="subflow_inner_echo", imported_flow_metadata={})
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="exec_out",
+                target_node_name=node3_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="text_out",
+                target_node_name=node3_name,
+                target_parameter_name="actual",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["fa4f5520-01cd-4a03-9dd9-78fa15a1361b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["c034888e-d70f-415c-9692-1d3b02d5db89"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["fd3a45ea-fe86-4a28-a55a-46f37528879f"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["fd3a45ea-fe86-4a28-a55a-46f37528879f"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["26bf9e7d-a849-488e-b01e-b18ee6f21031"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["26bf9e7d-a849-488e-b01e-b18ee6f21031"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_in",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["16a4e3da-7750-48a0-bf92-52c21959b7c3"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["77073b7e-4d6d-47e4-81b3-51e63c71bd22"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="actual",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["77073b7e-4d6d-47e4-81b3-51e63c71bd22"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="expected",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["16a4e3da-7750-48a0-bf92-52c21959b7c3"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="operator",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["ac33ec68-f656-4af7-b4ed-70c43c8509e7"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="message",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["77073b7e-4d6d-47e4-81b3-51e63c71bd22"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["fa4f5520-01cd-4a03-9dd9-78fa15a1361b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["fa4f5520-01cd-4a03-9dd9-78fa15a1361b"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["027adbaf-6932-4bff-bee4-2d27e9debf28"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="result_details",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["027adbaf-6932-4bff-bee4-2d27e9debf28"],
+                    initial_setup=True,
+                    is_output=True,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        # === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+        # Entering the executor broadcasts AppInitializationComplete -> refresh_workflow_registry
+        # -> clear_user_workflows(), which drops the inner workflow registered during
+        # build_workflow() above. Re-register it here so the Workflow node can resolve it when
+        # the flow runs. (The CI path via test_integration_workflows.py runs build_workflow
+        # inside arun(), after entry, so it is unaffected; this keeps the standalone
+        # `python test_subflow_workflow_node.py` run working too.)
+        await _ensure_inner_workflow_registered()
+        # === END ADDED SECTION ===
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/unit/engine/test_subflow_workflow_node.py
+++ b/tests/unit/engine/test_subflow_workflow_node.py
@@ -1,0 +1,154 @@
+"""Tests for ``SubflowWorkflowNode`` shape handling under Start/End node renames.
+
+Regression coverage for issue #5134 (same root cause as the earlier, closed-in-error #4993):
+when a child workflow is imported and its ``Start Flow`` / ``End Flow`` nodes collide with
+existing node names, they are renamed (``Start Flow_1`` / ``End Flow_1``). The child's saved
+``workflow_shape`` still holds the ORIGINAL names, so routing by those names silently drops the
+values.
+
+The fix re-derives the shape from the freshly-imported subflow via the same discovery logic
+used at save time (``WorkflowManager.extract_workflow_shape``), so the shape's node-name keys
+match the live nodes. These tests drive ``aprocess`` with the surrounding engine calls stubbed
+and assert that (a) inputs/outputs are routed to the live (renamed) nodes, and (b) a subflow
+without a shape fails with a clear message.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import EndNode, StartNode
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, WorkflowShape
+from griptape_nodes.retained_mode.events.execution_events import StartLocalSubflowResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.events.workflow_events import ListCallableWorkflowsResultSuccess
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
+from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
+from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
+
+from griptape_nodes_library.engine.subflow_workflow_node import SubflowWorkflowNode
+
+
+@pytest.fixture
+def shape_param() -> dict[str, Any]:
+    """Minimal parameter-shape dict as stored in a ``workflow_shape`` entry."""
+    return {"type": "str", "input_types": ["str"], "output_type": "str", "default_value": ""}
+
+
+@pytest.fixture
+def node(monkeypatch: pytest.MonkeyPatch) -> SubflowWorkflowNode:
+    """A ``SubflowWorkflowNode`` primed to run against a stubbed, already-loaded subflow.
+
+    ``__init__`` issues a ``ListCallableWorkflowsRequest`` to populate the workflow dropdown; we
+    return "child" as the sole choice so it becomes the selected ``workflow_file`` default.
+    """
+    list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
+    list_result.workflow_names = ["child"]
+    monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
+    node = SubflowWorkflowNode(name="Workflow Node")
+    # Pretend the child's subflow has already been imported.
+    node.metadata["subflow_name"] = "sub"
+    return node
+
+
+@pytest.fixture
+def workflow_manager(monkeypatch: pytest.MonkeyPatch, shape_param: dict[str, Any]) -> Mock:
+    """Stub the engine calls ``aprocess`` makes up to the routing step and return the
+    ``WorkflowManager`` mock so each test can configure ``extract_workflow_shape``.
+    """
+    monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+
+    # The saved shape keeps the ORIGINAL (pre-rename) node names. If the fix regressed to using
+    # this instead of re-deriving from the live subflow, the routing assertions below would fail.
+    stale_shape = WorkflowShape(
+        inputs={"Start Flow": {"text_in": shape_param}},
+        outputs={"End Flow": {"text_out": shape_param}},
+    )
+    monkeypatch.setattr(
+        WorkflowRegistry,
+        "get_workflow_by_name",
+        lambda _name: SimpleNamespace(metadata=SimpleNamespace(workflow_shape=stale_shape)),
+    )
+
+    object_manager = Mock(spec=ObjectManager)
+    object_manager.get_filtered_subset.return_value = {"sub": object()}  # subflow already loaded
+    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+    manager = Mock(spec=WorkflowManager)
+    monkeypatch.setattr(GriptapeNodes, "WorkflowManager", lambda: manager)
+
+    async def _ok(_request: Any) -> Mock:
+        return Mock(spec=StartLocalSubflowResultSuccess)  # not a failure -> aprocess proceeds
+
+    monkeypatch.setattr(GriptapeNodes, "ahandle_request", _ok)
+    return manager
+
+
+class TestAprocessReDerivesShapeFromSubflow:
+    """aprocess must route using the shape extracted from the live subflow, not the stale
+    saved shape whose node names may have been renamed on import.
+    """
+
+    @pytest.mark.asyncio
+    async def test_routes_io_to_renamed_subflow_nodes(
+        self,
+        node: SubflowWorkflowNode,
+        monkeypatch: pytest.MonkeyPatch,
+        shape_param: dict[str, Any],
+        workflow_manager: Mock,
+    ) -> None:
+        # The live subflow's Start/End were renamed on import; extract reports the live names.
+        workflow_manager.extract_workflow_shape.return_value = {
+            "input": {"Start Flow_1": {"text_in": shape_param}},
+            "output": {"End Flow_1": {"text_out": shape_param}},
+        }
+
+        # The node carries the input value to forward and an output slot to receive.
+        node.add_parameter(
+            Parameter(
+                name="text_in",
+                type="str",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                default_value="",
+            )
+        )
+        node.set_parameter_value("text_in", "hello")
+        node.add_parameter(
+            Parameter(name="text_out", type="str", allowed_modes={ParameterMode.OUTPUT}, default_value="")
+        )
+
+        # The live subflow with the renamed nodes the routing must target.
+        end_node = Mock(spec=EndNode)
+        end_node.parameter_output_values = {"text_out": "world"}
+        flow = SimpleNamespace(nodes={"Start Flow_1": Mock(spec=StartNode), "End Flow_1": end_node})
+        flow_manager = Mock(spec=FlowManager)
+        flow_manager.get_flow_by_name.return_value = flow
+        monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
+
+        # Let _set_workflow_inputs run and capture the SetParameterValueRequests it issues.
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        await node.aprocess()
+
+        # Input routed to the renamed start node...
+        set_requests = [r for r in requests if isinstance(r, SetParameterValueRequest)]
+        assert any(
+            r.node_name == "Start Flow_1" and r.parameter_name == "text_in" and r.value == "hello" for r in set_requests
+        ), f"input was not routed to the renamed start node; requests={set_requests}"
+        # ...and output collected from the renamed end node.
+        assert node.parameter_output_values["text_out"] == "world"
+
+    @pytest.mark.asyncio
+    async def test_missing_shape_reports_failure(self, node: SubflowWorkflowNode, workflow_manager: Mock) -> None:
+        # extract_workflow_shape raises ValueError when the subflow has no Start/End nodes.
+        workflow_manager.extract_workflow_shape.side_effect = ValueError("no start/end nodes")
+
+        # The failure output is unconnected on a bare node, so the failure re-raises.
+        with pytest.raises(RuntimeError, match="has no shape defined"):
+            await node.aprocess()


### PR DESCRIPTION
Closes #459.

SubflowWorkflowNode loads the child workflow's nodes into the active session. Because node names must be unique, any child node whose name clashes with a parent node gets renamed on import (e.g. the child's Start Flow / End Flow become Start Flow_1 / End Flow_1).

However, the child's serialized workflow_shape metadata still holds the original, pre-dedup node names.

So recompute the workflow shape when executing the node, i.e. after the child workflow is definitively loaded.

Add a simple "echo" workflow integration test for this case. This requires patching the serialised outer workflow, such that it registers the inner workflow first.