### PR TITLE
feat: catalog Amazon Bedrock and Ollama providers

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1018,7 +1018,7 @@
           },
           "nvidia_nim": {
             "display_name": "NVIDIA NIM",
-            "notes": "NVIDIA NIM is a serving platform, not a model vendor; the models below (Llama, Gemma, DeepSeek, Mistral, etc.) are served through NVIDIA's infrastructure under NVIDIA's own model ids. Using the serving platform as the provider key here is provisional pending the platform-as-provider convention discussion in issue #429 (Amazon Bedrock).",
+            "notes": "NVIDIA NIM is a serving platform, not a model vendor; the models below (Llama, Gemma, DeepSeek, Mistral, etc.) are served through NVIDIA's infrastructure under NVIDIA's own model ids. Cataloguing the serving platform as the provider key follows the same convention settled for Amazon Bedrock (see issue #429): provider_model_id stays the literal wire id the platform's API expects, even when it duplicates a model also catalogued under its original vendor.",
             "models": {
               "nim_deepseek_v3_1": {
                 "display_name": "DeepSeek V3.1",
@@ -1111,6 +1111,84 @@
                 "key_support": "REQUIRES_CUSTOMER_KEY"
               }
             }
+          },
+          "amazon_bedrock": {
+            "display_name": "Amazon Bedrock",
+            "notes": "Amazon Bedrock re-serves models from other vendors (Anthropic, DeepSeek, Meta) plus Amazon's own Titan models, all under Bedrock's own wire ids -- often region-prefixed cross-region inference profile ids (a 'us.' prefix) and sometimes date-suffixed -- which don't match the bare provider_model_ids the same underlying models use under the anthropic, deepseek, and meta providers elsewhere in this catalog. Bedrock is catalogued as its own provider so provider_model_id stays the literal wire id Bedrock's API expects; the same underlying model can therefore appear under two providers with two different provider_model_ids.",
+            "models": {
+              "bedrock_claude_opus_4_7": {
+                "display_name": "Claude Opus 4.7",
+                "family": "Claude 4",
+                "provider_model_id": "us.anthropic.claude-opus-4-7",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_claude_sonnet_4_6": {
+                "display_name": "Claude Sonnet 4.6",
+                "family": "Claude 4",
+                "provider_model_id": "us.anthropic.claude-sonnet-4-6",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_claude_sonnet_4_5": {
+                "display_name": "Claude Sonnet 4.5",
+                "family": "Claude 4",
+                "provider_model_id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_claude_haiku_4_5": {
+                "display_name": "Claude Haiku 4.5",
+                "family": "Claude 4",
+                "provider_model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_deepseek_v3_2": {
+                "display_name": "DeepSeek V3.2",
+                "family": "DeepSeek V3",
+                "provider_model_id": "deepseek.v3.2",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_deepseek_r1": {
+                "display_name": "DeepSeek R1",
+                "family": "DeepSeek R1",
+                "provider_model_id": "us.deepseek.r1-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_llama_3_3_70b": {
+                "display_name": "Llama 3.3 70B Instruct",
+                "family": "Llama 3",
+                "provider_model_id": "us.meta.llama3-3-70b-instruct-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_llama_3_1_70b": {
+                "display_name": "Llama 3.1 70B Instruct",
+                "family": "Llama 3",
+                "provider_model_id": "us.meta.llama3-1-70b-instruct-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_titan_text_premier": {
+                "display_name": "Titan Text Premier",
+                "family": "Titan Text",
+                "provider_model_id": "amazon.titan-text-premier-v1:0",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_titan_text_express": {
+                "display_name": "Titan Text Express",
+                "family": "Titan Text",
+                "provider_model_id": "amazon.titan-text-express-v1",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              },
+              "bedrock_titan_text_lite": {
+                "display_name": "Titan Text Lite",
+                "family": "Titan Text",
+                "provider_model_id": "amazon.titan-text-lite-v1",
+                "key_support": "REQUIRES_CUSTOMER_KEY"
+              }
+            }
+          },
+          "ollama": {
+            "display_name": "Ollama",
+            "notes": "Ollama is a local-runtime provider: models are whatever the user has pulled into their own local Ollama server, discovered dynamically by OllamaPrompt at runtime rather than declared statically here. The provider declares no models and sets key_support at the provider level instead, per KeySupport's documented default for a local-runtime provider with no enumerated models of its own.",
+            "key_support": "NO_KEY_REQUIRED",
+            "models": {}
           }
         }
       }
@@ -4025,6 +4103,24 @@
           "aws",
           "bedrock",
           "llm"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "bedrock_claude_opus_4_7",
+              "bedrock_claude_sonnet_4_6",
+              "bedrock_claude_sonnet_4_5",
+              "bedrock_claude_haiku_4_5",
+              "bedrock_deepseek_v3_2",
+              "bedrock_deepseek_r1",
+              "bedrock_llama_3_3_70b",
+              "bedrock_llama_3_1_70b",
+              "bedrock_titan_text_premier",
+              "bedrock_titan_text_express",
+              "bedrock_titan_text_lite"
+            ]
+          }
         ]
       }
     },
@@ -4271,6 +4367,14 @@
           "ollama",
           "llm",
           "local"
+        ],
+        "declarations": [
+          {
+            "type": "model_provider_usage",
+            "provider_ids": [
+              "ollama"
+            ]
+          }
         ]
       }
     },

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -7,6 +7,12 @@ Python, while the proxy base node resolves a runtime selection back to its
 stable catalog key from the library registry. Either way the catalog and the
 served models must agree, and these tests are the guard that keeps them from
 drifting.
+
+A local-runtime provider like Ollama is the exception: it declares no models
+of its own, and the node that uses it (`OllamaPrompt`) references the whole
+provider via `model_provider_usage` instead of a fixed `model_usage` list.
+There is no static choice list to compare against there, so those tests check
+the shape of that declaration and the provider metadata instead.
 """
 
 from __future__ import annotations
@@ -16,12 +22,16 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from griptape_nodes.node_library.library_declarations import find_model_catalog, resolve_node_models
+from griptape_nodes.node_library.library_registry import LibrarySchema
+from griptape_nodes.node_library.library_validation import validate_library_declarations
 
 from griptape_nodes_library.config.image.griptape_cloud_image_driver import (
     MODEL_CHOICES as GRIPTAPE_CLOUD_IMAGE_MODEL_CHOICES,
 )
 from griptape_nodes_library.config.image.grok_image_driver import MODEL_CHOICES as GROK_IMAGE_MODEL_CHOICES
 from griptape_nodes_library.config.image.openai_image_driver import MODEL_CHOICES as OPENAI_IMAGE_MODEL_CHOICES
+from griptape_nodes_library.config.prompt.amazon_bedrock_prompt import MODEL_CHOICES as AMAZON_BEDROCK_MODEL_CHOICES
 from griptape_nodes_library.config.prompt.anthropic_prompt import MODEL_CHOICES as ANTHROPIC_MODEL_CHOICES
 from griptape_nodes_library.config.prompt.cloud_models import MODEL_CHOICES_ARGS
 from griptape_nodes_library.config.prompt.cohere_prompt import MODEL_CHOICES as COHERE_PROMPT_MODEL_CHOICES
@@ -64,6 +74,17 @@ def _nodes_with_model_usage(library: dict[str, Any]) -> list[str]:
     ]
 
 
+def _model_provider_usage_ids(library: dict[str, Any], class_name: str) -> list[str]:
+    node = next(n for n in library["nodes"] if n["class_name"] == class_name)
+    usage = next(d for d in node["metadata"]["declarations"] if d["type"] == "model_provider_usage")
+    return usage["provider_ids"]
+
+
+def _provider(library: dict[str, Any], provider_id: str) -> dict[str, Any]:
+    catalog = next(d for d in library["metadata"]["declarations"] if d["type"] == "model_catalog")
+    return catalog["providers"][provider_id]
+
+
 @pytest.mark.parametrize("class_name", ["Agent", "GriptapeCloudPrompt"])
 def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
     """The chat model list in Python and the models the node declares must agree.
@@ -95,6 +116,7 @@ def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
         ("CoherePrompt", COHERE_PROMPT_MODEL_CHOICES),
         ("GroqPrompt", GROQ_PROMPT_MODEL_CHOICES),
         ("NimPrompt", NIM_PROMPT_MODEL_CHOICES),
+        ("AmazonBedrockPrompt", AMAZON_BEDROCK_MODEL_CHOICES),
     ],
 )
 def test_model_selection_node_usage_matches_static_choices(
@@ -135,3 +157,73 @@ def test_declared_models_resolve_uniquely_per_node() -> None:
             duplicates[class_name] = repeated
 
     assert not duplicates, f"nodes declare catalog ids that share a provider_model_id: {duplicates}"
+
+
+def test_ollama_provider_declares_no_models_and_requires_no_key() -> None:
+    """The `ollama` provider documents the local-runtime, no-enumerated-models case.
+
+    `OllamaPrompt` discovers its models dynamically from whatever the user has
+    pulled into their local Ollama server, so the provider carries no static
+    model list. `KeySupport` docs the provider-level `key_support` as the
+    fallback for exactly this shape of provider, and `OllamaPrompt` requires no
+    API key at runtime (unlike every other prompt config node), so the
+    provider-level value must be `NO_KEY_REQUIRED`.
+    """
+    library = _load_library()
+    provider = _provider(library, "ollama")
+
+    assert provider["models"] == {}
+    assert provider["key_support"] == "NO_KEY_REQUIRED"
+
+
+def test_ollama_prompt_declares_provider_usage_for_ollama() -> None:
+    """`OllamaPrompt` references the whole `ollama` provider, not specific models.
+
+    A node that enumerates every model a provider offers at runtime (rather
+    than a fixed set) declares `model_provider_usage`, not `model_usage`. Guard
+    that `OllamaPrompt` uses that declaration shape and points at the `ollama`
+    provider.
+    """
+    library = _load_library()
+
+    assert _model_provider_usage_ids(library, "OllamaPrompt") == ["ollama"]
+
+
+def test_ollama_provider_usage_resolves_to_no_catalog_models() -> None:
+    """Resolving `OllamaPrompt`'s declared usage against the catalog yields nothing.
+
+    `OllamaPrompt` builds its own model dropdown by querying the local Ollama
+    server (`_get_available_models`) rather than reading the catalog.
+    Declaring `model_provider_usage` against a provider with no enumerated
+    models is how that split is represented: `resolve_node_models` -- the same
+    function the engine calls to build a node's model list from the catalog --
+    must resolve it to an empty list, confirming the catalog stays inert for
+    this node instead of silently feeding it models it doesn't actually offer.
+    """
+    library = _load_library()
+    schema = LibrarySchema.model_validate(library)
+    catalog = find_model_catalog(schema.metadata.declarations)
+    assert catalog is not None
+
+    node = next(n for n in schema.nodes if n.class_name == "OllamaPrompt")
+    resolved = resolve_node_models(catalog, node.metadata.declarations)
+
+    assert resolved == []
+
+
+def test_full_manifest_validates_against_engine_schema() -> None:
+    """The manifest as a whole must satisfy the engine's own schema and cross-reference checks.
+
+    `LibrarySchema.model_validate` enforces shape (discriminated unions,
+    required fields); `validate_library_declarations` enforces cross-references
+    (every `model_usage` / `model_provider_usage` entry resolves against the
+    `model_catalog`, no duplicate model ids). This is the same path the engine
+    takes when it loads the library, so a manifest that passes here loads
+    cleanly at runtime too.
+    """
+    library = _load_library()
+
+    schema = LibrarySchema.model_validate(library)
+    problems = validate_library_declarations(schema)
+
+    assert problems == []


### PR DESCRIPTION
Settles the two catalog conventions blocking full `model_usage` coverage (#429, #430), part of griptape-ai/internal#172.

Bedrock is catalogued as its own `amazon_bedrock` provider whose `provider_model_id`s are the literal Bedrock wire ids (region-prefixed inference-profile ids and all), rather than mapping onto the existing `anthropic`/`deepseek`/`meta` vendor providers. That keeps the convention from #338 that `provider_model_id` is the id the API actually receives, at the cost of the same underlying model appearing under two providers; #437 already accepted that trade for Groq and NIM, and the provider `notes` record it. `AmazonBedrockPrompt` declares all 11 models it offers.

Ollama is the local-runtime case the `KeySupport` docs anticipate: models are discovered from the user's local server at runtime, so the provider declares no models and carries provider-level `key_support: NO_KEY_REQUIRED`. `OllamaPrompt` references the whole provider via `model_provider_usage`. A test pins that `resolve_node_models` yields nothing for it, so the catalog stays descriptive rather than feeding the node a model list, matching the decision recorded in #338.

Also adds a manifest-wide validation test that runs the engine's own `LibrarySchema` + `validate_library_declarations` path, so cross-reference breakage (dangling `model_usage` ids, duplicate model keys) fails in CI instead of at library load.

Closes #429. Closes #430.

> [!NOTE]
> Beep boop. This PR description was written by AI.