### PR TITLE
fix(subflow): don't serialize subflow import command

### DIFF
--- a/griptape_nodes_library/engine/subflow_workflow_node.py
+++ b/griptape_nodes_library/engine/subflow_workflow_node.py
@@ -10,7 +10,14 @@ from griptape_nodes.retained_mode.events.execution_events import (
     StartLocalSubflowRequest,
     StartLocalSubflowResultFailure,
 )
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    DeleteFlowRequest,
+    GetFlowDetailsRequest,
+    GetFlowDetailsResultSuccess,
+    GetFlowMetadataRequest,
+    GetFlowMetadataResultSuccess,
+    SetFlowMetadataRequest,
+)
 from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
@@ -28,14 +35,39 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
+# Flow-metadata flag marking a subflow as a runtime-only artifact the engine
+# must never serialize. The node (re)imports its subflow at execution time, so
+# it should never round-trip through a save.
+TRANSIENT_KEY = "transient"
+
+# Legacy (pre-transient) node metadata: the recorded name of the baked child
+# subflow (may be stale after a de-dup rename on import) and the workflow it was
+# imported from. Only present on workflows saved before the transient scheme;
+# used solely to migrate them (see _claim_legacy_serialised_flow).
+SUBFLOW_NAME_KEY = "subflow_name"
+SUBFLOW_WORKFLOW_KEY = "_subflow_workflow"
+
 
 class SubflowWorkflowNode(SuccessFailureNode):
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
+
+        # The imported subflow is a transient, execution-time artifact tracked
+        # via a runtime ``subflow_name`` metadata hint (see _load_subflow). The
+        # subflow itself is never serialized, so any ``subflow_name`` present at
+        # load time is stale; or worse, in the case of copy-paste it belongs to
+        # another node.
+        #
+        # Use the defunct ``_subflow_workflow`` metadata as a signal that the
+        # node was restored from a legacy saved workflow. Keep track of both keys
+        # to help us claim the legacy baked subflow and migrate it.
+        self._legacy_workflow: str | None = self.metadata.pop(SUBFLOW_WORKFLOW_KEY, None)
+        recorded_subflow_name = self.metadata.pop(SUBFLOW_NAME_KEY, None)
+        self._legacy_flow_name: str | None = recorded_subflow_name if self._legacy_workflow else None
+
         result = GriptapeNodes.handle_request(ListCallableWorkflowsRequest())
         if isinstance(result, ListCallableWorkflowsResultSuccess):
-            # Add pyright ignore here becuase we know ListCallableWOrkflowsResultSuccess reutrns workflow_names
-            workflow_names = result.workflow_names  # pyright: ignore[reportAttributeAccessIssue]
+            workflow_names = result.workflow_names
             choices = workflow_names
         else:
             workflow_names = []
@@ -76,22 +108,17 @@ class SubflowWorkflowNode(SuccessFailureNode):
         self._create_status_parameters()
 
     def after_node_deleted(self) -> None:
-        subflow_name = self.metadata.get("subflow_name")
-        if subflow_name is not None:
-            # The subflow may have already been deleted if the parent flow was deleted first
-            # (parent flow deletion deletes child flows before nodes).
-            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
-            if subflow is not None:
-                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+        # Tear down the transient subflow we imported (if it is still live).
+        self._discard_subflow()
 
     def _on_refresh_workflow(self, button: Button, button_details: ButtonDetailsMessagePayload) -> None:  # noqa: ARG002
         workflow_name = self.get_parameter_value("workflow_file")
         if not workflow_name:
             return
         self._update_workflow_shape_parameters(workflow_name, preserve_matching=True)
-        # Clear so _reload_subflow doesn't skip the reload for the same workflow.
-        self.metadata.pop("_subflow_workflow", None)
-        self._reload_subflow(workflow_name)
+        # Drop the live subflow so the next execution re-imports the latest
+        # workflow definition.
+        self._discard_subflow()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter == self.workflow_file:
@@ -102,7 +129,9 @@ class SubflowWorkflowNode(SuccessFailureNode):
             if value != current:
                 self._update_workflow_shape_parameters(value)
                 self.metadata["_workflow_file_value"] = value
-                self._reload_subflow(value)
+                # The selection changed; drop the old subflow so the next
+                # execution imports the new one.
+                self._discard_subflow()
         super().after_value_set(parameter, value)
 
     def get_node_dependencies(self) -> NodeDependencies | None:
@@ -117,33 +146,167 @@ class SubflowWorkflowNode(SuccessFailureNode):
             logger.warning(msg)
         return deps
 
-    def _reload_subflow(self, workflow_name: str) -> None:
-        existing_subflow = self.metadata.get("subflow_name")
-        if existing_subflow:
-            existing_flow_names = set(GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow).keys())
-            # Skip if this workflow is already loaded and the flow still exists.
-            if self.metadata.get("_subflow_workflow") == workflow_name and existing_subflow in existing_flow_names:
-                return
-            # Only delete if the flow still exists (it may be stale from a previous session).
-            if existing_subflow in existing_flow_names:
-                GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=existing_subflow))
-            del self.metadata["subflow_name"]
-            self.metadata.pop("_subflow_workflow", None)
+    def _load_subflow(self, workflow_name: str) -> str | None:
+        """Import ``workflow_name`` as a transient child subflow and return its
+        name (``None`` on failure).
+
+        Reuses the subflow already imported by this node if it is still live.
+        The created flow is flagged ``transient`` so the engine never serializes
+        it — the node re-imports it at execution time, which keeps the
+        node<->subflow link out of the saved workflow, preventing a whole class
+        of serialization issues with flow name de-duplication.
+
+        The live subflow name is stored in ``metadata[SUBFLOW_NAME_KEY]``. It
+        serves purely as a runtime hint the editor reads to show the in-memory
+        subflow ("View Subflow" button); it is popped again on the next load.
+        """
+        # Reuse the subflow we already imported, if it still exists.
+        tracked = self.metadata.get(SUBFLOW_NAME_KEY)
+        if tracked is not None:
+            existing = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(tracked, ControlFlow)
+            if existing is not None:
+                return tracked
+            # It was torn down out from under us (e.g. parent-flow deletion);
+            # drop the stale hint.
+            self.metadata.pop(SUBFLOW_NAME_KEY, None)
 
         if not workflow_name or not WorkflowRegistry.has_workflow_with_name(workflow_name):
-            return
+            return None
 
-        # Resolve the parent flow for this node so the import knows where to create the subflow.
+        # Migrate a legacy baked subflow on first use (adopt it instead of
+        # importing a duplicate).
+        # Defensively check that we're loading the workflow_name corresponding
+        # to the legacy workflow, but technically not necessary since changing
+        # the dropdown will trigger after_value_set(), which will adopt and
+        # discard the legacy flow before we get here.
+        if self._legacy_workflow == workflow_name:
+            legacy_subflow = self._claim_legacy_serialised_flow()
+            if legacy_subflow is not None:
+                self.metadata[SUBFLOW_NAME_KEY] = legacy_subflow
+                return legacy_subflow
+
+        # Resolve the parent flow for this node so the import knows where to
+        # create the subflow.
         flow_result = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
         if not isinstance(flow_result, GetFlowForNodeResultSuccess):
-            return
+            return None
 
         result = GriptapeNodes.handle_request(
-            ImportWorkflowAsReferencedSubFlowRequest(workflow_name=workflow_name, flow_name=flow_result.flow_name)
+            ImportWorkflowAsReferencedSubFlowRequest(
+                workflow_name=workflow_name,
+                flow_name=flow_result.flow_name,
+                # Flag as transient so the flow is not serialized on save.
+                imported_flow_metadata={TRANSIENT_KEY: True},
+            )
         )
-        if isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess):
-            self.metadata["subflow_name"] = result.created_flow_name
-            self.metadata["_subflow_workflow"] = workflow_name
+        if not isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess):
+            return None
+        self.metadata[SUBFLOW_NAME_KEY] = result.created_flow_name
+        return result.created_flow_name
+
+    def _discard_subflow(self) -> None:
+        """Delete the subflow this node owns, if it is still live, and stop
+        tracking it.
+
+        A legacy node loaded but never executed has no tracked subflow yet;
+        adopt its baked flow first so it is torn down rather than leaked.
+        """
+        tracked = self.metadata.get(SUBFLOW_NAME_KEY)
+        if tracked is None:
+            tracked = self._claim_legacy_serialised_flow()
+        if tracked is None:
+            return
+        subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(tracked, ControlFlow)
+        if subflow is not None:
+            GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=tracked))
+        self.metadata.pop(SUBFLOW_NAME_KEY, None)
+
+    def _claim_legacy_serialised_flow(self) -> str | None:
+        """Adopt this node's legacy baked subflow and flag it ``transient``.
+
+        Workflows saved before the `"transient"` metadata was added serialize
+        the subflow as a baked ``ImportWorkflowAsReferencedSubFlowRequest`` that
+        recreates a persistent child flow at load, recording its (possibly
+        incorrect due to de-duping) name and source workflow in metadata. That
+        pair is lifted into ``self._legacy_flow_name`` /
+        ``self._legacy_workflow`` at load (see ``__init__``). Migration adopts
+        that flow as this node's live subflow and marks it ``transient`` so it
+        is never persisted again — after which a re-save is clean new-scheme.
+
+        Returns the adopted flow name, or ``None`` when this node has no
+        un-migrated legacy subflow — including every native new-scheme node,
+        which carries no legacy workflow marker.
+        """
+        if not self._legacy_workflow:
+            return None
+
+        # A node's subflow is always a direct child of the node's own flow.
+        # Resolve that flow once so both the recorded-name and scan paths can
+        # require the candidate to be parented to it.
+        flow_result = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
+        if not isinstance(flow_result, GetFlowForNodeResultSuccess):
+            return None
+        containing_flow = flow_result.flow_name
+
+        # Fast path: the recorded name, when it was not renamed on import.
+        claimed = self._claim_flow_if_legacy(self._legacy_flow_name, self._legacy_workflow, containing_flow)
+        # Fallback: the recorded name went stale (de-dup rename) -> scan this
+        # node's own child flows.
+        if claimed is None:
+            claimed = self._scan_for_and_claim_legacy_flow(self._legacy_workflow, containing_flow)
+
+        if claimed is not None:
+            logger.warning(
+                "%s (%s): claiming legacy serialised sub-flow '%s'. This claim might be incorrect in complex graphs"
+                " with nested workflows where flow name de-duplication has occurred. Save and reload the parent"
+                " workflow so that child workflows load just-in-time instead, avoiding this problem.",
+                self.name,
+                self._legacy_workflow,
+                claimed,
+            )
+            # Migrated: forget the legacy markers so a re-claim is a no-op.
+            self._legacy_workflow = None
+            self._legacy_flow_name = None
+
+        return claimed
+
+    def _claim_flow_if_legacy(self, flow_name: str | None, expected_workflow: str, containing_flow: str) -> str | None:
+        """Return ``flow_name`` (after flagging it ``transient``) iff it is an
+        un-migrated legacy import of ``expected_workflow`` parented to
+        ``containing_flow`` (this node's own flow)."""
+        if not flow_name:
+            return None
+        metadata_result = GriptapeNodes.handle_request(GetFlowMetadataRequest(flow_name=flow_name))
+        if not isinstance(metadata_result, GetFlowMetadataResultSuccess):
+            # Flow not found.
+            return None
+        if metadata_result.metadata.get(TRANSIENT_KEY):
+            # Already claimed.
+            return None
+        details = GriptapeNodes.handle_request(GetFlowDetailsRequest(flow_name=flow_name))
+        if not isinstance(details, GetFlowDetailsResultSuccess):
+            return None
+        if details.parent_flow_name != containing_flow:
+            # Wrong parent. Likely due to flow name de-duping.
+            return None
+        if details.referenced_workflow_name != expected_workflow:
+            # Wrong workflow file. Again, likely due to flow name de-duping.
+            return None
+        # Tag as transient so that (a) the flow will no longer be serialised;
+        # and (b) another SubflowWorkflowNode will not try to claim it.
+        self._mark_flow_transient(flow_name)
+        return flow_name
+
+    def _scan_for_and_claim_legacy_flow(self, expected_workflow: str, containing_flow: str) -> str | None:
+        """Find and claim an un-migrated legacy import of ``expected_workflow``
+        among this node's own child flows."""
+        for candidate_name in GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow):
+            if self._claim_flow_if_legacy(candidate_name, expected_workflow, containing_flow) is not None:
+                return candidate_name
+        return None
+
+    def _mark_flow_transient(self, flow_name: str) -> None:
+        GriptapeNodes.handle_request(SetFlowMetadataRequest(flow_name=flow_name, metadata={TRANSIENT_KEY: True}))
 
     def _create_shape_parameter(
         self, param_name: str, param_dict: dict, allowed_modes: set[ParameterMode]
@@ -264,18 +427,14 @@ class SubflowWorkflowNode(SuccessFailureNode):
             self._handle_failure_exception(RuntimeError(msg))
             return
 
-        # Use the pre-loaded subflow if available; otherwise load it now. Load it before
-        # deriving the shape so the shape reflects the live (imported) nodes.
-        existing_flow_names = set(GriptapeNodes.ObjectManager().get_filtered_subset(type=ControlFlow).keys())
-        subflow_name = self.metadata.get("subflow_name")
-        if not subflow_name or subflow_name not in existing_flow_names:
-            self._reload_subflow(workflow_name)
-            subflow_name = self.metadata.get("subflow_name")
-            if not subflow_name:
-                msg = f"Failed to load subflow for workflow '{workflow_name}'."
-                self._set_status_results(was_successful=False, result_details=msg)
-                self._handle_failure_exception(RuntimeError(msg))
-                return
+        # Import the subflow now (execution time), reusing it if this node already has one live.
+        # Load it before deriving the shape so the shape reflects the live (imported) nodes.
+        subflow_name = self._load_subflow(workflow_name)
+        if subflow_name is None:
+            msg = f"Failed to load subflow for workflow '{workflow_name}'."
+            self._set_status_results(was_successful=False, result_details=msg)
+            self._handle_failure_exception(RuntimeError(msg))
+            return
 
         # Re-derive the shape from the freshly-imported subflow instead of
         # trusting the shape saved with the workflow. Importing renames any node

--- a/tests/integration/subflow_middle_echo_legacy.py
+++ b/tests/integration/subflow_middle_echo_legacy.py
@@ -1,0 +1,537 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "subflow_middle_echo_legacy"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.82.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"]]
+# workflows_referenced = ["subflow_inner_echo"]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-15T16:21:56.998099Z
+# last_modified_date = 2026-07-15T16:25:41.869853Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"a\":{\"name\":\"a\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"b\":{\"name\":\"b\",\"tooltip\":\"workflow input\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"out_a\":{\"name\":\"out_a\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null},\"out_b\":{\"name\":\"out_b\",\"tooltip\":\"workflow output\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":\"\",\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":true,\"mode_allowed_output\":true,\"ui_options\":{\"is_custom\":true,\"is_user_added\":true},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":\"\",\"parent_element_name\":null}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+
+# --- ADDED FOR THE INTEGRATION TEST (not emitted by the serialiser) ---
+# Used by the inner-workflow registration block inside build_workflow() below.
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    AlterParameterDetailsRequest,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    LoadWorkflowMetadata,
+    LoadWorkflowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# --- END ADDED IMPORTS ---
+
+
+# === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+async def _ensure_inner_workflow_registered() -> None:
+    """Register the co-located inner echo workflow under its bare registry key.
+
+    This legacy middle workflow references ``subflow_inner_echo`` by its bare key TWICE (the two
+    ``ImportWorkflowAsReferencedSubFlowRequest`` calls below). When the middle is itself imported as
+    a referenced sub-flow, ``WorkflowManager.run_workflow`` execs this module and awaits
+    ``build_workflow()``, so the inner workflow must be registered here before those imports run.
+    It lives next to this file rather than in the engine workspace, so we register the bare key
+    (the stable stem the serialisation expects) against the absolute path resolved from __file__.
+    """
+    if WorkflowRegistry.has_workflow_with_name("subflow_inner_echo"):
+        return
+    inner_path = Path(__file__).parent / "subflow_inner_echo.py"
+    meta = await GriptapeNodes.ahandle_request(LoadWorkflowMetadata(file_name=str(inner_path)))
+    if not isinstance(meta, LoadWorkflowMetadataResultSuccess):
+        msg = f"Failed to load inner workflow metadata from '{inner_path}': {meta.result_details}"
+        raise RuntimeError(msg)
+    WorkflowRegistry.generate_new_workflow(
+        registry_key="subflow_inner_echo", metadata=meta.metadata, file_path=str(inner_path)
+    )
+
+
+# === END ADDED SECTION ===
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # === ADDED FOR THE INTEGRATION TEST — register the co-located inner workflow before the
+    # two ImportWorkflowAsReferencedSubFlowRequest calls (and the nodes) that reference it. ===
+    await _ensure_inner_workflow_registered()
+    # === END ADDED SECTION ===
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "360483f7-f0e3-403a-aa89-6bce19bb0b0d": pickle.loads(
+            b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
+        ),
+        "ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac": pickle.loads(b"\x80\x04\x89."),
+        "bbbefa40-853b-45f6-a60e-f0ea2defe850": pickle.loads(
+            b"\x80\x04\x95\x16\x00\x00\x00\x00\x00\x00\x00\x8c\x12subflow_inner_echo\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="a",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="b",
+                    default_value="",
+                    tooltip="workflow input",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_a",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AddParameterToNodeRequest(
+                    parameter_name="out_b",
+                    default_value="",
+                    tooltip="workflow output",
+                    type="str",
+                    input_types=["str"],
+                    output_type="str",
+                    ui_options={"is_custom": True, "is_user_added": True},
+                    parent_container_name="",
+                    initial_setup=True,
+                )
+            )
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow A",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_in", "text_out"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_2",
+                        "_subflow_workflow": "subflow_inner_echo",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in",
+                    default_value="INNER_DEFAULT_NOT_FROM_OUTER",
+                    tooltip="workflow input",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        node3_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow B",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["text_in", "text_out"],
+                        "left_parameters": ["text_in"],
+                        "right_parameters": ["text_out"],
+                        "_workflow_file_value": "subflow_inner_echo",
+                        "subflow_name": "ControlFlow_3",
+                        "_subflow_workflow": "subflow_inner_echo",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_in",
+                    default_value="INNER_DEFAULT_NOT_FROM_OUTER",
+                    tooltip="workflow input",
+                    initial_setup=True,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="text_out", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        # Serialiser emits `flowN_name = (await ...).created_flow_name`; the returned names are unused
+        # here, so we keep only the side-effecting imports to satisfy ruff (F841). This is a LEGACY
+        # (pre-UUID) fixture: imported_flow_metadata is empty, so the recreated inner flows carry no
+        # owner UUID and the fix must bind each node by its recorded name / owner-claim path.
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name="subflow_inner_echo", imported_flow_metadata={})
+        )
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name="subflow_inner_echo", imported_flow_metadata={})
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="exec_out",
+                target_node_name=node3_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="a",
+                target_node_name=node2_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_a",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="b",
+                target_node_name=node3_name,
+                target_parameter_name="text_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="text_out",
+                target_node_name=node1_name,
+                target_parameter_name="out_b",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node0_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="a",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="b",
+                    node_name=node0_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["bbbefa40-853b-45f6-a60e-f0ea2defe850"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["bbbefa40-853b-45f6-a60e-f0ea2defe850"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["ff347a65-ed3a-4fa3-84b9-2ed6f27fe6ac"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="text_out",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["360483f7-f0e3-403a-aa89-6bce19bb0b0d"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    parser.add_argument("--a", dest="a", default=None, help="workflow input")
+    parser.add_argument("--b", dest="b", default=None, help="workflow input")
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+        if args.a is not None:
+            flow_input["Start Flow"]["a"] = args.a
+        if args.b is not None:
+            flow_input["Start Flow"]["b"] = args.b
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/integration/test_subflow_workflow_node_legacy.py
+++ b/tests/integration/test_subflow_workflow_node_legacy.py
@@ -1,0 +1,559 @@
+# /// script
+# dependencies = []
+#
+# [tool.griptape-nodes]
+# name = "test_subflow_workflow_node_legacy"
+# schema_version = "0.20.0"
+# engine_version_created_with = "0.93.0"
+# node_libraries_referenced = [["Griptape Nodes Testing Library", "0.1.0"], ["Griptape Nodes Library", "0.82.0"]]
+# node_types_used = [["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "SubflowWorkflowNode"], ["Griptape Nodes Testing Library", "AssertStrings"]]
+# workflows_referenced = ["subflow_middle_echo_legacy"]
+# is_griptape_provided = false
+# is_internal = false
+# creation_date = 2026-07-15T16:26:41.850456Z
+# last_modified_date = 2026-07-15T16:28:06.782714Z
+# workflow_shape = "{\"inputs\":{\"Start Flow\":{\"exec_out\":{\"name\":\"exec_out\",\"tooltip\":\"Connection to the next node in the execution chain\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":false,\"mode_allowed_output\":true,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Flow Out\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null}}},\"outputs\":{\"End Flow\":{\"exec_in\":{\"name\":\"exec_in\",\"tooltip\":\"Control path when the flow completed successfully\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Succeeded\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"failed\":{\"name\":\"failed\",\"tooltip\":\"Control path when the flow failed\",\"type\":\"parametercontroltype\",\"input_types\":[\"parametercontroltype\"],\"output_type\":\"parametercontroltype\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"parameter_render_location\":\"top\",\"display_name\":\"Failed\"},\"settable\":true,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":null},\"was_successful\":{\"name\":\"was_successful\",\"tooltip\":\"Indicates whether it completed without errors.\",\"type\":\"bool\",\"input_types\":[\"bool\"],\"output_type\":\"bool\",\"default_value\":false,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":false,\"mode_allowed_property\":true,\"mode_allowed_output\":false,\"ui_options\":{},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"},\"result_details\":{\"name\":\"result_details\",\"tooltip\":\"Details about the operation result\",\"type\":\"str\",\"input_types\":[\"str\"],\"output_type\":\"str\",\"default_value\":null,\"tooltip_as_input\":null,\"tooltip_as_property\":null,\"tooltip_as_output\":null,\"mode_allowed_input\":true,\"mode_allowed_property\":false,\"mode_allowed_output\":false,\"ui_options\":{\"multiline\":true,\"placeholder_text\":\"Details about the completion or failure will be shown here.\"},\"settable\":false,\"is_user_defined\":true,\"private\":false,\"parent_container_name\":null,\"parent_element_name\":\"Status\"}}}}"
+#
+# ///
+
+import argparse
+import asyncio
+import json
+import logging
+import pickle
+
+# --- ADDED FOR THE INTEGRATION TEST (not emitted by the serialiser) ---
+# Used by the referenced-workflow registration block inside build_workflow() below.
+from pathlib import Path
+from typing import Any
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.bootstrap.workflow_executors.workflow_executor import WorkflowExecutor
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    LoadWorkflowMetadata,
+    LoadWorkflowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# --- END ADDED IMPORTS ---
+
+
+# === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+# LEGACY-compatibility variant of test_subflow_workflow_node: the same nested stack (outer ->
+# subflow_middle_echo_legacy -> subflow_inner_echo x2) but serialised on a PRE-transient engine, so
+# every SubflowWorkflowNode carries a baked ImportWorkflowAsReferencedSubFlowRequest plus
+# ``subflow_name`` / ``_subflow_workflow`` metadata (no ``transient`` flag). It proves such workflows
+# still load and run under the transient scheme: on first execution each node adopts its baked
+# (possibly de-dup-renamed) subflow via _claim_legacy_serialised_flow and flags it transient rather
+# than importing a duplicate — no infinite recursion, and the per-branch asserts (a -> out_a,
+# b -> out_b) confirm no cross-binding.
+_REFERENCED_WORKFLOWS = ("subflow_inner_echo", "subflow_middle_echo_legacy")
+
+
+async def _ensure_referenced_workflows_registered() -> None:
+    """Register the co-located referenced workflows under their bare registry keys.
+
+    The serialised outer refers to ``subflow_middle_echo_legacy`` by its bare key, which in turn
+    refers to ``subflow_inner_echo`` by its bare key. At test time neither is in the engine workspace
+    (they live next to this file), so we register both here. Called from build_workflow() (so the
+    build-time import resolves) and again after the executor is entered (entry broadcasts
+    AppInitializationComplete -> refresh_workflow_registry -> clear_user_workflows(), which would
+    otherwise drop these registrations before the flow runs in the standalone __main__ path).
+    """
+    for key in _REFERENCED_WORKFLOWS:
+        if WorkflowRegistry.has_workflow_with_name(key):
+            continue
+        path = Path(__file__).parent / f"{key}.py"
+        meta = await GriptapeNodes.ahandle_request(LoadWorkflowMetadata(file_name=str(path)))
+        if not isinstance(meta, LoadWorkflowMetadataResultSuccess):
+            msg = f"Failed to load referenced workflow metadata from '{path}': {meta.result_details}"
+            raise RuntimeError(msg)
+        WorkflowRegistry.generate_new_workflow(registry_key=key, metadata=meta.metadata, file_path=str(path))
+
+
+# === END ADDED SECTION ===
+
+
+async def build_workflow() -> None:
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(
+            library_name="Griptape Nodes Testing Library", perform_discovery_if_not_found=True
+        )
+    )
+    await GriptapeNodes.ahandle_request(
+        RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+    )
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_workflow():
+        context_manager.push_workflow(file_path=__file__)
+    # === ADDED FOR THE INTEGRATION TEST — register the co-located referenced workflows before any
+    # node or ImportWorkflowAsReferencedSubFlowRequest that resolves them by bare key. ===
+    await _ensure_referenced_workflows_registered()
+    # === END ADDED SECTION ===
+    # 1. We've collated all of the unique parameter values into a dictionary so that we do not have to duplicate them.
+    #    This minimizes the size of the code, especially for large objects like serialized image files.
+    # 2. We're using a prefix so that it's clear which Flow these values are associated with.
+    # 3. The values are serialized using pickle, which is a binary format. This makes them harder to read, but makes
+    #    them consistently save and load. It allows us to serialize complex objects like custom classes, which otherwise
+    #    would be difficult to serialize.
+    top_level_unique_values_dict = {
+        "df2be1af-e3af-4c24-85ea-6284477c3d6b": pickle.loads(b"\x80\x04\x89."),
+        "10a91064-91b5-4977-aa19-dba0d63c7333": pickle.loads(
+            b"\x80\x04\x95\x1e\x00\x00\x00\x00\x00\x00\x00\x8c\x1asubflow_middle_echo_legacy\x94."
+        ),
+        "5856d55d-72f0-42d4-8b20-ea741ff27a05": pickle.loads(
+            b"\x80\x04\x95\t\x00\x00\x00\x00\x00\x00\x00\x8c\x05alpha\x94."
+        ),
+        "1b1146b1-de22-43df-a9d6-c68c86903b10": pickle.loads(
+            b"\x80\x04\x95\t\x00\x00\x00\x00\x00\x00\x00\x8c\x05bravo\x94."
+        ),
+        "51750017-4791-4916-b2d5-433e606dcfae": pickle.loads(
+            b"\x80\x04\x95\x04\x00\x00\x00\x00\x00\x00\x00\x8c\x00\x94."
+        ),
+        "b3df0b06-0237-4202-8c45-657fe7980756": pickle.loads(
+            b"\x80\x04\x95\x06\x00\x00\x00\x00\x00\x00\x00\x8c\x02==\x94."
+        ),
+    }
+    # Create the Flow, then do work within it as context.
+    flow0_name = (
+        await GriptapeNodes.ahandle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+        )
+    ).flow_name
+    with GriptapeNodes.ContextManager().flow(flow0_name):
+        node0_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="StartFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Start Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the start of a workflow and pass parameters into the flow",
+                            "display_name": "Start Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "StartFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node1_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="EndFlow",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="End Flow",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "workflows",
+                            "description": "Define the end of a workflow and return parameters from the flow",
+                            "display_name": "End Flow",
+                            "tags": ["workflow", "execution"],
+                            "icon": None,
+                            "color": None,
+                            "group": "create",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "EndFlow",
+                        "showaddparameter": True,
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node2_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="SubflowWorkflowNode",
+                    specific_library_name="Griptape Nodes Library",
+                    node_name="Workflow Node",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "execution_flow",
+                            "description": "Selects and executes a registered workflow, routing inputs and outputs via the workflow shape",
+                            "display_name": "Workflow Node",
+                            "tags": ["workflow", "execution", "subflow"],
+                            "icon": "Layers",
+                            "color": None,
+                            "group": None,
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Library",
+                        "node_type": "SubflowWorkflowNode",
+                        "workflow_node": True,
+                        "workflow_shape_params": ["out_b", "b", "a", "out_a"],
+                        "left_parameters": ["a", "b"],
+                        "right_parameters": ["out_a", "out_b"],
+                        "_workflow_file_value": "subflow_middle_echo_legacy",
+                        "subflow_name": "ControlFlow_2",
+                        "_subflow_workflow": "subflow_middle_echo_legacy",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="a", default_value="", tooltip="workflow input", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="b", default_value="", tooltip="workflow input", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="out_a", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                AlterParameterDetailsRequest(
+                    parameter_name="out_b", default_value="", tooltip="workflow output", initial_setup=True
+                )
+            )
+        node3_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="AssertStrings",
+                    specific_library_name="Griptape Nodes Testing Library",
+                    node_name="Assert A",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "assert",
+                            "description": "Asserts a string comparison using a selected operator.",
+                            "display_name": "Assert Strings",
+                            "tags": None,
+                            "icon": "ShieldCheck",
+                            "color": None,
+                            "group": "assert",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Testing Library",
+                        "node_type": "AssertStrings",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        node4_name = (
+            await GriptapeNodes.ahandle_request(
+                CreateNodeRequest(
+                    node_type="AssertStrings",
+                    specific_library_name="Griptape Nodes Testing Library",
+                    node_name="Assert B",
+                    metadata={
+                        "library_node_metadata": {
+                            "category": "assert",
+                            "description": "Asserts a string comparison using a selected operator.",
+                            "display_name": "Assert Strings",
+                            "tags": None,
+                            "icon": "ShieldCheck",
+                            "color": None,
+                            "group": "assert",
+                            "deprecation": None,
+                            "is_node_group": None,
+                            "declarations": [],
+                        },
+                        "library": "Griptape Nodes Testing Library",
+                        "node_type": "AssertStrings",
+                    },
+                    initial_setup=True,
+                )
+            )
+        ).node_name
+        # Serialiser emits `flow1_name = (await ...).created_flow_name`; the returned name is unused,
+        # so we keep only the side-effecting import to satisfy ruff (F841). LEGACY: imported_flow_metadata
+        # is empty (pre-UUID), so the recreated middle carries no owner UUID.
+        await GriptapeNodes.ahandle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(
+                workflow_name="subflow_middle_echo_legacy", imported_flow_metadata={}
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node0_name,
+                source_parameter_name="exec_out",
+                target_node_name=node2_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="exec_out",
+                target_node_name=node3_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node3_name,
+                source_parameter_name="exec_out",
+                target_node_name=node4_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node4_name,
+                source_parameter_name="exec_out",
+                target_node_name=node1_name,
+                target_parameter_name="exec_in",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="out_a",
+                target_node_name=node3_name,
+                target_parameter_name="actual",
+                initial_setup=True,
+            )
+        )
+        await GriptapeNodes.ahandle_request(
+            CreateConnectionRequest(
+                source_node_name=node2_name,
+                source_parameter_name="out_b",
+                target_node_name=node4_name,
+                target_parameter_name="actual",
+                initial_setup=True,
+            )
+        )
+        with GriptapeNodes.ContextManager().node(node1_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node1_name,
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node2_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="workflow_file",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["10a91064-91b5-4977-aa19-dba0d63c7333"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="a",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["5856d55d-72f0-42d4-8b20-ea741ff27a05"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="b",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["1b1146b1-de22-43df-a9d6-c68c86903b10"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="out_a",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="out_b",
+                    node_name=node2_name,
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node3_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="expected",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["5856d55d-72f0-42d4-8b20-ea741ff27a05"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="operator",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["b3df0b06-0237-4202-8c45-657fe7980756"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="message",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node3_name,
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+        with GriptapeNodes.ContextManager().node(node4_name):
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="expected",
+                    node_name=node4_name,
+                    value=top_level_unique_values_dict["1b1146b1-de22-43df-a9d6-c68c86903b10"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="operator",
+                    node_name=node4_name,
+                    value=top_level_unique_values_dict["b3df0b06-0237-4202-8c45-657fe7980756"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="message",
+                    node_name=node4_name,
+                    value=top_level_unique_values_dict["51750017-4791-4916-b2d5-433e606dcfae"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+            await GriptapeNodes.ahandle_request(
+                SetParameterValueRequest(
+                    parameter_name="was_successful",
+                    node_name=node4_name,
+                    value=top_level_unique_values_dict["df2be1af-e3af-4c24-85ea-6284477c3d6b"],
+                    initial_setup=True,
+                    is_output=False,
+                )
+            )
+
+
+async def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_request = GetTopLevelFlowRequest()
+        top_level_flow_result = await GriptapeNodes.ahandle_request(top_level_flow_request)
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:
+    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))
+
+
+async def aexecute_workflow(
+    input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any
+) -> dict | None:
+    await build_workflow()
+    await _ensure_workflow_context()
+    if workflow_executor is None:
+        kwargs.setdefault("pickle_control_flow_result", False)
+        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
+    async with workflow_executor as executor:
+        # === ADDED FOR THE INTEGRATION TEST — NOT PART OF THE SERIALISED WORKFLOW ===
+        # Entering the executor broadcasts AppInitializationComplete -> refresh_workflow_registry
+        # -> clear_user_workflows(), which drops the referenced workflows registered during
+        # build_workflow() above. Re-register them here so the Workflow node (and the nested import
+        # inside subflow_middle_echo_legacy) can resolve them when the flow runs.
+        await _ensure_referenced_workflows_registered()
+        # === END ADDED SECTION ===
+        await executor.arun(flow_input=input, **kwargs)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+    parser.add_argument(
+        "--json-input",
+        default=None,
+        help="JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.",
+    )
+    parser.add_argument(
+        "--exec_out", dest="exec_out", default=None, help="Connection to the next node in the execution chain"
+    )
+    args = parser.parse_args()
+    flow_input = {}
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    if args.json_input is None:
+        if "Start Flow" not in flow_input:
+            flow_input["Start Flow"] = {}
+        if args.exec_out is not None:
+            flow_input["Start Flow"]["exec_out"] = args.exec_out
+    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
+    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
+    print(workflow_output)

--- a/tests/unit/engine/test_subflow_workflow_node.py
+++ b/tests/unit/engine/test_subflow_workflow_node.py
@@ -1,16 +1,17 @@
-"""Tests for ``SubflowWorkflowNode`` shape handling under Start/End node renames.
+"""Tests for ``SubflowWorkflowNode``: transient-subflow lifecycle + shape handling under renames.
 
-Regression coverage for issue #5134 (same root cause as the earlier, closed-in-error #4993):
-when a child workflow is imported and its ``Start Flow`` / ``End Flow`` nodes collide with
-existing node names, they are renamed (``Start Flow_1`` / ``End Flow_1``). The child's saved
-``workflow_shape`` still holds the ORIGINAL names, so routing by those names silently drops the
-values.
+The node imports its selected workflow as a **transient** child subflow — a runtime-only artifact
+that is never serialized (the engine skips flows flagged ``transient``). The live subflow name is
+tracked as a runtime ``subflow_name`` metadata hint that is popped on load (so it never round-trips
+to go stale, collide across copy-paste, or mis-bind under nesting) and re-established when the subflow
+is (re)imported at execution time; it is reused while it stays live. The editor reads that hint (via a
+fresh ``GetNodeMetadataRequest`` when the preview opens) to show the in-memory subflow.
 
-The fix re-derives the shape from the freshly-imported subflow via the same discovery logic
-used at save time (``WorkflowManager.extract_workflow_shape``), so the shape's node-name keys
-match the live nodes. These tests drive ``aprocess`` with the surrounding engine calls stubbed
-and assert that (a) inputs/outputs are routed to the live (renamed) nodes, and (b) a subflow
-without a shape fails with a clear message.
+Also retains regression coverage for issue #5134: when a child workflow is imported and its
+``Start Flow`` / ``End Flow`` nodes collide with existing names, they are renamed
+(``Start Flow_1`` / ``End Flow_1``). The child's saved ``workflow_shape`` still holds the ORIGINAL
+names, so ``aprocess`` re-derives the shape from the freshly-imported subflow via
+``WorkflowManager.extract_workflow_shape`` instead of trusting the saved shape.
 """
 
 from __future__ import annotations
@@ -24,8 +25,23 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import EndNode, StartNode
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.execution_events import StartLocalSubflowResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    DeleteFlowRequest,
+    GetFlowDetailsRequest,
+    GetFlowDetailsResultSuccess,
+    GetFlowMetadataRequest,
+    GetFlowMetadataResultFailure,
+    GetFlowMetadataResultSuccess,
+    SetFlowMetadataRequest,
+    SetFlowMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import GetFlowForNodeRequest, GetFlowForNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.events.workflow_events import ListCallableWorkflowsResultSuccess
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
+    ListCallableWorkflowsResultSuccess,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
 from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
@@ -42,24 +58,54 @@ def shape_param() -> dict[str, Any]:
 
 @pytest.fixture
 def node(monkeypatch: pytest.MonkeyPatch) -> SubflowWorkflowNode:
-    """A ``SubflowWorkflowNode`` primed to run against a stubbed, already-loaded subflow.
+    """A ``SubflowWorkflowNode`` with the workflow dropdown stubbed.
 
-    ``__init__`` issues a ``ListCallableWorkflowsRequest`` to populate the workflow dropdown; we
-    return "child" as the sole choice so it becomes the selected ``workflow_file`` default.
+    ``__init__`` issues a ``ListCallableWorkflowsRequest`` to populate the dropdown; we return
+    "child" as the sole choice so it becomes the selected ``workflow_file`` default.
     """
     list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
     list_result.workflow_names = ["child"]
     monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
-    node = SubflowWorkflowNode(name="Workflow Node")
-    # Pretend the child's subflow has already been imported.
-    node.metadata["subflow_name"] = "sub"
-    return node
+    return SubflowWorkflowNode(name="Workflow Node")
+
+
+def _live_flow(name: str) -> SimpleNamespace:
+    """A stand-in ``ControlFlow`` exposing only the ``.metadata`` dict."""
+    return SimpleNamespace(name=name, metadata={})
+
+
+def _stub_object_manager(monkeypatch: pytest.MonkeyPatch, live_flows: dict[str, Any]) -> None:
+    """Back ``ObjectManager.attempt_get_object_by_name_as_type`` with a fixed name -> flow map."""
+    object_manager = Mock(spec=ObjectManager)
+    object_manager.attempt_get_object_by_name_as_type.side_effect = lambda name, _type: live_flows.get(name)
+    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+
+def _install_import_handler(
+    monkeypatch: pytest.MonkeyPatch, *, parent_flow: str = "ParentFlow", created_flow: str = "sub"
+) -> list[Any]:
+    """Install a ``handle_request`` that answers the import path and captures every request."""
+    requests: list[Any] = []
+
+    def _handle(request: Any) -> Any:
+        requests.append(request)
+        if isinstance(request, GetFlowForNodeRequest):
+            return GetFlowForNodeResultSuccess(flow_name=parent_flow, result_details="stubbed")
+        if isinstance(request, ImportWorkflowAsReferencedSubFlowRequest):
+            return ImportWorkflowAsReferencedSubFlowResultSuccess(
+                created_flow_name=created_flow, result_details="stubbed"
+            )
+        return None
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+    return requests
 
 
 @pytest.fixture
 def workflow_manager(monkeypatch: pytest.MonkeyPatch, shape_param: dict[str, Any]) -> Mock:
-    """Stub the engine calls ``aprocess`` makes up to the routing step and return the
-    ``WorkflowManager`` mock so each test can configure ``extract_workflow_shape``.
+    """Stub the engine calls ``aprocess`` makes up to the routing step, with the subflow already live.
+
+    Returns the ``WorkflowManager`` mock so each test can configure ``extract_workflow_shape``.
     """
     monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
 
@@ -75,9 +121,8 @@ def workflow_manager(monkeypatch: pytest.MonkeyPatch, shape_param: dict[str, Any
         lambda _name: SimpleNamespace(metadata=SimpleNamespace(workflow_shape=stale_shape)),
     )
 
-    object_manager = Mock(spec=ObjectManager)
-    object_manager.get_filtered_subset.return_value = {"sub": object()}  # subflow already loaded
-    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+    # The subflow "sub" is already imported and live -> _load_subflow reuses it (no import).
+    _stub_object_manager(monkeypatch, {"sub": _live_flow("sub")})
 
     manager = Mock(spec=WorkflowManager)
     monkeypatch.setattr(GriptapeNodes, "WorkflowManager", lambda: manager)
@@ -89,9 +134,126 @@ def workflow_manager(monkeypatch: pytest.MonkeyPatch, shape_param: dict[str, Any
     return manager
 
 
+class TestLoadSubflowImportsTransient:
+    """``_load_subflow`` imports the selected workflow as a transient, execution-time subflow."""
+
+    def test_imports_and_flags_created_flow_transient(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        _stub_object_manager(monkeypatch, {})  # nothing live yet
+        requests = _install_import_handler(monkeypatch, created_flow="sub")
+
+        result = node._load_subflow("child")
+
+        assert result == "sub"
+        # The live subflow name is tracked in metadata (a runtime hint the editor reads to
+        # preview the in-memory subflow); it is popped on load so it never goes stale.
+        assert node.metadata.get("subflow_name") == "sub"
+        # The import flagged the created flow transient so it is never serialized.
+        import_requests = [r for r in requests if isinstance(r, ImportWorkflowAsReferencedSubFlowRequest)]
+        assert len(import_requests) == 1
+        assert import_requests[0].imported_flow_metadata == {"transient": True}
+        # No legacy association marker is written by a new-scheme node.
+        assert "_subflow_workflow" not in node.metadata
+
+    def test_reuses_live_subflow_without_reimporting(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        node.metadata["subflow_name"] = "sub"
+        _stub_object_manager(monkeypatch, {"sub": _live_flow("sub")})
+        requests = _install_import_handler(monkeypatch)
+
+        result = node._load_subflow("child")
+
+        assert result == "sub"
+        # Already live -> no new import.
+        assert not [r for r in requests if isinstance(r, ImportWorkflowAsReferencedSubFlowRequest)]
+
+    def test_reimports_when_tracked_subflow_no_longer_exists(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tracked name points at a flow that was torn down (e.g. parent flow deleted) -> re-import.
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        node.metadata["subflow_name"] = "gone"
+        _stub_object_manager(monkeypatch, {})  # "gone" is not live
+        requests = _install_import_handler(monkeypatch, created_flow="sub_2")
+
+        result = node._load_subflow("child")
+
+        assert result == "sub_2"
+        assert node.metadata.get("subflow_name") == "sub_2"
+        assert len([r for r in requests if isinstance(r, ImportWorkflowAsReferencedSubFlowRequest)]) == 1
+
+    def test_returns_none_when_workflow_not_registered(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: False)
+        _stub_object_manager(monkeypatch, {})
+        requests = _install_import_handler(monkeypatch)
+
+        assert node._load_subflow("child") is None
+        assert not [r for r in requests if isinstance(r, ImportWorkflowAsReferencedSubFlowRequest)]
+
+
+class TestDiscardSubflow:
+    """The node tears down the live subflow it imported (on delete / workflow change / refresh)."""
+
+    def test_discard_deletes_live_subflow(self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch) -> None:
+        node.metadata["subflow_name"] = "sub"
+        _stub_object_manager(monkeypatch, {"sub": _live_flow("sub")})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node._discard_subflow()
+
+        assert [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)] == ["sub"]
+        assert "subflow_name" not in node.metadata
+
+    def test_discard_is_noop_when_nothing_tracked(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_object_manager(monkeypatch, {})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node._discard_subflow()
+
+        assert not [r for r in requests if isinstance(r, DeleteFlowRequest)]
+
+    def test_discard_clears_tracking_when_flow_already_gone(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The subflow was already deleted (e.g. parent-flow teardown) -> no delete request, but the
+        # stale metadata hint is cleared.
+        node.metadata["subflow_name"] = "sub"
+        _stub_object_manager(monkeypatch, {})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node._discard_subflow()
+
+        assert not [r for r in requests if isinstance(r, DeleteFlowRequest)]
+        assert "subflow_name" not in node.metadata
+
+    def test_after_node_deleted_discards_subflow(
+        self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        node.metadata["subflow_name"] = "sub"
+        _stub_object_manager(monkeypatch, {"sub": _live_flow("sub")})
+        requests: list[Any] = []
+        monkeypatch.setattr(GriptapeNodes, "handle_request", requests.append)
+
+        node.after_node_deleted()
+
+        assert [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)] == ["sub"]
+        assert "subflow_name" not in node.metadata
+
+
 class TestAprocessReDerivesShapeFromSubflow:
-    """aprocess must route using the shape extracted from the live subflow, not the stale
-    saved shape whose node names may have been renamed on import.
+    """aprocess routes using the shape extracted from the live subflow, not the stale saved shape
+    whose node names may have been renamed on import.
     """
 
     @pytest.mark.asyncio
@@ -102,6 +264,9 @@ class TestAprocessReDerivesShapeFromSubflow:
         shape_param: dict[str, Any],
         workflow_manager: Mock,
     ) -> None:
+        # The subflow is already live; aprocess reuses it.
+        node.metadata["subflow_name"] = "sub"
+
         # The live subflow's Start/End were renamed on import; extract reports the live names.
         workflow_manager.extract_workflow_shape.return_value = {
             "input": {"Start Flow_1": {"text_in": shape_param}},
@@ -146,9 +311,276 @@ class TestAprocessReDerivesShapeFromSubflow:
 
     @pytest.mark.asyncio
     async def test_missing_shape_reports_failure(self, node: SubflowWorkflowNode, workflow_manager: Mock) -> None:
+        node.metadata["subflow_name"] = "sub"
         # extract_workflow_shape raises ValueError when the subflow has no Start/End nodes.
         workflow_manager.extract_workflow_shape.side_effect = ValueError("no start/end nodes")
 
         # The failure output is unconnected on a bare node, so the failure re-raises.
         with pytest.raises(RuntimeError, match="has no shape defined"):
             await node.aprocess()
+
+
+def _legacy_flow(name: str, referenced: str, *, transient: bool = False) -> SimpleNamespace:
+    """A stand-in referenced ``ControlFlow``: carries its referenced-workflow name and transient flag.
+
+    ``_referenced`` is the workflow the flow was imported from — what ``GetFlowDetailsRequest`` reports
+    as ``referenced_workflow_name``.
+    """
+    metadata: dict[str, Any] = {}
+    if transient:
+        metadata["transient"] = True
+    return SimpleNamespace(name=name, metadata=metadata, _referenced=referenced)
+
+
+def _install_legacy_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    flows: dict[str, SimpleNamespace],
+    parents: dict[str, str],
+    node_flow: str = "ParentFlow",
+) -> list[Any]:
+    """Stub the engine surface ``_claim_legacy_serialised_flow`` walks and capture every request.
+
+    ``flows`` maps flow name -> stub flow (see ``_legacy_flow``); ``parents`` maps flow name -> its
+    parent flow name; ``node_flow`` is the node's containing flow (answer to GetFlowForNodeRequest).
+    ``GetFlowMetadataRequest`` reports each flow's metadata (or failure when absent);
+    ``GetFlowDetailsRequest`` reports each flow's parent + referenced workflow; ``SetFlowMetadataRequest``
+    is mirrored onto the stub flow's metadata so a claim's transient flag is visible to a subsequent
+    scan (as the real merge handler would make it).
+    """
+    object_manager = Mock(spec=ObjectManager)
+    object_manager.attempt_get_object_by_name_as_type.side_effect = lambda name, _type: flows.get(name)
+    object_manager.get_filtered_subset.return_value = flows
+    monkeypatch.setattr(GriptapeNodes, "ObjectManager", lambda: object_manager)
+
+    requests: list[Any] = []
+
+    def _handle(request: Any) -> Any:
+        requests.append(request)
+        if isinstance(request, GetFlowForNodeRequest):
+            return GetFlowForNodeResultSuccess(flow_name=node_flow, result_details="stubbed")
+        if isinstance(request, GetFlowMetadataRequest):
+            flow = flows.get(request.flow_name) if request.flow_name is not None else None
+            if flow is None:
+                return GetFlowMetadataResultFailure(result_details="not found")
+            return GetFlowMetadataResultSuccess(metadata=flow.metadata, result_details="stubbed")
+        if isinstance(request, GetFlowDetailsRequest):
+            flow = flows.get(request.flow_name) if request.flow_name is not None else None
+            return GetFlowDetailsResultSuccess(
+                referenced_workflow_name=getattr(flow, "_referenced", None) if flow is not None else None,
+                parent_flow_name=parents.get(request.flow_name) if request.flow_name is not None else None,
+                flow_type=None,
+                result_details="stubbed",
+            )
+        if isinstance(request, SetFlowMetadataRequest):
+            flow = flows.get(request.flow_name) if request.flow_name is not None else None
+            if flow is not None:
+                flow.metadata.update(request.metadata)
+            return SetFlowMetadataResultSuccess(result_details="stubbed")
+        return None
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", _handle)
+    return requests
+
+
+def _make_legacy_node(
+    monkeypatch: pytest.MonkeyPatch, name: str, *, recorded: str, workflow: str
+) -> SubflowWorkflowNode:
+    """Construct a node from pre-transient legacy metadata (recorded subflow name + source workflow).
+
+    The metadata is passed to ``__init__`` (as it is on load) so the node extracts the legacy pair into
+    instance vars and pops the keys — matching how a legacy workflow file deserializes.
+    """
+    list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
+    list_result.workflow_names = [workflow]
+    monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
+    return SubflowWorkflowNode(
+        name=name,
+        metadata={"subflow_name": recorded, "_subflow_workflow": workflow},
+    )
+
+
+class TestClaimLegacySerialisedFlow:
+    """Migrating pre-transient baked subflows: adopt once, flag ``transient``, drop legacy metadata.
+
+    Legacy workflows serialize the subflow as a baked ``ImportWorkflowAsReferencedSubFlowRequest``
+    that recreates a persistent child flow at load and record its (possibly renamed) name in
+    ``metadata["subflow_name"]``. The node adopts that flow as its live subflow and flags it
+    ``transient`` so a re-save is clean new-scheme.
+    """
+
+    def test_adopts_recorded_flow_and_marks_transient(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        requests = _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        assert node._claim_legacy_serialised_flow() == "ControlFlow_2"
+        # Flagged transient so the engine never serializes it again.
+        assert flows["ControlFlow_2"].metadata.get("transient") is True
+        assert any(
+            isinstance(r, SetFlowMetadataRequest)
+            and r.flow_name == "ControlFlow_2"
+            and r.metadata.get("transient") is True
+            for r in requests
+        )
+        # Legacy metadata dropped so a re-save is clean new-scheme.
+        assert "subflow_name" not in node.metadata
+        assert "_subflow_workflow" not in node.metadata
+
+    def test_ignores_flow_already_migrated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child", transient=True)}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        assert node._claim_legacy_serialised_flow() is None
+
+    def test_rejects_flow_referencing_other_workflow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "some_other_workflow")}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        assert node._claim_legacy_serialised_flow() is None
+
+    def test_new_scheme_node_is_noop(self, node: SubflowWorkflowNode, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A native new-scheme node carries no _subflow_workflow metadata -> never a legacy candidate.
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        requests = _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        assert node._claim_legacy_serialised_flow() is None
+        assert not [r for r in requests if isinstance(r, SetFlowMetadataRequest)]
+
+    def test_scan_recovers_from_stale_recorded_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # subflow_name points at a name deduped away on import; the real flow (ControlFlow_5) is a
+        # child of the node's own flow that references the expected workflow.
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_5": _legacy_flow("ControlFlow_5", "child")}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_5": "ParentFlow"})
+
+        assert node._claim_legacy_serialised_flow() == "ControlFlow_5"
+        assert flows["ControlFlow_5"].metadata.get("transient") is True
+
+    def test_recorded_name_in_wrong_parent_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The recorded name still resolves and references the expected workflow, but the flow is a
+        # child of a DIFFERENT parent (e.g. a sibling's subflow after a de-dup rename). The
+        # containing-flow check must reject it on the fast path (not just the scan).
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "SomeOtherParent"})
+
+        assert node._claim_legacy_serialised_flow() is None
+
+    def test_scan_skips_flow_in_another_parent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Same referenced workflow, but a child of a DIFFERENT parent -> not this node's subflow.
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="stale", workflow="child")
+        flows = {"OtherChild": _legacy_flow("OtherChild", "child")}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"OtherChild": "SomeOtherParent"})
+
+        assert node._claim_legacy_serialised_flow() is None
+
+    def test_scan_distributes_duplicate_siblings(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Two legacy sibling nodes, two baked flows referencing the same workflow under the same
+        # parent, both recorded names stale. Each must claim a DIFFERENT flow: claiming marks the
+        # flow transient and the scan skips transient flows.
+        node_a = _make_legacy_node(monkeypatch, "A", recorded="stale", workflow="child")
+        node_b = _make_legacy_node(monkeypatch, "B", recorded="stale", workflow="child")
+        flows = {"F1": _legacy_flow("F1", "child"), "F2": _legacy_flow("F2", "child")}
+        _install_legacy_env(monkeypatch, flows=flows, parents={"F1": "ParentFlow", "F2": "ParentFlow"})
+
+        claimed_a = node_a._claim_legacy_serialised_flow()
+        claimed_b = node_b._claim_legacy_serialised_flow()
+
+        assert claimed_a is not None
+        assert claimed_b is not None
+        assert claimed_a != claimed_b
+        assert flows["F1"].metadata.get("transient") is True
+        assert flows["F2"].metadata.get("transient") is True
+
+
+class TestLoadSubflowAdoptsLegacy:
+    """``_load_subflow`` adopts a node's legacy baked subflow instead of importing a duplicate."""
+
+    def test_adopts_legacy_instead_of_importing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        requests = _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        assert node._load_subflow("child") == "ControlFlow_2"
+        assert node.metadata.get("subflow_name") == "ControlFlow_2"
+        # No fresh import — the pre-existing baked flow was adopted.
+        assert not [r for r in requests if isinstance(r, ImportWorkflowAsReferencedSubFlowRequest)]
+
+    def test_does_not_adopt_legacy_when_selection_changed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The baked flow was imported from "child", but the selection is now "other" (changed since
+        # the legacy save). Adopting + running it under "other"'s shape would be wrong, so the node
+        # must ignore the baked flow and import a fresh transient subflow for the new selection.
+        monkeypatch.setattr(WorkflowRegistry, "has_workflow_with_name", lambda _name: True)
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        requests = _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        node._load_subflow("other")
+
+        # The baked "child" flow was neither adopted nor claimed (no transient stamp)...
+        assert node.metadata.get("subflow_name") != "ControlFlow_2"
+        assert not [r for r in requests if isinstance(r, SetFlowMetadataRequest)]
+        # ...instead a fresh transient import was attempted for the new selection.
+        assert any(
+            isinstance(r, ImportWorkflowAsReferencedSubFlowRequest) and r.workflow_name == "other" for r in requests
+        )
+
+
+class TestAfterNodeDeletedCleansLegacy:
+    """Deleting a legacy node that was never run still tears down its baked subflow."""
+
+    def test_deletes_legacy_baked_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_legacy_node(monkeypatch, "Workflow Node", recorded="ControlFlow_2", workflow="child")
+        flows = {"ControlFlow_2": _legacy_flow("ControlFlow_2", "child")}
+        requests = _install_legacy_env(monkeypatch, flows=flows, parents={"ControlFlow_2": "ParentFlow"})
+
+        node.after_node_deleted()
+
+        assert [r.flow_name for r in requests if isinstance(r, DeleteFlowRequest)] == ["ControlFlow_2"]
+
+
+def _make_node_with_metadata(monkeypatch: pytest.MonkeyPatch, metadata: dict[str, Any]) -> SubflowWorkflowNode:
+    """Construct a node with arbitrary initial metadata passed to ``__init__`` (as on load)."""
+    list_result = Mock(spec=ListCallableWorkflowsResultSuccess)
+    list_result.workflow_names = ["child"]
+    monkeypatch.setattr(GriptapeNodes, "handle_request", lambda _request: list_result)
+    return SubflowWorkflowNode(name="Workflow Node", metadata=dict(metadata))
+
+
+class TestInitExtractsLegacyMetadata:
+    """``__init__`` clears the runtime ``subflow_name`` hint from loaded metadata and retains the
+    legacy migration pair only when the ``_subflow_workflow`` marker identifies a pre-transient save.
+
+    The subflow is never serialized, so any ``subflow_name`` present at load time is stale: either a
+    runtime hint saved while a subflow was live (new scheme) or a baked legacy reference. Popping it
+    stops the editor previewing a dead/stale flow; the legacy pair is kept (in instance vars) so the
+    first execution can adopt the baked flow.
+    """
+
+    def test_legacy_metadata_is_extracted_and_popped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        node = _make_node_with_metadata(monkeypatch, {"subflow_name": "ControlFlow_2", "_subflow_workflow": "child"})
+
+        # Popped from serializable metadata so the editor never previews the baked flow directly.
+        assert "subflow_name" not in node.metadata
+        assert "_subflow_workflow" not in node.metadata
+        # Retained as instance state for one-time migration on first use.
+        assert node._legacy_workflow == "child"
+        assert node._legacy_flow_name == "ControlFlow_2"
+
+    def test_stale_runtime_hint_is_popped_without_legacy_migration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # New-scheme node saved while a subflow was live: subflow_name present, no _subflow_workflow.
+        # The referenced transient flow was not serialized, so the hint is stale -> drop it, and it is
+        # NOT a legacy candidate.
+        node = _make_node_with_metadata(monkeypatch, {"subflow_name": "ControlFlow_9"})
+
+        assert "subflow_name" not in node.metadata
+        assert node._legacy_workflow is None
+        assert node._legacy_flow_name is None
+
+    def test_native_new_scheme_node_has_no_legacy_state(self, node: SubflowWorkflowNode) -> None:
+        assert node._legacy_workflow is None
+        assert node._legacy_flow_name is None


### PR DESCRIPTION
Closes #466.  Depends on https://github.com/griptape-ai/griptape-nodes-engine/pull/5161.

Nodes are grouped into flows. Flows are uniquely identified by their name (distinct from node names). These flow names can change due to de-duplication when loading a workflow file.

In particular the SubflowWorkflowNode node loads a flow and its nodes from an external workflow file, and if the external workflow file happens to have a flow whose name conflicts with another (the parent or another previously loaded flow), then it is renamed. An external workflow file can itself have SubflowWorkflowNode nodes, adding a cascade of renames during the deserialization process.

Therefore, flow names are unstable identifiers. The SubflowWorkflowNode made the mistake of assuming the flow it is associated with could be stably identified by its name, and so baked in a fixed flow name into the node's metadata.

This could manifest as the subflow not being found, or the wrong subflow being used, infinite recursion, and deletion of the wrong subflow when the node is deleted.

In addition, attempting to copy-paste a SubflowWorkflowNode duplicates the node's metadata, meaning both old and new nodes have a claim on the same flow.

So don't persist the subflow import in the parent workflow file when it is serialized, by making use of the new `"transient"` metadata tag respected by the engine, whereby flows with this tag simply won't be serialized.

Instead, load the subflow only at node execution time, and keep in memory after that (for performance and in case of persistent state between runs).

Make a best effort to support legacy workflows that still have subflow imports baked into their serialization. Honour the legacy `"subflow_name"` metadata, but apply checks to validate it is not stale; and heuristically search for a match if `"subflow_name"` does not match a (valid) flow.

Add a workflow integration test, using a set of worflows that were serialized before this fix. I.e. test_subflow_workflow_node_legacy.py hosts a SubflowWorkflowNode pointing to subflow_middle_echo_legacy.py, which itself has two SubflowWorkflowNodes that both point to the same subflow_inner_echo.py workflow (introduced in #459). So this tests the case of migrating from a baked subflow import to a just-in-time import on execution.