### PR TITLE
Fix: Trim Video accuracy

### DIFF
--- a/griptape_nodes_library/utils/ffmpeg_utils.py
+++ b/griptape_nodes_library/utils/ffmpeg_utils.py
@@ -436,6 +436,8 @@ def build_video_segment_cmd(
     start_sec: float,
     end_sec: float,
     output_path: str,
+    *,
+    frame_accurate: bool = False,
 ) -> list[str]:
     """Build an ffmpeg command to extract a video segment.
 
@@ -445,6 +447,12 @@ def build_video_segment_cmd(
     Stream copy requires fast seek — post-input accurate seek with -c copy silently
     drops video frames for many codecs/containers (e.g. H.264 in MOV/MP4).
     Data streams like timecode tracks (tmcd) are excluded since MP4 doesn't support them.
+
+    Stream copy also cuts on decode-order (DTS) packet boundaries, not presentation-order
+    (PTS): on B-frame-encoded sources this pulls in extra trailing frames past the
+    requested cutoff, one per frame of B-frame reorder depth. Pass frame_accurate=True
+    (e.g. for frame-range trims where an exact frame count is required) to always use the
+    re-encode path, which is immune to this.
     """
     ss = seconds_to_ts(start_sec)
     to = seconds_to_ts(end_sec)
@@ -454,7 +462,7 @@ def build_video_segment_cmd(
     maps = ["-map", "0:v", "-map", "0:a?"]
     tail = ["-movflags", "+faststart", output_path]
 
-    if duration >= MIN_SEGMENT_DURATION_FOR_STREAM_COPY and start_sec < 1e-5:
+    if not frame_accurate and duration >= MIN_SEGMENT_DURATION_FOR_STREAM_COPY and start_sec < 1e-5:
         return base + ["-ss", ss, "-to", to, "-i", input_path] + maps + ["-c", "copy"] + tail
 
     return (

--- a/griptape_nodes_library/video/split_video.py
+++ b/griptape_nodes_library/video/split_video.py
@@ -46,13 +46,16 @@ class Segment:
     end_sec: float
     title: str
     raw_id: str | None = None
+    frame_accurate: bool = False
 
 
 def build_ffmpeg_cmd(input_path: str, seg: Segment, outdir: str) -> list[str]:
     """Return a single ffmpeg command as a list for the given segment."""
     Path(outdir).mkdir(parents=True, exist_ok=True)
     out_path = Path(outdir) / f"{sanitize_filename(seg.title)}.mp4"
-    return build_video_segment_cmd("ffmpeg", input_path, seg.start_sec, seg.end_sec, str(out_path))
+    return build_video_segment_cmd(
+        "ffmpeg", input_path, seg.start_sec, seg.end_sec, str(out_path), frame_accurate=seg.frame_accurate
+    )
 
 
 class SplitVideo(SuccessFailureNode):
@@ -435,7 +438,7 @@ If no title is provided, just use "Segment X:" format.
 
             start_sec = start_frame / frame_rate
             end_sec = end_frame / frame_rate
-            segments.append(Segment(start_sec=start_sec, end_sec=end_sec, title=title.strip()))
+            segments.append(Segment(start_sec=start_sec, end_sec=end_sec, title=title.strip(), frame_accurate=True))
 
         return segments
 

--- a/griptape_nodes_library/video/trim_video.py
+++ b/griptape_nodes_library/video/trim_video.py
@@ -180,13 +180,15 @@ class TrimVideo(SuccessFailureNode):
 
         return exceptions if exceptions else None
 
-    def _process(self, input_url: str, start_sec: float, end_sec: float) -> None:
+    def _process(self, input_url: str, start_sec: float, end_sec: float, *, frame_accurate: bool) -> None:
         """Run ffmpeg and save the trimmed video to the output parameter."""
         ffmpeg_path, _ = get_ffmpeg_paths()
 
         with tempfile.TemporaryDirectory() as temp_dir:
             out_path = Path(temp_dir) / "trimmed.mp4"
-            cmd = build_video_segment_cmd(ffmpeg_path, input_url, start_sec, end_sec, str(out_path))
+            cmd = build_video_segment_cmd(
+                ffmpeg_path, input_url, start_sec, end_sec, str(out_path), frame_accurate=frame_accurate
+            )
             run_ffmpeg_cmd(cmd, log=lambda msg: self.append_value_to_parameter("logs", msg))
 
             if not out_path.exists():
@@ -262,7 +264,9 @@ class TrimVideo(SuccessFailureNode):
                     raise ValueError("After clamping to video duration, end is not after start")  # noqa: TRY301
 
             self.append_value_to_parameter("logs", f"Trimming {start_sec:.3f}s → {end_sec:.3f}s\n")
-            await asyncio.to_thread(self._process, input_url, start_sec, end_sec)
+            await asyncio.to_thread(
+                self._process, input_url, start_sec, end_sec, frame_accurate=trim_by == "frame range"
+            )
             self.append_value_to_parameter("logs", "[Finished video trim.]\n")
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- Fixes #472: `Trim Video` in **frame range** mode could return more frames than requested (e.g. `0`–`81` overshot to 83 frames), while `0`–`41` worked correctly.
- Root cause (verified empirically, not the keyframe-snap theory in the issue): `build_video_segment_cmd`'s stream-copy fast path (`-c copy`) cuts on decode-order (DTS) packet boundaries rather than presentation order (PTS). On B-frame-encoded sources this pulls in extra trailing frames past the requested cutoff — reproduced directly with a synthetic B-frame H.264 clip (83 frames via stream copy vs. 81 via re-encode for the same `0`–`81` range).
- Added a `frame_accurate: bool = False` parameter to `build_video_segment_cmd` that forces the accurate re-encode path regardless of duration/start offset. `TrimVideo` and `SplitVideo` now pass `frame_accurate=True` only for their `"frame range"` mode; timecode-mode trims keep the existing stream-copy fast path (no behavior change there).
- Audited every other node using `-c:v copy` (`add_film_grain`, `flip_video`, `blur_video`, `hold_video_frames`, `add_rgb_shift`, `adjust_video_eq`, `add_vignette`, `resize_video`, `concatenate_videos`) — none combine it with a partial time/frame-range seek, so no other nodes are affected by this bug.

## Test plan
- [x] Reproduced the bug with a synthetic B-frame H.264 test video and confirmed `frame_accurate=True` fixes it (81 frames instead of 83) via direct `ffprobe -count_frames` check
- [x] Confirmed short ranges (previously correct via the re-encode path) still work
- [x] Confirmed timecode-mode trims on long, start-at-zero segments still take the stream-copy fast path (no perf regression)
- [x] `uv run ruff check` clean on changed files
- [x] `uv run pytest tests/unit` — 627 passed, 11 skipped
