### PR TITLE
report failure when billed generation output can't be retrieved

### DIFF
--- a/griptape_nodes_library/image/flux_2_image_generation.py
+++ b/griptape_nodes_library/image/flux_2_image_generation.py
@@ -412,30 +412,31 @@ class Flux2ImageGeneration(GriptapeProxyNode):
             )
             return
 
-        # Download and save the image using generation_id in filename
+        # Download and save the image using generation_id in filename. A billed
+        # generation whose image cannot be retrieved is a failure, not a silent
+        # success; the provider URL is surfaced so the user can retrieve it manually.
         try:
             self._log("Downloading image from URL")
             image_bytes = await File(sample_url).aread_bytes()
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
-                self._log(f"Saved image as {saved.name}")
-                self._set_status_results(
-                    was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
-                )
-            else:
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(value=sample_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
-                )
-        except Exception as e:
-            self._log(f"Failed to save image from URL: {e}")
-            self.parameter_output_values["image_url"] = ImageUrlArtifact(value=sample_url)
+            if not image_bytes:
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(image_bytes)
+            self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
+            self._log(f"Saved image as {saved.name}")
             self._set_status_results(
-                was_successful=True,
-                result_details=f"Image generated successfully. Using provider URL (could not save to static storage: {e}).",
+                was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
+            )
+        except Exception as e:
+            self._log(f"Failed to retrieve image from {sample_url}: {e}")
+            self.parameter_output_values["image_url"] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"{self.name} generation completed upstream but the image could not be retrieved: {e}. "
+                    f"Provider URL (may be temporary): {sample_url}"
+                ),
             )
 
     async def _process_input_image(self, image_input: Any) -> str | None:

--- a/griptape_nodes_library/image/flux_image_generation.py
+++ b/griptape_nodes_library/image/flux_image_generation.py
@@ -351,30 +351,35 @@ class FluxImageGeneration(GriptapeProxyNode):
         )
 
     async def _save_image_from_url(self, image_url: str) -> None:
-        """Download and save the image from the provided URL."""
+        """Download and save the image from the provided URL.
+
+        A billed generation whose image cannot be retrieved is a failure, not a
+        silent success. On any download or save failure the output is cleared and
+        the provider URL is surfaced in the status so the user can retrieve it
+        manually.
+        """
         try:
             self._log("Downloading image from URL")
             image_bytes = await File(image_url).aread_bytes()
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
-                self._log(f"Saved image as {saved.name}")
-                self._set_status_results(
-                    was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
-                )
-            else:
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(image_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
-                )
-        except Exception as e:
-            self._log(f"Failed to save image from URL: {e}")
-            self.parameter_output_values["image_url"] = ImageUrlArtifact(image_url)
+            if not image_bytes:
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(image_bytes)
+            self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
+            self._log(f"Saved image as {saved.name}")
             self._set_status_results(
-                was_successful=True,
-                result_details=f"Image generated successfully. Using provider URL (could not save to static storage: {e}).",
+                was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
+            )
+        except Exception as e:
+            self._log(f"Failed to retrieve image from {image_url}: {e}")
+            self.parameter_output_values["image_url"] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"{self.name} generation completed upstream but the image could not be retrieved: {e}. "
+                    f"Provider URL (may be temporary): {image_url}"
+                ),
             )
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:

--- a/griptape_nodes_library/image/grok_image_edit.py
+++ b/griptape_nodes_library/image/grok_image_edit.py
@@ -286,6 +286,7 @@ class GrokImageEdit(GriptapeProxyNode):
             return
 
         image_artifacts: list[ImageUrlArtifact] = []
+        failed_urls: list[str] = []
         for idx, image_data in enumerate(data):
             image_url = image_data.get("url")
             if not image_url:
@@ -294,13 +295,19 @@ class GrokImageEdit(GriptapeProxyNode):
             artifact = await self._save_single_image_from_url(image_url, generation_id, idx)
             if artifact:
                 image_artifacts.append(artifact)
+            else:
+                failed_urls.append(image_url)
 
         if not image_artifacts:
             self._set_safe_defaults()
-            self._set_status_results(
-                was_successful=False,
-                result_details=f"{self.name} generation completed but no image URLs were found in the response.",
-            )
+            if failed_urls:
+                details = (
+                    f"{self.name} generation completed upstream but the image(s) could not be retrieved. "
+                    f"Provider URL(s) (may be temporary): {', '.join(failed_urls)}"
+                )
+            else:
+                details = f"{self.name} generation completed but no image URLs were found in the response."
+            self._set_status_results(was_successful=False, result_details=details)
             return
 
         self._show_image_output_parameters(len(image_artifacts))
@@ -328,12 +335,16 @@ class GrokImageEdit(GriptapeProxyNode):
         try:
             image_bytes = await File(image_url).aread_bytes()
             if not image_bytes:
-                return ImageUrlArtifact(value=image_url)
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
 
             dest = self._output_file.build_file()
             saved = await dest.awrite_bytes(image_bytes)
             return ImageUrlArtifact(value=saved.location, name=saved.name)
         except Exception as e:
+            # A billed generation whose image cannot be retrieved is a failure, not a
+            # silent success. Return None so this image is not counted as saved; the
+            # caller reports failure and surfaces the provider URL for manual retrieval.
             with suppress(Exception):
-                logger.warning("%s failed to save image %s: %s", self.name, index, e)
-            return ImageUrlArtifact(value=image_url)
+                logger.warning("%s failed to retrieve image %s from %s: %s", self.name, index, image_url, e)
+            return None

--- a/griptape_nodes_library/image/grok_image_generation.py
+++ b/griptape_nodes_library/image/grok_image_generation.py
@@ -277,6 +277,7 @@ class GrokImageGeneration(GriptapeProxyNode):
             return
 
         image_artifacts: list[ImageUrlArtifact] = []
+        failed_urls: list[str] = []
         for idx, image_data in enumerate(data):
             image_url = image_data.get("url")
             if not image_url:
@@ -285,13 +286,19 @@ class GrokImageGeneration(GriptapeProxyNode):
             artifact = await self._save_single_image_from_url(image_url, generation_id, idx)
             if artifact:
                 image_artifacts.append(artifact)
+            else:
+                failed_urls.append(image_url)
 
         if not image_artifacts:
             self._set_safe_defaults()
-            self._set_status_results(
-                was_successful=False,
-                result_details=f"{self.name} generation completed but no image URLs were found in the response.",
-            )
+            if failed_urls:
+                details = (
+                    f"{self.name} generation completed upstream but the image(s) could not be retrieved. "
+                    f"Provider URL(s) (may be temporary): {', '.join(failed_urls)}"
+                )
+            else:
+                details = f"{self.name} generation completed but no image URLs were found in the response."
+            self._set_status_results(was_successful=False, result_details=details)
             return
 
         self._show_image_output_parameters(len(image_artifacts))
@@ -319,12 +326,16 @@ class GrokImageGeneration(GriptapeProxyNode):
         try:
             image_bytes = await File(image_url).aread_bytes()
             if not image_bytes:
-                return ImageUrlArtifact(value=image_url)
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
 
             dest = self._output_file.build_file()
             saved = await dest.awrite_bytes(image_bytes)
             return ImageUrlArtifact(value=saved.location, name=saved.name)
         except Exception as e:
+            # A billed generation whose image cannot be retrieved is a failure, not a
+            # silent success. Return None so this image is not counted as saved; the
+            # caller reports failure and surfaces the provider URL for manual retrieval.
             with suppress(Exception):
-                logger.warning("%s failed to save image %s: %s", self.name, index, e)
-            return ImageUrlArtifact(value=image_url)
+                logger.warning("%s failed to retrieve image %s from %s: %s", self.name, index, image_url, e)
+            return None

--- a/griptape_nodes_library/image/qwen_image_edit.py
+++ b/griptape_nodes_library/image/qwen_image_edit.py
@@ -403,30 +403,34 @@ class QwenImageEdit(GriptapeProxyNode):
             )
 
     async def _save_image_from_url(self, image_url: str) -> None:
-        """Download and save the image from the provided URL."""
+        """Download and save the image from the provided URL.
+
+        A billed generation whose image cannot be retrieved is a failure, not a
+        silent success; the provider URL is surfaced so the user can retrieve it
+        manually.
+        """
         try:
             logger.info("Downloading image from URL")
             image_bytes = await File(image_url).aread_bytes()
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
-                logger.info("Saved image as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Image edited successfully and saved as {saved.name}."
-                )
-            else:
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image edited successfully. Using provider URL (could not download image bytes).",
-                )
-        except Exception as e:
-            logger.error("Failed to save image from URL: %s", e)
-            self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
+            if not image_bytes:
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(image_bytes)
+            self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
+            logger.info("Saved image as %s", saved.name)
             self._set_status_results(
-                was_successful=True,
-                result_details=f"Image edited successfully. Using provider URL (could not save to static storage: {e}).",
+                was_successful=True, result_details=f"Image edited successfully and saved as {saved.name}."
+            )
+        except Exception as e:
+            logger.error("Failed to retrieve image from %s: %s", image_url, e)
+            self.parameter_output_values["image_url"] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"{self.name} generation completed upstream but the image could not be retrieved: {e}. "
+                    f"Provider URL (may be temporary): {image_url}"
+                ),
             )
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:

--- a/griptape_nodes_library/image/qwen_image_generation.py
+++ b/griptape_nodes_library/image/qwen_image_generation.py
@@ -280,30 +280,34 @@ class QwenImageGeneration(GriptapeProxyNode):
             )
 
     async def _save_image_from_url(self, image_url: str) -> None:
-        """Download and save the image from the provided URL."""
+        """Download and save the image from the provided URL.
+
+        A billed generation whose image cannot be retrieved is a failure, not a
+        silent success; the provider URL is surfaced so the user can retrieve it
+        manually.
+        """
         try:
             logger.info("Downloading image from URL")
             image_bytes = await File(image_url).aread_bytes()
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
-                logger.info("Saved image as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
-                )
-            else:
-                self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image generated successfully. Using provider URL (could not download image bytes).",
-                )
-        except Exception as e:
-            logger.error("Failed to save image from URL: %s", e)
-            self.parameter_output_values["image_url"] = ImageUrlArtifact(value=image_url)
+            if not image_bytes:
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(image_bytes)
+            self.parameter_output_values["image_url"] = ImageUrlArtifact(saved.location)
+            logger.info("Saved image as %s", saved.name)
             self._set_status_results(
-                was_successful=True,
-                result_details=f"Image generated successfully. Using provider URL (could not save to static storage: {e}).",
+                was_successful=True, result_details=f"Image generated successfully and saved as {saved.name}."
+            )
+        except Exception as e:
+            logger.error("Failed to retrieve image from %s: %s", image_url, e)
+            self.parameter_output_values["image_url"] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"{self.name} generation completed upstream but the image could not be retrieved: {e}. "
+                    f"Provider URL (may be temporary): {image_url}"
+                ),
             )
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:

--- a/griptape_nodes_library/image/seedream_image_generation.py
+++ b/griptape_nodes_library/image/seedream_image_generation.py
@@ -417,6 +417,7 @@ class SeedreamImageGeneration(GriptapeProxyNode):
 
         # Process all images from the response
         image_artifacts = []
+        failed_urls = []
         for idx, image_data in enumerate(data):
             image_url = image_data.get("url")
             if not image_url:
@@ -426,14 +427,20 @@ class SeedreamImageGeneration(GriptapeProxyNode):
             artifact = await self._save_single_image_from_url(image_url, generation_id, idx)
             if artifact:
                 image_artifacts.append(artifact)
+            else:
+                failed_urls.append(image_url)
 
         if not image_artifacts:
             self._log("No images could be saved")
             self._set_safe_defaults()
-            self._set_status_results(
-                was_successful=False,
-                result_details=f"{self.name} generation completed but no image URLs were found in the response.",
-            )
+            if failed_urls:
+                details = (
+                    f"{self.name} generation completed upstream but the image(s) could not be retrieved. "
+                    f"Provider URL(s) (may be temporary): {', '.join(failed_urls)}"
+                )
+            else:
+                details = f"{self.name} generation completed but no image URLs were found in the response."
+            self._set_status_results(was_successful=False, result_details=details)
             return
 
         # Show the appropriate number of image output parameters based on actual image count
@@ -665,9 +672,6 @@ class SeedreamImageGeneration(GriptapeProxyNode):
         try:
             self._log(f"Downloading image {index} from URL")
             image_bytes = await self._download_bytes_from_url(image_url)
-            if not image_bytes:
-                self._log(f"Could not download image {index}, using provider URL")
-                return ImageUrlArtifact(value=image_url)
 
             # Convert to PNG format to enable automatic workflow metadata embedding
             pil_image = Image.open(BytesIO(image_bytes))
@@ -681,8 +685,11 @@ class SeedreamImageGeneration(GriptapeProxyNode):
             return ImageUrlArtifact(value=saved.location, name=saved.name)
 
         except Exception as e:
-            self._log(f"Failed to save image {index} from URL: {e}")
-            return ImageUrlArtifact(value=image_url)
+            # A billed generation whose image cannot be retrieved is a failure, not a
+            # silent success. Return None so this image is not counted as saved; the
+            # caller reports failure and surfaces the provider URL for manual retrieval.
+            self._log(f"Failed to retrieve image {index} from {image_url}: {e}")
+            return None
 
     def _extract_error_message(self, response_json: dict[str, Any]) -> str:
         """Extract error message from failed/errored generation response.

--- a/griptape_nodes_library/image/topaz_image_enhance.py
+++ b/griptape_nodes_library/image/topaz_image_enhance.py
@@ -952,7 +952,13 @@ class TopazImageEnhance(GriptapeProxyNode):
 
         sample_url = result_json.get("result", {}).get("sample")
         if sample_url:
-            await self._save_image_from_url(sample_url)
+            await self._download_and_save(
+                sample_url,
+                "image_output",
+                lambda v, n: ImageUrlArtifact(value=v, name=n),
+                media_kind="image",
+                action="processed",
+            )
             return
 
         self._log("No sample URL found in result")
@@ -978,33 +984,6 @@ class TopazImageEnhance(GriptapeProxyNode):
             self._set_status_results(
                 was_successful=False,
                 result_details=f"Image processing succeeded but failed to save: {e}",
-            )
-
-    async def _save_image_from_url(self, image_url: str) -> None:
-        """Download and save the image from the provided URL."""
-        try:
-            self._log("Downloading image from URL")
-            image_bytes = await self._download_bytes_from_url(image_url)
-            if image_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(image_bytes)
-                self.parameter_output_values["image_output"] = ImageUrlArtifact(value=saved.location, name=saved.name)
-                self._log(f"Saved image as {saved.name}")
-                self._set_status_results(
-                    was_successful=True, result_details=f"Image processed successfully and saved as {saved.name}."
-                )
-            else:
-                self.parameter_output_values["image_output"] = ImageUrlArtifact(value=image_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details="Image processed successfully. Using provider URL (could not download image bytes).",
-                )
-        except Exception as e:
-            self._log(f"Failed to save image from URL: {e}")
-            self.parameter_output_values["image_output"] = ImageUrlArtifact(value=image_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details=f"Image processed successfully. Using provider URL (could not save to static storage: {e}).",
             )
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -276,17 +276,24 @@ class WanImageGeneration(GriptapeProxyNode):
 
         # Download and save all images
         image_artifacts: list[ImageUrlArtifact] = []
+        failed_urls: list[str] = []
         for index, url in enumerate(image_urls):
             artifact = await self._save_single_image_from_url(url, index)
             if artifact:
                 image_artifacts.append(artifact)
+            else:
+                failed_urls.append(url)
 
         if not image_artifacts:
             self._set_safe_defaults()
-            self._set_status_results(
-                was_successful=False,
-                result_details="Generation completed but no images could be saved.",
-            )
+            if failed_urls:
+                details = (
+                    f"{self.name} generation completed upstream but the image(s) could not be retrieved. "
+                    f"Provider URL(s) (may be temporary): {', '.join(failed_urls)}"
+                )
+            else:
+                details = "Generation completed but no images could be saved."
+            self._set_status_results(was_successful=False, result_details=details)
             return
 
         # Show the appropriate number of image output parameters
@@ -320,16 +327,19 @@ class WanImageGeneration(GriptapeProxyNode):
             logger.info("Downloading image %d from URL", index)
             image_bytes = await File(image_url).aread_bytes()
             if not image_bytes:
-                logger.warning("Could not download image %d, using provider URL", index)
-                return ImageUrlArtifact(value=image_url)
+                msg = "downloaded image was empty"
+                raise ValueError(msg)  # noqa: TRY301
 
             dest = self._output_file.build_file(_index=index)
             saved = await dest.awrite_bytes(image_bytes)
             logger.info("Saved image %d as %s", index, saved.name)
             return ImageUrlArtifact(value=saved.location, name=saved.name)
         except Exception as e:
-            logger.error("Failed to save image %d from URL: %s", index, e)
-            return ImageUrlArtifact(value=image_url)
+            # A billed generation whose image cannot be retrieved is a failure, not a
+            # silent success. Return None so this image is not counted as saved; the
+            # caller reports failure and surfaces the provider URL for manual retrieval.
+            logger.error("Failed to retrieve image %d from %s: %s", index, image_url, e)
+            return None
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for outputs."""

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -6,6 +6,7 @@ import logging
 import re
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from contextlib import suppress
 from typing import Any
 from urllib.parse import urljoin
@@ -13,6 +14,7 @@ from urllib.parse import urljoin
 import httpx
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
@@ -33,6 +35,12 @@ STATUS_ERRORED = "ERRORED"
 STATUS_FAILED = "FAILED"
 STATUS_COMPLETED = "COMPLETED"
 STATUS_TIMED_OUT = "TIMED_OUT"
+
+# Number of HTTP client errors (4xx) that indicate a permanent failure not worth retrying.
+HTTP_CLIENT_ERROR_MIN = 400
+HTTP_CLIENT_ERROR_MAX = 500
+# Short delay before the single retry on a transient download failure.
+DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
 
 
 class GriptapeProxyNode(SuccessFailureNode, ABC):
@@ -58,6 +66,9 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
     # Polling configuration
     DEFAULT_POLL_INTERVAL = 5
     DEFAULT_MAX_ATTEMPTS = 120  # 10 minutes with 5s intervals
+
+    # Subclasses that download media set this to the destination for saved output.
+    _output_file: ProjectFileParameter
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -851,19 +862,90 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         await self._process_generation()
 
     @staticmethod
-    async def _download_bytes_from_url(url: str) -> bytes | None:
-        """Download bytes from a URL.
+    async def _download_bytes_from_url(url: str) -> bytes:
+        """Download bytes from a URL, retrying once on transient failures.
+
+        Transient failures (timeouts, connection errors, and 5xx responses) are
+        retried a single time after a short delay. Permanent failures (4xx, e.g.
+        an expired or missing provider URL) are raised immediately, since
+        retrying cannot help. The underlying exception is propagated so callers
+        can surface an actionable reason rather than a bare ``None``.
 
         Args:
             url: The URL to download from
 
         Returns:
-            bytes | None: The downloaded bytes, or None if download failed
+            bytes: The downloaded bytes.
+
+        Raises:
+            httpx.HTTPError: If the download fails (after a retry for transient errors).
+        """
+        attempts = 2
+        for attempt in range(1, attempts + 1):
+            try:
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(url, timeout=120)
+                    resp.raise_for_status()
+                    return resp.content
+            except httpx.HTTPStatusError as e:
+                # 4xx are permanent (expired/missing URL); do not retry.
+                if HTTP_CLIENT_ERROR_MIN <= e.response.status_code < HTTP_CLIENT_ERROR_MAX:
+                    raise
+                if attempt >= attempts:
+                    raise
+            except (httpx.TimeoutException, httpx.TransportError):
+                if attempt >= attempts:
+                    raise
+            await asyncio.sleep(DOWNLOAD_RETRY_DELAY_SECONDS)
+
+        # Unreachable: the loop either returns or raises on the final attempt.
+        msg = f"Failed to download from {url}"
+        raise httpx.HTTPError(msg)
+
+    async def _download_and_save(
+        self,
+        url: str,
+        output_param: str,
+        artifact_factory: Callable[[str, str], Any],
+        *,
+        media_kind: str = "video",
+        action: str = "generated",
+    ) -> None:
+        """Download media from a provider URL, save it to project storage, and set status.
+
+        On success, saves the bytes via ``self._output_file`` and sets the given
+        output parameter to the artifact produced by ``artifact_factory``. On any
+        download or save failure, clears the output parameter and reports failure
+        with an actionable message that names the provider URL, so the user can
+        retrieve the asset manually. A generation that completed (and was billed)
+        upstream but whose output cannot be retrieved is a failure, not a success.
+
+        Args:
+            url: The provider URL to download from.
+            output_param: Name of the output parameter to set with the saved artifact.
+            artifact_factory: Callable taking (value, name) and returning a ``*UrlArtifact``.
+            media_kind: Human-readable media type for log and status messages.
+            action: Past-tense verb describing what the node produced (e.g. "generated",
+                "edited", "extended"), used in the success message.
         """
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(url, timeout=120)
-                resp.raise_for_status()
-                return resp.content
-        except Exception:
-            return None
+            logger.info("%s downloading %s from provider URL", self.name, media_kind)
+            media_bytes = await self._download_bytes_from_url(url)
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(media_bytes)
+            self.parameter_output_values[output_param] = artifact_factory(saved.location, saved.name)
+            logger.info("%s saved %s as %s", self.name, media_kind, saved.name)
+            self._set_status_results(
+                was_successful=True,
+                result_details=f"{media_kind.capitalize()} {action} successfully and saved as {saved.name}.",
+            )
+        except Exception as e:
+            logger.error("%s failed to retrieve %s: %s", self.name, media_kind, e)
+            self.parameter_output_values[output_param] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=(
+                    f"{self.name} generation completed upstream but the {media_kind} could not be retrieved: {e}. "
+                    f"Provider URL (may be temporary): {url}"
+                ),
+            )

--- a/griptape_nodes_library/video/grok_video_edit.py
+++ b/griptape_nodes_library/video/grok_video_edit.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-from contextlib import suppress
 from typing import Any, ClassVar
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
@@ -14,8 +12,6 @@ from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
-
-logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["GrokVideoEdit"]
 
@@ -210,32 +206,8 @@ class GrokVideoEdit(GriptapeProxyNode):
             )
             return
 
-        try:
-            video_bytes = await self._download_bytes_from_url(video_url)
-        except Exception as e:
-            with suppress(Exception):
-                logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-            except (OSError, PermissionError) as e:
-                with suppress(Exception):
-                    logger.warning("%s failed to save video: %s", self.name, e)
-            else:
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video edited successfully and saved as {saved.name}.",
-                )
-                return
-
-        self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-        self._set_status_results(
-            was_successful=True,
-            result_details="Video edited successfully. Using provider URL (could not save to static storage).",
+        await self._download_and_save(
+            video_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n), action="edited"
         )
 
     def _set_safe_defaults(self) -> None:

--- a/griptape_nodes_library/video/grok_video_generation.py
+++ b/griptape_nodes_library/video/grok_video_generation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import suppress
 from typing import Any, ClassVar
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
@@ -267,33 +266,7 @@ class GrokVideoGeneration(GriptapeProxyNode):
             )
             return
 
-        try:
-            video_bytes = await self._download_bytes_from_url(video_url)
-        except Exception as e:
-            with suppress(Exception):
-                logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-            except (OSError, PermissionError) as e:
-                with suppress(Exception):
-                    logger.warning("%s failed to save video: %s", self.name, e)
-            else:
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully and saved as {saved.name}.",
-                )
-                return
-
-        self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-        self._set_status_results(
-            was_successful=True,
-            result_details="Video generated successfully. Using provider URL (could not save to static storage).",
-        )
+        await self._download_and_save(video_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _set_safe_defaults(self) -> None:
         self.parameter_output_values["video_url"] = None

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -918,35 +918,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
             logger.info("Video ID: %s", video_id)
 
         # Download and save video
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _set_safe_defaults(self) -> None:
         """Clear output parameters on error."""

--- a/griptape_nodes_library/video/kling_motion_control.py
+++ b/griptape_nodes_library/video/kling_motion_control.py
@@ -255,35 +255,7 @@ class KlingMotionControl(GriptapeProxyNode):
             logger.info("Video ID: %s", video_id)
 
         # Download and save video
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _set_safe_defaults(self) -> None:
         """Clear output parameters on error."""

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -639,35 +639,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             logger.info("Video ID: %s", video_id)
 
         # Download and save video
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _set_safe_defaults(self) -> None:
         """Clear output parameters on error."""

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -719,35 +719,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             logger.info("Video ID: %s", video_id)
 
         # Download and save video
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _set_safe_defaults(self) -> None:
         """Clear output parameters on error."""

--- a/griptape_nodes_library/video/kling_video_extension.py
+++ b/griptape_nodes_library/video/kling_video_extension.py
@@ -193,35 +193,9 @@ class KlingVideoExtension(GriptapeProxyNode):
             logger.info("Video ID: %s", video_id)
 
         # Download and save video
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video extended successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video extended successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video extended successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(
+            download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n), action="extended"
+        )
 
     def _set_safe_defaults(self) -> None:
         """Clear output parameters on error."""

--- a/griptape_nodes_library/video/minimax_hailuo_video_generation.py
+++ b/griptape_nodes_library/video/minimax_hailuo_video_generation.py
@@ -406,35 +406,7 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
             )
             return
 
-        try:
-            logger.info("%s downloading video from provider URL", self.name)
-            video_bytes = await self._download_bytes_from_url(download_url)
-        except Exception as e:
-            logger.warning("%s failed to download video: %s", self.name, e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("%s saved video as %s", self.name, saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except (OSError, PermissionError) as e:
-                logger.warning("%s failed to save video: %s, using provider URL", self.name, e)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=download_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(download_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _extract_error_message(self, response_json: dict[str, Any]) -> str:
         if not response_json:

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -516,25 +516,7 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
             )
             return
 
-        self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-        try:
-            self._log("Downloading video bytes from provider URL")
-            saved_location = await self._save_video_bytes(video_url)
-        except Exception as e:
-            self._log(f"Failed to download video: {e}")
-            saved_location = None
-
-        if saved_location:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved_location)
-            self._set_status_results(
-                was_successful=True,
-                result_details=f"Video generation completed successfully. Saved as: {saved_location}",
-            )
-        else:
-            self._set_status_results(
-                was_successful=True,
-                result_details=f"Video generation completed successfully. Video URL: {video_url}",
-            )
+        await self._download_and_save(video_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     @staticmethod
     def _extract_video_url(response_json: dict[str, Any]) -> str | None:
@@ -545,20 +527,6 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
             return video_url
 
         return None
-
-    async def _save_video_bytes(self, url: str) -> str | None:
-        """Download video bytes from URL and save to project storage."""
-        try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(url, timeout=120)
-                resp.raise_for_status()
-                video_bytes = resp.content
-            dest = self._output_file.build_file()
-            saved = await dest.awrite_bytes(video_bytes)
-        except Exception:
-            return None
-
-        return saved.location
 
     def _set_safe_defaults(self) -> None:
         """Set safe default values for outputs on error."""

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -1139,35 +1139,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             return
 
         # Download and save video
-        try:
-            self._log("Downloading video bytes from provider URL")
-            video_bytes = await self._download_bytes_from_url(extracted_url)
-        except Exception as e:
-            self._log(f"Failed to download video: {e}")
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                self._log(f"Saved video as {saved.name}")
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except Exception as e:
-                self._log(f"Failed to save video: {e}, using provider URL")
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=extracted_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=extracted_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(extracted_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _extract_error_message(self, response_json: dict[str, Any]) -> str:
         """Extract error message from failed response."""

--- a/griptape_nodes_library/video/seedance_video_generation.py
+++ b/griptape_nodes_library/video/seedance_video_generation.py
@@ -426,37 +426,8 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
             )
             return
 
-        # Download video bytes
-        try:
-            self._log("Downloading video bytes from provider URL")
-            video_bytes = await self._download_bytes_from_url(extracted_url)
-        except Exception as e:
-            self._log(f"Failed to download video: {e}")
-            video_bytes = None
-
-        # Save video or use provider URL as fallback
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                self._log(f"Saved video as {saved.name}")
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except Exception as e:
-                self._log(f"Failed to save video: {e}, using provider URL")
-                self.parameter_output_values["video_url"] = VideoUrlArtifact(value=extracted_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save to storage: {e}).",
-                )
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=extracted_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        # Download and save video
+        await self._download_and_save(extracted_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _extract_error_message(self, response_json: dict[str, Any]) -> str:
         """Extract error message from failed/errored generation response.

--- a/griptape_nodes_library/video/sora_video_generation.py
+++ b/griptape_nodes_library/video/sora_video_generation.py
@@ -417,20 +417,7 @@ class SoraVideoGeneration(GriptapeProxyNode):
 
     async def _handle_video_url_completion(self, video_url: str) -> None:
         """Handle completion when a video URL is received."""
-        try:
-            video_bytes = await self._download_bytes_from_url(video_url)
-        except Exception as e:
-            self._log(f"Failed to download video: {e}")
-            video_bytes = None
-
-        if video_bytes:
-            await self._handle_video_completion(video_bytes)
-        else:
-            self.parameter_output_values["video_url"] = VideoUrlArtifact(value=video_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(video_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _load_pil_from_input(self, image_value: Any) -> Image.Image | None:
         if isinstance(image_value, dict):

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -319,35 +319,7 @@ class WanAnimateGeneration(GriptapeProxyNode):
             )
             return
 
-        try:
-            logger.debug("Downloading video bytes from provider URL")
-            video_bytes = await self._download_bytes_from_url(extracted_url)
-        except Exception as e:
-            logger.debug("Failed to download video: %s", e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.debug("Saved video as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except Exception as e:
-                logger.debug("Failed to save video: %s, using provider URL", e)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=extracted_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save: {e}).",
-                )
-        else:
-            self.parameter_output_values["video"] = VideoUrlArtifact(value=extracted_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(extracted_url, "video", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:
         """Extract error details from API response."""

--- a/griptape_nodes_library/video/wan_image_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_image_to_video_generation.py
@@ -579,38 +579,13 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
 
         video_url = result_json.get("video_url")
         if video_url:
-            await self._save_video_from_url(video_url)
+            await self._download_and_save(video_url, "video", lambda v, n: VideoUrlArtifact(value=v, name=n))
         else:
             logger.warning("No video_url found in response")
             self._set_safe_defaults()
             self._set_status_results(
                 was_successful=False,
                 result_details="Generation completed but no video URL was found in the response.",
-            )
-
-    async def _save_video_from_url(self, video_url: str) -> None:
-        """Download and save the video from the provided URL."""
-        try:
-            logger.info("Downloading video from URL")
-            video_bytes = await self._download_bytes_from_url(video_url)
-            if video_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("Saved video as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            else:
-                self._set_status_results(
-                    was_successful=False,
-                    result_details="Video generation completed but could not download video bytes from URL.",
-                )
-        except Exception as e:
-            logger.error("Failed to save video from URL: %s", e)
-            self._set_status_results(
-                was_successful=False,
-                result_details=f"Video generation completed but could not save to static storage: {e}",
             )
 
     async def _prepare_audio_data_url_async(self, audio_input: Any) -> str | None:

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -511,35 +511,7 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
             )
             return
 
-        try:
-            logger.debug("Downloading video bytes from provider URL")
-            video_bytes = await self._download_bytes_from_url(extracted_url)
-        except Exception as e:
-            logger.debug("Failed to download video: %s", e)
-            video_bytes = None
-
-        if video_bytes:
-            try:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.debug("Saved video as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            except Exception as e:
-                logger.debug("Failed to save video: %s, using provider URL", e)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=extracted_url)
-                self._set_status_results(
-                    was_successful=True,
-                    result_details=f"Video generated successfully. Using provider URL (could not save: {e}).",
-                )
-        else:
-            self.parameter_output_values["video"] = VideoUrlArtifact(value=extracted_url)
-            self._set_status_results(
-                was_successful=True,
-                result_details="Video generated successfully. Using provider URL (could not download video bytes).",
-            )
+        await self._download_and_save(extracted_url, "video", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
     def _extract_error_message(self, response_json: dict[str, Any] | None) -> str:
         """Extract error details from API response."""

--- a/griptape_nodes_library/video/wan_text_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_text_to_video_generation.py
@@ -482,38 +482,13 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
 
         video_url = result_json.get("video_url")
         if video_url:
-            await self._save_video_from_url(video_url)
+            await self._download_and_save(video_url, "video", lambda v, n: VideoUrlArtifact(value=v, name=n))
         else:
             logger.warning("No video_url found in response")
             self._set_safe_defaults()
             self._set_status_results(
                 was_successful=False,
                 result_details="Generation completed but no video URL was found in the response.",
-            )
-
-    async def _save_video_from_url(self, video_url: str) -> None:
-        """Download and save the video from the provided URL."""
-        try:
-            logger.info("Downloading video from URL")
-            video_bytes = await self._download_bytes_from_url(video_url)
-            if video_bytes:
-                dest = self._output_file.build_file()
-                saved = await dest.awrite_bytes(video_bytes)
-                self.parameter_output_values["video"] = VideoUrlArtifact(value=saved.location, name=saved.name)
-                logger.info("Saved video as %s", saved.name)
-                self._set_status_results(
-                    was_successful=True, result_details=f"Video generated successfully and saved as {saved.name}."
-                )
-            else:
-                self._set_status_results(
-                    was_successful=False,
-                    result_details="Video generation completed but could not download video bytes from URL.",
-                )
-        except Exception as e:
-            logger.error("Failed to save video from URL: %s", e)
-            self._set_status_results(
-                was_successful=False,
-                result_details=f"Video generation completed but could not save to static storage: {e}",
             )
 
     async def _prepare_audio_data_url_async(self, audio_input: Any) -> str | None:

--- a/tests/unit/test_griptape_proxy_node_download.py
+++ b/tests/unit/test_griptape_proxy_node_download.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code: int = 200, content: bytes = b"data") -> None:
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self) -> None:
+        if httpx.codes.is_error(self.status_code):
+            request = httpx.Request("GET", "https://provider.example/asset")
+            response = httpx.Response(self.status_code, request=request)
+            raise httpx.HTTPStatusError("error", request=request, response=response)
+
+
+def _install_fake_client(monkeypatch: pytest.MonkeyPatch, get_impl: Any) -> None:
+    class FakeAsyncClient:
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+            return None
+
+        async def get(self, url: str, timeout: int) -> _FakeResponse:
+            return await get_impl(url, timeout)
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+
+    async def noop_sleep(_: float) -> None:
+        pass
+
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.asyncio.sleep", noop_sleep)
+
+
+@pytest.mark.asyncio
+async def test_download_retries_once_on_transient_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def get_impl(_url: str, _timeout: int) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("boom")
+        return _FakeResponse(content=b"video-bytes")
+
+    _install_fake_client(monkeypatch, get_impl)
+
+    result = await Flux2ImageGeneration._download_bytes_from_url("https://provider.example/asset")
+
+    assert result == b"video-bytes"
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_download_does_not_retry_on_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def get_impl(_url: str, _timeout: int) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse(status_code=403)
+
+    _install_fake_client(monkeypatch, get_impl)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await Flux2ImageGeneration._download_bytes_from_url("https://provider.example/asset")
+
+    # 4xx is permanent; must fail fast without a retry.
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_download_retries_once_on_server_error_then_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    async def get_impl(_url: str, _timeout: int) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse(status_code=503)
+
+    _install_fake_client(monkeypatch, get_impl)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await Flux2ImageGeneration._download_bytes_from_url("https://provider.example/asset")
+
+    # 5xx is transient; one retry (2 attempts total) before giving up.
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_download_and_save_failure_reports_unsuccessful_and_surfaces_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def get_impl(_url: str, _timeout: int) -> _FakeResponse:
+        return _FakeResponse(status_code=403)
+
+    _install_fake_client(monkeypatch, get_impl)
+
+    node = Flux2ImageGeneration(name="Flux2")
+
+    status_calls: list[dict[str, Any]] = []
+    node._set_status_results = lambda **kwargs: status_calls.append(kwargs)  # type: ignore[method-assign]
+
+    url = "https://provider.example/asset"
+    await node._download_and_save(url, "image_url", lambda v, n: {"value": v, "name": n}, media_kind="image")
+
+    assert node.parameter_output_values["image_url"] is None
+    assert len(status_calls) == 1
+    assert status_calls[0]["was_successful"] is False
+    assert url in status_calls[0]["result_details"]
+
+
+@pytest.mark.asyncio
+async def test_download_and_save_success_saves_and_reports_successful(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def get_impl(_url: str, _timeout: int) -> _FakeResponse:
+        return _FakeResponse(content=b"image-bytes")
+
+    _install_fake_client(monkeypatch, get_impl)
+
+    node = Flux2ImageGeneration(name="Flux2")
+
+    class _SavedFile:
+        location = "project/files/output.png"
+        name = "output.png"
+
+    class _Dest:
+        async def awrite_bytes(self, _data: bytes) -> _SavedFile:
+            return _SavedFile()
+
+    class _OutputFile:
+        def build_file(self, **_extra: Any) -> _Dest:
+            return _Dest()
+
+    node._output_file = _OutputFile()  # type: ignore[assignment]
+
+    status_calls: list[dict[str, Any]] = []
+    node._set_status_results = lambda **kwargs: status_calls.append(kwargs)  # type: ignore[method-assign]
+
+    await node._download_and_save(
+        "https://provider.example/asset",
+        "image_url",
+        lambda v, n: {"value": v, "name": n},
+        media_kind="image",
+    )
+
+    assert node.parameter_output_values["image_url"] == {"value": "project/files/output.png", "name": "output.png"}
+    assert len(status_calls) == 1
+    assert status_calls[0]["was_successful"] is True
+    assert "output.png" in status_calls[0]["result_details"]


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/482

Proxy-backed media generation nodes (Kling, Seedance, Sora, Grok, WAN, flux, qwen, topaz, omnihuman) could run a generation all the way to `COMPLETED` upstream — billing the user's credits — and then report **success** while delivering no usable output. When the download/save of the result failed, the node silently fell back to handing the user a raw provider URL and still set `was_successful=True`.

Two defects combined:

1. `GriptapeProxyNode._download_bytes_from_url` caught bare `Exception` and returned `None`, discarding *why* the download failed.
2. Nodes treated that `None` as a soft fallback: they set the output to a `*UrlArtifact` pointing at the provider URL and reported success.

From the user's side the run charged money and produced nothing, with clean-looking logs (no `saved video as …` line) that made triage guess backwards from an absent output.

## Fix

A billed generation whose output can't be retrieved is now a **failure**, not a silent success — and the failure message names the provider URL so the user can still retrieve the asset manually.

- **`_download_bytes_from_url` no longer swallows.** It raises, with a single conditional retry: retry once on transient failures (timeouts, connection/transport errors, 5xx); fail fast on 4xx (an expired/missing provider URL won't heal).
- **New shared `GriptapeProxyNode._download_and_save(...)` helper** centralizes the download → save → status logic. On success it saves via `self._output_file` and reports success; on any failure it clears the output and reports `was_successful=False` with the underlying error and the provider URL.
- **Routed the affected nodes through the helper** (Kling ×5, Seedance ×2, Sora, Grok video ×2, MiniMax, WAN video ×4, omnihuman, topaz).
- **Fixed the `File().aread_bytes()`-based image nodes in place** (flux, flux_2, qwen ×2): fail, clear output, surface the URL.
- **Fixed the multi-image nodes** (seedream, wan_image, grok_image ×2): a per-image download failure now returns `None` (not counted as saved) and the failed URLs are surfaced in the failure message.

## Out of scope / deferred

- Partial-success in multi-image nodes (some images save, some fail → still reports success and drops the failed URLs). Pre-existing behavior, not worsened here; worth a separate issue if partial billing matters.
- The companion Seedance base64 complaint noted in #482.
- The `kling-v3:image2video` not-in-catalog warning (tracked in griptape-nodes-engine#4592).