### PR TITLE
fix(video): stop Create Video from Frames stringifying Sequence input

### DIFF
--- a/griptape_nodes_library/video/create_video_from_frames.py
+++ b/griptape_nodes_library/video/create_video_from_frames.py
@@ -16,7 +16,7 @@ from griptape.artifacts.image_url_artifact import ImageUrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.common.sequences import Sequence
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
-from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.node_types import BaseNode, SuccessFailureNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
@@ -72,8 +72,9 @@ class CreateVideoFromFrames(SuccessFailureNode):
         super().__init__(name, metadata)
 
         self.add_parameter(
-            ParameterString(
+            Parameter(
                 name="frames_input",
+                type="str",
                 input_types=["Sequence", "list", "str", "ImageUrlArtifact"],
                 tooltip=(
                     "Frame source. Use the file browser to pick a folder or image sequence "
@@ -195,6 +196,19 @@ class CreateVideoFromFrames(SuccessFailureNode):
                 self.hide_parameter_by_name("output_gif_file")
                 self.show_parameter_by_name("output_file")
                 self.show_parameter_by_name("processing_speed")
+
+    def after_incoming_connection_removed(
+        self,
+        source_node: BaseNode,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        # Clear the stale connection value so the FileSystemPicker doesn't try to
+        # open a serialized Sequence dict as a path. A connection overwrites any
+        # previously-picked path anyway, so an empty field is the correct end state.
+        if target_parameter.name == "frames_input":
+            self.set_parameter_value("frames_input", "")
+        super().after_incoming_connection_removed(source_node, source_parameter, target_parameter)
 
     async def aprocess(self) -> None:
         self._clear_execution_status()


### PR DESCRIPTION
## Problem

Wiring **Scan Sequence → Create Video from Frames** crashed at runtime with:

```
[Errno 36] File name too long: "entries=[SequenceEntry(number=1015, padded_number='1015', path='...')...]"
```

That "File name too long" text is the OS kernel's `ENAMETOOLONG` — Python re-raised it when `Path(frames_input).exists()` got a ~10 KB "path": the Pydantic `repr` of a `Sequence`.

## Root cause

`frames_input` was declared as a `ParameterString`. Despite passing `input_types=["Sequence", "list", "str", "ImageUrlArtifact"]`, `ParameterString`:

1. **ignores `input_types`** (marked `# noqa: ARG002`; with `accept_any=True` it hardcodes `["any"]`), and
2. **force-stringifies every incoming value** via `accept_any`'s `_accept_any` converter, which falls to `str(value)` for a `Sequence`.

So the live `Sequence` was collapsed to its repr in-memory on the connection path, and the node's own `_is_sequence` branch in `_get_frame_paths` became dead code. (Verified the engine's cattrs serializer is *not* the culprit — it produces a clean dict; this was purely the `ParameterString` converter.)

## Fix

- Switch `frames_input` to a plain `Parameter(type="str", input_types=[...])` that honors `input_types` and injects no converter. A live `Sequence`/list/str/`ImageUrlArtifact` now reaches `_get_frame_paths` intact. `type="str"` is honest for the `FileSystemPicker` property case and drives no coercion (only specialized `Parameter` subclasses inject converters).
- Add `after_incoming_connection_removed` to clear `frames_input` on disconnect — once the coercion was fixed, connecting a Sequence wrote its dict into the stored property value, and disconnecting left that stale dict behind, so the file picker tried to open it as a path. Mirrors the pattern in `splat/load_splat.py` and `sequence/inspect_sequence.py`.

## Testing

- `make check` — clean (0 errors/warnings).
- Manual: Scan Sequence (`inputs/sequences/01_contiguous/render.####.png`) → Create Video from Frames → produces a video, no `ENAMETOOLONG`. Disconnect clears the field and the file picker works again.

## Out of scope

`.exr` support: `SUPPORTED_IMAGE_EXTENSIONS` is JPG/PNG/WEBP only. The customer's pipeline is 99% `.exr`; that's a separate enhancement, not addressed here.

Fixes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)