### PR TITLE
feat(seedance): add multimodal reference list input mode

### DIFF
--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
+import os
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, ClassVar
@@ -40,6 +41,9 @@ from griptape_nodes_library.assets import (
 )
 from griptape_nodes_library.media import coerce_media_url_or_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.utils.audio_utils import is_audio_url_artifact
+from griptape_nodes_library.utils.image_utils import SUPPORTED_IMAGE_EXTENSIONS
+from griptape_nodes_library.utils.video_utils import SUPPORTED_VIDEO_EXTENSIONS, is_video_url_artifact
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -48,12 +52,20 @@ __all__ = ["Seedance20VideoGeneration"]
 INPUT_MODE_TEXT_ONLY = "Text Only"
 INPUT_MODE_FIRST_LAST_FRAME = "First/Last Frame"
 INPUT_MODE_MULTIMODAL_REFERENCES = "Multimodal References"
+INPUT_MODE_MULTIMODAL_REFERENCE_LIST = "Multimodal Reference List"
 MODEL_NAME_SEEDANCE_2_0 = "Seedance 2.0"
 MODEL_NAME_SEEDANCE_2_0_FAST = "Seedance 2.0 Fast"
 MODEL_NAME_SEEDANCE_2_0_MINI = "Seedance 2.0 Mini"
 SEEDANCE_2_0_MODEL_ID = "dreamina-seedance-2-0-260128"
 SEEDANCE_2_0_FAST_MODEL_ID = "dreamina-seedance-2-0-fast-260128"
 SEEDANCE_2_0_MINI_MODEL_ID = "dreamina-seedance-2-0-mini-260615"
+
+# Maximum number of each reference media type Seedance 2.0 accepts per request (BytePlus
+# docs). Applied both to the individual reference inputs (Multimodal References) and the
+# mixed list (Multimodal Reference List).
+MAX_REFERENCE_IMAGES = 9
+MAX_REFERENCE_VIDEOS = 3
+MAX_REFERENCE_AUDIO = 3
 
 
 @dataclass(frozen=True)
@@ -118,6 +130,8 @@ ASSET_MODERATION = {"Strategy": "Skip"}
 # docs). The local File/mimetypes layer emits other subtypes for the same formats (e.g. an .mp3
 # resolves to `audio/mpeg`, a .wav to `audio/x-wav`), which Seedance rejects as
 # "Invalid base64 audio_url". Map those aliases back to the accepted subtypes before sending.
+SEEDANCE_SUPPORTED_AUDIO_EXTENSIONS = {".mp3", ".wav"}
+
 SEEDANCE_AUDIO_SUBTYPE_ALIASES = {
     "mpeg": "mp3",
     "mp3": "mp3",
@@ -153,21 +167,23 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
     the same feature set; they differ in output resolution: standard 2.0 supports up to 4k, while
     Fast and Mini top out at 720p.
 
-    Supports three input modes:
+    Supports four input modes:
     - Text Only: Pure text-to-video generation (default)
     - First/Last Frame: Traditional i2v with first and/or last frame images
-    - Multimodal References: Up to 9 images + 3 videos + 3 audio files as references
+    - Multimodal References: Up to 9 images + 3 videos + 3 audio files as separate reference inputs
+    - Multimodal Reference List: Single mixed-type list input for images, videos, and audio
 
     Inputs:
         - prompt (str): Text prompt for the video
         - model_id (str): Model to use (default: Seedance 2.0)
-        - input_mode (str): "Text Only", "First/Last Frame", or "Multimodal References" (default: Text Only)
+        - input_mode (str): "Text Only", "First/Last Frame", "Multimodal References", or "Multimodal Reference List" (default: Text Only)
         - resolution (str): Output resolution (default: 720p, options: 480p, 720p, 1080p, 4k [1080p and 4k are Seedance 2.0 only])
         - ratio (str): Output aspect ratio (default: adaptive)
         - duration (int): Video duration in seconds (default: 5, range: 4-15 or -1 for smart)
         - generate_audio (bool): Generate audio with video (default: False)
         - first_frame/last_frame: Optional frame images (First/Last Frame mode only)
-        - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal mode only)
+        - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal References mode only)
+        - reference_media: Mixed list of reference images, audio, and videos (Multimodal Reference List mode only)
 
     Outputs:
         - generation_id (str): Griptape Cloud generation id
@@ -218,12 +234,20 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             ParameterString(
                 name="input_mode",
                 default_value=INPUT_MODE_TEXT_ONLY,
-                tooltip="Input mode: Text Only for pure text-to-video, First/Last Frame for i2v, or Multimodal References for images/videos/audio",
+                tooltip=(
+                    "Input mode: Text Only for pure text-to-video, First/Last Frame for i2v, Multimodal References for"
+                    " images/videos/audio, or Multimodal Reference List for a single mixed-type list input."
+                ),
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 ui_options={"display_name": "Input Mode", "hide": False},
                 traits={
                     Options(
-                        choices=[INPUT_MODE_TEXT_ONLY, INPUT_MODE_FIRST_LAST_FRAME, INPUT_MODE_MULTIMODAL_REFERENCES]
+                        choices=[
+                            INPUT_MODE_TEXT_ONLY,
+                            INPUT_MODE_FIRST_LAST_FRAME,
+                            INPUT_MODE_MULTIMODAL_REFERENCES,
+                            INPUT_MODE_MULTIMODAL_REFERENCE_LIST,
+                        ]
                     )
                 },
             )
@@ -350,6 +374,38 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             )
         )
 
+        # A plain list-typed Parameter (not a ParameterList): the whole point of this
+        # mode is to wire in a single list produced by a list node (CreateList /
+        # CreateImageList / CombineLists, whose `output` is a bare `list`).
+        reference_media_param = Parameter(
+            name="reference_media",
+            type="list",
+            input_types=["list"],
+            output_type="list",
+            default_value=[],
+            tooltip=(
+                "Mixed list of reference images, audio, and videos, produced by a list node (e.g. Create List). Each"
+                f" item is routed by type (up to {MAX_REFERENCE_IMAGES} images, {MAX_REFERENCE_VIDEOS} videos,"
+                f" {MAX_REFERENCE_AUDIO} audio). Local videos are uploaded to a short-lived public URL on execution;"
+                " audio must be mp3 or wav format."
+            ),
+            allowed_modes={ParameterMode.INPUT},
+            ui_options={"display_name": "Reference Media"},
+        )
+        # Mirror the per-slot "Media Upload" badge shown by the individual
+        reference_media_param.set_badge(
+            variant="cloud-upload",
+            title="Media Upload",
+            message=(
+                f"The {self.name} node requires a public URL for any videos in this list.\n\n"
+                "The Seedance 2.0 service utilizes this URL to access the reference video.\n"
+                "Executing this node will generate a short lived, public URL for each local video, which will be"
+                " cleaned up after execution. Images and audio are sent inline and are not uploaded.\n"
+            ),
+            hide_clear_button=False,
+        )
+        self.add_parameter(reference_media_param)
+
         # Generation settings
         with ParameterGroup(name="Generation Settings") as settings_group:
             ParameterString(
@@ -458,6 +514,23 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             if updated_list != value:
                 self.set_parameter_value("reference_audio", updated_list)
 
+        if parameter.name == "reference_media" and isinstance(value, list):
+            updated_list: list[Any] = []
+            changed = False
+            for item in value:
+                kind = self._classify_media_item(item)
+                if kind == ASSET_KIND_IMAGE:
+                    normalized = normalize_artifact_input(item, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+                elif kind == ASSET_KIND_AUDIO:
+                    normalized = normalize_artifact_input(item, AudioUrlArtifact, accepted_types=(AudioArtifact,))
+                else:
+                    normalized = item
+                if normalized is not item:
+                    changed = True
+                updated_list.append(normalized)
+            if changed:
+                self.set_parameter_value("reference_media", updated_list)
+
         return super().after_value_set(parameter, value)
 
     def _update_parameter_visibility(self) -> None:
@@ -467,36 +540,50 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
         self._update_resolution_options(model_id)
 
-        if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
-            # Show multimodal inputs, hide first/last frame
-            self.hide_parameter_by_name("first_frame")
-            self.hide_parameter_by_name("last_frame")
-            self.show_parameter_by_name("reference_images")
-            self.show_parameter_by_name("reference_audio")
-            self._update_reference_video_visibility()
-        elif input_mode == INPUT_MODE_FIRST_LAST_FRAME:
-            # Show first/last frame, hide multimodal inputs
-            self.show_parameter_by_name("first_frame")
-            self.hide_parameter_by_name("reference_images")
-            self.hide_parameter_by_name("reference_audio")
-            self.hide_parameter_by_name(["reference_video_1", "reference_video_2", "reference_video_3"])
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_1")
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_2")
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_3")
-            if self._supports_last_frame(model_id):
-                self.show_parameter_by_name("last_frame")
-            else:
+        match input_mode:
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCES:
+                self.hide_parameter_by_name("first_frame")
                 self.hide_parameter_by_name("last_frame")
-        else:
-            # Text Only mode: hide all media inputs
-            self.hide_parameter_by_name("first_frame")
-            self.hide_parameter_by_name("last_frame")
-            self.hide_parameter_by_name("reference_images")
-            self.hide_parameter_by_name("reference_audio")
-            self.hide_parameter_by_name(["reference_video_1", "reference_video_2", "reference_video_3"])
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_1")
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_2")
-            self.hide_message_by_name("artifact_url_parameter_message_reference_video_3")
+                self.show_parameter_by_name("reference_images")
+                self.show_parameter_by_name("reference_audio")
+                self._update_reference_video_visibility()
+                self.hide_parameter_by_name("reference_media")
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCE_LIST:
+                self.hide_parameter_by_name("first_frame")
+                self.hide_parameter_by_name("last_frame")
+                self.hide_parameter_by_name("reference_images")
+                self.hide_parameter_by_name("reference_audio")
+                self.hide_parameter_by_name(["reference_video_1", "reference_video_2", "reference_video_3"])
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_1")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_2")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_3")
+                self.show_parameter_by_name("reference_media")
+            case x if x == INPUT_MODE_FIRST_LAST_FRAME:
+                self.show_parameter_by_name("first_frame")
+                self.hide_parameter_by_name("reference_images")
+                self.hide_parameter_by_name("reference_audio")
+                self.hide_parameter_by_name(["reference_video_1", "reference_video_2", "reference_video_3"])
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_1")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_2")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_3")
+                self.hide_parameter_by_name("reference_media")
+                if self._supports_last_frame(model_id):
+                    self.show_parameter_by_name("last_frame")
+                else:
+                    self.hide_parameter_by_name("last_frame")
+            case x if x == INPUT_MODE_TEXT_ONLY:
+                self.hide_parameter_by_name("first_frame")
+                self.hide_parameter_by_name("last_frame")
+                self.hide_parameter_by_name("reference_images")
+                self.hide_parameter_by_name("reference_audio")
+                self.hide_parameter_by_name(["reference_video_1", "reference_video_2", "reference_video_3"])
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_1")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_2")
+                self.hide_message_by_name("artifact_url_parameter_message_reference_video_3")
+                self.hide_parameter_by_name("reference_media")
+            case _:
+                msg = f"{self.name}: unknown input_mode {input_mode!r}"
+                raise ValueError(msg)
 
     def _update_reference_video_visibility(self) -> None:
         """Progressively reveal reference video inputs in multimodal mode."""
@@ -609,6 +696,21 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             else []
         )
 
+        reference_media = self.get_parameter_value("reference_media") or []
+        normalized_reference_media: list[Any] = []
+        for item in reference_media:
+            kind = self._classify_media_item(item)
+            if kind == ASSET_KIND_IMAGE:
+                normalized_reference_media.append(
+                    normalize_artifact_input(item, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+                )
+            elif kind == ASSET_KIND_AUDIO:
+                normalized_reference_media.append(
+                    normalize_artifact_input(item, AudioUrlArtifact, accepted_types=(AudioArtifact,))
+                )
+            else:
+                normalized_reference_media.append(item)
+
         return {
             "prompt": self.get_parameter_value("prompt") or "",
             "model_id": model_id,
@@ -624,6 +726,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             "reference_video_2": self.get_parameter_value("reference_video_2"),
             "reference_video_3": self.get_parameter_value("reference_video_3"),
             "reference_audio": normalized_reference_audio,
+            "reference_media": normalized_reference_media,
         }
 
     def _validate_parameters(self, params: dict[str, Any]) -> None:
@@ -636,71 +739,103 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         reference_video_inputs = self._get_reference_video_inputs(params)
         has_reference_videos = bool(reference_video_inputs)
         has_reference_audio = bool(params.get("reference_audio") and len(params["reference_audio"]) > 0)
+        has_reference_media = bool(params.get("reference_media"))
         has_any_media = (
-            has_first_frame or has_last_frame or has_reference_images or has_reference_videos or has_reference_audio
+            has_first_frame
+            or has_last_frame
+            or has_reference_images
+            or has_reference_videos
+            or has_reference_audio
+            or has_reference_media
         )
 
-        # Text Only mode: no media allowed
-        if input_mode == INPUT_MODE_TEXT_ONLY:
-            if has_any_media:
-                msg = (
-                    f"{self.name}: {INPUT_MODE_TEXT_ONLY} mode does not accept any media inputs. "
-                    f"Switch to {INPUT_MODE_FIRST_LAST_FRAME} or {INPUT_MODE_MULTIMODAL_REFERENCES} mode, "
-                    "or clear all media inputs."
-                )
-                raise ValueError(msg)
-
-        # First/Last Frame mode: only first/last frame allowed
-        elif input_mode == INPUT_MODE_FIRST_LAST_FRAME:
-            if has_reference_images or has_reference_videos or has_reference_audio:
-                msg = (
-                    f"{self.name}: reference_images/reference_video_1/reference_video_2/reference_video_3/reference_audio are only used in "
-                    f"{INPUT_MODE_MULTIMODAL_REFERENCES} mode. Switch input_mode to {INPUT_MODE_MULTIMODAL_REFERENCES} "
-                    "or clear the multimodal reference inputs."
-                )
-                raise ValueError(msg)
-
-            if params.get("last_frame") and not self._supports_last_frame(params["model_id"]):
-                msg = (
-                    f"{self.name}: the selected model does not support a last frame. "
-                    "Use first_frame only, or switch to a model that supports first+last frame generation."
-                )
-                raise ValueError(msg)
-
-        # Multimodal References mode: only reference media allowed
-        elif input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
-            if has_first_frame or has_last_frame:
-                msg = (
-                    f"{self.name}: first_frame/last_frame inputs are only used in {INPUT_MODE_FIRST_LAST_FRAME} mode. "
-                    f"Switch input_mode to {INPUT_MODE_FIRST_LAST_FRAME} or clear the frame inputs."
-                )
-                raise ValueError(msg)
-
-        # Multimodal mode validation
-        if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
-            # Audio requires at least one image or video
-            if has_reference_audio and not (has_reference_images or has_reference_videos):
-                msg = (
-                    f"{self.name}: Seedance 2.0 requires at least one reference image or video when using audio. "
-                    "Audio cannot be used alone."
-                )
-                raise ValueError(msg)
-
-            # Validate counts
-            if has_reference_images and len(params["reference_images"]) > 9:
-                msg = f"{self.name}: Seedance 2.0 supports up to 9 reference images, got {len(params['reference_images'])}."
-                raise ValueError(msg)
-
-            if params.get("reference_video_2") and not params.get("reference_video_1"):
-                msg = f"{self.name}: reference_video_2 requires reference_video_1 to be set first."
-                raise ValueError(msg)
-
-            if params.get("reference_video_3") and not params.get("reference_video_2"):
-                msg = f"{self.name}: reference_video_3 requires reference_video_2 to be set first."
-                raise ValueError(msg)
-
-            if has_reference_audio and len(params["reference_audio"]) > 3:
-                msg = f"{self.name}: Seedance 2.0 supports up to 3 reference audio files, got {len(params['reference_audio'])}."
+        match input_mode:
+            case x if x == INPUT_MODE_TEXT_ONLY:
+                if has_any_media:
+                    msg = (
+                        f"{self.name}: {INPUT_MODE_TEXT_ONLY} mode does not accept any media inputs. "
+                        f"Switch to {INPUT_MODE_FIRST_LAST_FRAME} or {INPUT_MODE_MULTIMODAL_REFERENCES} mode, "
+                        "or clear all media inputs."
+                    )
+                    raise ValueError(msg)
+            case x if x == INPUT_MODE_FIRST_LAST_FRAME:
+                if has_reference_images or has_reference_videos or has_reference_audio or has_reference_media:
+                    msg = (
+                        f"{self.name}: reference_images/reference_video_1/reference_video_2/reference_video_3/reference_audio are only used in "
+                        f"{INPUT_MODE_MULTIMODAL_REFERENCES} mode. Switch input_mode to {INPUT_MODE_MULTIMODAL_REFERENCES} "
+                        "or clear the multimodal reference inputs."
+                    )
+                    raise ValueError(msg)
+                if params.get("last_frame") and not self._supports_last_frame(params["model_id"]):
+                    msg = (
+                        f"{self.name}: the selected model does not support a last frame. "
+                        "Use first_frame only, or switch to a model that supports first+last frame generation."
+                    )
+                    raise ValueError(msg)
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCES:
+                if has_first_frame or has_last_frame:
+                    msg = (
+                        f"{self.name}: first_frame/last_frame inputs are only used in {INPUT_MODE_FIRST_LAST_FRAME} mode. "
+                        f"Switch input_mode to {INPUT_MODE_FIRST_LAST_FRAME} or clear the frame inputs."
+                    )
+                    raise ValueError(msg)
+                if has_reference_media:
+                    msg = (
+                        f"{self.name}: reference_media is not used in {INPUT_MODE_MULTIMODAL_REFERENCES} mode. "
+                        "Use the individual reference inputs, or switch to Multimodal Reference List mode."
+                    )
+                    raise ValueError(msg)
+                if has_reference_audio and not (has_reference_images or has_reference_videos):
+                    msg = (
+                        f"{self.name}: Seedance 2.0 requires at least one reference image or video when using audio. "
+                        "Audio cannot be used alone."
+                    )
+                    raise ValueError(msg)
+                if has_reference_images and len(params["reference_images"]) > MAX_REFERENCE_IMAGES:
+                    msg = f"{self.name}: Seedance 2.0 supports up to {MAX_REFERENCE_IMAGES} reference images, got {len(params['reference_images'])}."
+                    raise ValueError(msg)
+                if params.get("reference_video_2") and not params.get("reference_video_1"):
+                    msg = f"{self.name}: reference_video_2 requires reference_video_1 to be set first."
+                    raise ValueError(msg)
+                if params.get("reference_video_3") and not params.get("reference_video_2"):
+                    msg = f"{self.name}: reference_video_3 requires reference_video_2 to be set first."
+                    raise ValueError(msg)
+                if has_reference_audio and len(params["reference_audio"]) > MAX_REFERENCE_AUDIO:
+                    msg = f"{self.name}: Seedance 2.0 supports up to {MAX_REFERENCE_AUDIO} reference audio files, got {len(params['reference_audio'])}."
+                    raise ValueError(msg)
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCE_LIST:
+                if has_first_frame or has_last_frame:
+                    msg = (
+                        f"{self.name}: first_frame/last_frame inputs are only used in {INPUT_MODE_FIRST_LAST_FRAME} mode. "
+                        f"Switch input_mode to {INPUT_MODE_FIRST_LAST_FRAME} or clear the frame inputs."
+                    )
+                    raise ValueError(msg)
+                if has_reference_images or has_reference_audio or has_reference_videos:
+                    msg = (
+                        f"{self.name}: reference_images/reference_audio/reference_video are not used in "
+                        f"{INPUT_MODE_MULTIMODAL_REFERENCE_LIST} mode. "
+                        "Use the reference_media list instead, or switch to Multimodal References mode."
+                    )
+                    raise ValueError(msg)
+                reference_media = params.get("reference_media") or []
+                list_images, list_videos, list_audio = self._split_media_list(reference_media)
+                if list_audio and not (list_images or list_videos):
+                    msg = (
+                        f"{self.name}: Seedance 2.0 requires at least one reference image or video when using audio. "
+                        "Audio cannot be used alone."
+                    )
+                    raise ValueError(msg)
+                if len(list_images) > MAX_REFERENCE_IMAGES:
+                    msg = f"{self.name}: Seedance 2.0 supports up to {MAX_REFERENCE_IMAGES} reference images in the list, got {len(list_images)}."
+                    raise ValueError(msg)
+                if len(list_videos) > MAX_REFERENCE_VIDEOS:
+                    msg = f"{self.name}: Seedance 2.0 supports up to {MAX_REFERENCE_VIDEOS} reference videos in the list, got {len(list_videos)}."
+                    raise ValueError(msg)
+                if len(list_audio) > MAX_REFERENCE_AUDIO:
+                    msg = f"{self.name}: Seedance 2.0 supports up to {MAX_REFERENCE_AUDIO} reference audio files in the list, got {len(list_audio)}."
+                    raise ValueError(msg)
+            case _:
+                msg = f"{self.name}: unknown input_mode {input_mode!r}"
                 raise ValueError(msg)
 
         # Validate duration range (4-15 or -1)
@@ -748,6 +883,8 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 checks.append((value, ASSET_KIND_VIDEO))
         for item in params.get("reference_audio") or []:
             checks.append((item, ASSET_KIND_AUDIO))
+        for item in params.get("reference_media") or []:
+            checks.append((item, self._classify_media_item(item)))
         return checks
 
     def _validate_private_asset_model(self, params: dict[str, Any]) -> None:
@@ -807,7 +944,8 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             f"last_frame_type={type(params['last_frame']).__name__ if params['last_frame'] is not None else 'None'}, "
             f"reference_images={len(params['reference_images'])}, "
             f"reference_videos={len(self._get_reference_video_inputs(params))}, "
-            f"reference_audio={len(params['reference_audio'])}"
+            f"reference_audio={len(params['reference_audio'])}, "
+            f"reference_media={len(params.get('reference_media') or [])}"
         )
 
         # Build payload with text prompt
@@ -837,89 +975,202 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         """Add media inputs to content list based on input mode."""
         input_mode = params["input_mode"]
 
-        if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
-            self._log(f"{self.name} building multimodal content")
-            supports_assets = self._private_assets_active(params["model_id"])
-            order_log: list[str] = []
+        match input_mode:
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCES:
+                self._log(f"{self.name} building multimodal content")
+                supports_assets = self._private_assets_active(params["model_id"])
+                order_log: list[str] = []
 
-            # Reference images (Image 1..N within this list, normal or private asset).
-            for idx, ref_image in enumerate(params.get("reference_images", [])[:9], start=1):
-                if supports_assets and is_provider_asset_reference(ref_image):
-                    asset_url = await self._append_private_asset(
-                        ref_image, expected_kind=ASSET_KIND_IMAGE, label=f"reference image {idx}"
+                for idx, ref_image in enumerate(params.get("reference_images", [])[:MAX_REFERENCE_IMAGES], start=1):
+                    tag = await self._append_reference_image(
+                        content_list,
+                        ref_image,
+                        idx,
+                        supports_assets=supports_assets,
+                        asset_label=f"reference image {idx}",
                     )
+                    if tag:
+                        order_log.append(tag)
+
+                for idx, ref_video in enumerate(self._get_reference_video_inputs(params), start=1):
+                    order_log.append(
+                        await self._append_reference_video(
+                            content_list,
+                            ref_video["value"],
+                            idx,
+                            supports_assets=supports_assets,
+                            asset_label=f"reference video {idx}",
+                            slot_param_name=ref_video["parameter_name"],
+                        )
+                    )
+
+                for idx, ref_audio in enumerate(params.get("reference_audio", [])[:MAX_REFERENCE_AUDIO], start=1):
+                    tag = await self._append_reference_audio(
+                        content_list,
+                        ref_audio,
+                        idx,
+                        supports_assets=supports_assets,
+                        asset_label=f"reference audio {idx}",
+                    )
+                    if tag:
+                        order_log.append(tag)
+
+                if order_log:
+                    self._log(f"{self.name} resolved reference order: " + "; ".join(order_log))
+
+            case x if x == INPUT_MODE_MULTIMODAL_REFERENCE_LIST:
+                self._log(f"{self.name} building multimodal reference-list content")
+                supports_assets = self._private_assets_active(params["model_id"])
+                reference_media = params.get("reference_media") or []
+                list_images, list_videos, list_audio = self._split_media_list(reference_media)
+                order_log_list: list[str] = []
+
+                for idx, ref_image in enumerate(list_images[:MAX_REFERENCE_IMAGES], start=1):
+                    tag = await self._append_reference_image(
+                        content_list,
+                        ref_image,
+                        idx,
+                        supports_assets=supports_assets,
+                        asset_label=f"reference_media image {idx}",
+                    )
+                    if tag:
+                        order_log_list.append(tag)
+
+                for idx, ref_video in enumerate(list_videos[:MAX_REFERENCE_VIDEOS], start=1):
+                    order_log_list.append(
+                        await self._append_reference_video(
+                            content_list,
+                            ref_video,
+                            idx,
+                            supports_assets=supports_assets,
+                            asset_label=f"reference_media video {idx}",
+                            slot_param_name=None,
+                        )
+                    )
+
+                for idx, ref_audio in enumerate(list_audio[:MAX_REFERENCE_AUDIO], start=1):
+                    tag = await self._append_reference_audio(
+                        content_list,
+                        ref_audio,
+                        idx,
+                        supports_assets=supports_assets,
+                        asset_label=f"reference_media audio {idx}",
+                    )
+                    if tag:
+                        order_log_list.append(tag)
+
+                if order_log_list:
+                    self._log(f"{self.name} resolved reference_media order: " + "; ".join(order_log_list))
+
+            case x if x == INPUT_MODE_FIRST_LAST_FRAME:
+                self._log(f"{self.name} building first/last-frame content")
+                first_frame_url = await self._prepare_frame_url_async(params["first_frame"], frame_label="first_frame")
+                if first_frame_url:
                     content_list.append(
-                        {"type": "image_url", "image_url": {"url": asset_url}, "role": "reference_image"}
+                        {"type": "image_url", "image_url": {"url": first_frame_url}, "role": "first_frame"}
                     )
-                    order_log.append(f"Image {idx}: private asset")
-                else:
-                    ref_url = await self._prepare_frame_url_async(ref_image, frame_label="reference_image")
-                    if ref_url:
+
+                if self._supports_last_frame(params["model_id"]):
+                    last_frame_url = await self._prepare_frame_url_async(params["last_frame"], frame_label="last_frame")
+                    if last_frame_url:
                         content_list.append(
-                            {"type": "image_url", "image_url": {"url": ref_url}, "role": "reference_image"}
+                            {"type": "image_url", "image_url": {"url": last_frame_url}, "role": "last_frame"}
                         )
-                        order_log.append(f"Image {idx}: reference")
 
-            # Reference videos (Video 1..3 by slot).
-            for idx, ref_video in enumerate(self._get_reference_video_inputs(params), start=1):
-                value = ref_video["value"]
-                if supports_assets and is_provider_asset_reference(value):
-                    asset_url = await self._append_private_asset(
-                        value, expected_kind=ASSET_KIND_VIDEO, label=f"reference video {idx}"
-                    )
-                    content_list.append(
-                        {"type": "video_url", "video_url": {"url": asset_url}, "role": "reference_video"}
-                    )
-                    order_log.append(f"Video {idx}: private asset")
-                else:
-                    video_url = self._get_reference_video_url(ref_video["parameter_name"], value)
-                    if not video_url:
-                        msg = (
-                            f"{self.name}: {ref_video['parameter_name']} only supports public URLs, uploaded asset URLs, "
-                            "or asset:// IDs. Seedance 2.0 does not accept video base64."
-                        )
-                        raise ValueError(msg)
-                    content_list.append(
-                        {"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"}
-                    )
-                    order_log.append(f"Video {idx}: reference")
+            case x if x == INPUT_MODE_TEXT_ONLY:
+                self._log(f"{self.name} text-only mode, no media inputs")
 
-            # Reference audio (Audio 1..N within this list, normal or private asset).
-            for idx, ref_audio in enumerate(params.get("reference_audio", [])[:3], start=1):
-                if supports_assets and is_provider_asset_reference(ref_audio):
-                    asset_url = await self._append_private_asset(
-                        ref_audio, expected_kind=ASSET_KIND_AUDIO, label=f"reference audio {idx}"
-                    )
-                    content_list.append(
-                        {"type": "audio_url", "audio_url": {"url": asset_url}, "role": "reference_audio"}
-                    )
-                    order_log.append(f"Audio {idx}: private asset")
-                else:
-                    audio_url = await self._prepare_audio_url_async(ref_audio, audio_label="reference_audio")
-                    if audio_url:
-                        content_list.append(
-                            {"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"}
-                        )
-                        order_log.append(f"Audio {idx}: reference")
+            case _:
+                msg = f"{self.name}: unknown input_mode {input_mode!r}"
+                raise ValueError(msg)
 
-            if order_log:
-                self._log(f"{self.name} resolved reference order: " + "; ".join(order_log))
-        elif input_mode == INPUT_MODE_FIRST_LAST_FRAME:
-            self._log(f"{self.name} building first/last-frame content")
-            # First/Last Frame mode
-            first_frame_url = await self._prepare_frame_url_async(params["first_frame"], frame_label="first_frame")
-            if first_frame_url:
-                content_list.append({"type": "image_url", "image_url": {"url": first_frame_url}, "role": "first_frame"})
+    async def _append_reference_image(
+        self,
+        content_list: list[dict[str, Any]],
+        ref_image: Any,
+        idx: int,
+        *,
+        supports_assets: bool,
+        asset_label: str,
+    ) -> str | None:
+        """Append one reference image to the payload content, routing private assets vs public/data URLs.
 
-            if self._supports_last_frame(params["model_id"]):
-                last_frame_url = await self._prepare_frame_url_async(params["last_frame"], frame_label="last_frame")
-                if last_frame_url:
-                    content_list.append(
-                        {"type": "image_url", "image_url": {"url": last_frame_url}, "role": "last_frame"}
-                    )
-        else:
-            # Text Only mode: no media inputs
-            self._log(f"{self.name} text-only mode, no media inputs")
+        Shared by Multimodal References and Multimodal Reference List modes; only the source list and
+        the private-asset `asset_label` differ. Returns an order-log tag, or None if the image was skipped.
+        """
+        if supports_assets and is_provider_asset_reference(ref_image):
+            asset_url = await self._append_private_asset(ref_image, expected_kind=ASSET_KIND_IMAGE, label=asset_label)
+            content_list.append({"type": "image_url", "image_url": {"url": asset_url}, "role": "reference_image"})
+            return f"Image {idx}: private asset"
+        ref_url = await self._prepare_frame_url_async(ref_image, frame_label="reference_image")
+        if ref_url:
+            content_list.append({"type": "image_url", "image_url": {"url": ref_url}, "role": "reference_image"})
+            return f"Image {idx}: reference"
+        return None
+
+    async def _append_reference_audio(
+        self,
+        content_list: list[dict[str, Any]],
+        ref_audio: Any,
+        idx: int,
+        *,
+        supports_assets: bool,
+        asset_label: str,
+    ) -> str | None:
+        """Append one reference audio clip to the payload content, routing private assets vs public/data URLs.
+
+        Shared by Multimodal References and Multimodal Reference List modes; only the source list and
+        the private-asset `asset_label` differ. Returns an order-log tag, or None if the audio was skipped.
+        """
+        if supports_assets and is_provider_asset_reference(ref_audio):
+            asset_url = await self._append_private_asset(ref_audio, expected_kind=ASSET_KIND_AUDIO, label=asset_label)
+            content_list.append({"type": "audio_url", "audio_url": {"url": asset_url}, "role": "reference_audio"})
+            return f"Audio {idx}: private asset"
+        audio_url = await self._prepare_audio_url_async(ref_audio, audio_label="reference_audio")
+        if audio_url:
+            content_list.append({"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"})
+            return f"Audio {idx}: reference"
+        return None
+
+    async def _append_reference_video(
+        self,
+        content_list: list[dict[str, Any]],
+        ref_video: Any,
+        idx: int,
+        *,
+        supports_assets: bool,
+        asset_label: str,
+        slot_param_name: str | None,
+    ) -> str:
+        """Append one reference video to the payload content.
+
+        Shared by Multimodal References (`slot_param_name` set → upload via the slot's
+        PublicArtifactUrlParameter) and Multimodal Reference List (`slot_param_name` None → upload via
+        a transient helper). Provider-asset references register as `asset://`; other inputs are
+        resolved to a public URL, uploading local media if needed (Seedance requires a public URL for
+        video, unlike images/audio which can be sent inline). Returns an order-log tag; raises if a
+        video can't be resolved to a public URL.
+        """
+        if supports_assets and is_provider_asset_reference(ref_video):
+            asset_url = await self._append_private_asset(ref_video, expected_kind=ASSET_KIND_VIDEO, label=asset_label)
+            content_list.append({"type": "video_url", "video_url": {"url": asset_url}, "role": "reference_video"})
+            return f"Video {idx}: private asset"
+
+        video_url = self._resolve_reference_video_url(ref_video, slot_param_name=slot_param_name, label=asset_label)
+        if not video_url:
+            if slot_param_name is not None:
+                msg = (
+                    f"{self.name}: {slot_param_name} only supports public URLs, uploaded asset URLs, or asset:// IDs. "
+                    "Seedance 2.0 does not accept video base64."
+                )
+            else:
+                msg = (
+                    f"{self.name}: video #{idx} in reference_media could not be resolved to a public URL. "
+                    "Provide a public http/https or asset:// URL, or a local video that can be uploaded to public storage."
+                )
+            raise ValueError(msg)
+        content_list.append({"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"})
+        return f"Video {idx}: reference"
 
     # --- Provider private-asset registration (Seedance 2.0 variants, Griptape auth only) -----
 
@@ -962,6 +1213,17 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         if media_value.startswith(("http://", "https://")) and "localhost" not in media_value:
             return media_value
 
+        return self._upload_media_to_public_url(
+            media_value, asset_kind=asset_kind, label=f"the {asset_kind} private asset"
+        )
+
+    def _upload_media_to_public_url(self, media_value: Any, *, asset_kind: str, label: str) -> str:
+        """Upload a non-public media value to GTC static storage and return its public URL.
+
+        Uses a transient PublicArtifactUrlParameter tracked in `_pending_asset_uploads` for cleanup —
+        the same upload path the named reference-video slots use. Raises if a public URL can't be
+        obtained (e.g. a data URI, which the provider cannot fetch).
+        """
         artifact_type = {
             ASSET_KIND_IMAGE: "ImageUrlArtifact",
             ASSET_KIND_VIDEO: "VideoUrlArtifact",
@@ -994,8 +1256,8 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         public_url = helper.get_public_url_for_parameter()
         if not (public_url.startswith(("http://", "https://")) and "localhost" not in public_url):
             msg = (
-                f"{self.name}: could not obtain a public URL for the {asset_kind} private asset. "
-                "Provider asset registration requires a publicly fetchable URL (data URIs are not supported)."
+                f"{self.name}: could not obtain a public URL for {label}. "
+                "A publicly fetchable URL is required (data URIs are not supported)."
             )
             raise RuntimeError(msg)
         return public_url
@@ -1229,6 +1491,54 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         return None
 
     @staticmethod
+    def _classify_media_item(item: Any) -> str:
+        """Classify as ASSET_KIND_IMAGE / ASSET_KIND_VIDEO / ASSET_KIND_AUDIO."""
+        if is_provider_asset_reference(item):
+            kind = get_provider_asset_kind(item)
+            if kind in (ASSET_KIND_IMAGE, ASSET_KIND_VIDEO, ASSET_KIND_AUDIO):
+                return kind
+            return ASSET_KIND_IMAGE
+        if isinstance(item, (ImageUrlArtifact, ImageArtifact)):
+            return ASSET_KIND_IMAGE
+        if is_video_url_artifact(item):
+            return ASSET_KIND_VIDEO
+        if is_audio_url_artifact(item) or isinstance(item, AudioArtifact):
+            return ASSET_KIND_AUDIO
+        if isinstance(item, str):
+            # Strip any query string first so os.path.splitext doesn't fold it into the
+            # extension (e.g. ".mp4?token=abc"), then take the extension of the final
+            # path component.
+            path = item.strip().split("?", 1)[0]
+            ext = os.path.splitext(path)[1].lower()
+            if ext in SEEDANCE_SUPPORTED_AUDIO_EXTENSIONS:
+                return ASSET_KIND_AUDIO
+            if ext in SUPPORTED_VIDEO_EXTENSIONS:
+                return ASSET_KIND_VIDEO
+            if ext in SUPPORTED_IMAGE_EXTENSIONS:
+                return ASSET_KIND_IMAGE
+        return ASSET_KIND_IMAGE
+
+    @classmethod
+    def _split_media_list(cls, media_list: list[Any]) -> tuple[list[Any], list[Any], list[Any]]:
+        """Split a mixed reference_media list into (images, videos, audio)."""
+        images: list[Any] = []
+        videos: list[Any] = []
+        audio: list[Any] = []
+        for item in media_list:
+            kind = cls._classify_media_item(item)
+            match kind:
+                case s if s == ASSET_KIND_IMAGE:
+                    images.append(item)
+                case s if s == ASSET_KIND_VIDEO:
+                    videos.append(item)
+                case s if s == ASSET_KIND_AUDIO:
+                    audio.append(item)
+                case _:
+                    msg = f"Unknown media kind {kind!r} returned by _classify_media_item"
+                    raise ValueError(msg)
+        return images, videos, audio
+
+    @staticmethod
     def _coerce_video_url(val: Any) -> str | None:
         """Convert video input to a Seedance-supported public URL or asset ID."""
         if val is None:
@@ -1274,27 +1584,39 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             if params.get(parameter_name)
         ]
 
-    def _get_reference_video_url(self, parameter_name: str, value: Any) -> str | None:
+    def _resolve_reference_video_url(self, value: Any, *, slot_param_name: str | None, label: str) -> str | None:
+        """Resolve a reference video to a Seedance-ready public/asset URL, uploading local media if needed.
+
+        Already-public http(s) / asset:// URLs pass through. Otherwise the local media is uploaded to
+        GTC static storage so the provider can fetch it (Seedance does not accept video base64):
+        Multimodal References (`slot_param_name` set) uploads via the slot's dedicated
+        PublicArtifactUrlParameter; Multimodal Reference List (`slot_param_name` None) uploads via a
+        transient helper. Returns None if the media can't be resolved or uploaded.
+        """
         direct_url = self._coerce_video_url(value)
         if direct_url:
             return direct_url
 
-        helper_map = {
-            "reference_video_1": self._public_reference_video_parameter_1,
-            "reference_video_2": self._public_reference_video_parameter_2,
-            "reference_video_3": self._public_reference_video_parameter_3,
-        }
-        helper = helper_map.get(parameter_name)
-        if helper is None:
-            return None
+        if slot_param_name is not None:
+            helper = {
+                "reference_video_1": self._public_reference_video_parameter_1,
+                "reference_video_2": self._public_reference_video_parameter_2,
+                "reference_video_3": self._public_reference_video_parameter_3,
+            }.get(slot_param_name)
+            if helper is None:
+                return None
+            try:
+                public_url = helper.get_public_url_for_parameter()
+            except Exception as e:
+                self._log(f"{self.name} failed to prepare public URL for {slot_param_name}: {e}")
+                return None
+            return self._coerce_video_url(public_url)
 
         try:
-            public_url = helper.get_public_url_for_parameter()
+            return self._upload_media_to_public_url(value, asset_kind=ASSET_KIND_VIDEO, label=label)
         except Exception as e:
-            self._log(f"{self.name} failed to prepare public URL for {parameter_name}: {e}")
+            self._log(f"{self.name} failed to upload {label} to a public URL: {e}")
             return None
-
-        return self._coerce_video_url(public_url)
 
     @staticmethod
     def _supports_last_frame(model_id: str) -> bool:

--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -876,6 +876,7 @@ def generate_advanced_workflow(cfg: dict) -> str:
 MANUAL_FLOW_INPUTS: dict[str, dict] = {
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_seedance_2_0_multimodal_list.py": {"Start Flow": {"prompt": "Animate the reference image with sound"}},
     "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }

--- a/tests/integration/SEEDANCE_TESTING.md
+++ b/tests/integration/SEEDANCE_TESTING.md
@@ -10,6 +10,26 @@ This directory contains integration tests for the Seedance video generation node
    - Model IDs: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`
    - API key configured
 
+## CI workflow tests
+
+The auto-discovered CI workflow tests (run by `tests/workflows/test_integration_workflows.py`)
+live alongside this doc as `test_seedance_2_0*.py`. They run against Griptape Cloud using the
+local workspace credentials (discovered automatically — no local proxy required) or, in CI, the
+`GT_CLOUD_API_KEY` secret.
+
+- `test_seedance_2_0.py` — text-to-video, Seedance 2.0.
+- `test_seedance_2_0_fast.py` — text-to-video, Seedance 2.0 Fast.
+- `test_seedance_2_0_multimodal_list.py` — "Multimodal Reference List" mode: a mixed
+  image + audio list (Create Color Bars + ElevenLabs sound effect combined via a Create List
+  node) wired into the single `reference_media` input. Covers issue #488 (wiring a variable,
+  mixed asset list into one Seedance node).
+
+Run one locally with:
+
+```bash
+uv run pytest -v tests/workflows/test_integration_workflows.py -k seedance_2_0_multimodal_list
+```
+
 ## Test Files
 
 ### `test_seedance_video_generation.py`
@@ -100,12 +120,15 @@ python tests/integration/test_seedance_2_0_features.py --storage-backend gtc --t
 - ✓ Resolution validation (1080p/4k are Seedance 2.0 standard only; Fast/Mini cap at 720p)
 - ✓ First/last frame supported on all three variants
 
+### Multimodal Reference List (mixed-type list input, issue #488)
+- ✓ Whole-list connection from a list node into `reference_media` (image + audio)
+- ✓ Per-item routing by type (image → reference_image, audio → reference_audio)
+- ✓ End-to-end generation via `test_seedance_2_0_multimodal_list.py`
+
 ### Future Tests (TODO)
-- [ ] Reference images (multimodal, 0-9 images)
-- [ ] Reference videos (0-3 videos)
-- [ ] Reference audio (0-3 audio files)
+- [ ] Reference videos in the list (0-3 videos)
 - [ ] Validation: multimodal refs cannot mix with first/last frame
-- [ ] Validation: audio requires image/video
+- [ ] Validation: audio requires image/video (unit-tested; not yet an integration workflow)
 
 ## Debugging
 

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -22,6 +22,7 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_elevenlabs_music_generation.py": {"Start Flow": {"prompt": "Upbeat jazz"}},
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_seedance_2_0_multimodal_list.py": {"Start Flow": {"prompt": "Animate the reference image with sound"}},
     "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from griptape.artifacts import ImageUrlArtifact
+from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterList, ParameterMode
@@ -17,9 +17,12 @@ from griptape_nodes.traits.options import Options
 from griptape_nodes_library.assets import (
     ASSET_KIND_AUDIO,
     ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
     create_provider_asset_reference,
 )
 from griptape_nodes_library.video.seedance_2_0_video_generation import (
+    INPUT_MODE_MULTIMODAL_REFERENCE_LIST,
+    INPUT_MODE_MULTIMODAL_REFERENCES,
     SEEDANCE_2_0_FAST_MODEL_ID,
     SEEDANCE_2_0_MINI_MODEL_ID,
     SEEDANCE_2_0_MODEL_ID,
@@ -30,14 +33,16 @@ from griptape_nodes_library.video.seedance_2_0_video_generation import (
 
 
 def _set_parameter_list_values(node: Seedance20VideoGeneration, parameter_name: str, values: list[object]) -> None:
-    parameter_list = next(
-        parameter
-        for parameter in node.parameters
-        if isinstance(parameter, ParameterList) and parameter.name == parameter_name
-    )
-    parameter_list.clear_list()
+    parameter = _parameter_by_name(node, parameter_name)
+    # reference_media is a plain list-typed Parameter (whole-list connection input), so set the
+    # value directly the way a connection delivers it. Real ParameterLists (reference_images /
+    # reference_audio) populate individual child slots instead.
+    if not isinstance(parameter, ParameterList):
+        node.set_parameter_value(parameter_name, list(values))
+        return
+    parameter.clear_list()
     for value in values:
-        child = parameter_list.add_child_parameter()
+        child = parameter.add_child_parameter()
         node.set_parameter_value(child.name, value)
 
 
@@ -610,3 +615,498 @@ def test_scratch_upload_parameters_are_removed_after_cleanup(monkeypatch: pytest
         node.remove_parameter_element_by_name(scratch_name)
 
     assert all(node.get_parameter_by_name(name) is None for name in scratch_names)
+
+
+# --- _classify_media_item tests ---------------------------------------------------------------
+
+
+def test_classify_image_url_artifact() -> None:
+    assert Seedance20VideoGeneration._classify_media_item(ImageUrlArtifact("https://ex.com/a.png")) == ASSET_KIND_IMAGE
+
+
+def test_classify_image_artifact() -> None:
+    assert (
+        Seedance20VideoGeneration._classify_media_item(ImageArtifact(b"\x89PNG", format="png", width=1, height=1))
+        == ASSET_KIND_IMAGE
+    )
+
+
+def test_classify_video_url_artifact() -> None:
+    assert Seedance20VideoGeneration._classify_media_item(VideoUrlArtifact("https://ex.com/v.mp4")) == ASSET_KIND_VIDEO
+
+
+def test_classify_audio_url_artifact() -> None:
+    assert Seedance20VideoGeneration._classify_media_item(AudioUrlArtifact("https://ex.com/a.wav")) == ASSET_KIND_AUDIO
+
+
+def test_classify_audio_artifact() -> None:
+    assert Seedance20VideoGeneration._classify_media_item(AudioArtifact(b"\x00", format="wav")) == ASSET_KIND_AUDIO
+
+
+def test_classify_provider_asset_image() -> None:
+    ref = create_provider_asset_reference(value="https://ex.com/portrait.png", asset_kind=ASSET_KIND_IMAGE)
+    assert Seedance20VideoGeneration._classify_media_item(ref) == ASSET_KIND_IMAGE
+
+
+def test_classify_provider_asset_video() -> None:
+    ref = create_provider_asset_reference(value="https://ex.com/clip.mp4", asset_kind=ASSET_KIND_VIDEO)
+    assert Seedance20VideoGeneration._classify_media_item(ref) == ASSET_KIND_VIDEO
+
+
+def test_classify_provider_asset_audio() -> None:
+    ref = create_provider_asset_reference(value="https://ex.com/clip.mp3", asset_kind=ASSET_KIND_AUDIO)
+    assert Seedance20VideoGeneration._classify_media_item(ref) == ASSET_KIND_AUDIO
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_kind"),
+    [
+        ("https://ex.com/clip.mp3", ASSET_KIND_AUDIO),
+        ("https://ex.com/clip.wav", ASSET_KIND_AUDIO),
+        ("https://ex.com/vid.mp4", ASSET_KIND_VIDEO),
+        ("https://ex.com/vid.mov", ASSET_KIND_VIDEO),
+        ("https://ex.com/photo.jpg", ASSET_KIND_IMAGE),
+        ("https://ex.com/photo.png", ASSET_KIND_IMAGE),
+        ("https://ex.com/photo.webp", ASSET_KIND_IMAGE),
+    ],
+)
+def test_classify_string_by_extension(url: str, expected_kind: str) -> None:
+    assert Seedance20VideoGeneration._classify_media_item(url) == expected_kind
+
+
+def test_classify_string_with_query_params() -> None:
+    assert Seedance20VideoGeneration._classify_media_item("https://ex.com/vid.mp4?token=abc") == ASSET_KIND_VIDEO
+
+
+def test_classify_unknown_string_falls_back_to_image() -> None:
+    assert Seedance20VideoGeneration._classify_media_item("https://ex.com/unknown") == ASSET_KIND_IMAGE
+
+
+def test_classify_ogg_not_treated_as_seedance_audio() -> None:
+    # Seedance only accepts mp3/wav; .ogg should NOT classify as audio
+    assert Seedance20VideoGeneration._classify_media_item("https://ex.com/clip.ogg") != ASSET_KIND_AUDIO
+
+
+def test_classify_none_falls_back_to_image() -> None:
+    assert Seedance20VideoGeneration._classify_media_item(None) == ASSET_KIND_IMAGE
+
+
+# --- _split_media_list tests ------------------------------------------------------------------
+
+
+def test_split_media_list_empty() -> None:
+    images, videos, audio = Seedance20VideoGeneration._split_media_list([])
+    assert images == []
+    assert videos == []
+    assert audio == []
+
+
+def test_split_media_list_mixed() -> None:
+    items = [
+        ImageUrlArtifact("https://ex.com/a.png"),
+        VideoUrlArtifact("https://ex.com/v.mp4"),
+        AudioUrlArtifact("https://ex.com/a.wav"),
+        ImageUrlArtifact("https://ex.com/b.png"),
+    ]
+    images, videos, audio = Seedance20VideoGeneration._split_media_list(items)
+    assert len(images) == 2
+    assert len(videos) == 1
+    assert len(audio) == 1
+
+
+def test_split_media_list_strings() -> None:
+    items = [
+        "https://ex.com/photo.jpg",
+        "https://ex.com/clip.mp4",
+        "https://ex.com/sound.mp3",
+    ]
+    images, videos, audio = Seedance20VideoGeneration._split_media_list(items)
+    assert len(images) == 1
+    assert len(videos) == 1
+    assert len(audio) == 1
+
+
+# --- Multimodal Reference List mode: validation tests ----------------------------------------
+
+
+def test_reference_list_mode_rejects_first_frame() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("first_frame", "data:image/png;base64,AAA")
+
+    with pytest.raises(ValueError, match="only used in First/Last Frame mode"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_individual_reference_images() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(node, "reference_images", [ImageUrlArtifact("https://ex.com/a.png")])
+
+    with pytest.raises(ValueError, match="not used in.*Multimodal Reference List.*mode"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_individual_reference_audio() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(node, "reference_audio", [AudioUrlArtifact("https://ex.com/a.wav")])
+
+    with pytest.raises(ValueError, match="not used in.*Multimodal Reference List.*mode"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_individual_reference_video() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("reference_video_1", "https://ex.com/v.mp4")
+
+    with pytest.raises(ValueError, match="not used in.*Multimodal Reference List.*mode"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_multimodal_references_mode_rejects_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCES)
+    _set_parameter_list_values(node, "reference_media", [ImageUrlArtifact("https://ex.com/a.png")])
+
+    with pytest.raises(ValueError, match="reference_media is not used in.*Multimodal References.*mode"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_text_only_mode_rejects_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", "Text Only")
+    _set_parameter_list_values(node, "reference_media", [ImageUrlArtifact("https://ex.com/a.png")])
+
+    with pytest.raises(ValueError, match="does not accept any media inputs"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_audio_alone() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(node, "reference_media", [AudioUrlArtifact("https://ex.com/a.wav")])
+
+    with pytest.raises(ValueError, match="requires at least one reference image or video"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_more_than_9_images() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(
+        node, "reference_media", [ImageUrlArtifact(f"https://ex.com/{i}.png") for i in range(10)]
+    )
+
+    with pytest.raises(ValueError, match="up to 9 reference images"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_more_than_3_videos() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(node, "reference_media", [VideoUrlArtifact(f"https://ex.com/{i}.mp4") for i in range(4)])
+
+    with pytest.raises(ValueError, match="up to 3 reference videos"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_rejects_more_than_3_audio() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [ImageUrlArtifact("https://ex.com/img.png")] + [AudioUrlArtifact(f"https://ex.com/{i}.wav") for i in range(4)],
+    )
+
+    with pytest.raises(ValueError, match="up to 3 reference audio"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_mode_accepts_valid_mixed_list() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [
+            ImageUrlArtifact("https://ex.com/a.png"),
+            VideoUrlArtifact("https://ex.com/v.mp4"),
+            AudioUrlArtifact("https://ex.com/a.wav"),
+        ],
+    )
+
+    # Should not raise
+    node._validate_parameters(node._get_parameters())
+
+
+# --- Multimodal Reference List mode: visibility tests ----------------------------------------
+
+
+def test_reference_list_mode_shows_only_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+
+    assert _parameter_by_name(node, "reference_media").hide is False
+    assert _parameter_by_name(node, "first_frame").hide is True
+    assert _parameter_by_name(node, "last_frame").hide is True
+    assert _parameter_by_name(node, "reference_images").hide is True
+    assert _parameter_by_name(node, "reference_audio").hide is True
+    assert _parameter_by_name(node, "reference_video_1").hide is True
+
+
+def test_other_modes_hide_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+
+    for mode in ["Text Only", "First/Last Frame", "Multimodal References"]:
+        node.set_parameter_value("input_mode", mode)
+        assert _parameter_by_name(node, "reference_media").hide is True, f"reference_media should be hidden in {mode}"
+
+
+def test_input_mode_choices_include_reference_list() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    input_mode_param = _parameter_by_name(node, "input_mode")
+    choices = input_mode_param.find_elements_by_type(Options)[0].choices
+    assert INPUT_MODE_MULTIMODAL_REFERENCE_LIST in choices
+
+
+# --- Multimodal Reference List mode: whole-list connection acceptance (#488) -----------------
+
+
+def test_reference_media_accepts_whole_list_connection() -> None:
+    """The core #488 requirement: a list-producing node (output type bare ``list``) must be
+    wireable into reference_media. It is a plain list-typed Parameter, so the connection
+    type-check (Parameter.is_incoming_type_allowed, the same gate the engine's FlowManager uses)
+    accepts any list-shaped source — bare ``list`` and typed ``list[X]`` alike.
+    """
+    node = Seedance20VideoGeneration(name="Seedance20")
+    reference_media = _parameter_by_name(node, "reference_media")
+
+    # CreateList / CreateImageList expose an ``output`` of type ``list``.
+    assert reference_media.is_incoming_type_allowed("list")
+    # Typed list outputs still connect.
+    assert reference_media.is_incoming_type_allowed("list[ImageUrlArtifact]")
+    assert reference_media.is_incoming_type_allowed("list[any]")
+    # A single (non-list) artifact is not accepted — this mode takes a whole list.
+    assert not reference_media.is_incoming_type_allowed("ImageUrlArtifact")
+
+
+def test_reference_media_whole_list_value_round_trips() -> None:
+    """A connection delivers the whole list via set_parameter_value; the node must read it back
+    intact (a ParameterList would collapse it to an empty list — the bug behind #488)."""
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    incoming = [ImageUrlArtifact("https://ex.com/a.png"), AudioUrlArtifact("https://ex.com/b.wav")]
+    node.set_parameter_value("reference_media", incoming)
+
+    assert node.get_parameter_value("reference_media") == incoming
+    assert node._get_parameters()["reference_media"] == incoming
+
+
+def test_reference_media_has_media_upload_badge() -> None:
+    """Parity with the per-slot reference-video inputs: reference_media carries a Media Upload badge
+    warning that local videos are uploaded to a short-lived public URL."""
+    node = Seedance20VideoGeneration(name="Seedance20")
+    badge = _parameter_by_name(node, "reference_media").get_badge()
+    assert badge is not None
+    assert badge.title == "Media Upload"
+    assert badge.variant == "cloud-upload"
+
+
+# --- Multimodal Reference List mode: _iter_reference_asset_checks ----------------------------
+
+
+def test_iter_reference_asset_checks_includes_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    img_ref = create_provider_asset_reference(value="https://ex.com/img.png", asset_kind=ASSET_KIND_IMAGE)
+    vid_ref = create_provider_asset_reference(value="https://ex.com/vid.mp4", asset_kind=ASSET_KIND_VIDEO)
+    params = node._get_parameters()
+    params["reference_media"] = [img_ref, vid_ref]
+
+    checks = node._iter_reference_asset_checks(params)
+    assert (img_ref, ASSET_KIND_IMAGE) in checks
+    assert (vid_ref, ASSET_KIND_VIDEO) in checks
+
+
+# --- Multimodal Reference List mode: _get_parameters includes reference_media ----------------
+
+
+def test_get_parameters_includes_reference_media() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [ImageUrlArtifact("https://ex.com/a.png")],
+    )
+
+    params = node._get_parameters()
+    assert "reference_media" in params
+    assert len(params["reference_media"]) == 1
+
+
+# --- Multimodal Reference List mode: payload building ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_payload_reference_list_images_and_audio(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("prompt", "Animate the references")
+
+    async def fake_aread_data_uri(self: File, fallback_mime: str = "application/octet-stream") -> str:
+        return "data:image/png;base64,VALID_IMAGE"
+
+    monkeypatch.setattr(File, "aread_data_uri", fake_aread_data_uri)
+
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [
+            ImageUrlArtifact("https://ex.com/photo.png"),
+            AudioUrlArtifact("data:audio/wav;base64,RAW_AUDIO_BASE64"),
+        ],
+    )
+
+    payload = await node._build_payload()
+
+    image_entries = [item for item in payload["content"] if item["type"] == "image_url"]
+    audio_entries = [item for item in payload["content"] if item["type"] == "audio_url"]
+
+    assert len(image_entries) == 1
+    assert image_entries[0]["role"] == "reference_image"
+    assert len(audio_entries) == 1
+    assert audio_entries[0]["role"] == "reference_audio"
+
+
+@pytest.mark.asyncio
+async def test_build_payload_reference_list_video_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("prompt", "Use the reference video")
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [VideoUrlArtifact("https://public.example/reference.mp4")],
+    )
+
+    payload = await node._build_payload()
+
+    video_entries = [item for item in payload["content"] if item["type"] == "video_url"]
+    assert len(video_entries) == 1
+    assert video_entries[0] == {
+        "type": "video_url",
+        "video_url": {"url": "https://public.example/reference.mp4"},
+        "role": "reference_video",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_payload_reference_list_uploads_local_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Parity with Multimodal References: a local (non-public) video in the list is uploaded to a
+    # short-lived public URL rather than rejected. The upload goes through a transient
+    # PublicArtifactUrlParameter tracked for cleanup, mirroring the private-asset path.
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("prompt", "Animate")
+
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter,
+        "get_public_url_for_parameter",
+        lambda self: "https://public.example/uploaded.mp4",
+    )
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: None)
+
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [VideoUrlArtifact("/local/path/video.mp4")],
+    )
+
+    payload = await node._build_payload()
+
+    video_entries = [item for item in payload["content"] if item["type"] == "video_url"]
+    assert video_entries == [
+        {"type": "video_url", "video_url": {"url": "https://public.example/uploaded.mp4"}, "role": "reference_video"}
+    ]
+    # A transient scratch upload parameter was minted (and will be cleaned up by _process_generation).
+    assert [name for _, name in node._pending_asset_uploads], "expected a scratch upload parameter"
+
+
+@pytest.mark.asyncio
+async def test_build_payload_reference_list_local_video_upload_failure_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("prompt", "Animate")
+
+    def _boom(self: PublicArtifactUrlParameter) -> str:
+        raise RuntimeError("upload failed")
+
+    monkeypatch.setattr(PublicArtifactUrlParameter, "get_public_url_for_parameter", _boom)
+    monkeypatch.setattr(PublicArtifactUrlParameter, "delete_uploaded_artifact", lambda self: None)
+
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [VideoUrlArtifact("/local/path/video.mp4")],
+    )
+
+    with pytest.raises(ValueError, match="could not be resolved to a public URL"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_reference_list_private_asset(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    node.set_parameter_value("prompt", "Animate the portrait")
+
+    registered: list[tuple[str, str]] = []
+
+    async def fake_create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
+        registered.append((public_url, asset_kind))
+        return "generated-asset-id"
+
+    monkeypatch.setattr(Seedance20VideoGeneration, "_create_provider_asset", fake_create_provider_asset)
+    monkeypatch.setattr(Seedance20VideoGeneration, "_validate_api_key", lambda self: "test-key")
+
+    _set_parameter_list_values(
+        node,
+        "reference_media",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    payload = await node._build_payload()
+
+    assert registered == [("https://public.example/portrait.png", ASSET_KIND_IMAGE)]
+    assert payload["content"] == [
+        {"type": "text", "text": "Animate the portrait"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "asset://generated-asset-id"},
+            "role": "reference_image",
+        },
+    ]
+
+
+def test_reference_list_mode_validates_private_asset_kind_mismatch() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0")
+    node.set_parameter_value("input_mode", INPUT_MODE_MULTIMODAL_REFERENCE_LIST)
+    # Audio asset reference classified as audio, but then tested against its own kind —
+    # should validate fine since the classifier matches
+    audio_ref = create_provider_asset_reference(value="https://ex.com/clip.wav", asset_kind=ASSET_KIND_AUDIO)
+    img_ref = create_provider_asset_reference(value="https://ex.com/portrait.png", asset_kind=ASSET_KIND_IMAGE)
+    _set_parameter_list_values(node, "reference_media", [img_ref, audio_ref])
+
+    # Should not raise — kinds match their classified types
+    node._validate_parameters(node._get_parameters())


### PR DESCRIPTION
Closes #488.

Add support for an arbitrary list input mode to the Seedance 2.0 Video Generation node, "Multimodal Reference List", which is equivalent to "Multimodal References", but that takes a list as a single argument, where the list contains mixed audio, image and video references.