### PR TITLE
fix(openai-image): upload reference images and send public URLs

### DIFF
--- a/griptape_nodes_library/image/openai_image_generation.py
+++ b/griptape_nodes_library/image/openai_image_generation.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 import base64
 import logging
 import re
+from contextlib import suppress
 from typing import Any, ClassVar
+from uuid import uuid4
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterList, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterList, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_list
 
@@ -86,6 +90,11 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate images using OpenAI GPT Image models via Griptape model proxy"
+
+        # Reference images are uploaded to Griptape Cloud and passed to the proxy as public URLs
+        # rather than base64-inlined into the request body. Each upload uses a transient
+        # PublicArtifactUrlParameter tracked here so it can be cleaned up after the run.
+        self._pending_reference_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
         self.add_parameter(
             ParameterString(
@@ -492,6 +501,20 @@ class OpenAiImageGeneration(GriptapeProxyNode):
 
         return exceptions if exceptions else None
 
+    async def _process_generation(self) -> None:
+        self._pending_reference_uploads = []
+        try:
+            await super()._process_generation()
+        finally:
+            # Delete each uploaded reference and remove its scratch parameter. The scratch name is
+            # unique per upload, so leaving it would accumulate parameters on the node across runs.
+            for helper, scratch_name in self._pending_reference_uploads:
+                with suppress(Exception):
+                    helper.delete_uploaded_artifact()
+                with suppress(Exception):
+                    self.remove_parameter_element_by_name(scratch_name)
+            self._pending_reference_uploads = []
+
     async def _build_payload(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": self._get_payload_model_id(),
@@ -592,14 +615,50 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         if not image_value:
             raise ValueError(f"{self.name}: Input image must be a file path, URL, data URI, or image artifact.")
 
-        if image_value.startswith("data:"):
+        # Upload the reference to Griptape Cloud and pass the proxy a public URL instead of
+        # base64-inlining the bytes. Base64 inflates the payload ~33%, so a couple of large
+        # references can exceed the proxy's request-body cap; a URL keeps the body tiny.
+        try:
+            return self._resolve_public_url_for_reference(image_value)
+        except Exception as e:
+            msg = f"{self.name}: Failed to prepare input image {image_input!r}: {e}"
+            raise ValueError(msg) from e
+
+    def _resolve_public_url_for_reference(self, image_value: str) -> str:
+        """Return a publicly fetchable URL for a reference image.
+
+        Already-public http(s) URLs pass through unchanged. Everything else — local paths, data
+        URIs, and localhost URLs — is uploaded to Griptape Cloud via a transient
+        PublicArtifactUrlParameter (tracked for cleanup) and its public URL is returned.
+        """
+        if image_value.startswith(("http://", "https://")) and "localhost" not in image_value:
             return image_value
 
-        try:
-            return await File(image_value).aread_data_uri(fallback_mime=self.DEFAULT_INPUT_IMAGE_MIME_TYPE)
-        except FileLoadError as e:
-            msg = f"{self.name}: Failed to read input image {image_input!r}: {e}"
-            raise ValueError(msg) from e
+        # The scratch parameter is a transient, worker-local helper that only exists to feed the
+        # upload (PublicArtifactUrlParameter reads its value locally). Its name is unique per call
+        # and it is removed before the run ends. Mutating parameters during aprocess trips the
+        # strict-mode warning, which is expected and harmless here.
+        scratch_name = f"_reference_upload_{uuid4().hex}"
+        helper = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=Parameter(
+                name=scratch_name,
+                input_types=["ImageUrlArtifact"],
+                type="ImageUrlArtifact",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.PROPERTY},
+                hide=True,
+                hide_property=True,
+            ),
+        )
+        helper.add_input_parameters()
+        self._pending_reference_uploads.append((helper, scratch_name))
+        self.set_parameter_value(scratch_name, image_value)
+
+        # Must run on the aprocess event loop, not a worker thread: the upload resolves macro paths
+        # (e.g. "{inputs}/...") via GriptapeNodes.handle_request, which needs the node's project context.
+        return helper.get_public_url_for_parameter()
 
     def _extract_input_image_value(self, image_input: Any) -> str | None:
         if isinstance(image_input, str):

--- a/tests/unit/image/test_openai_image_generation.py
+++ b/tests/unit/image/test_openai_image_generation.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 
 import pytest
 from griptape.artifacts import ImageArtifact
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
@@ -15,6 +18,7 @@ from griptape_nodes_library.image.openai_image_generation import (
     GPT_IMAGE_2_MODEL_NAME,
     OpenAiImageGeneration,
 )
+from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 
 
 def _is_param_hidden(node: OpenAiImageGeneration, name: str) -> bool:
@@ -197,7 +201,18 @@ async def test_build_payload_sends_new_aspect_ratio_to_api(node: OpenAiImageGene
 
 
 @pytest.mark.asyncio
-async def test_build_payload_uses_base64_from_image_artifact(node: OpenAiImageGeneration) -> None:
+async def test_build_payload_uploads_reference_image_and_sends_public_url(
+    node: OpenAiImageGeneration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reference images are uploaded to Griptape Cloud and passed to the proxy as public URLs
+    # rather than base64-inlined into the request body.
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter,
+        "get_public_url_for_parameter",
+        lambda self: "https://public.example/reference.png",
+    )
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: None)
+
     node.set_parameter_value("model", "GPT Image 1")
     node.set_parameter_value("prompt", "Use the artifact image")
     node.set_parameter_value("size", "1024x1024")
@@ -208,20 +223,94 @@ async def test_build_payload_uses_base64_from_image_artifact(node: OpenAiImageGe
 
     payload = await node._build_payload()
 
-    assert payload["images"] == [
-        {"image_url": f"data:image/png;base64,{base64.b64encode(b'artifact-image-bytes').decode('utf-8')}"}
-    ]
+    assert payload["images"] == [{"image_url": "https://public.example/reference.png"}]
 
 
 @pytest.mark.asyncio
-async def test_build_payload_raises_for_invalid_input_image(node: OpenAiImageGeneration) -> None:
+async def test_build_payload_passes_public_url_reference_through_unchanged(
+    node: OpenAiImageGeneration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # An already-public http(s) URL must not be re-uploaded.
+    def fail_if_uploaded(self: PublicArtifactUrlParameter) -> str:
+        msg = "should not upload an already-public URL"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(PublicArtifactUrlParameter, "get_public_url_for_parameter", fail_if_uploaded)
+
+    node.set_parameter_value("model", "GPT Image 1.5")
+    node.set_parameter_value("prompt", "Use the reference image")
+    node.set_parameter_value("size", "1024x1024")
+    node.set_parameter_value("input_images", ["https://cdn.example/already-public.png"])
+
+    payload = await node._build_payload()
+
+    assert payload["images"] == [{"image_url": "https://cdn.example/already-public.png"}]
+    assert node._pending_reference_uploads == []
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_for_invalid_input_image(
+    node: OpenAiImageGeneration, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def raise_load_error(self: PublicArtifactUrlParameter) -> str:
+        msg = "file not found"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(PublicArtifactUrlParameter, "get_public_url_for_parameter", raise_load_error)
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: None)
+
     node.set_parameter_value("model", "GPT Image 1.5")
     node.set_parameter_value("prompt", "Use the reference image")
     node.set_parameter_value("size", "1024x1024")
     node.set_parameter_value("input_images", ["/definitely/missing/image.png"])
 
-    with pytest.raises(ValueError, match="Failed to read input image"):
+    with pytest.raises(ValueError, match="Failed to prepare input image"):
         await node._build_payload()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("base_raises", [False, True])
+async def test_reference_upload_scratch_parameters_removed_after_generation(
+    node: OpenAiImageGeneration, monkeypatch: pytest.MonkeyPatch, *, base_raises: bool
+) -> None:
+    # Each uploaded reference creates a uniquely-named scratch parameter; _process_generation's
+    # finally block must remove it so parameters don't accumulate across runs — even when the
+    # underlying generation raises.
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter,
+        "get_public_url_for_parameter",
+        lambda self: "https://public.example/uploaded.png",
+    )
+    delete_calls: list[PublicArtifactUrlParameter] = []
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: delete_calls.append(self))
+
+    # A data URI forces the upload path that mints a scratch parameter. Build the payload from
+    # inside the stubbed base generation so the scratch params exist when the finally block runs.
+    reference = ImageArtifact(value=b"artifact-image-bytes", format="png", width=1, height=1)
+    node.set_parameter_value("input_images", [reference])
+
+    captured: dict[str, list[str]] = {}
+
+    async def fake_base_generation(self: OpenAiImageGeneration) -> None:
+        await self._build_input_images_payload()
+        captured["scratch_names"] = [name for _, name in self._pending_reference_uploads]
+        if base_raises:
+            msg = "generation failed"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr(GriptapeProxyNode, "_process_generation", fake_base_generation)
+
+    if base_raises:
+        with pytest.raises(RuntimeError, match="generation failed"):
+            await node._process_generation()
+    else:
+        await node._process_generation()
+
+    scratch_names = captured["scratch_names"]
+    assert scratch_names, "expected a scratch upload parameter to be created"
+    assert all(node.get_parameter_by_name(name) is None for name in scratch_names)
+    assert len(delete_calls) == len(scratch_names)
+    assert node._pending_reference_uploads == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #474

## Problem

The `OpenAI Image Generation` node base64-inlined reference images into the JSON request body sent to the Griptape Cloud model proxy. Base64 encoding inflates payload size by ~33%, so a couple of large reference images could push the request body past the proxy's 100MB cap (`DATA_UPLOAD_MAX_MEMORY_SIZE`), causing a hard failure *before* generation even started.

## Fix

Upload each reference image to Griptape Cloud and pass the proxy a **public URL** instead of base64-inlined bytes. The URL keeps the request body tiny regardless of reference size.

- Verified empirically that the proxy forwards `images:[{image_url: ...}]` verbatim to OpenAI's `/v1/images/edits`, and that gpt-image accepts a plain HTTPS URL in `image_url`.
- Each reference is uploaded via a transient `PublicArtifactUrlParameter` (a hidden, PROPERTY-mode scratch parameter minted per upload). Already-public non-localhost `http(s)` URLs pass through unchanged and are not re-uploaded.
- Uploads are tracked and cleaned up (artifact deleted + scratch parameter removed) in `_process_generation`'s `finally` block, so nothing accumulates across runs — including when generation raises.
- The upload runs on the aprocess event loop (not a worker thread) because it resolves macro paths (e.g. `{inputs}/...`) via `GriptapeNodes.handle_request`, which needs the node's project context.

Follows the established multi-upload pattern from `seedance_2_0_video_generation.py`.

## Tests

- Reference image is uploaded and the payload carries the returned public URL.
- Already-public URLs pass through unchanged and mint no scratch parameter.
- Invalid/unreadable input raises a clear `Failed to prepare input image` error.
- Scratch parameters and uploaded artifacts are cleaned up after generation — parametrized to cover both the success path and the case where the underlying generation raises.

<img width="1181" height="867" alt="Clownin" src="https://github.com/user-attachments/assets/05b20d58-541a-4edd-aaa4-55317f8bd5e5" />

