### PR TITLE
Update: add stable lifecycle stage

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -54,6 +54,10 @@
     },
     "declarations": [
       {
+        "type": "lifecycle_stage",
+        "stage": "STABLE"
+      },
+      {
         "type": "model_catalog",
         "providers": {
           "anthropic": {


### PR DESCRIPTION
the standard library didn't have a lifecycle_stage set. Adding it.

fixes: https://github.com/griptape-ai/griptape-nodes-library-standard/issues/483