### PR TITLE
feat: model governance for the task/text node family

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -5467,6 +5467,17 @@
           "agent",
           "math",
           "fun"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5659,6 +5670,14 @@
         "tags": [
           "text",
           "random"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1_nano"
+            ]
+          }
         ]
       }
     },
@@ -5675,6 +5694,17 @@
           "text",
           "utility",
           "datetime"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5720,6 +5750,17 @@
           "agent",
           "ai",
           "evaluation"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5753,6 +5794,17 @@
           "web",
           "api",
           "scrape"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5786,6 +5838,17 @@
           "web",
           "api",
           "search"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5803,6 +5866,17 @@
           "agent",
           "ai",
           "summarize"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1",
+              "gtc_gpt_4_1_mini",
+              "gtc_gpt_4_1_nano",
+              "gtc_gpt_5"
+            ]
+          }
         ]
       }
     },
@@ -5899,6 +5973,14 @@
           "agent",
           "mcp",
           "api"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_gpt_4_1"
+            ]
+          }
         ]
       }
     },

--- a/griptape_nodes_library/number/askulator.py
+++ b/griptape_nodes_library/number/askulator.py
@@ -7,11 +7,15 @@ from griptape.rules import Rule
 from griptape.structures import Agent, Structure
 from griptape.tools import CalculatorTool as GtCalculatorTool
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.traits.options import Options
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from json_repair import repair_json  # json_repair
 from pydantic import BaseModel
 
 from griptape_nodes_library.tasks.base_task import BaseTask
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
+
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1-mini"
 
 
 class Output(BaseModel):
@@ -31,15 +35,19 @@ class Askulator(BaseTask):
                 ui_options={"multiline": True, "placeholder_text": "Enter something to calculate."},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1-mini",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
         self.add_parameter(
             Parameter(
@@ -63,7 +71,25 @@ class Askulator(BaseTask):
             )
         )
 
-    def _process(self, agent: Agent, prompt: BaseArtifact | str) -> Structure:
+    def after_value_set(
+        self,
+        parameter: Parameter,
+        value: Any,
+    ) -> None:
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
+        return super().after_value_set(parameter, value)
+
+    def _process(self, agent: Agent, prompt: BaseArtifact | str, model: str) -> Structure:
+        # License-policy gate immediately before the framework driver call. Askulator overrides
+        # BaseTask._process wholesale (different streaming/parsing loop), so it declares here
+        # rather than relying on the base implementation's declaration.
+        declaration = declare_model_invocation_sync(self, model)
+        if declaration.failed():
+            details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+            msg = f"Cannot run {type(self).__name__}: {details}"
+            raise RuntimeError(msg)
+
         args = [prompt] if prompt else []
         full_result = ""
         last_reasoning = ""
@@ -95,6 +121,10 @@ class Askulator(BaseTask):
         instruction = self.get_parameter_value("instruction")
         model = self.get_parameter_value("model")
 
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
+
         # Create the tool
         tool = GtCalculatorTool()
 
@@ -121,4 +151,4 @@ class Askulator(BaseTask):
 
         if instruction and not instruction.isspace():
             # Run the agent asynchronously
-            yield lambda: self._process(agent, user_input)
+            yield lambda: self._process(agent, user_input, model)

--- a/griptape_nodes_library/tasks/base_task.py
+++ b/griptape_nodes_library/tasks/base_task.py
@@ -5,6 +5,8 @@ from griptape.structures import Agent, Structure
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
+
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
 
@@ -22,7 +24,17 @@ class BaseTask(ControlNode):
             stream=True,
         )
 
-    def _process(self, agent: Agent, prompt: BaseArtifact | str) -> Structure:
+    def _process(self, agent: Agent, prompt: BaseArtifact | str, model: str) -> Structure:
+        # License-policy gate immediately before the framework driver call. Shared by every
+        # subclass that runs its agent through this method (a subclass that invokes its own
+        # driver call directly -- e.g. bypassing this method -- must declare at its own site
+        # instead; see that subclass for its own declaration).
+        declaration = declare_model_invocation_sync(self, model)
+        if declaration.failed():
+            details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+            msg = f"Cannot run {type(self).__name__}: {details}"
+            raise RuntimeError(msg)
+
         args = [prompt] if prompt else []
         for event in agent.run_stream(
             *args, event_types=[StartStructureRunEvent, TextChunkEvent, ActionChunkEvent, FinishStructureRunEvent]

--- a/griptape_nodes_library/tasks/mcp_task.py
+++ b/griptape_nodes_library/tasks/mcp_task.py
@@ -24,6 +24,9 @@ from griptape_nodes_library.utils.mcp_utils import (
     get_server_config,
     validate_mcp_server,
 )
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
+
+DEFAULT_MODEL = "gpt-4.1"
 
 
 def _create_ruleset_from_rules_string(rules_string: str | None, server_name: str) -> Ruleset | None:
@@ -343,6 +346,17 @@ class MCPTaskNode(SuccessFailureNode):
             raise TypeError(msg)
         prompt_driver = task.prompt_driver
 
+        # License-policy gate immediately before the framework driver call. MCPTaskNode has no
+        # user-facing model dropdown -- the model is either the fixed default declared below
+        # (no upstream agent connected) or comes from a connected agent's own driver, whose
+        # model identity that agent's own node is responsible for gating. Either way, the
+        # declaration below is this node's own gate on the actual invocation.
+        declaration = declare_model_invocation_sync(self, prompt_driver.model)
+        if declaration.failed():
+            details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+            msg = f"Cannot run {type(self).__name__}: {details}"
+            raise RuntimeError(msg)
+
         if prompt_driver.stream:
             for event in agent.run_stream(
                 *args, event_types=[StartStructureRunEvent, TextChunkEvent, ActionChunkEvent, FinishStructureRunEvent]
@@ -366,7 +380,7 @@ class MCPTaskNode(SuccessFailureNode):
 
         return agent
 
-    def _create_driver(self, model: str = "gpt-4.1") -> GriptapeCloudPromptDriver:
+    def _create_driver(self, model: str = DEFAULT_MODEL) -> GriptapeCloudPromptDriver:
         """Create a GriptapeCloudPromptDriver."""
         return GriptapeCloudPromptDriver(
             model=model,

--- a/griptape_nodes_library/text/date_and_time.py
+++ b/griptape_nodes_library/text/date_and_time.py
@@ -4,6 +4,7 @@ from griptape.structures import Agent, Structure
 from griptape.tools import DateTimeTool as GtDateTimeTool
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.tasks.base_task import BaseTask
@@ -17,6 +18,8 @@ FORMAT_CHOICES = [
     "This Saturday at 7 PM",
     "Custom format",
 ]
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1-mini"
 
 
 class DateAndTime(BaseTask):
@@ -50,15 +53,19 @@ class DateAndTime(BaseTask):
                 ui_options={"hide": True, "placeholder_text": "any custom format"},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1-mini",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
 
         self.add_parameter(
@@ -83,6 +90,8 @@ class DateAndTime(BaseTask):
                 self.show_parameter_by_name("custom_format")
             else:
                 self.hide_parameter_by_name("custom_format")
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
         return super().after_value_set(parameter, value)
 
     def process(self) -> AsyncResult[Structure]:
@@ -91,6 +100,10 @@ class DateAndTime(BaseTask):
         date_format = self.get_parameter_value("format")
         if date_format == "Custom format":
             date_format = self.get_parameter_value("custom_format")
+
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
 
         # Create the tool
         tool = GtDateTimeTool()
@@ -101,4 +114,4 @@ class DateAndTime(BaseTask):
 
         if prompt and not prompt.isspace():
             # Run the agent asynchronously
-            yield lambda: self._process(agent, user_input)
+            yield lambda: self._process(agent, user_input, model)

--- a/griptape_nodes_library/text/evaluate_text_result.py
+++ b/griptape_nodes_library/text/evaluate_text_result.py
@@ -4,9 +4,11 @@ from griptape.engines import EvalEngine
 from griptape.structures import Agent, Structure
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.tasks.base_task import BaseTask
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
 
 EXAMPLES = [
     {
@@ -36,6 +38,8 @@ EXAMPLES = [
 ]
 
 EXAMPLE_OPTIONS = [example["label"] for example in EXAMPLES]
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1"
 
 
 class EvaluateTextResult(BaseTask):
@@ -107,15 +111,19 @@ class EvaluateTextResult(BaseTask):
             )
         )
 
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
         self.add_node_element(
             ParameterMessage(
@@ -165,20 +173,35 @@ class EvaluateTextResult(BaseTask):
             self.parameter_output_values["expected_output"] = EXAMPLES[EXAMPLE_OPTIONS.index(value)]["expected_output"]
             self.parameter_output_values["actual_output"] = EXAMPLES[EXAMPLE_OPTIONS.index(value)]["actual_output"]
 
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
+
         return super().after_value_set(parameter, value)
 
     def process(self) -> AsyncResult[Structure]:
         criteria = self.get_parameter_value("criteria")
+        model = self.get_parameter_value("model")
 
-        engine = EvalEngine(
-            criteria=criteria, prompt_driver=self.create_driver(model=self.get_parameter_value("model"))
-        )
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
+
+        engine = EvalEngine(criteria=criteria, prompt_driver=self.create_driver(model=model))
 
         user_input = self.get_parameter_value("input")
         expected_output = self.get_parameter_value("expected_output")
         actual_output = self.get_parameter_value("actual_output")
 
         def _process() -> Structure:
+            # License-policy gate immediately before the framework driver call. EvalEngine.evaluate
+            # invokes the prompt driver directly rather than through BaseTask._process, so it
+            # declares here rather than relying on the base implementation's declaration.
+            declaration = declare_model_invocation_sync(self, model)
+            if declaration.failed():
+                details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+                msg = f"Cannot run {type(self).__name__}: {details}"
+                raise RuntimeError(msg)
+
             score, reason = engine.evaluate(
                 input=user_input,
                 expected_output=expected_output,

--- a/griptape_nodes_library/text/random_text.py
+++ b/griptape_nodes_library/text/random_text.py
@@ -14,6 +14,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
@@ -243,6 +244,15 @@ class RandomText(DataNode):
 
         # Run the agent
         if self.agent:
+            # License-policy gate immediately before the framework driver call. RandomText has
+            # no user-facing model selection (MODEL is a fixed constant), so there is no
+            # dropdown to gate with ModelAccessComponent -- this declaration is the sole gate.
+            declaration = declare_model_invocation_sync(self, MODEL)
+            if declaration.failed():
+                details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+                msg = f"Cannot run {type(self).__name__}: {details}"
+                raise RuntimeError(msg)
+
             result = self.agent.run(prompt)
             if isinstance(result, BaseArtifact):
                 return result.output.value

--- a/griptape_nodes_library/text/scrape_web.py
+++ b/griptape_nodes_library/text/scrape_web.py
@@ -1,12 +1,18 @@
+from typing import Any
+
 from griptape.artifacts import ListArtifact
 from griptape.structures import Agent, Structure
 from griptape.tasks import PromptTask
 from griptape.tools import WebScraperTool as GtWebScraperTool
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import AsyncResult
-from griptape_nodes.traits.options import Options
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 
 from griptape_nodes_library.tasks.base_task import BaseTask
+from griptape_nodes_library.utils.model_invocation import declare_model_invocation_sync
+
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1-mini"
 
 
 class ScrapeWeb(BaseTask):
@@ -21,15 +27,19 @@ class ScrapeWeb(BaseTask):
                 ui_options={"placeholder_text": "Enter the URL to scrape."},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1-mini",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
 
         self.add_parameter(
@@ -44,9 +54,22 @@ class ScrapeWeb(BaseTask):
             )
         )
 
+    def after_value_set(
+        self,
+        parameter: Parameter,
+        value: Any,
+    ) -> None:
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
+        return super().after_value_set(parameter, value)
+
     def process(self) -> AsyncResult[Structure]:
         prompt = self.get_parameter_value("prompt")
         model = self.get_parameter_value("model")
+
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
 
         # Create the tool
         tool = GtWebScraperTool()
@@ -57,6 +80,15 @@ class ScrapeWeb(BaseTask):
         )
 
         def _process() -> Structure:
+            # License-policy gate immediately before the framework driver call. PromptTask.run
+            # invokes the prompt driver directly rather than through BaseTask._process, so it
+            # declares here rather than relying on the base implementation's declaration.
+            declaration = declare_model_invocation_sync(self, model)
+            if declaration.failed():
+                details = str(declaration.result_details or f"{self.name}: model invocation was not permitted.")
+                msg = f"Cannot run {type(self).__name__}: {details}"
+                raise RuntimeError(msg)
+
             # Run the task
             output = ""
             response = scrape_task.run(f"Scrape the web for information about: {prompt}")

--- a/griptape_nodes_library/text/search_web.py
+++ b/griptape_nodes_library/text/search_web.py
@@ -7,6 +7,7 @@ from griptape.tasks import PromptTask
 from griptape.tools import WebSearchTool
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
@@ -24,6 +25,8 @@ SEARCH_ENGINE_MAP = {
     },
 }
 SEARCH_ENGINES = list(SEARCH_ENGINE_MAP.keys())
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1-mini"
 
 
 class SearchWeb(BaseTask):
@@ -47,15 +50,19 @@ class SearchWeb(BaseTask):
                 ui_options={"hide": False},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1-mini",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
         self.add_parameter(
             Parameter(
@@ -131,6 +138,8 @@ class SearchWeb(BaseTask):
                     self.show_message_by_name("api_keys_message")
                 else:
                     self.hide_message_by_name("api_keys_message")
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
         super().after_value_set(parameter, value)
 
     def validate_before_workflow_run(self) -> list[Exception] | None:
@@ -141,6 +150,11 @@ class SearchWeb(BaseTask):
     def process(self) -> AsyncResult[Structure]:
         prompt = self.get_parameter_value("prompt")
         search_engine = self.get_parameter_value("search_engine")
+        model = self.get_parameter_value("model")
+
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
 
         if search_engine == "DuckDuckGo":
             driver = self._duck_duck_go_driver()
@@ -157,7 +171,7 @@ class SearchWeb(BaseTask):
         task = PromptTask(
             tools=[tool],
             reflect_on_tool_use=self.get_parameter_value("summarize"),
-            prompt_driver=GriptapeCloudPromptDriver(model=self.get_parameter_value("model"), stream=True),
+            prompt_driver=GriptapeCloudPromptDriver(model=model, stream=True),
         )
 
         agent = Agent(tasks=[task])
@@ -165,6 +179,6 @@ class SearchWeb(BaseTask):
         user_input = f"Search the web for {prompt}"
         if prompt and not prompt.isspace():
             # Run the agent asynchronously
-            yield lambda: self._process(agent, user_input)
+            yield lambda: self._process(agent, user_input, model)
 
         self.parameter_output_values["output"] = str(agent.output)

--- a/griptape_nodes_library/text/summarize_text_task.py
+++ b/griptape_nodes_library/text/summarize_text_task.py
@@ -1,11 +1,16 @@
+from typing import Any
+
 from griptape.engines import PromptSummaryEngine
 from griptape.structures import Agent, Structure
 from griptape.tasks import TextSummaryTask
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult
-from griptape_nodes.traits.options import Options
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 
 from griptape_nodes_library.tasks.base_task import BaseTask
+
+MODEL_CHOICES = ["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"]
+DEFAULT_MODEL = "gpt-4.1-nano"
 
 
 class SummarizeText(BaseTask):
@@ -28,15 +33,19 @@ class SummarizeText(BaseTask):
                 ui_options={"multiline": True, "placeholder_text": "Input text to process"},
             )
         )
-        self.add_parameter(
-            Parameter(
-                name="model",
-                type="str",
-                default_value="gpt-4.1-nano",
-                tooltip="The model to use for the task.",
-                traits={Options(choices=["gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-5"])},
-                ui_options={"hide": True},
-            )
+        model_param = Parameter(
+            name="model",
+            type="str",
+            default_value=DEFAULT_MODEL,
+            tooltip="The model to use for the task.",
+            ui_options={"hide": True},
+        )
+        self.add_parameter(model_param)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=DEFAULT_MODEL,
         )
 
         self.add_parameter(
@@ -51,12 +60,26 @@ class SummarizeText(BaseTask):
             )
         )
 
+    def after_value_set(
+        self,
+        parameter: Parameter,
+        value: Any,
+    ) -> None:
+        if parameter.name == "model":
+            self._model_access.on_value_changed(value)
+        return super().after_value_set(parameter, value)
+
     def process(self) -> AsyncResult[Structure]:
         model = self.get_parameter_value("model")
+
+        # License-policy runtime gate. Raises RuntimeError if the currently-selected
+        # model is denied.
+        self._model_access.raise_if_denied(model)
+
         engine = PromptSummaryEngine(prompt_driver=self.create_driver(model=model))
         task = TextSummaryTask(summary_engine=engine)
         agent = Agent(tasks=[task])
         prompt = self.get_parameter_value("prompt")
         if prompt and not prompt.isspace():
             # Run the agent asynchronously
-            yield lambda: self._process(agent, prompt)
+            yield lambda: self._process(agent, prompt, model)

--- a/tests/unit/tasks/test_model_invocation_governance.py
+++ b/tests/unit/tasks/test_model_invocation_governance.py
@@ -1,0 +1,343 @@
+"""License-policy gating for the task/text node family.
+
+Two independent checkpoints protect a model invocation:
+
+  - `OFFER_MODEL` gates the dropdown a `ModelAccessComponent`-backed node
+    exposes. `raise_if_denied()` re-queries it at the top of `process()`, so a
+    selection that was permitted when the node was constructed but has since
+    been denied stops the node before it builds anything.
+  - `INVOKE_MODEL` gates the actual framework-driver call via
+    `declare_model_invocation_sync`, dispatched immediately before the
+    network call regardless of whether the model came from a dropdown or is
+    hardcoded. This is the fail-closed backstop even for nodes with no
+    dropdown at all.
+
+These tests register a policy hook directly on `GriptapeNodes.EventManager()`
+(the same extension point the app's license policy uses) and prove each
+checkpoint actually stops the corresponding node -- not just that a
+declaration is dispatched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from griptape.engines import EvalEngine
+from griptape.structures import Agent
+from griptape.tasks import PromptTask
+from griptape.tools import CalculatorTool
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointDenial,
+    CheckpointFailure,
+)
+
+from griptape_nodes_library.tasks.mcp_task import MCPTaskNode
+from griptape_nodes_library.text.random_text import RandomText
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape.events import BaseEvent
+    from griptape.tools import MCPTool
+
+LIBRARY_NAME = "Griptape Nodes Library"
+
+type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | None]
+
+
+def _create_node(node_type: str) -> BaseNode:
+    """Create a node through the library so its metadata carries `library` / `node_type`.
+
+    `resolve_catalog_model_id` (and therefore `declare_model_invocation_sync`)
+    reads those two metadata keys to resolve a node's declared models; a bare
+    `NodeClass(name=...)` construction (as many other unit tests use) does not
+    set them and would silently fall back to the raw provider model id.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return library.create_node(node_type=node_type, name=node_type)
+
+
+def _first_yielded_thunk(node: BaseNode) -> Callable[[], Any]:
+    """Advance a generator-based `process()` to its first `yield` and return the thunk.
+
+    Raises whatever `process()` raises before its first `yield` (e.g. a
+    `raise_if_denied()` gate) -- callers asserting on that use `pytest.raises`
+    around this call directly.
+    """
+    generator = node.process()
+    assert generator is not None
+    return next(generator)
+
+
+def _deny_hook(action: CheckpointAction, subject_id: str) -> AuthorizationHook:
+    """Build a hook that denies one action against one catalog model id, else allows."""
+
+    def hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        if checkpoint.action == action and checkpoint.subject_id == subject_id:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="denied for test"),))
+        return None
+
+    return hook
+
+
+@pytest.fixture(autouse=True)
+def _stub_griptape_cloud_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every node under test builds a `GriptapeCloudPromptDriver` in `process()` itself
+    (before the deferred thunk that the license-policy gate protects), so a missing key
+    would raise before the test ever reaches what it's asserting on. `SecretsManager`
+    checks OS environment variables first, so this satisfies every call path uniformly.
+    """
+    monkeypatch.setenv("GT_CLOUD_API_KEY", "test-key")
+
+
+@pytest.fixture
+def authorization_hook() -> Iterator[Callable[[AuthorizationHook], None]]:
+    """Register an authorization hook for the test, guaranteed removed afterward."""
+    registered: list[AuthorizationHook] = []
+
+    def register(hook: AuthorizationHook) -> None:
+        GriptapeNodes.EventManager().add_authorization_hook(hook)
+        registered.append(hook)
+
+    try:
+        yield register
+    finally:
+        for hook in registered:
+            GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+
+def _fake_run_stream(calls: list[Any]) -> Callable[..., Iterator[Any]]:
+    def run_stream(self: Agent, *args: Any, event_types: list[type[BaseEvent]] | None = None) -> Iterator[Any]:  # noqa: ARG001
+        calls.append(args)
+        return iter([])
+
+    return run_stream
+
+
+class TestInvokeModelDenialStopsSharedBaseRunSite:
+    """`BaseTask._process` is the shared framework-driver call site for the three
+    subclasses that don't override it (DateAndTime, SearchWeb, SummarizeText).
+    """
+
+    @pytest.mark.parametrize(
+        ("node_type", "prompt_param", "default_catalog_id"),
+        [
+            ("DateAndTime", "prompt", "gtc_gpt_4_1_mini"),
+            ("SearchWeb", "prompt", "gtc_gpt_4_1_mini"),
+            ("SummarizeText", "prompt", "gtc_gpt_4_1_nano"),
+        ],
+    )
+    def test_denied_invocation_raises_before_run_stream(
+        self,
+        node_type: str,
+        prompt_param: str,
+        default_catalog_id: str,
+        authorization_hook: Callable[[AuthorizationHook], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        node = _create_node(node_type)
+        node.set_parameter_value(prompt_param, "hello")
+
+        run_stream_calls: list[Any] = []
+        monkeypatch.setattr(Agent, "run_stream", _fake_run_stream(run_stream_calls))
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, default_catalog_id))
+
+        thunk = _first_yielded_thunk(node)
+
+        with pytest.raises(RuntimeError, match="denied"):
+            thunk()
+
+        assert run_stream_calls == []
+
+    @pytest.mark.parametrize(
+        ("node_type", "prompt_param"),
+        [
+            ("DateAndTime", "prompt"),
+            ("SearchWeb", "prompt"),
+            ("SummarizeText", "prompt"),
+        ],
+    )
+    def test_allowed_invocation_still_runs(
+        self,
+        node_type: str,
+        prompt_param: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sanity check: with no denying hook registered, the same node reaches run_stream."""
+        node = _create_node(node_type)
+        node.set_parameter_value(prompt_param, "hello")
+
+        run_stream_calls: list[Any] = []
+        monkeypatch.setattr(Agent, "run_stream", _fake_run_stream(run_stream_calls))
+
+        thunk = _first_yielded_thunk(node)
+        thunk()
+
+        assert len(run_stream_calls) == 1
+
+
+class TestInvokeModelDenialStopsOwnCallSites:
+    """Nodes that bypass `BaseTask._process` declare at their own call site instead."""
+
+    def test_askulator_denied_invocation_raises_before_run_stream(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        node = _create_node("Askulator")
+        node.set_parameter_value("instruction", "what is 2 + 2?")
+
+        run_stream_calls: list[Any] = []
+        monkeypatch.setattr(Agent, "run_stream", _fake_run_stream(run_stream_calls))
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, "gtc_gpt_4_1_mini"))
+
+        thunk = _first_yielded_thunk(node)
+
+        with pytest.raises(RuntimeError, match="denied"):
+            thunk()
+
+        assert run_stream_calls == []
+
+    def test_evaluate_text_result_denied_invocation_never_calls_engine(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        node = _create_node("EvaluateTextResult")
+        node.set_parameter_value("criteria", "Is this correct?")
+        node.set_parameter_value("input", "1 + 1")
+        node.set_parameter_value("expected_output", "2")
+        node.set_parameter_value("actual_output", "2")
+
+        evaluate_calls: list[Any] = []
+
+        def fake_evaluate(self: EvalEngine, **kwargs: Any) -> tuple[float, str]:
+            evaluate_calls.append(kwargs)
+            return 1.0, "ok"
+
+        monkeypatch.setattr(EvalEngine, "evaluate", fake_evaluate)
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, "gtc_gpt_4_1"))
+
+        thunk = _first_yielded_thunk(node)
+
+        with pytest.raises(RuntimeError, match="denied"):
+            thunk()
+
+        assert evaluate_calls == []
+
+    def test_scrape_web_denied_invocation_never_calls_task(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        node = _create_node("ScrapeWeb")
+        node.set_parameter_value("prompt", "https://example.com")
+
+        run_calls: list[Any] = []
+
+        def fake_run(self: PromptTask, *args: Any) -> Any:
+            run_calls.append(args)
+            return None
+
+        monkeypatch.setattr(PromptTask, "run", fake_run)
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, "gtc_gpt_4_1_mini"))
+
+        thunk = _first_yielded_thunk(node)
+
+        with pytest.raises(RuntimeError, match="denied"):
+            thunk()
+
+        assert run_calls == []
+
+
+class TestInvokeModelDenialStopsHardcodedModelNodes:
+    """Nodes with no user-facing model dropdown still gate the actual invocation."""
+
+    def test_random_text_denied_invocation_never_calls_agent(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+    ) -> None:
+        node = cast("RandomText", _create_node("RandomText"))
+        # Selection types other than character/word fall through to the agent when
+        # there's no input text -- exercise that path.
+        node.set_parameter_value("selection_type", "sentence")
+
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, "gtc_gpt_4_1_nano"))
+
+        with pytest.raises(RuntimeError, match="denied"):
+            node._generate_with_agent("sentence", seed=1)
+
+    def test_mcp_task_denied_invocation_never_streams(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        node = cast("MCPTaskNode", _create_node("MCPTaskNode"))
+
+        run_stream_calls: list[Any] = []
+        monkeypatch.setattr(Agent, "run_stream", _fake_run_stream(run_stream_calls))
+        authorization_hook(_deny_hook(CheckpointAction.INVOKE_MODEL, "gtc_gpt_4_1"))
+
+        agent, driver, tools, rulesets = node._setup_agent()
+        assert agent is not None
+        assert node._add_task_to_agent(
+            agent,
+            tool=cast("MCPTool", CalculatorTool()),
+            driver=driver,
+            tools=tools,
+            rulesets=rulesets,
+            max_subtasks=20,
+        )
+
+        with pytest.raises(RuntimeError, match="denied"):
+            node._process_with_streaming(agent, "hello")
+
+        assert run_stream_calls == []
+
+
+class TestOfferModelDenialStopsSelection:
+    """A model denied via `OFFER_MODEL` (the dropdown-populating checkpoint) must not
+    run even before `INVOKE_MODEL` is ever declared -- `raise_if_denied()` at the top
+    of `process()` re-queries live policy and stops the node first.
+    """
+
+    def test_askulator_denied_selection_raises_from_process_before_yielding(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+    ) -> None:
+        # Construct the node BEFORE the policy denies its default model, so the
+        # ModelAccessComponent's constructor-time snapshot is clean and does not
+        # relocate the stored value away from the (about-to-be-denied) default.
+        node = _create_node("Askulator")
+        node.set_parameter_value("instruction", "what is 2 + 2?")
+
+        authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, "gtc_gpt_4_1_mini"))
+
+        with pytest.raises(RuntimeError, match="not permitted"):
+            _first_yielded_thunk(node)
+
+    def test_summarize_text_denied_selection_raises_from_process_before_yielding(
+        self,
+        authorization_hook: Callable[[AuthorizationHook], None],
+    ) -> None:
+        node = _create_node("SummarizeText")
+        node.set_parameter_value("prompt", "hello")
+
+        authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, "gtc_gpt_4_1_nano"))
+
+        with pytest.raises(RuntimeError, match="not permitted"):
+            _first_yielded_thunk(node)
+
+    def test_allowed_selection_does_not_raise_from_process(self) -> None:
+        """Sanity check: with no denying hook registered, `raise_if_denied` is a no-op."""
+        node = _create_node("Askulator")
+        node.set_parameter_value("instruction", "what is 2 + 2?")
+
+        # Must not raise; the generator proceeds to its first yield.
+        _first_yielded_thunk(node)

--- a/tests/unit/test_model_catalog_consistency.py
+++ b/tests/unit/test_model_catalog_consistency.py
@@ -41,6 +41,14 @@ from griptape_nodes_library.config.prompt.nim_prompt import MODEL_CHOICES as NIM
 from griptape_nodes_library.config.prompt.openai_prompt import MODEL_CHOICES as OPENAI_MODEL_CHOICES
 from griptape_nodes_library.image.create_image import MODEL_CHOICES as GENERATE_IMAGE_MODEL_CHOICES
 from griptape_nodes_library.image.describe_image import GTC_VISION_MODEL_CHOICES as DESCRIBE_IMAGE_MODEL_CHOICES
+from griptape_nodes_library.number.askulator import MODEL_CHOICES as ASKULATOR_MODEL_CHOICES
+from griptape_nodes_library.tasks.mcp_task import DEFAULT_MODEL as MCP_TASK_DEFAULT_MODEL
+from griptape_nodes_library.text.date_and_time import MODEL_CHOICES as DATE_AND_TIME_MODEL_CHOICES
+from griptape_nodes_library.text.evaluate_text_result import MODEL_CHOICES as EVALUATE_TEXT_RESULT_MODEL_CHOICES
+from griptape_nodes_library.text.random_text import MODEL as RANDOM_TEXT_MODEL
+from griptape_nodes_library.text.scrape_web import MODEL_CHOICES as SCRAPE_WEB_MODEL_CHOICES
+from griptape_nodes_library.text.search_web import MODEL_CHOICES as SEARCH_WEB_MODEL_CHOICES
+from griptape_nodes_library.text.summarize_text_task import MODEL_CHOICES as SUMMARIZE_TEXT_MODEL_CHOICES
 
 LIBRARY_JSON = Path(__file__).parents[2] / "griptape_nodes_library.json"
 
@@ -117,6 +125,14 @@ def test_chat_node_model_usage_matches_static_choices(class_name: str) -> None:
         ("GroqPrompt", GROQ_PROMPT_MODEL_CHOICES),
         ("NimPrompt", NIM_PROMPT_MODEL_CHOICES),
         ("AmazonBedrockPrompt", AMAZON_BEDROCK_MODEL_CHOICES),
+        ("Askulator", ASKULATOR_MODEL_CHOICES),
+        ("DateAndTime", DATE_AND_TIME_MODEL_CHOICES),
+        ("EvaluateTextResult", EVALUATE_TEXT_RESULT_MODEL_CHOICES),
+        ("ScrapeWeb", SCRAPE_WEB_MODEL_CHOICES),
+        ("SearchWeb", SEARCH_WEB_MODEL_CHOICES),
+        ("SummarizeText", SUMMARIZE_TEXT_MODEL_CHOICES),
+        ("RandomText", [RANDOM_TEXT_MODEL]),
+        ("MCPTaskNode", [MCP_TASK_DEFAULT_MODEL]),
     ],
 )
 def test_model_selection_node_usage_matches_static_choices(


### PR DESCRIPTION
The task/text/utility family leg of #431 and #432, part of griptape-ai/internal#172. Covers `Askulator`, `MCPTask`, `EvaluateTextResult`, `RandomText`, `SummarizeText`, `ScrapeWeb`, `SearchWeb`, and `DateAndTime`.

<img width="1060" height="741" alt="image" src="https://github.com/user-attachments/assets/20ef2116-0f96-4eff-a174-4e8c1f3071f2" />
