### PR TITLE
fix(subflow): disambiguate node<->flow link using UUID

### DIFF
--- a/griptape_nodes_library/engine/subflow_workflow_node.py
+++ b/griptape_nodes_library/engine/subflow_workflow_node.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import uuid4
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -10,7 +11,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartLocalSubflowRequest,
     StartLocalSubflowResultFailure,
 )
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest
+from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, SetFlowMetadataRequest
 from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
@@ -28,10 +29,30 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
+# Node-metadata key holding the name of the imported child flow this node last
+# bound to. It is a fast hint only; ``SUBFLOW_OWNER_KEY`` is the authoritative
+# link (see below).
+SUBFLOW_NAME_KEY = "subflow_name"
+
+# Node-metadata key recording which registered workflow the current subflow was
+# imported from, so a reload can tell "already loaded" from "workflow changed".
+SUBFLOW_WORKFLOW_KEY = "_subflow_workflow"
+
+# Metadata key stored on BOTH the Workflow node and its imported child flow. The
+# shared UUID binds a specific node to the specific subflow it imported, so the
+# two stay linked across saves, flow-name de-duplication, and nesting where the
+# recorded ``subflow_name`` may no longer match.
+SUBFLOW_OWNER_KEY = "subflow_owner_uuid"
+
 
 class SubflowWorkflowNode(SuccessFailureNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
+        # Establish this node's stable owner UUID once, up front, so it exists
+        # before any subflow import needs it. Preserved from saved metadata on
+        # load; generated for brand-new nodes. It binds the node to the specific
+        # child flow it imports.
+        self.metadata.setdefault(SUBFLOW_OWNER_KEY, str(uuid4()))
         result = GriptapeNodes.handle_request(ListCallableWorkflowsRequest())
         if isinstance(result, ListCallableWorkflowsResultSuccess):
             # Add pyright ignore here becuase we know ListCallableWOrkflowsResultSuccess reutrns workflow_names
@@ -76,13 +97,22 @@ class SubflowWorkflowNode(SuccessFailureNode):
         self._create_status_parameters()
 
     def after_node_deleted(self) -> None:
-        subflow_name = self.metadata.get("subflow_name")
-        if subflow_name is not None:
-            # The subflow may have already been deleted if the parent flow was deleted first
-            # (parent flow deletion deletes child flows before nodes).
-            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
-            if subflow is not None:
-                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+        # Delete the child flow we own.
+        #
+        # A None result can mean either:
+        #
+        # - our subflow was already legitimately deleted (flows are cleaned
+        #   before nodes when the parent flow is deleted); or
+        # - we point to a legacy subflow (i.e. without UUID) AND this node has
+        #   never been executed (so a matching subflow has not been claimed).
+        #
+        # In the second case, we may leak the subflow. This seems preferable to
+        # potentially deleting an unrelated flow (since in this case we only have
+        # subflow_name to match with, which is an unstable reference).
+        owned_subflow = self._find_owned_subflow_name()
+        if owned_subflow is None:
+            return
+        GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=owned_subflow))
 
     def _on_refresh_workflow(self, button: Button, button_details: ButtonDetailsMessagePayload) -> None:  # noqa: ARG002
         workflow_name = self.get_parameter_value("workflow_file")
@@ -90,7 +120,7 @@ class SubflowWorkflowNode(SuccessFailureNode):
             return
         self._update_workflow_shape_parameters(workflow_name, preserve_matching=True)
         # Clear so _reload_subflow doesn't skip the reload for the same workflow.
-        self.metadata.pop("_subflow_workflow", None)
+        self.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)
         self._reload_subflow(workflow_name)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
@@ -118,17 +148,19 @@ class SubflowWorkflowNode(SuccessFailureNode):
         return deps
 
     def _reload_subflow(self, workflow_name: str) -> None:
-        existing_subflow = self.metadata.get("subflow_name")
-        if existing_subflow:
-            existing_flow_names = set(GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow).keys())
-            # Skip if this workflow is already loaded and the flow still exists.
-            if self.metadata.get("_subflow_workflow") == workflow_name and existing_subflow in existing_flow_names:
+        # Find the subflow this node actually owns (by UUID), never one it
+        # merely shares a name with.
+        owned_subflow = self._resolve_subflow_name(workflow_name)
+        if owned_subflow is not None:
+            # Already own a live subflow for THIS workflow -> keep it.
+            if self.metadata.get(SUBFLOW_WORKFLOW_KEY) == workflow_name:
+                self.metadata[SUBFLOW_NAME_KEY] = owned_subflow
                 return
-            # Only delete if the flow still exists (it may be stale from a previous session).
-            if existing_subflow in existing_flow_names:
-                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=existing_subflow))
-            del self.metadata["subflow_name"]
-            self.metadata.pop("_subflow_workflow", None)
+            # Own a subflow for a DIFFERENT workflow -> tear it down before
+            # importing the new one.
+            GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=owned_subflow))
+        self.metadata.pop(SUBFLOW_NAME_KEY, None)
+        self.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)
 
         if not workflow_name or not WorkflowRegistry.has_workflow_with_name(workflow_name):
             return
@@ -142,8 +174,106 @@ class SubflowWorkflowNode(SuccessFailureNode):
             ImportWorkflowAsReferencedSubFlowRequest(workflow_name=workflow_name, flow_name=flow_result.flow_name)
         )
         if isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess):
-            self.metadata["subflow_name"] = result.created_flow_name
-            self.metadata["_subflow_workflow"] = workflow_name
+            self.metadata[SUBFLOW_NAME_KEY] = result.created_flow_name
+            self.metadata[SUBFLOW_WORKFLOW_KEY] = workflow_name
+            # Mirror this node's owner UUID (established in __init__) onto the
+            # imported flow so the pairing survives serialization and any later
+            # flow-name changes.
+            self._stamp_subflow_uuid(result.created_flow_name, self.metadata[SUBFLOW_OWNER_KEY])
+
+    def _resolve_subflow_name(self, workflow_name: str) -> str | None:
+        """Return the name of the subflow this node owns, or ``None`` if it isn't loaded.
+
+        Prefers the flow stamped with this node's owner UUID, so two nodes
+        referencing the same workflow - or a nested node whose recorded name
+        shifted on import - each bind to their OWN subflow rather than
+        colliding. Falls back to adopting a legacy (pre-UUID) recorded subflow,
+        stamping it so future lookups match by UUID.
+        """
+        owned = self._find_owned_subflow_name()
+        if owned is not None:
+            return owned
+
+        # Fallback for legacy workflows saved without UUID metadata.
+        recorded = self._recorded_subflow_if_unclaimed()
+        if recorded is None:
+            return None
+
+        # Legacy (pre-UUID) subflow: adopt the recorded flow by stamping this
+        # node's owner UUID.
+        self._stamp_subflow_uuid(recorded, self.metadata[SUBFLOW_OWNER_KEY])
+        logger.warning(
+            "Node '%s' adopted legacy referenced subflow '%s' (workflow '%s') that carried no owner UUID. Stamped"
+            " owner UUID '%s' onto it; re-save the workflow to persist the link.",
+            self.name,
+            recorded,
+            workflow_name,
+            self.metadata[SUBFLOW_OWNER_KEY],
+        )
+        return recorded
+
+    def _find_owned_subflow_name(self) -> str | None:
+        """Return the flow stamped with this node's owner UUID, or ``None``.
+
+        The authoritative node<->flow link, with no side effects. Tries the
+        recorded ``subflow_name`` first as an O(1) lookup (the common case) and
+        only scans every flow when that hint is missing or no longer points at a
+        flow we own (e.g. after de-dup / nesting renames).
+        """
+        owner_uuid = self.metadata[SUBFLOW_OWNER_KEY]
+
+        # Quick path: the recorded name usually still points at the flow we own.
+        recorded = self.metadata.get(SUBFLOW_NAME_KEY)
+        if recorded:
+            recorded_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(recorded, ControlFlow)
+            if recorded_flow is not None and recorded_flow.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid:
+                return recorded
+
+        # Slow path: scan every flow for this node's owner UUID.
+        flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
+        for candidate_name, flow in flows.items():
+            if flow.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid:
+                return candidate_name
+        return None
+
+    def _recorded_subflow_if_unclaimed(self) -> str | None:
+        """Return the recorded ``subflow_name`` only if it is safe to treat as ours.
+
+        .. deprecated::
+            Legacy-compatibility only. Covers pre-UUID subflows that were never
+            stamped with an owner UUID (so ``_find_owned_subflow_name`` misses
+            them), binding by recorded name instead. Once every saved workflow
+            carries owner UUIDs, nothing reaches this path and it (with its
+            callers' fallbacks) can be removed.
+
+        We only claim the recorded flow if it still exists, carries no owner
+        UUID (or ours) — never one already owned by a different node — AND was
+        imported from the workflow this node expects. O(1) name lookup.
+        """
+        recorded = self.metadata.get(SUBFLOW_NAME_KEY)
+        expected_workflow = self.metadata.get(SUBFLOW_WORKFLOW_KEY)
+        # SUBFLOW_NAME_KEY and SUBFLOW_WORKFLOW_KEY are always written together;
+        # require both so we never adopt a flow without knowing which workflow
+        # it should reference.
+        if not recorded or not expected_workflow:
+            return None
+        flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(recorded, ControlFlow)
+        if flow is None:
+            return None
+        if flow.metadata.get(SUBFLOW_OWNER_KEY) not in (None, self.metadata[SUBFLOW_OWNER_KEY]):
+            # Already claimed by a different owner.
+            return None
+        # Confidence check: the recorded flow must actually be an import of the
+        # workflow we expect.
+        if GriptapeNodes.FlowManager().get_referenced_workflow_name(flow) != expected_workflow:
+            return None
+
+        return recorded
+
+    def _stamp_subflow_uuid(self, flow_name: str, owner_uuid: str) -> None:
+        GriptapeNodes.handle_request(
+            SetFlowMetadataRequest(flow_name=flow_name, metadata={SUBFLOW_OWNER_KEY: owner_uuid})
+        )
 
     def _create_shape_parameter(
         self, param_name: str, param_dict: dict, allowed_modes: set[ParameterMode]
@@ -264,18 +394,19 @@ class SubflowWorkflowNode(SuccessFailureNode):
             self._handle_failure_exception(RuntimeError(msg))
             return
 
-        # Use the pre-loaded subflow if available; otherwise load it now. Load it before
-        # deriving the shape so the shape reflects the live (imported) nodes.
-        existing_flow_names = set(GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow).keys())
-        subflow_name = self.metadata.get("subflow_name")
-        if not subflow_name or subflow_name not in existing_flow_names:
+        # Bind to the subflow this node owns (by UUID); import it if it isn't
+        # loaded yet. Bind before deriving the shape so the shape reflects the
+        # live (imported) nodes.
+        subflow_name = self._resolve_subflow_name(workflow_name)
+        if subflow_name is None:
             self._reload_subflow(workflow_name)
-            subflow_name = self.metadata.get("subflow_name")
+            subflow_name = self.metadata.get(SUBFLOW_NAME_KEY)
             if not subflow_name:
                 msg = f"Failed to load subflow for workflow '{workflow_name}'."
                 self._set_status_results(was_successful=False, result_details=msg)
                 self._handle_failure_exception(RuntimeError(msg))
                 return
+        self.metadata[SUBFLOW_NAME_KEY] = subflow_name
 
         # Re-derive the shape from the freshly-imported subflow instead of
         # trusting the shape saved with the workflow. Importing renames any node

--- a/griptape_nodes_library/engine/subflow_workflow_node.py
+++ b/griptape_nodes_library/engine/subflow_workflow_node.py
@@ -119,9 +119,8 @@ class SubflowWorkflowNode(SuccessFailureNode):
         if not workflow_name:
             return
         self._update_workflow_shape_parameters(workflow_name, preserve_matching=True)
-        # Clear so _reload_subflow doesn't skip the reload for the same workflow.
-        self.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)
-        self._reload_subflow(workflow_name)
+        # Force the reload even though the workflow is unchanged.
+        self._reload_subflow(workflow_name, force_reload=True)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter == self.workflow_file:
@@ -147,17 +146,19 @@ class SubflowWorkflowNode(SuccessFailureNode):
             logger.warning(msg)
         return deps
 
-    def _reload_subflow(self, workflow_name: str) -> None:
+    def _reload_subflow(self, workflow_name: str, *, force_reload: bool = False) -> None:
         # Find the subflow this node actually owns (by UUID), never one it
         # merely shares a name with.
         owned_subflow = self._resolve_subflow_name(workflow_name)
         if owned_subflow is not None:
-            # Already own a live subflow for THIS workflow -> keep it.
-            if self.metadata.get(SUBFLOW_WORKFLOW_KEY) == workflow_name:
+            # Already own a live subflow for THIS workflow -> keep it, unless the
+            # caller forces a reload (e.g. the Refresh button re-pulling the
+            # latest definition), in which case fall through to re-import it.
+            if not force_reload and self.metadata.get(SUBFLOW_WORKFLOW_KEY) == workflow_name:
                 self.metadata[SUBFLOW_NAME_KEY] = owned_subflow
                 return
-            # Own a subflow for a DIFFERENT workflow -> tear it down before
-            # importing the new one.
+            # Own a subflow for a DIFFERENT workflow (or a forced reload) -> tear
+            # it down before importing the new one.
             GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=owned_subflow))
         self.metadata.pop(SUBFLOW_NAME_KEY, None)
         self.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)

--- a/griptape_nodes_library/engine/subflow_workflow_node.py
+++ b/griptape_nodes_library/engine/subflow_workflow_node.py
@@ -11,7 +11,12 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartLocalSubflowRequest,
     StartLocalSubflowResultFailure,
 )
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, SetFlowMetadataRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    DeleteFlowRequest,
+    GetFlowDetailsRequest,
+    GetFlowDetailsResultSuccess,
+    SetFlowMetadataRequest,
+)
 from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
@@ -214,28 +219,54 @@ class SubflowWorkflowNode(SuccessFailureNode):
         return recorded
 
     def _find_owned_subflow_name(self) -> str | None:
-        """Return the flow stamped with this node's owner UUID, or ``None``.
+        """Return the flow this node owns, or ``None``.
 
-        The authoritative node<->flow link, with no side effects. Tries the
-        recorded ``subflow_name`` first as an O(1) lookup (the common case) and
-        only scans every flow when that hint is missing or no longer points at a
-        flow we own (e.g. after de-dup / nesting renames).
+        A flow is ours per ``_is_owner_of_flow`` (our owner UUID AND parented to
+        this node's own flow). No side effects. Tries the recorded
+        ``subflow_name`` first as an O(1) hint, then scans if that no longer
+        resolves to a flow we own (e.g. after de-dup / nesting renames).
         """
-        owner_uuid = self.metadata[SUBFLOW_OWNER_KEY]
-
         # Quick path: the recorded name usually still points at the flow we own.
         recorded = self.metadata.get(SUBFLOW_NAME_KEY)
-        if recorded:
-            recorded_flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(recorded, ControlFlow)
-            if recorded_flow is not None and recorded_flow.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid:
-                return recorded
+        if recorded and self._is_owner_of_flow(recorded):
+            return recorded
 
-        # Slow path: scan every flow for this node's owner UUID.
+        # Slow path: scan for a flow we own.
         flows = GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow)
-        for candidate_name, flow in flows.items():
-            if flow.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid:
+        for candidate_name in flows:
+            if self._is_owner_of_flow(candidate_name):
                 return candidate_name
         return None
+
+    def _is_owner_of_flow(self, flow_name: str) -> bool:
+        """Whether this node owns ``flow_name``: it carries our owner UUID AND
+        is a direct child of this node's containing flow.
+
+        Both halves are required because the owner UUID alone isn't a unique key.
+        Consider:
+            - ``middle.py`` contains a Workflow node that imports ``inner.py``
+              and stamps the created flow with the node's baked UUID ``U``.
+            - ``outer.py`` contains TWO Workflow nodes that both import
+              ``middle.py``.
+        Importing the middle twice re-runs its file, so both instances' Workflow
+        nodes carry the same baked ``U`` and each stamps its own imported inner
+        flow with ``U`` — leaving two live flows stamped ``U``. Matching by UUID
+        alone is ambiguous (and can bind a node to a flow that transitively
+        contains it → infinite recursion). But a node's imported subflow is
+        always created as a direct child of the node's OWN flow, and the two
+        ``U`` flows have different parents, so ``(containing flow, UUID)`` is
+        the real primary key.
+        """
+        flow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+        if flow is None or flow.metadata.get(SUBFLOW_OWNER_KEY) != self.metadata[SUBFLOW_OWNER_KEY]:
+            return False
+        flow_for_node = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
+        if not isinstance(flow_for_node, GetFlowForNodeResultSuccess):
+            return False
+        details = GriptapeNodes.handle_request(GetFlowDetailsRequest(flow_name=flow_name))
+        if not isinstance(details, GetFlowDetailsResultSuccess):
+            return False
+        return details.parent_flow_name == flow_for_node.flow_name
 
     def _recorded_subflow_if_unclaimed(self) -> str | None:
         """Return the recorded ``subflow_name`` only if it is safe to treat as ours.

--- a/tests/integration/subflow_middle_echo.py
+++ b/tests/integration/subflow_middle_echo.py
@@ -1,0 +1,539 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "subflow_middle_echo"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.82.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"]]
+# workflows_referenced = ["subflow_inner_echo"]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-15T11:39:02.660858Z
+# last_modified_date = 2026-07-15T11:39:02.665086Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"a\":{\"name\":\"a\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"b\":{\"name\":\"b\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"out_a\":{\"name\":\"out_a\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"out_b\":{\"name\":\"out_b\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+
+# --- ADDED FOR THE INTEGRATION TEST (not emitted by the serialiser) ---
+# Used by the inner-workflow registration block inside build_workflow() below.
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    AlterParameterDetailsRequest,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    LoadWorkflowMetadata,
+    LoadWorkflowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# --- END ADDED IMPORTS ---
+
+
+# === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+async def _ensure_inner_workflow_registered() -> None:
+    """Register the co-located inner echo workflow under its bare registry key.
+
+    This middle workflow references ``subflow_inner_echo`` by its bare key TWICE (the two
+    ``ImportWorkflowAsReferencedSubFlowRequest`` calls below). When the middle is itself imported
+    as a referenced sub-flow, ``WorkflowManager.run_workflow`` execs this module and awaits
+    ``build_workflow()``, so the inner workflow must be registered here before those imports run.
+    It lives next to this file rather than in the engine workspace, so we register the bare key
+    (the stable stem the serialisation expects) against the absolute path resolved from __file__.
+    """
+    if WorkflowRegistry.has_workflow_with_name("subflow_inner_echo"):
+        return
+    inner_path = Path(__file__).parent / "subflow_inner_echo.py"
+    meta = await GriptapeNodes.ahandle_request(LoadWorkflowMetadata(file_name=str(inner_path)))
+    if not isinstance(meta, LoadWorkflowMetadataResultSuccess):
+        msg = f"Failed to load inner workflow metadata from '{inner_path}': {meta.result_details}"
+        raise RuntimeError(msg)
+    WorkflowRegistry.generate_new_workflow(
+        registry_key="subflow_inner_echo", metadata=meta.metadata, file_path=str(inner_path)
+    )
+
+
+# === END ADDED SECTION ===
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # === ADDED FOR THE INTEGRATION TEST — register the co-located inner workflow before the
+    # two ImportWorkflowAsReferencedSubFlowRequest calls (and the nodes) that reference it. ===
+    await _ensure_inner_workflow_registered()
+    # === END ADDED SECTION ===
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "a5ba7020-4296-4d1a-80c3-7944857b18c1": pickle.loads(
+            b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
+        ),
+        "280817bc-b91e-486c-9c8f-1506be65cbc1": pickle.loads(b"\x80\x04\x89."),
+        "c3aa9af3-06c1-4f1b-b618-df8c83f283d4": pickle.loads(
+            b"\x80\x04\x95\x16\x00\x00\x00\x00\x00\x00\x00\x8c\x12subflow_inner_echo\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="a",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="b",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_a",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_b",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow A",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_out", "text_in"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_2",
+                        "_subflow_workflow": "subflow_inner_echo",
+                        "subflow_owner_uuid": "94ee3e95-6ad3-4488-9e03-68a6d52a6ec1",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in", default_value="", tooltip="workflow input", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        node3_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow B",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_out", "text_in"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_3",
+                        "_subflow_workflow": "subflow_inner_echo",
+                        "subflow_owner_uuid": "020a4d8f-1a36-426f-a71b-f0e147f06b9f",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in", default_value="", tooltip="workflow input", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        # Serialiser emits `flowN_name = (await ...).created_flow_name`; the returned names are
+        # unused here (each Workflow node rebinds its own subflow by owner UUID at run time), so we
+        # keep only the side-effecting imports to satisfy ruff (F841). imported_flow_metadata carries
+        # each node's owner UUID so the recreated inner flows are stamped and can be rebound.
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(
+                workflow_name="subflow_inner_echo",
+                imported_flow_metadata={"subflow_owner_uuid": "94ee3e95-6ad3-4488-9e03-68a6d52a6ec1"},
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(
+                workflow_name="subflow_inner_echo",
+                imported_flow_metadata={"subflow_owner_uuid": "020a4d8f-1a36-426f-a71b-f0e147f06b9f"},
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="exec_out",
+                target_node_name=node3_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="a",
+                target_node_name=node2_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_a",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="b",
+                target_node_name=node3_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_b",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="a",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["a5ba7020-4296-4d1a-80c3-7944857b18c1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="b",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["a5ba7020-4296-4d1a-80c3-7944857b18c1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["280817bc-b91e-486c-9c8f-1506be65cbc1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["c3aa9af3-06c1-4f1b-b618-df8c83f283d4"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["280817bc-b91e-486c-9c8f-1506be65cbc1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["a5ba7020-4296-4d1a-80c3-7944857b18c1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["c3aa9af3-06c1-4f1b-b618-df8c83f283d4"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["280817bc-b91e-486c-9c8f-1506be65cbc1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["a5ba7020-4296-4d1a-80c3-7944857b18c1"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    parser.add_argument("--a", dest="a", default=None, help="workflow input")
+    parser.add_argument("--b", dest="b", default=None, help="workflow input")
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+        if args.a is not None:
+            flow_input["Start Flow"]["a"] = args.a
+        if args.b is not None:
+            flow_input["Start Flow"]["b"] = args.b
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/integration/subflow_middle_echo_legacy.py
+++ b/tests/integration/subflow_middle_echo_legacy.py
@@ -1,0 +1,537 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "subflow_middle_echo_legacy"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.82.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"]]
+# workflows_referenced = ["subflow_inner_echo"]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-15T16:21:56.998099Z
+# last_modified_date = 2026-07-15T16:25:41.869853Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"a\":{\"name\":\"a\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"b\":{\"name\":\"b\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"out_a\":{\"name\":\"out_a\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"out_b\":{\"name\":\"out_b\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+
+# --- ADDED FOR THE INTEGRATION TEST (not emitted by the serialiser) ---
+# Used by the inner-workflow registration block inside build_workflow() below.
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    AlterParameterDetailsRequest,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    LoadWorkflowMetadata,
+    LoadWorkflowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# --- END ADDED IMPORTS ---
+
+
+# === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+async def _ensure_inner_workflow_registered() -> None:
+    """Register the co-located inner echo workflow under its bare registry key.
+
+    This legacy middle workflow references ``subflow_inner_echo`` by its bare key TWICE (the two
+    ``ImportWorkflowAsReferencedSubFlowRequest`` calls below). When the middle is itself imported as
+    a referenced sub-flow, ``WorkflowManager.run_workflow`` execs this module and awaits
+    ``build_workflow()``, so the inner workflow must be registered here before those imports run.
+    It lives next to this file rather than in the engine workspace, so we register the bare key
+    (the stable stem the serialisation expects) against the absolute path resolved from __file__.
+    """
+    if WorkflowRegistry.has_workflow_with_name("subflow_inner_echo"):
+        return
+    inner_path = Path(__file__).parent / "subflow_inner_echo.py"
+    meta = await GriptapeNodes.ahandle_request(LoadWorkflowMetadata(file_name=str(inner_path)))
+    if not isinstance(meta, LoadWorkflowMetadataResultSuccess):
+        msg = f"Failed to load inner workflow metadata from '{inner_path}': {meta.result_details}"
+        raise RuntimeError(msg)
+    WorkflowRegistry.generate_new_workflow(
+        registry_key="subflow_inner_echo", metadata=meta.metadata, file_path=str(inner_path)
+    )
+
+
+# === END ADDED SECTION ===
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # === ADDED FOR THE INTEGRATION TEST — register the co-located inner workflow before the
+    # two ImportWorkflowAsReferencedSubFlowRequest calls (and the nodes) that reference it. ===
+    await _ensure_inner_workflow_registered()
+    # === END ADDED SECTION ===
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "360483f7-f0e3-403a-aa89-6bce19bb0b0d": pickle.loads(
+            b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
+        ),
+        "ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac": pickle.loads(b"\x80\x04\x89."),
+        "bbbefa40-853b-45f6-a60e-f0ea2defe850": pickle.loads(
+            b"\x80\x04\x95\x16\x00\x00\x00\x00\x00\x00\x00\x8c\x12subflow_inner_echo\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="a",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="b",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_a",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_b",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow A",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_in", "text_out"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_2",
+                        "_subflow_workflow": "subflow_inner_echo",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in",
+                    default_value="INNER_DEFAULT_NOT_FROM_OUTER",
+                    tooltip="workflow input",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        node3_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow B",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_in", "text_out"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_3",
+                        "_subflow_workflow": "subflow_inner_echo",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in",
+                    default_value="INNER_DEFAULT_NOT_FROM_OUTER",
+                    tooltip="workflow input",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        # Serialiser emits `flowN_name = (await ...).created_flow_name`; the returned names are unused
+        # here, so we keep only the side-effecting imports to satisfy ruff (F841). This is a LEGACY
+        # (pre-UUID) fixture: imported_flow_metadata is empty, so the recreated inner flows carry no
+        # owner UUID and the fix must bind each node by its recorded name / owner-claim path.
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name="subflow_inner_echo", imported_flow_metadata={})
+        )
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name="subflow_inner_echo", imported_flow_metadata={})
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="exec_out",
+                target_node_name=node3_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="a",
+                target_node_name=node2_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_a",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="b",
+                target_node_name=node3_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_b",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="a",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="b",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["bbbefa40-853b-45f6-a60e-f0ea2defe850"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["bbbefa40-853b-45f6-a60e-f0ea2defe850"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    parser.add_argument("--a", dest="a", default=None, help="workflow input")
+    parser.add_argument("--b", dest="b", default=None, help="workflow input")
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+        if args.a is not None:
+            flow_input["Start Flow"]["a"] = args.a
+        if args.b is not None:
+            flow_input["Start Flow"]["b"] = args.b
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/integration/test_subflow_workflow_node_legacy.py
+++ b/tests/integration/test_subflow_workflow_node_legacy.py
@@ -2,16 +2,16 @@
 # dependencies = []
 #
 # [tool.griptape-nodes]
-# name = "subflow_outer_nested"
+# name = "test_subflow_workflow_node_legacy"
 # schema_version = "0.20.0"
 # engine_version_created_with = "0.93.0"
 # node_libraries_referenced = [["Griptape Nodes Testing Library", "0.1.0"], ["Griptape Nodes Library", "0.82.0"]]
 # node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"], ["Griptape Nodes Testing Library", "AssertStrings"]]
-# workflows_referenced = ["subflow_middle_echo"]
+# workflows_referenced = ["subflow_middle_echo_legacy"]
 # is_griptape_provided = false
 # is_internal = false
-# creation_date = 2026-07-15T11:50:17.799272Z
-# last_modified_date = 2026-07-15T11:50:17.803425Z
+# creation_date = 2026-07-15T16:26:41.850456Z
+# last_modified_date = 2026-07-15T16:28:06.782714Z
 # workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"}}}}"
 #
 # ///
@@ -38,10 +38,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import (
-    AlterParameterDetailsRequest,
-    SetParameterValueRequest,
-)
+from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest, SetParameterValueRequest
 from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     LoadWorkflowMetadata,
@@ -53,26 +50,22 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 # === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
-# This test exercises a THREE-level stack: this outer workflow -> subflow_middle_echo ->
-# subflow_inner_echo (x2). It covers both subflow bugs at once:
-#   * #5134 — importing subflow_inner_echo twice into the middle (and the middle into this outer)
-#     renames colliding Start/End nodes ("Start Flow_1", ...), which the Workflow node must survive
-#     by re-deriving the shape from the live subflow.
-#   * #5116 — the middle's two Workflow nodes bake subflow_names captured when the middle was saved
-#     standalone; once nested here those names collide with the middle's own top flow, so each node
-#     must rebind to the flow it actually imported via its owner UUID rather than the stale name.
-# The middle sends distinct values down each branch (a="alpha" -> out_a, b="bravo" -> out_b); if the
-# nodes cross-bind or bind to the wrong flow, the per-branch asserts below flip or come back empty.
-_REFERENCED_WORKFLOWS = ("subflow_inner_echo", "subflow_middle_echo")
+# LEGACY variant of test_subflow_workflow_node: the same three-level stack (outer ->
+# subflow_middle_echo_legacy -> subflow_inner_echo x2) but serialised on a PRE-UUID engine, so no
+# node/flow carries a ``subflow_owner_uuid``. It proves the fix still binds nested subflows correctly
+# for workflows saved before the owner-UUID mechanism existed: on the fix branch each node establishes
+# a fresh UUID and adopts its recorded (unstamped) subflow via the legacy-claim path — no infinite
+# recursion, and the per-branch asserts (a="alpha" -> out_a, b="bravo" -> out_b) still hold.
+_REFERENCED_WORKFLOWS = ("subflow_inner_echo", "subflow_middle_echo_legacy")
 
 
 async def _ensure_referenced_workflows_registered() -> None:
     """Register the co-located referenced workflows under their bare registry keys.
 
-    The serialised outer refers to ``subflow_middle_echo`` by its bare key, which in turn refers to
-    ``subflow_inner_echo`` by its bare key. At test time neither is in the engine workspace (they
-    live next to this file), so we register both here. Called from build_workflow() (so the build-time
-    import resolves) and again after the executor is entered (entry broadcasts
+    The serialised outer refers to ``subflow_middle_echo_legacy`` by its bare key, which in turn
+    refers to ``subflow_inner_echo`` by its bare key. At test time neither is in the engine workspace
+    (they live next to this file), so we register both here. Called from build_workflow() (so the
+    build-time import resolves) and again after the executor is entered (entry broadcasts
     AppInitializationComplete -> refresh_workflow_registry -> clear_user_workflows(), which would
     otherwise drop these registrations before the flow runs in the standalone __main__ path).
     """
@@ -113,20 +106,20 @@ async def build_workflow() -> None:
     #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
     #    would be difficult to serialize.
     top_level_unique_values_dict = {
-        "cb7e1d46-5c87-4de6-a0cf-0ec1f4373ddb": pickle.loads(b"\x80\x04\x89."),
-        "e47798de-024a-4899-9937-d2f4ac9602ae": pickle.loads(
-            b"\x80\x04\x95\x17\x00\x00\x00\x00\x00\x00\x00\x8c\x13subflow_middle_echo\x94."
+        "df2be1af-e3af-4c24-85ea-6284477c3d6b": pickle.loads(b"\x80\x04\x89."),
+        "10a91064-91b5-4977-aa19-dba0d63c7333": pickle.loads(
+            b"\x80\x04\x95\x1e\x00\x00\x00\x00\x00\x00\x00\x8c\x1asubflow_middle_echo_legacy\x94."
         ),
-        "e1dfe0b3-b278-4300-b551-2428dfea6610": pickle.loads(
+        "5856d55d-72f0-42d4-8b20-ea741ff27a05": pickle.loads(
             b"\x80\x04\x95\t\x00\x00\x00\x00\x00\x00\x00\x8c\x05alpha\x94."
         ),
-        "672d0f6f-6009-4879-b1e2-035eb417bec1": pickle.loads(
+        "1b1146b1-de22-43df-a9d6-c68c86903b10": pickle.loads(
             b"\x80\x04\x95\t\x00\x00\x00\x00\x00\x00\x00\x8c\x05bravo\x94."
         ),
-        "53246268-6e99-412e-bed0-ae9a2379e7f4": pickle.loads(
+        "51750017-4791-4916-b2d5-433e606dcfae": pickle.loads(
             b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
         ),
-        "a859bf93-0101-4549-87e2-e3d0340c507b": pickle.loads(
+        "b3df0b06-0237-4202-8c45-657fe7980756": pickle.loads(
             b"\x80\x04\x95\x06\x00\x00\x00\x00\x00\x00\x00\x8c\x02==\x94."
         ),
     }
@@ -213,13 +206,12 @@ async def build_workflow() -> None:
                         "library": "Griptape Nodes Library",
                         "node_type": "SubflowWorkflowNode",
                         "workflow_node": True,
-                        "workflow_shape_params": ["a", "out_a", "out_b", "b"],
+                        "workflow_shape_params": ["out_b", "b", "a", "out_a"],
                         "left_parameters": ["a", "b"],
                         "right_parameters": ["out_a", "out_b"],
-                        "_workflow_file_value": "subflow_middle_echo",
+                        "_workflow_file_value": "subflow_middle_echo_legacy",
                         "subflow_name": "ControlFlow_2",
-                        "_subflow_workflow": "subflow_middle_echo",
-                        "subflow_owner_uuid": "778e0b2b-4770-4a59-9136-66a7a87a0c7d",
+                        "_subflow_workflow": "subflow_middle_echo_legacy",
                     },
                     initial_setup=True,
                 )
@@ -298,13 +290,12 @@ async def build_workflow() -> None:
                 )
             )
         ).node_name
-        # Serialiser emits `flow1_name = (await ...).created_flow_name`; the returned name is unused
-        # (the Workflow node rebinds its own subflow by owner UUID at run time), so we keep only the
-        # side-effecting import to satisfy ruff (F841).
+        # Serialiser emits `flow1_name = (await ...).created_flow_name`; the returned name is unused,
+        # so we keep only the side-effecting import to satisfy ruff (F841). LEGACY: imported_flow_metadata
+        # is empty (pre-UUID), so the recreated middle carries no owner UUID.
         await GriptapeNodes.ahandle_request(
             ImportWorkflowAsReferencedSubFlowRequest(
-                workflow_name="subflow_middle_echo",
-                imported_flow_metadata={"subflow_owner_uuid": "778e0b2b-4770-4a59-9136-66a7a87a0c7d"},
+                workflow_name="subflow_middle_echo_legacy", imported_flow_metadata={}
             )
         )
         await GriptapeNodes.ahandle_request(
@@ -366,7 +357,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="was_successful",
                     node_name=node1_name,
-                    value=top_level_unique_values_dict["cb7e1d46-5c87-4de6-a0cf-0ec1f4373ddb"],
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -376,7 +367,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="workflow_file",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["e47798de-024a-4899-9937-d2f4ac9602ae"],
+                    value=top_level_unique_values_dict["10a91064-91b5-4977-aa19-dba0d63c7333"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -385,7 +376,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="was_successful",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["cb7e1d46-5c87-4de6-a0cf-0ec1f4373ddb"],
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -394,7 +385,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="a",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["e1dfe0b3-b278-4300-b551-2428dfea6610"],
+                    value=top_level_unique_values_dict["5856d55d-72f0-42d4-8b20-ea741ff27a05"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -403,7 +394,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="b",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["672d0f6f-6009-4879-b1e2-035eb417bec1"],
+                    value=top_level_unique_values_dict["1b1146b1-de22-43df-a9d6-c68c86903b10"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -412,7 +403,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="out_a",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["53246268-6e99-412e-bed0-ae9a2379e7f4"],
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -421,7 +412,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="out_b",
                     node_name=node2_name,
-                    value=top_level_unique_values_dict["53246268-6e99-412e-bed0-ae9a2379e7f4"],
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -431,7 +422,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="expected",
                     node_name=node3_name,
-                    value=top_level_unique_values_dict["e1dfe0b3-b278-4300-b551-2428dfea6610"],
+                    value=top_level_unique_values_dict["5856d55d-72f0-42d4-8b20-ea741ff27a05"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -440,7 +431,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="operator",
                     node_name=node3_name,
-                    value=top_level_unique_values_dict["a859bf93-0101-4549-87e2-e3d0340c507b"],
+                    value=top_level_unique_values_dict["b3df0b06-0237-4202-8c45-657fe7980756"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -449,7 +440,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="message",
                     node_name=node3_name,
-                    value=top_level_unique_values_dict["53246268-6e99-412e-bed0-ae9a2379e7f4"],
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -458,7 +449,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="was_successful",
                     node_name=node3_name,
-                    value=top_level_unique_values_dict["cb7e1d46-5c87-4de6-a0cf-0ec1f4373ddb"],
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -468,7 +459,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="expected",
                     node_name=node4_name,
-                    value=top_level_unique_values_dict["672d0f6f-6009-4879-b1e2-035eb417bec1"],
+                    value=top_level_unique_values_dict["1b1146b1-de22-43df-a9d6-c68c86903b10"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -477,7 +468,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="operator",
                     node_name=node4_name,
-                    value=top_level_unique_values_dict["a859bf93-0101-4549-87e2-e3d0340c507b"],
+                    value=top_level_unique_values_dict["b3df0b06-0237-4202-8c45-657fe7980756"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -486,7 +477,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="message",
                     node_name=node4_name,
-                    value=top_level_unique_values_dict["53246268-6e99-412e-bed0-ae9a2379e7f4"],
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -495,7 +486,7 @@ async def build_workflow() -> None:
                 SetParameterValueRequest(
                     parameter_name="was_successful",
                     node_name=node4_name,
-                    value=top_level_unique_values_dict["cb7e1d46-5c87-4de6-a0cf-0ec1f4373ddb"],
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
                     initial_setup=True,
                     is_output=False,
                 )
@@ -533,7 +524,7 @@ async def aexecute_workflow(
         # Entering the executor broadcasts AppInitializationComplete -> refresh_workflow_registry
         # -> clear_user_workflows(), which drops the referenced workflows registered during
         # build_workflow() above. Re-register them here so the Workflow node (and the nested import
-        # inside subflow_middle_echo) can resolve them when the flow runs.
+        # inside subflow_middle_echo_legacy) can resolve them when the flow runs.
         await _ensure_referenced_workflows_registered()
         # === END ADDED SECTION ===
         await executor.arun(flow_input=input, **kwargs)

--- a/tests/unit/engine/test_subflow_workflow_node.py
+++ b/tests/unit/engine/test_subflow_workflow_node.py
@@ -25,7 +25,12 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.execution_events import StartLocalSubflowResultSuccess
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, SetFlowMetadataRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    DeleteFlowRequest,
+    GetFlowDetailsRequest,
+    GetFlowDetailsResultSuccess,
+    SetFlowMetadataRequest,
+)
 from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
 from griptape_nodes.retained_mode.events.workflow_events import (
@@ -147,9 +152,9 @@ class TestAprocessReDerivesShapeFromSubflow:
         flow_manager.get_flow_by_name.return_value = flow
         monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
 
-        # Let _set_workflow_inputs run and capture the SetParameterValueRequests it issues.
-        requests: list[Any] = []
-        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+        # Answer the resolver's topology queries (so the node binds its owned "sub") and capture the
+        # SetParameterValueRequests _set_workflow_inputs issues.
+        requests = _install_topology_handler(monkeypatch)
 
         await node.aprocess()
 
@@ -162,9 +167,13 @@ class TestAprocessReDerivesShapeFromSubflow:
         assert node.parameter_output_values["text_out"] == "world"
 
     @pytest.mark.asyncio
-    async def test_missing_shape_reports_failure(self, node: SubflowWorkflowNode, workflow_manager: Mock) -> None:
+    async def test_missing_shape_reports_failure(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch, workflow_manager: Mock
+    ) -> None:
         # extract_workflow_shape raises ValueError when the subflow has no Start/End nodes.
         workflow_manager.extract_workflow_shape.side_effect = ValueError("no start/end nodes")
+        # Let the node bind its owned "sub" so aprocess reaches the shape-extraction step.
+        _install_topology_handler(monkeypatch)
 
         # The failure output is unconnected on a bare node, so the failure re-raises.
         with pytest.raises(RuntimeError, match="has no shape defined"):
@@ -194,6 +203,146 @@ def _stub_referenced_workflow(monkeypatch: pytest.MonkeyPatch, workflow_name: st
     monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
 
 
+def _install_topology_handler(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    node_flow: str = "ParentFlow",
+    parents: dict[str, str | None] | None = None,
+    import_created_flow_name: str | None = None,
+) -> list[Any]:
+    """Install a ``handle_request`` that answers the flow-topology queries the resolver makes.
+
+    ``_is_owner_of_flow`` issues ``GetFlowForNodeRequest`` (this node's containing flow) and
+    ``GetFlowDetailsRequest`` (a candidate flow's parent) to confirm a candidate is parented to
+    this node's own flow. This handler answers both — every flow defaults to being parented to
+    ``node_flow`` (i.e. owned), unless overridden in ``parents`` (to model a sibling's flow that
+    must be skipped). It also captures every request and returns the capture list, and optionally
+    answers ``ImportWorkflowAsReferencedSubFlowRequest`` with ``import_created_flow_name``.
+    """
+    parents = parents or {}
+    requests: list[Any] = []
+
+    def _handle(request: Any) -> Any:
+        requests.append(request)
+        if isinstance(request, GetFlowForNodeRequest):
+            return GetFlowForNodeResultSuccess(flow_name=node_flow, result_details="stubbed")
+        if isinstance(request, GetFlowDetailsRequest):
+            flow_name = request.flow_name
+            parent_flow_name = parents.get(flow_name, node_flow) if flow_name is not None else node_flow
+            return GetFlowDetailsResultSuccess(
+                referenced_workflow_name="child",
+                parent_flow_name=parent_flow_name,
+                flow_type=None,
+                result_details="stubbed",
+            )
+        if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest) and import_created_flow_name is not None:
+            return ImportWorkflowAsReferencedSubFlowResultSuccess(
+                created_flow_name=import_created_flow_name, result_details="stubbed"
+            )
+        return None
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+    return requests
+
+
+def _make_subflow_node(monkeypatch: pytest.MonkeyPatch, name: str) -> SubflowWorkflowNode:
+    """Construct a ``SubflowWorkflowNode`` with the workflow dropdown stubbed (see the ``node`` fixture)."""
+    list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
+    list_result.workflow_names = ["child"]
+    monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
+    return SubflowWorkflowNode(name=name)
+
+
+def _stub_flow_topology(
+    monkeypatch: pytest.MonkeyPatch,
+    flows: dict[str, tuple[str | None, str | None]],
+    node_to_flow: dict[str, str],
+) -> None:
+    """Stub the flow graph the scoped resolver walks.
+
+    ``flows`` maps flow name -> (owner UUID or None, parent flow name or None); ``node_to_flow`` maps
+    node name -> its containing flow. Backs ObjectManager lookups plus the ``GetFlowForNodeRequest`` /
+    ``GetFlowDetailsRequest`` calls used to check whether a candidate flow is parented to the node.
+    """
+    flow_objs = {
+        name: SimpleNamespace(metadata=({SUBFLOW_OWNER_KEY: owner} if owner is not None else {}))
+        for name, (owner, _parent) in flows.items()
+    }
+    object_manager = Mock(spec=ObjectManager)
+    object_manager.get_filtered_subset.return_value = flow_objs
+    object_manager.attempt_get_object_by_name_as_type.side_effect = lambda name, _type: flow_objs.get(name)
+    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+    def _handle(request: Any) -> Any:
+        if isinstance(request, GetFlowForNodeRequest):
+            return GetFlowForNodeResultSuccess(flow_name=node_to_flow[request.node_name], result_details="stubbed")
+        if isinstance(request, GetFlowDetailsRequest):
+            flow_name = request.flow_name
+            entry = flows.get(flow_name) if flow_name is not None else None
+            parent_flow_name = entry[1] if entry is not None else None
+            return GetFlowDetailsResultSuccess(
+                referenced_workflow_name="child",
+                parent_flow_name=parent_flow_name,
+                flow_type=None,
+                result_details="stubbed",
+            )
+        return Mock()
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+
+
+class TestFindOwnedScopesByContainingFlow:
+    """``_find_owned_subflow_name`` disambiguates flows that share an owner UUID by containing flow.
+
+    Regression coverage for the nested duplicate-UUID case: a middle workflow that imports an inner
+    workflow bakes its Workflow node's owner UUID into the file. When an outer workflow imports that
+    middle TWICE, both instances' Workflow nodes carry the SAME baked UUID and each stamps its own
+    imported child flow with it — so two live flows share the UUID. Matching node<->flow by UUID alone
+    is then ambiguous; the tie-breaker is that a node's real subflow is the one parented to that
+    node's OWN containing flow.
+    """
+
+    def test_two_nested_nodes_sharing_uuid_bind_to_own_child_flows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node_a = _make_subflow_node(monkeypatch, "Workflow A")
+        node_b = _make_subflow_node(monkeypatch, "Workflow B")
+        for subflow_node in (node_a, node_b):
+            subflow_node.metadata[SUBFLOW_OWNER_KEY] = "shared-uuid"
+            subflow_node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+            # Both bake the same recorded name (from the same middle file); it resolves to A's flow.
+            subflow_node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+
+        _stub_flow_topology(
+            monkeypatch,
+            flows={
+                "ControlFlow_2": ("shared-uuid", "ParentA"),  # node A's child
+                "ControlFlow_5": ("shared-uuid", "ParentB"),  # node B's child (deduped on import)
+            },
+            node_to_flow={"Workflow A": "ParentA", "Workflow B": "ParentB"},
+        )
+
+        # Each node binds the child parented to its OWN flow — not simply the first UUID match.
+        assert node_a._find_owned_subflow_name() == "ControlFlow_2"
+        assert node_b._find_owned_subflow_name() == "ControlFlow_5"
+
+    def test_slow_scan_prefers_flow_parented_to_this_node(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No usable recorded name -> slow scan. A sibling's flow (same UUID, different parent) is
+        # scanned first; the resolver must skip it and pick the flow parented to this node.
+        node.metadata[SUBFLOW_OWNER_KEY] = "shared-uuid"
+        node.metadata.pop(SUBFLOW_NAME_KEY, None)
+        _stub_flow_topology(
+            monkeypatch,
+            flows={
+                "sibling_child": ("shared-uuid", "OtherParent"),
+                "my_child": ("shared-uuid", "MyFlow"),
+            },
+            node_to_flow={"Workflow Node": "MyFlow"},
+        )
+
+        assert node._find_owned_subflow_name() == "my_child"
+
+
 class TestResolveOwnedSubflow:
     """``_resolve_subflow_name`` binds a node to the subflow it owns via a stable owner UUID.
 
@@ -208,6 +357,7 @@ class TestResolveOwnedSubflow:
         node.metadata[SUBFLOW_OWNER_KEY] = "U1"
         node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
         _stub_flows(monkeypatch, {"ControlFlow_2": _flow("U1")})
+        _install_topology_handler(monkeypatch)
 
         assert node._resolve_subflow_name("child") == "ControlFlow_2"
 
@@ -219,6 +369,7 @@ class TestResolveOwnedSubflow:
         node.metadata[SUBFLOW_OWNER_KEY] = "U1"
         node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
         _stub_flows(monkeypatch, {"ControlFlow_2": _flow("OTHER"), "ControlFlow_3": _flow("U1")})
+        _install_topology_handler(monkeypatch)
 
         assert node._resolve_subflow_name("child") == "ControlFlow_3"
 
@@ -227,6 +378,7 @@ class TestResolveOwnedSubflow:
     ) -> None:
         # Same recorded name, different owner UUIDs -> each node resolves to its own flow.
         _stub_flows(monkeypatch, {"ControlFlow_2": _flow("U1"), "ControlFlow_3": _flow("U2")})
+        _install_topology_handler(monkeypatch)
         node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
 
         node.metadata[SUBFLOW_OWNER_KEY] = "U1"
@@ -369,8 +521,7 @@ class TestAfterNodeDeleted:
         node.metadata[SUBFLOW_OWNER_KEY] = "U1"
         node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
         _stub_flows(monkeypatch, {"ControlFlow_2": _flow("OTHER"), "ControlFlow_5": _flow("U1")})
-        requests: list[Any] = []
-        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+        requests = _install_topology_handler(monkeypatch)
 
         node.after_node_deleted()
 
@@ -439,20 +590,7 @@ class TestOnRefreshWorkflow:
         monkeypatch.setattr(node, "_update_workflow_shape_parameters", lambda *args, **kwargs: None)
         monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
         _stub_flows(monkeypatch, {"ControlFlow_2": _flow("owner-sub")})
-
-        requests: list[Any] = []
-
-        def _handle(request: Any) -> Any:
-            requests.append(request)
-            if isinstance(request, GetFlowForNodeRequest):
-                return GetFlowForNodeResultSuccess(flow_name="ParentFlow", result_details="stubbed")
-            if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest):
-                return ImportWorkflowAsReferencedSubFlowResultSuccess(
-                    created_flow_name="ControlFlow_9", result_details="stubbed"
-                )
-            return Mock()
-
-        monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+        requests = _install_topology_handler(monkeypatch, import_created_flow_name="ControlFlow_9")
 
         node._on_refresh_workflow(Mock(), Mock())
 

--- a/tests/unit/engine/test_subflow_workflow_node.py
+++ b/tests/unit/engine/test_subflow_workflow_node.py
@@ -462,6 +462,43 @@ class TestOnRefreshWorkflow:
         assert any(isinstance(r, ImportWorkflowAsReferencedSubFlowRequest) for r in requests)
         assert node.metadata[SUBFLOW_NAME_KEY] == "ControlFlow_9"
 
+    def test_forces_reload_of_unclaimed_legacy_workflow_deletes_old_flow(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Legacy node: the recorded flow exists but was never UUID-stamped (pre-UUID save, never
+        # executed), so it resolves only via the legacy path, which needs SUBFLOW_WORKFLOW_KEY.
+        # Refresh must adopt-and-delete the old flow, then re-import — not orphan it. Regression for
+        # the bug where refresh popped SUBFLOW_WORKFLOW_KEY, blinding the legacy resolver so the old
+        # flow leaked (a fresh flow imported while the original was left behind).
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"  # the node has a UUID, but its flow does NOT (legacy)
+        node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+        monkeypatch.setattr(node, "_update_workflow_shape_parameters", lambda *args, **kwargs: None)
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow(None)})  # unclaimed legacy flow
+        _stub_referenced_workflow(monkeypatch, "child")  # it does reference the expected workflow
+
+        requests: list[Any] = []
+
+        def _handle(request: Any) -> Any:
+            requests.append(request)
+            if isinstance(request, GetFlowForNodeRequest):
+                return GetFlowForNodeResultSuccess(flow_name="ParentFlow", result_details="stubbed")
+            if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest):
+                return ImportWorkflowAsReferencedSubFlowResultSuccess(
+                    created_flow_name="ControlFlow_9", result_details="stubbed"
+                )
+            return Mock()
+
+        monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+
+        node._on_refresh_workflow(Mock(), Mock())
+
+        # The old legacy flow was torn down (not orphaned) and a fresh one imported.
+        assert "ControlFlow_2" in [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)]
+        assert any(isinstance(r, ImportWorkflowAsReferencedSubFlowRequest) for r in requests)
+        assert node.metadata[SUBFLOW_NAME_KEY] == "ControlFlow_9"
+
     def test_noop_when_no_workflow_selected(self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch) -> None:
         # No workflow selected -> refresh is a no-op (stub the getter to avoid after_value_set churn).
         monkeypatch.setattr(node, "get_parameter_value", lambda name: "" if name == "workflow_file" else None)

--- a/tests/unit/engine/test_subflow_workflow_node.py
+++ b/tests/unit/engine/test_subflow_workflow_node.py
@@ -15,6 +15,7 @@ without a shape fails with a clear message.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
@@ -24,14 +25,25 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.execution_events import StartLocalSubflowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, SetFlowMetadataRequest
+from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.events.workflow_events import ListCallableWorkflowsResultSuccess
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
+    ListCallableWorkflowsResultSuccess,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
 from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
 from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-from griptape_nodes_library.engine.subflow_workflow_node import SubflowWorkflowNode
+from griptape_nodes_library.engine.subflow_workflow_node import (
+    SUBFLOW_NAME_KEY,
+    SUBFLOW_OWNER_KEY,
+    SUBFLOW_WORKFLOW_KEY,
+    SubflowWorkflowNode,
+)
 
 
 @pytest.fixture
@@ -51,8 +63,9 @@ def node(monkeypatch: pytest.MonkeyPatch) -> SubflowWorkflowNode:
     list_result.workflow_names = ["child"]
     monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
     node = SubflowWorkflowNode(name="Workflow Node")
-    # Pretend the child's subflow has already been imported.
-    node.metadata["subflow_name"] = "sub"
+    # Pretend the child's subflow has already been imported and this node owns it.
+    node.metadata[SUBFLOW_NAME_KEY] = "sub"
+    node.metadata[SUBFLOW_OWNER_KEY] = "owner-sub"
     return node
 
 
@@ -76,7 +89,11 @@ def workflow_manager(monkeypatch: pytest.MonkeyPatch, shape_param: dict[str, Any
     )
 
     object_manager = Mock(spec=ObjectManager)
-    object_manager.get_filtered_subset.return_value = {"sub": object()}  # subflow already loaded
+    # The loaded subflow carries the node's owner UUID so the quick-path resolver binds to it
+    # without any legacy-claim side effects.
+    loaded_flows = {"sub": SimpleNamespace(metadata={SUBFLOW_OWNER_KEY: "owner-sub"})}
+    object_manager.get_filtered_subset.return_value = loaded_flows
+    object_manager.attempt_get_object_by_name_as_type.side_effect = lambda name, _type: loaded_flows.get(name)
     monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
 
     manager = Mock(spec=WorkflowManager)
@@ -152,3 +169,305 @@ class TestAprocessReDerivesShapeFromSubflow:
         # The failure output is unconnected on a bare node, so the failure re-raises.
         with pytest.raises(RuntimeError, match="has no shape defined"):
             await node.aprocess()
+
+
+def _flow(owner_uuid: str | None = None) -> SimpleNamespace:
+    """A stand-in ``ControlFlow`` exposing only the ``.metadata`` dict the resolver reads."""
+    metadata: dict[str, Any] = {}
+    if owner_uuid is not None:
+        metadata[SUBFLOW_OWNER_KEY] = owner_uuid
+    return SimpleNamespace(metadata=metadata)
+
+
+def _stub_flows(monkeypatch: pytest.MonkeyPatch, flows: dict[str, Any]) -> None:
+    """Back both the O(1) name lookup and the full scan with a fixed name -> flow mapping."""
+    object_manager = Mock(spec=ObjectManager)
+    object_manager.get_filtered_subset.return_value = flows
+    object_manager.attempt_get_object_by_name_as_type.side_effect = lambda name, _type: flows.get(name)
+    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+
+def _stub_referenced_workflow(monkeypatch: pytest.MonkeyPatch, workflow_name: str | None) -> None:
+    """Make ``FlowManager.get_referenced_workflow_name`` report the workflow any flow was imported from."""
+    flow_manager = Mock(spec=FlowManager)
+    flow_manager.get_referenced_workflow_name.return_value = workflow_name
+    monkeypatch.setattr(GriptapeNodes, "FlowManager", lambda: flow_manager)
+
+
+class TestResolveOwnedSubflow:
+    """``_resolve_subflow_name`` binds a node to the subflow it owns via a stable owner UUID.
+
+    Regression coverage for issue #5116: two Workflow nodes referencing the same child workflow
+    (or a nested Workflow node whose ``subflow_name`` was de-duplicated / shifted on import) must
+    each bind to their OWN imported subflow rather than colliding on a shared/stale ``subflow_name``.
+    """
+
+    def test_quick_path_returns_recorded_name_when_uuid_matches(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("U1")})
+
+        assert node._resolve_subflow_name("child") == "ControlFlow_2"
+
+    def test_slow_path_finds_flow_by_uuid_when_recorded_name_is_stale(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ``subflow_name`` points at a flow owned by a DIFFERENT node (names shifted on nested
+        # import); the resolver must scan by UUID and return the flow this node actually owns.
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("OTHER"), "ControlFlow_3": _flow("U1")})
+
+        assert node._resolve_subflow_name("child") == "ControlFlow_3"
+
+    def test_two_nodes_same_workflow_bind_to_distinct_flows(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same recorded name, different owner UUIDs -> each node resolves to its own flow.
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("U1"), "ControlFlow_3": _flow("U2")})
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        assert node._resolve_subflow_name("child") == "ControlFlow_2"
+
+        node.metadata[SUBFLOW_OWNER_KEY] = "U2"
+        assert node._resolve_subflow_name("child") == "ControlFlow_3"
+
+    def test_returns_none_when_no_owned_flow_exists(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("OTHER")})
+
+        assert node._resolve_subflow_name("child") is None
+
+    def test_legacy_flow_without_uuid_is_claimed_and_warns(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Pre-UUID workflow: the node carries an owner UUID (established in __init__) but the recorded
+        # flow, recreated from pre-UUID saved data, has none. The recorded flow genuinely references
+        # the workflow this node expects, so the node claims it by stamping its own UUID, and warns.
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+        owner_uuid = node.metadata[SUBFLOW_OWNER_KEY]
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow(None)})
+        _stub_referenced_workflow(monkeypatch, "child")  # recorded flow references the expected workflow
+
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = node._resolve_subflow_name("child")
+
+        assert result == "ControlFlow_2"
+        # The node's owner UUID was stamped onto the claimed flow.
+        stamp_requests = [r for r in requests if isinstance(r, SetFlowMetadataRequest)]
+        assert any(
+            r.flow_name == "ControlFlow_2" and r.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid for r in stamp_requests
+        ), f"legacy flow was not stamped with the node's owner UUID; requests={stamp_requests}"
+        # ...and a loud warning was emitted.
+        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
+
+    def test_legacy_flow_referencing_other_workflow_is_not_adopted(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The recorded name resolves to an unclaimed flow, but that flow was imported from a DIFFERENT
+        # referenced workflow (e.g. a nested node whose stale name now points at a sibling/parent
+        # subflow). Without a UUID to disambiguate, the workflow-reference check must reject it so we
+        # never adopt the wrong subflow — regardless of execution order.
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow(None)})
+        _stub_referenced_workflow(monkeypatch, "some_other_workflow")
+
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        assert node._resolve_subflow_name("child") is None
+        # Nothing was claimed/stamped.
+        assert not [r for r in requests if isinstance(r, SetFlowMetadataRequest)]
+
+    def test_recorded_flow_without_expected_workflow_is_not_adopted(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Defensive: SUBFLOW_NAME_KEY and SUBFLOW_WORKFLOW_KEY are always written together, so a
+        # recorded name with no expected workflow is inconsistent state -> never adopt it.
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow(None)})
+
+        assert node._resolve_subflow_name("child") is None
+
+
+class TestReloadStampsOwnerUuid:
+    """``_reload_subflow`` mirrors the node's (already-established) owner UUID onto the imported flow."""
+
+    def test_import_stamps_owner_uuid_on_created_flow(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        # No subflow owned yet: the resolver called at the top of _reload_subflow finds nothing. The
+        # node's owner UUID was established in __init__ and must be reused (not regenerated).
+        node.metadata.pop(SUBFLOW_NAME_KEY, None)
+        owner_uuid = node.metadata[SUBFLOW_OWNER_KEY]
+        _stub_flows(monkeypatch, {})
+
+        requests: list[Any] = []
+
+        def _handle(request: Any) -> Any:
+            requests.append(request)
+            if isinstance(request, GetFlowForNodeRequest):
+                return GetFlowForNodeResultSuccess(flow_name="ParentFlow", result_details="stubbed")
+            if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest):
+                return ImportWorkflowAsReferencedSubFlowResultSuccess(
+                    created_flow_name="ControlFlow_2", result_details="stubbed"
+                )
+            return Mock()
+
+        monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+
+        node._reload_subflow("child")
+
+        # The owner UUID is unchanged (reused from __init__), and the created flow was stamped with it.
+        assert node.metadata[SUBFLOW_OWNER_KEY] == owner_uuid
+        assert node.metadata.get(SUBFLOW_NAME_KEY) == "ControlFlow_2"
+        stamp_requests = [r for r in requests if isinstance(r, SetFlowMetadataRequest)]
+        assert any(
+            r.flow_name == "ControlFlow_2" and r.metadata.get(SUBFLOW_OWNER_KEY) == owner_uuid for r in stamp_requests
+        ), f"created flow was not stamped with the node's owner UUID; requests={stamp_requests}"
+
+
+class TestInitEstablishesOwnerUuid:
+    """``__init__`` gives every node a stable owner UUID up front (generated once, preserved on load)."""
+
+    @staticmethod
+    def _make_node(monkeypatch: pytest.MonkeyPatch, metadata: dict[str, Any] | None = None) -> SubflowWorkflowNode:
+        list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
+        list_result.workflow_names = ["child"]
+        monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
+        return SubflowWorkflowNode(name="Workflow Node", metadata=metadata)
+
+    def test_generates_owner_uuid_for_new_node(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = self._make_node(monkeypatch)
+        assert node.metadata.get(SUBFLOW_OWNER_KEY)
+
+    def test_preserves_owner_uuid_from_saved_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = self._make_node(monkeypatch, {SUBFLOW_OWNER_KEY: "baked-uuid"})
+        assert node.metadata[SUBFLOW_OWNER_KEY] == "baked-uuid"
+
+
+class TestAfterNodeDeleted:
+    """Deleting the node cleans up the flow it OWNS (by UUID), never a stale-named flow."""
+
+    def test_deletes_owned_flow_not_stale_recorded_name(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # subflow_name is stale (points at another node's flow); the owned flow is elsewhere by UUID.
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("OTHER"), "ControlFlow_5": _flow("U1")})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node.after_node_deleted()
+
+        deleted = [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)]
+        assert deleted == ["ControlFlow_5"]
+
+    def test_does_not_delete_flow_owned_by_another_node(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"  # stale: owned by U2, and no U1 flow exists
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("U2")})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node.after_node_deleted()
+
+        assert not [r for r in requests if isinstance(r, DeleteFlowRequest)]
+
+    def test_does_not_delete_unowned_recorded_flow(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A recorded flow with no owner UUID is NOT deleted on node deletion: without a UUID match we
+        # can't prove it's ours, and a None owned-lookup can mean "our subflow was legitimately
+        # deleted" (its name possibly reused) rather than "we're a legacy node". Deleting by name
+        # would risk destroying an unrelated flow, so we leave it (parent-flow teardown cleans it up).
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow(None)})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node.after_node_deleted()
+
+        assert not [r for r in requests if isinstance(r, DeleteFlowRequest)]
+
+    def test_no_delete_when_owned_flow_already_gone(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node.metadata[SUBFLOW_OWNER_KEY] = "U1"
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"  # already deleted (parent-flow teardown)
+        _stub_flows(monkeypatch, {})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node.after_node_deleted()
+
+        assert not [r for r in requests if isinstance(r, DeleteFlowRequest)]
+
+
+class TestOnRefreshWorkflow:
+    """The Refresh button re-imports the child workflow even when the selection hasn't changed."""
+
+    def test_forces_reload_of_already_loaded_workflow(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Arrange the exact state in which _reload_subflow would normally SKIP: the node already owns a
+        # live subflow for the selected workflow (SUBFLOW_WORKFLOW_KEY == workflow_file, which the
+        # fixture defaults to "child"). Refresh must still tear it down and re-import, proving it
+        # forced the reload.
+        node.metadata[SUBFLOW_NAME_KEY] = "ControlFlow_2"
+        node.metadata[SUBFLOW_OWNER_KEY] = "owner-sub"
+        node.metadata[SUBFLOW_WORKFLOW_KEY] = "child"
+        # Shape-parameter maintenance is orthogonal to the reload; isolate it.
+        monkeypatch.setattr(node, "_update_workflow_shape_parameters", lambda *args, **kwargs: None)
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        _stub_flows(monkeypatch, {"ControlFlow_2": _flow("owner-sub")})
+
+        requests: list[Any] = []
+
+        def _handle(request: Any) -> Any:
+            requests.append(request)
+            if isinstance(request, GetFlowForNodeRequest):
+                return GetFlowForNodeResultSuccess(flow_name="ParentFlow", result_details="stubbed")
+            if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest):
+                return ImportWorkflowAsReferencedSubFlowResultSuccess(
+                    created_flow_name="ControlFlow_9", result_details="stubbed"
+                )
+            return Mock()
+
+        monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+
+        node._on_refresh_workflow(Mock(), Mock())
+
+        # The previously-owned subflow was deleted and a fresh one imported (neither would happen if
+        # the reload had been skipped for the unchanged workflow).
+        assert "ControlFlow_2" in [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)]
+        assert any(isinstance(r, ImportWorkflowAsReferencedSubFlowRequest) for r in requests)
+        assert node.metadata[SUBFLOW_NAME_KEY] == "ControlFlow_9"
+
+    def test_noop_when_no_workflow_selected(self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No workflow selected -> refresh is a no-op (stub the getter to avoid after_value_set churn).
+        monkeypatch.setattr(node, "get_parameter_value", lambda name: "" if name == "workflow_file" else None)
+        reload_calls: list[str] = []
+        monkeypatch.setattr(node, "_reload_subflow", lambda workflow_name: reload_calls.append(workflow_name))
+
+        node._on_refresh_workflow(Mock(), Mock())
+
+        assert reload_calls == []


### PR DESCRIPTION
Closes #466.

Nodes are grouped into flows. Flows are uniquely identified by their name (distinct from node names). These flow names can change due to de-duplication when loading a workflow file.

In particular the SubflowWorkflowNode node loads a flow and its nodes from an external workflow file, and if the external workflow file happens to have a flow whose name conflicts with another (the parent or another previously loaded flow), then it is renamed. An external workflow file can itself have SubflowWorkflowNode nodes, adding a cascade of renames during the deserialisation process.

Therefore, flow names are unstable identifiers. The SubflowWorkflowNode made the mistake of assuming the flow it is associated with could be stably identified by its name, and so baked in a fixed flow name into the node's metadata.

This could manifest as the subflow not being found, or the wrong subflow being used, infinite recursion, and deletion of the wrong subflow when the node is deleted.

So add a UUID to all new SubflowWorkflowNode nodes, and stamp that UUID on the flow loaded from its associated workflow file. Store the UUID in node/flow metadata so that is survives serialisation. Use the UUID to disambiguate subflow name collisions and search through available flows as a fallback.

Make a best effort to support workflows saved before these UUIDs were introduced, by claiming an available matching subflow by name if the flow is not already claimed by UUID and the flow has an association with the expected workflow file. I.e. equivalent to what we used to do, with the added protection of ensuring two SubflowWorkflowNodes cannot claim the same flow and that the flow came from the correct workflow file.

Update the test_subflow_workflow_node.py e2e workflow test introduced in #460 to have a middle workflow layer that holds 2x SubflowWorkflowNodes that both reference the same "echo" workflow. This is a minimal simulation of the original issue, whilst maintaining coverage of the fix in #460.

Add a duplicate e2e workflow test to the above, but created before this fix was introduced (i.e. so no serialised UUIDs), to test the legacy fallback path. Tag these tests with a `_legacy` suffix.