### PR TITLE
fix(ltx): resolve 413 payload errors in LTXVideoRetake and LTXVideoExtend

### DIFF
--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -590,6 +590,7 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         """Handle API key validation errors."""
         self._set_safe_defaults()
         self._set_status_results(was_successful=False, result_details=str(e))
+        logger.error("%s API key validation failed: %s", self.name, e)
         self._handle_failure_exception(e)
 
     def _handle_payload_build_error(self, e: Exception) -> None:

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -16,6 +16,7 @@ from griptape_nodes.traits.slider import Slider
 
 from griptape_nodes_library.media import prepare_media_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES, PublicVideoUrlMixin
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -35,7 +36,7 @@ MODEL_MAPPING = {
 DEFAULT_MODEL = "LTX 2.3 Pro"
 
 
-class LTXVideoExtend(GriptapeProxyNode):
+class LTXVideoExtend(PublicVideoUrlMixin, GriptapeProxyNode):
     """Extend an existing video by 2-20 seconds using LTX AI via Griptape Cloud model proxy.
 
     Inputs:
@@ -239,15 +240,35 @@ class LTXVideoExtend(GriptapeProxyNode):
             msg = f"{self.name} requires an input video to extend."
             raise ValueError(msg)
 
-        try:
-            video_data_uri = await self._prepare_video_data_uri_async(video)
-        except Exception as e:
-            logger.error("%s failed to process video: %s", self.name, e)
-            video_data_uri = None
+        # Tier 1: resolve to a public presigned URL (cloud deployments — avoids 413 entirely)
+        video_uri: str | None = self._resolve_to_public_url(video)
 
-        if not video_data_uri:
-            msg = f"{self.name} failed to process input video."
-            raise ValueError(msg)
+        if not video_uri:
+            # Tier 2: fall back to base64 with a pre-flight size check
+            try:
+                video_data_uri = await self._prepare_video_data_uri_async(video)
+            except Exception as e:
+                logger.error("%s failed to process video: %s", self.name, e)
+                video_data_uri = None
+
+            if not video_data_uri:
+                msg = f"{self.name} failed to process input video."
+                raise ValueError(msg)
+
+            _prefix, _sep, b64_content = video_data_uri.partition(",")
+            if _sep:
+                decoded_size = (len(b64_content) // 4) * 3 - b64_content.count("=")
+                if decoded_size > MAX_VIDEO_FILE_SIZE_BYTES:
+                    size_mb = decoded_size / 1_048_576
+                    limit_mb = MAX_VIDEO_FILE_SIZE_BYTES // 1_048_576
+                    msg = (
+                        f"{self.name}: Source video is too large ({size_mb:.1f} MB). "
+                        f"The maximum supported size is {limit_mb} MB. "
+                        "Trim the video to a shorter segment and try again."
+                    )
+                    raise ValueError(msg)
+
+            video_uri = video_data_uri
 
         if len(params["prompt"]) > MAX_PROMPT_LENGTH:
             msg = (
@@ -265,7 +286,7 @@ class LTXVideoExtend(GriptapeProxyNode):
         context = int(params["context"]) if params["context"] is not None else 0
 
         payload: dict[str, Any] = {
-            "video_uri": video_data_uri,
+            "video_uri": video_uri,
             "duration": duration,
             "mode": params["mode"],
             "model": MODEL_MAPPING.get(params["model"], MODEL_MAPPING[DEFAULT_MODEL]),
@@ -377,11 +398,6 @@ class LTXVideoExtend(GriptapeProxyNode):
             return
 
         super()._handle_payload_build_error(e)
-
-    def _handle_api_key_validation_error(self, e: ValueError) -> None:
-        self._set_safe_defaults()
-        self._set_status_results(was_successful=False, result_details=str(e))
-        logger.error("%s API key validation failed: %s", self.name, e)
 
     def _set_safe_defaults(self) -> None:
         self.parameter_output_values["generation_id"] = ""

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -16,7 +16,7 @@ from griptape_nodes.traits.slider import Slider
 
 from griptape_nodes_library.media import prepare_media_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
-from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES, PublicVideoUrlMixin
+from griptape_nodes_library.video.public_video_url_mixin import PublicVideoUrlMixin
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -210,6 +210,14 @@ class LTXVideoExtend(PublicVideoUrlMixin, GriptapeProxyNode):
         """Convert video input to a base64 data URI."""
         return await prepare_media_data_uri(video_input, kind="video", node_name=self.name)
 
+    async def _process_generation(self) -> None:
+        """Wrap generation with public-URL upload cleanup (delete scratch artifacts after run)."""
+        self._reset_video_uploads()
+        try:
+            await super()._process_generation()
+        finally:
+            self._cleanup_video_uploads()
+
     def _validate_duration(self, duration: Any) -> str | None:
         if not isinstance(duration, int) or isinstance(duration, bool):
             return f"{self.name}: Duration must be an integer number of seconds (got {duration!r})."
@@ -240,35 +248,9 @@ class LTXVideoExtend(PublicVideoUrlMixin, GriptapeProxyNode):
             msg = f"{self.name} requires an input video to extend."
             raise ValueError(msg)
 
-        # Tier 1: resolve to a public presigned URL (cloud deployments — avoids 413 entirely)
-        video_uri: str | None = self._resolve_to_public_url(video)
-
-        if not video_uri:
-            # Tier 2: fall back to base64 with a pre-flight size check
-            try:
-                video_data_uri = await self._prepare_video_data_uri_async(video)
-            except Exception as e:
-                logger.error("%s failed to process video: %s", self.name, e)
-                video_data_uri = None
-
-            if not video_data_uri:
-                msg = f"{self.name} failed to process input video."
-                raise ValueError(msg)
-
-            _prefix, _sep, b64_content = video_data_uri.partition(",")
-            if _sep:
-                decoded_size = (len(b64_content) // 4) * 3 - b64_content.count("=")
-                if decoded_size > MAX_VIDEO_FILE_SIZE_BYTES:
-                    size_mb = decoded_size / 1_048_576
-                    limit_mb = MAX_VIDEO_FILE_SIZE_BYTES // 1_048_576
-                    msg = (
-                        f"{self.name}: Source video is too large ({size_mb:.1f} MB). "
-                        f"The maximum supported size is {limit_mb} MB. "
-                        "Trim the video to a shorter segment and try again."
-                    )
-                    raise ValueError(msg)
-
-            video_uri = video_data_uri
+        # Tier 1: upload to Griptape Cloud and send LTX a public URL it fetches server-side
+        # (avoids the 413 from base64-inflating the body). Tier 2: base64 data URI + size guard.
+        video_uri = await self._resolve_video_uri(video)
 
         if len(params["prompt"]) > MAX_PROMPT_LENGTH:
             msg = (
@@ -300,18 +282,6 @@ class LTXVideoExtend(PublicVideoUrlMixin, GriptapeProxyNode):
             payload["context"] = context
 
         return payload
-
-    def _sanitize_video_uri_in_dict(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Redact base64 video data from dictionary for logging."""
-        sanitized = {**data}
-        if "video_uri" in sanitized and isinstance(sanitized["video_uri"], str):
-            video_uri = sanitized["video_uri"]
-            if video_uri.startswith("data:video/"):
-                parts = video_uri.split(",", 1)
-                header = parts[0] if parts else "data:video/"
-                b64_len = len(parts[1]) if len(parts) > 1 else 0
-                sanitized["video_uri"] = f"{header},<base64 data length={b64_len}>"
-        return sanitized
 
     async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
         video_bytes = result_json.get("raw_bytes")

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -20,6 +20,7 @@ from static_ffmpeg import run  # type: ignore[import-untyped]
 from griptape_nodes_library.media import coerce_media_url_or_data_uri, prepare_media_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.utils.ffmpeg_utils import describe_ffmpeg_failure
+from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES, PublicVideoUrlMixin
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -38,7 +39,7 @@ SUPPORTED_RESOLUTIONS = ("1920x1080", "2560x1440", "3840x2160")
 DEFAULT_RESOLUTION = "1920x1080"
 
 
-class LTXVideoRetake(GriptapeProxyNode):
+class LTXVideoRetake(PublicVideoUrlMixin, GriptapeProxyNode):
     """Regenerate a segment of an existing video using LTX AI via Griptape Cloud model proxy.
 
     Inputs:
@@ -430,15 +431,35 @@ class LTXVideoRetake(GriptapeProxyNode):
         if video_validation_error:
             raise ValueError(video_validation_error)
 
-        try:
-            video_data_uri = await self._prepare_video_data_uri_async(video)
-        except Exception as e:
-            logger.error("%s failed to process video: %s", self.name, e)
-            video_data_uri = None
+        # Tier 1: resolve to a public presigned URL (cloud deployments — avoids 413 entirely)
+        video_uri: str | None = self._resolve_to_public_url(video)
 
-        if not video_data_uri:
-            msg = f"{self.name} failed to process input video."
-            raise ValueError(msg)
+        if not video_uri:
+            # Tier 2: fall back to base64 with a pre-flight size check
+            try:
+                video_data_uri = await self._prepare_video_data_uri_async(video)
+            except Exception as e:
+                logger.error("%s failed to process video: %s", self.name, e)
+                video_data_uri = None
+
+            if not video_data_uri:
+                msg = f"{self.name} failed to process input video."
+                raise ValueError(msg)
+
+            _prefix, _sep, b64_content = video_data_uri.partition(",")
+            if _sep:
+                decoded_size = (len(b64_content) // 4) * 3 - b64_content.count("=")
+                if decoded_size > MAX_VIDEO_FILE_SIZE_BYTES:
+                    size_mb = decoded_size / 1_048_576
+                    limit_mb = MAX_VIDEO_FILE_SIZE_BYTES // 1_048_576
+                    msg = (
+                        f"{self.name}: Source video is too large ({size_mb:.1f} MB). "
+                        f"The maximum supported size is {limit_mb} MB. "
+                        "Trim the video to a shorter segment and try again."
+                    )
+                    raise ValueError(msg)
+
+            video_uri = video_data_uri
 
         if error := self._validate_retake_segment(params["retake_segment"]):
             raise ValueError(error)
@@ -465,7 +486,7 @@ class LTXVideoRetake(GriptapeProxyNode):
             raise ValueError(msg)
 
         payload: dict[str, Any] = {
-            "video_uri": video_data_uri,
+            "video_uri": video_uri,
             "start_time": start_time,
             "duration": duration,
             "prompt": params["prompt"].strip(),
@@ -577,11 +598,6 @@ class LTXVideoRetake(GriptapeProxyNode):
             return
 
         super()._handle_payload_build_error(e)
-
-    def _handle_api_key_validation_error(self, e: ValueError) -> None:
-        self._set_safe_defaults()
-        self._set_status_results(was_successful=False, result_details=str(e))
-        logger.error("%s API key validation failed: %s", self.name, e)
 
     def _set_safe_defaults(self) -> None:
         self.parameter_output_values["generation_id"] = ""

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -20,7 +20,7 @@ from static_ffmpeg import run  # type: ignore[import-untyped]
 from griptape_nodes_library.media import coerce_media_url_or_data_uri, prepare_media_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.utils.ffmpeg_utils import describe_ffmpeg_failure
-from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES, PublicVideoUrlMixin
+from griptape_nodes_library.video.public_video_url_mixin import PublicVideoUrlMixin
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -350,7 +350,11 @@ class LTXVideoRetake(PublicVideoUrlMixin, GriptapeProxyNode):
         return min(SUPPORTED_RESOLUTIONS, key=lambda r: abs(_pixels(r) - target_pixels))
 
     async def _process_generation(self) -> None:
-        await super()._process_generation()
+        self._reset_video_uploads()
+        try:
+            await super()._process_generation()
+        finally:
+            self._cleanup_video_uploads()
 
     def _get_parameters(self) -> dict[str, Any]:
         return {
@@ -431,35 +435,9 @@ class LTXVideoRetake(PublicVideoUrlMixin, GriptapeProxyNode):
         if video_validation_error:
             raise ValueError(video_validation_error)
 
-        # Tier 1: resolve to a public presigned URL (cloud deployments — avoids 413 entirely)
-        video_uri: str | None = self._resolve_to_public_url(video)
-
-        if not video_uri:
-            # Tier 2: fall back to base64 with a pre-flight size check
-            try:
-                video_data_uri = await self._prepare_video_data_uri_async(video)
-            except Exception as e:
-                logger.error("%s failed to process video: %s", self.name, e)
-                video_data_uri = None
-
-            if not video_data_uri:
-                msg = f"{self.name} failed to process input video."
-                raise ValueError(msg)
-
-            _prefix, _sep, b64_content = video_data_uri.partition(",")
-            if _sep:
-                decoded_size = (len(b64_content) // 4) * 3 - b64_content.count("=")
-                if decoded_size > MAX_VIDEO_FILE_SIZE_BYTES:
-                    size_mb = decoded_size / 1_048_576
-                    limit_mb = MAX_VIDEO_FILE_SIZE_BYTES // 1_048_576
-                    msg = (
-                        f"{self.name}: Source video is too large ({size_mb:.1f} MB). "
-                        f"The maximum supported size is {limit_mb} MB. "
-                        "Trim the video to a shorter segment and try again."
-                    )
-                    raise ValueError(msg)
-
-            video_uri = video_data_uri
+        # Tier 1: upload to Griptape Cloud and send LTX a public URL it fetches server-side
+        # (avoids the 413 from base64-inflating the body). Tier 2: base64 data URI + size guard.
+        video_uri = await self._resolve_video_uri(video)
 
         if error := self._validate_retake_segment(params["retake_segment"]):
             raise ValueError(error)
@@ -496,18 +474,6 @@ class LTXVideoRetake(PublicVideoUrlMixin, GriptapeProxyNode):
         }
 
         return payload
-
-    def _sanitize_video_uri_in_dict(self, data: dict[str, Any]) -> dict[str, Any]:
-        """Redact base64 video data from dictionary for logging."""
-        sanitized = {**data}
-        if "video_uri" in sanitized and isinstance(sanitized["video_uri"], str):
-            video_uri = sanitized["video_uri"]
-            if video_uri.startswith("data:video/"):
-                parts = video_uri.split(",", 1)
-                header = parts[0] if parts else "data:video/"
-                b64_len = len(parts[1]) if len(parts) > 1 else 0
-                sanitized["video_uri"] = f"{header},<base64 data length={b64_len}>"
-        return sanitized
 
     async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
         video_bytes = result_json.get("raw_bytes")

--- a/griptape_nodes_library/video/public_video_url_mixin.py
+++ b/griptape_nodes_library/video/public_video_url_mixin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
@@ -20,14 +21,28 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["MAX_VIDEO_DATA_URI_SIZE_BYTES", "PublicVideoUrlMixin", "decoded_data_uri_size"]
 
-# Hostnames whose URLs LTX can't fetch (docs.ltx.io/input-formats requires a publicly
-# reachable domain name). These are uploaded to Griptape Cloud instead of passed through.
-_LOCAL_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
-
-# LTX rejects inline base64 (data URI) videos above 15 MB (docs.ltx.io/input-formats).
+# LTX's data-URI limit is 15 MB on the *encoded* base64 string (docs.ltx.io/input-formats).
+# decoded = encoded × (3/4), so the decoded cap is 15 MB × 3/4 ≈ 11.25 MB.
 # The URL tier avoids this entirely by handing LTX a public URL it fetches server-side,
 # where the limit is a larger 32 MB; this guard only applies to the base64 fallback.
-MAX_VIDEO_DATA_URI_SIZE_BYTES = 15 * 1024 * 1024
+MAX_VIDEO_DATA_URI_SIZE_BYTES = 15 * 1024 * 1024 * 3 // 4  # ≈ 11.25 MB decoded
+
+
+def _is_public_https_domain_url(url: str) -> bool:
+    """Return True only for URLs LTX will accept directly: https:// with a proper domain name.
+
+    Rejects http://, bare IPs (0.0.0.0, 192.168.x.x, 127.0.0.1, ::1), and single-label
+    hostnames (localhost, container names) — all of which must upload to Griptape Cloud instead.
+    """
+    if not url.startswith("https://"):
+        return False
+    hostname = urlparse(url).hostname or ""
+    try:
+        ipaddress.ip_address(hostname)
+        return False
+    except ValueError:
+        pass
+    return "." in hostname
 
 
 def decoded_data_uri_size(data_uri: str) -> int:
@@ -95,8 +110,9 @@ class PublicVideoUrlMixin:
             size_mb = decoded_size / 1_048_576
             limit_mb = MAX_VIDEO_DATA_URI_SIZE_BYTES // 1_048_576
             msg = (
-                f"{self.name}: Source video is too large ({size_mb:.1f} MB). "  # type: ignore[attr-defined]
-                f"The maximum supported size is {limit_mb} MB. "
+                f"{self.name}: Source video is too large ({size_mb:.1f} MB decoded, "  # type: ignore[attr-defined]
+                f"~{size_mb * 4 / 3:.1f} MB encoded). "
+                f"The maximum supported encoded size is 15 MB (~{limit_mb} MB decoded). "
                 "Trim the video to a shorter segment and try again."
             )
             raise ValueError(msg)
@@ -113,7 +129,7 @@ class PublicVideoUrlMixin:
         video_value = coerce_media_url_or_data_uri(video_input, kind="video")
         if not video_value:
             return None
-        if video_value.startswith(("http://", "https://")) and urlparse(video_value).hostname not in _LOCAL_HOSTNAMES:
+        if _is_public_https_domain_url(video_value):
             return video_value
 
         # The scratch parameter is a transient, worker-local helper that only exists to feed the

--- a/griptape_nodes_library/video/public_video_url_mixin.py
+++ b/griptape_nodes_library/video/public_video_url_mixin.py
@@ -1,51 +1,147 @@
 from __future__ import annotations
 
-from typing import Any
+import logging
+from contextlib import suppress
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
+from uuid import uuid4
 
-from griptape_nodes.files.file import File
-from griptape_nodes.retained_mode.events.static_file_events import (
-    CreateStaticFileDownloadUrlFromPathRequest,
-    CreateStaticFileDownloadUrlFromPathResultSuccess,
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.media import coerce_media_url_or_data_uri
 
-__all__ = ["MAX_VIDEO_FILE_SIZE_BYTES", "PublicVideoUrlMixin"]
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["MAX_VIDEO_DATA_URI_SIZE_BYTES", "PublicVideoUrlMixin", "decoded_data_uri_size"]
+
+# Hostnames whose URLs LTX can't fetch (docs.ltx.io/input-formats requires a publicly
+# reachable domain name). These are uploaded to Griptape Cloud instead of passed through.
 _LOCAL_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
 
-# LTX nginx rejects payloads above ~23 MB encoded (~17 MB on disk). 16 MB gives a
-# conservative buffer below the observed 16.58 MB success ceiling.
-MAX_VIDEO_FILE_SIZE_BYTES = 16 * 1024 * 1024
+# LTX rejects inline base64 (data URI) videos above 15 MB (docs.ltx.io/input-formats).
+# The URL tier avoids this entirely by handing LTX a public URL it fetches server-side,
+# where the limit is a larger 32 MB; this guard only applies to the base64 fallback.
+MAX_VIDEO_DATA_URI_SIZE_BYTES = 15 * 1024 * 1024
+
+
+def decoded_data_uri_size(data_uri: str) -> int:
+    """Return the decoded byte size of a base64 ``data:`` URI.
+
+    Raises ValueError on a malformed URI (missing the ``,`` separator) rather than silently
+    skipping the size check on a payload we can't measure — a malformed URI would otherwise be
+    sent as-is and bounce back as the 413 this guard exists to prevent.
+    """
+    _prefix, sep, b64 = data_uri.partition(",")
+    if not sep:
+        msg = "Malformed data URI: missing ',' separator."
+        raise ValueError(msg)
+    return (len(b64) // 4) * 3 - b64.count("=")
 
 
 class PublicVideoUrlMixin:
-    def _resolve_to_public_url(self, video_input: Any) -> str | None:
-        """Return a public URL for the video if one can be resolved, or None to fall back to base64.
+    """Resolve a node's video input to a value for a proxy ``video_uri`` field.
 
-        Any http:// or https:// URL is returned as-is. For file paths, tries
-        CreateStaticFileDownloadUrlFromPathRequest (returns a real signed URL in cloud
-        deployments, a localhost URL in local dev). Returns None for data: URIs and
-        on any resolution failure.
+    Tier 1 uploads the video to Griptape Cloud via ``PublicArtifactUrlParameter`` and returns a
+    guaranteed-public HTTPS URL, which LTX fetches server-side — keeping the request body tiny
+    and side-stepping the ~33% base64 inflation that triggers 413s. Tier 2 falls back to a
+    base64 ``data:`` URI with a pre-flight size check for environments where the upload can't
+    run (e.g. local dev without Griptape Cloud credentials).
+
+    Consuming nodes must provide ``name``, ``get_parameter_value``, ``set_parameter_value``,
+    ``remove_parameter_element_by_name`` (all on ``BaseNode``) and an async
+    ``_prepare_video_data_uri_async(video_input)`` method, and must call
+    ``_reset_video_uploads()`` / ``_cleanup_video_uploads()`` around processing.
+    """
+
+    _pending_video_uploads: list[tuple[PublicArtifactUrlParameter, str]]
+
+    def _reset_video_uploads(self) -> None:
+        self._pending_video_uploads = []
+
+    def _cleanup_video_uploads(self) -> None:
+        """Delete uploaded Griptape Cloud artifacts and remove their scratch parameters.
+
+        Each scratch parameter name is unique per upload, so leaving them would accumulate
+        parameters on the node across runs.
         """
-        coerced = coerce_media_url_or_data_uri(video_input, kind="video")
-        if not coerced:
+        for helper, scratch_name in getattr(self, "_pending_video_uploads", []):
+            with suppress(Exception):
+                helper.delete_uploaded_artifact()
+            with suppress(Exception):
+                self.remove_parameter_element_by_name(scratch_name)  # type: ignore[attr-defined]
+        self._pending_video_uploads = []
+
+    async def _resolve_video_uri(self, video_input: Any) -> str:
+        """Return the value for the proxy ``video_uri`` field (public URL or base64 data URI)."""
+        public_url = self._upload_video_to_public_url(video_input)
+        if public_url:
+            return public_url
+
+        # Tier 2: base64 data URI with a pre-flight size guard.
+        prepare: Awaitable[str | None] = self._prepare_video_data_uri_async(video_input)  # type: ignore[attr-defined]
+        data_uri = await prepare
+        if not data_uri:
+            msg = f"{self.name} failed to process input video."  # type: ignore[attr-defined]
+            raise ValueError(msg)
+
+        decoded_size = decoded_data_uri_size(data_uri)
+        if decoded_size > MAX_VIDEO_DATA_URI_SIZE_BYTES:
+            size_mb = decoded_size / 1_048_576
+            limit_mb = MAX_VIDEO_DATA_URI_SIZE_BYTES // 1_048_576
+            msg = (
+                f"{self.name}: Source video is too large ({size_mb:.1f} MB). "  # type: ignore[attr-defined]
+                f"The maximum supported size is {limit_mb} MB. "
+                "Trim the video to a shorter segment and try again."
+            )
+            raise ValueError(msg)
+        return data_uri
+
+    def _upload_video_to_public_url(self, video_input: Any) -> str | None:
+        """Upload the video to Griptape Cloud and return a public URL, or None to fall back.
+
+        Already-public remote http(s) URLs pass through unchanged (LTX fetches them directly).
+        Local paths, ``data:`` URIs, and localhost URLs are uploaded via a transient
+        ``PublicArtifactUrlParameter``. Returns None (and logs a warning) if the upload can't
+        be performed so the caller falls back to base64.
+        """
+        video_value = coerce_media_url_or_data_uri(video_input, kind="video")
+        if not video_value:
             return None
-        if coerced.startswith(("http://", "https://")):
-            if urlparse(coerced).hostname in _LOCAL_HOSTNAMES:
-                return None
-            return coerced
-        if coerced.startswith("data:"):
-            return None
+        if video_value.startswith(("http://", "https://")) and urlparse(video_value).hostname not in _LOCAL_HOSTNAMES:
+            return video_value
+
+        # The scratch parameter is a transient, worker-local helper that only exists to feed the
+        # upload (PublicArtifactUrlParameter reads its value locally). Its name is unique per
+        # call and it is removed in _cleanup_video_uploads before the run ends.
+        scratch_name = f"_video_upload_{uuid4().hex}"
         try:
-            resolved = File(coerced).resolve()
-            result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
-            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
-                url = result.url
-                if urlparse(url).hostname not in _LOCAL_HOSTNAMES:
-                    return url
-        except Exception:
-            pass
-        return None
+            helper = PublicArtifactUrlParameter(
+                node=self,  # type: ignore[arg-type]
+                artifact_url_parameter=Parameter(
+                    name=scratch_name,
+                    input_types=["VideoUrlArtifact"],
+                    type="VideoUrlArtifact",
+                    default_value="",
+                    tooltip="",
+                    allowed_modes={ParameterMode.PROPERTY},
+                    hide=True,
+                    hide_property=True,
+                ),
+            )
+            helper.add_input_parameters()
+            self._pending_video_uploads.append((helper, scratch_name))
+            self.set_parameter_value(scratch_name, video_value)  # type: ignore[attr-defined]
+            return helper.get_public_url_for_parameter()
+        except Exception as e:  # noqa: BLE001 - any upload failure should degrade to base64
+            logger.warning(
+                "%s: public-URL upload failed, falling back to base64: %s",
+                self.name,  # type: ignore[attr-defined]
+                e,
+            )
+            return None

--- a/griptape_nodes_library/video/public_video_url_mixin.py
+++ b/griptape_nodes_library/video/public_video_url_mixin.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from griptape_nodes.files.file import File
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlFromPathResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+from griptape_nodes_library.media import coerce_media_url_or_data_uri
+
+__all__ = ["MAX_VIDEO_FILE_SIZE_BYTES", "PublicVideoUrlMixin"]
+
+_LOCAL_HOSTNAMES = frozenset({"localhost", "127.0.0.1", "::1"})
+
+# LTX nginx rejects payloads above ~23 MB encoded (~17 MB on disk). 16 MB gives a
+# conservative buffer below the observed 16.58 MB success ceiling.
+MAX_VIDEO_FILE_SIZE_BYTES = 16 * 1024 * 1024
+
+
+class PublicVideoUrlMixin:
+    def _resolve_to_public_url(self, video_input: Any) -> str | None:
+        """Return a public URL for the video if one can be resolved, or None to fall back to base64.
+
+        Any http:// or https:// URL is returned as-is. For file paths, tries
+        CreateStaticFileDownloadUrlFromPathRequest (returns a real signed URL in cloud
+        deployments, a localhost URL in local dev). Returns None for data: URIs and
+        on any resolution failure.
+        """
+        coerced = coerce_media_url_or_data_uri(video_input, kind="video")
+        if not coerced:
+            return None
+        if coerced.startswith(("http://", "https://")):
+            if urlparse(coerced).hostname in _LOCAL_HOSTNAMES:
+                return None
+            return coerced
+        if coerced.startswith("data:"):
+            return None
+        try:
+            resolved = File(coerced).resolve()
+            result = GriptapeNodes.handle_request(CreateStaticFileDownloadUrlFromPathRequest(file_path=resolved))
+            if isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess):
+                url = result.url
+                if urlparse(url).hostname not in _LOCAL_HOSTNAMES:
+                    return url
+        except Exception:
+            pass
+        return None

--- a/tests/unit/video/test_ltx_video_size_check.py
+++ b/tests/unit/video/test_ltx_video_size_check.py
@@ -1,0 +1,221 @@
+"""Unit tests for the two-tier video-URI resolution in LTX retake and extend nodes.
+
+Tier 1: resolve to a public presigned HTTPS URL (cloud path — no 413 risk).
+Tier 2: fall back to base64 encoding with a pre-flight size check (local dev).
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+
+from griptape_nodes_library.video.ltx_video_extend import LTXVideoExtend
+from griptape_nodes_library.video.ltx_video_retake import LTXVideoRetake
+from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES
+
+# Minimal valid base64 payload whose decoded size is well under the limit (~15 bytes).
+_SMALL_DATA_URI = "data:video/mp4;base64," + base64.b64encode(b"tiny video data").decode()
+
+# Large fake data URI whose decoded size exceeds the limit.
+# Formula used in the nodes: (b64_len // 4) * 3 - padding.
+# 'A' chars have no '=' padding. We need (b64_len // 4) * 3 > MAX_VIDEO_FILE_SIZE_BYTES.
+# b64_len must be a multiple of 4 for the formula to be consistent.
+_LARGE_B64_LEN = ((MAX_VIDEO_FILE_SIZE_BYTES // 3) + 1) * 4  # first multiple-of-4 that decodes to > MAX
+_LARGE_DATA_URI = "data:video/mp4;base64," + "A" * _LARGE_B64_LEN
+
+_PUBLIC_URL = "https://storage.griptapecloud.com/bucket/video.mp4?sig=abc123"
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoRetake — base64 fallback path (tier 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retake_rejects_video_exceeding_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoRetake(name="Retake")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/big.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("retake_segment", [0.0, 2.0])
+    node.set_parameter_value("resolution", "1920x1080")
+
+    monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_DATA_URI))
+
+    with pytest.raises(ValueError, match="too large"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_retake_error_message_includes_size_and_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoRetake(name="Retake")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/big.mp4"))
+    node.set_parameter_value("prompt", "")
+    node.set_parameter_value("retake_segment", [0.0, 2.0])
+    node.set_parameter_value("resolution", "1920x1080")
+
+    monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_DATA_URI))
+
+    with pytest.raises(ValueError) as exc_info:
+        await node._build_payload()
+
+    message = str(exc_info.value)
+    assert "MB" in message
+    assert str(MAX_VIDEO_FILE_SIZE_BYTES // (1024 * 1024)) in message
+
+
+@pytest.mark.asyncio
+async def test_retake_accepts_video_within_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoRetake(name="Retake")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/small.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("retake_segment", [0.0, 2.0])
+    node.set_parameter_value("resolution", "1920x1080")
+
+    monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_SMALL_DATA_URI))
+
+    payload = await node._build_payload()
+    assert payload["video_uri"] == _SMALL_DATA_URI
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoRetake — presigned URL path (tier 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retake_uses_public_url_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoRetake(name="Retake")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/big.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("retake_segment", [0.0, 2.0])
+    node.set_parameter_value("resolution", "1920x1080")
+
+    prepare_mock = AsyncMock()
+    monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: _PUBLIC_URL)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", prepare_mock)
+
+    payload = await node._build_payload()
+
+    assert payload["video_uri"] == _PUBLIC_URL
+    prepare_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retake_resolve_to_public_url_returns_https_url_directly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_resolve_to_public_url returns any https URL as-is."""
+    node = LTXVideoRetake(name="Retake")
+    result = node._resolve_to_public_url(VideoUrlArtifact(_PUBLIC_URL))
+    assert result == _PUBLIC_URL
+
+
+@pytest.mark.asyncio
+async def test_retake_resolve_to_public_url_returns_none_for_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_resolve_to_public_url returns None for localhost URLs so they fall through to base64."""
+    node = LTXVideoRetake(name="Retake")
+    result = node._resolve_to_public_url(VideoUrlArtifact("http://localhost:9999/static/video.mp4?token=abc"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_retake_resolve_to_public_url_returns_none_for_data_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_resolve_to_public_url returns None for data URIs (skip to base64 path)."""
+    node = LTXVideoRetake(name="Retake")
+    result = node._resolve_to_public_url(_SMALL_DATA_URI)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoExtend — base64 fallback path (tier 2)
+# ---------------------------------------------------------------------------
+
+_LARGE_EXTEND_B64_LEN = ((MAX_VIDEO_FILE_SIZE_BYTES // 3) + 1) * 4
+_LARGE_EXTEND_DATA_URI = "data:video/mp4;base64," + "A" * _LARGE_EXTEND_B64_LEN
+
+
+@pytest.mark.asyncio
+async def test_extend_rejects_video_exceeding_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoExtend(name="Extend")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/big.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("duration", 2)
+    node.set_parameter_value("context", 1)
+
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_EXTEND_DATA_URI))
+
+    with pytest.raises(ValueError, match="too large"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_extend_accepts_video_within_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoExtend(name="Extend")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/small.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("duration", 2)
+    node.set_parameter_value("context", 1)
+
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_SMALL_DATA_URI))
+
+    payload = await node._build_payload()
+    assert payload["video_uri"] == _SMALL_DATA_URI
+
+
+# ---------------------------------------------------------------------------
+# LTXVideoExtend — presigned URL path (tier 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extend_uses_public_url_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = LTXVideoExtend(name="Extend")
+    node.set_parameter_value("video", VideoUrlArtifact("https://example.com/big.mp4"))
+    node.set_parameter_value("prompt", "test prompt")
+    node.set_parameter_value("duration", 2)
+    node.set_parameter_value("context", 1)
+
+    prepare_mock = AsyncMock()
+    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: _PUBLIC_URL)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", prepare_mock)
+
+    payload = await node._build_payload()
+
+    assert payload["video_uri"] == _PUBLIC_URL
+    prepare_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# API key validation error — failure edge must propagate
+# ---------------------------------------------------------------------------
+
+
+def test_retake_api_key_error_triggers_failure_exception() -> None:
+    """_handle_api_key_validation_error must call _handle_failure_exception so the
+    SuccessFailureNode failure edge fires and the user sees the error in the UI."""
+    node = LTXVideoRetake(name="Retake")
+    err = ValueError("LTX Video Retake is missing GT_CLOUD_API_KEY.")
+    with patch.object(node, "_handle_failure_exception") as mock_failure:
+        node._handle_api_key_validation_error(err)
+    mock_failure.assert_called_once_with(err)
+
+
+def test_extend_api_key_error_triggers_failure_exception() -> None:
+    """Same check for LTXVideoExtend."""
+    node = LTXVideoExtend(name="Extend")
+    err = ValueError("LTX Video Extend is missing GT_CLOUD_API_KEY.")
+    with patch.object(node, "_handle_failure_exception") as mock_failure:
+        node._handle_api_key_validation_error(err)
+    mock_failure.assert_called_once_with(err)

--- a/tests/unit/video/test_ltx_video_size_check.py
+++ b/tests/unit/video/test_ltx_video_size_check.py
@@ -224,6 +224,70 @@ def test_upload_uploads_localhost_url(monkeypatch: pytest.MonkeyPatch) -> None:
     assert node._pending_video_uploads  # tracked for cleanup
 
 
+def test_upload_uploads_plain_http_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """http:// URLs must upload — LTX requires HTTPS-only with a domain name."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    helper.get_public_url_for_parameter.return_value = _PUBLIC_URL
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", MagicMock(return_value=helper))
+    monkeypatch.setattr(node, "set_parameter_value", lambda *_args, **_kwargs: None)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("http://example.com/video.mp4"))
+
+    assert result == _PUBLIC_URL
+    helper.get_public_url_for_parameter.assert_called_once()
+
+
+def test_upload_uploads_ip_address_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LAN IP URLs must upload — LTX requires a domain name, not a bare IP."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    helper.get_public_url_for_parameter.return_value = _PUBLIC_URL
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", MagicMock(return_value=helper))
+    monkeypatch.setattr(node, "set_parameter_value", lambda *_args, **_kwargs: None)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("https://192.168.1.20:8124/static/v.mp4"))
+
+    assert result == _PUBLIC_URL
+    helper.get_public_url_for_parameter.assert_called_once()
+
+
+def test_upload_uploads_zero_zero_ip_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """0.0.0.0 URLs must upload — not publicly reachable."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    helper.get_public_url_for_parameter.return_value = _PUBLIC_URL
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", MagicMock(return_value=helper))
+    monkeypatch.setattr(node, "set_parameter_value", lambda *_args, **_kwargs: None)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("https://0.0.0.0:8124/static/v.mp4"))
+
+    assert result == _PUBLIC_URL
+    helper.get_public_url_for_parameter.assert_called_once()
+
+
+def test_upload_uploads_bare_hostname_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare single-label hostnames (container names, etc.) must upload — not publicly reachable."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    helper.get_public_url_for_parameter.return_value = _PUBLIC_URL
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", MagicMock(return_value=helper))
+    monkeypatch.setattr(node, "set_parameter_value", lambda *_args, **_kwargs: None)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("https://my-container:8124/static/v.mp4"))
+
+    assert result == _PUBLIC_URL
+    helper.get_public_url_for_parameter.assert_called_once()
+
+
 def test_upload_falls_back_to_none_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """If the cloud upload raises, resolution degrades to base64 (returns None), not an error."""
     node = LTXVideoRetake(name="Retake")

--- a/tests/unit/video/test_ltx_video_size_check.py
+++ b/tests/unit/video/test_ltx_video_size_check.py
@@ -1,32 +1,53 @@
 """Unit tests for the two-tier video-URI resolution in LTX retake and extend nodes.
 
-Tier 1: resolve to a public presigned HTTPS URL (cloud path — no 413 risk).
-Tier 2: fall back to base64 encoding with a pre-flight size check (local dev).
+Tier 1: upload the video to Griptape Cloud via ``PublicArtifactUrlParameter`` and hand LTX a
+        guaranteed-public HTTPS URL it fetches server-side (no base64 inflation → no 413).
+Tier 2: fall back to a base64 ``data:`` URI with a pre-flight size check (local dev / no cloud).
 """
 
 from __future__ import annotations
 
 import base64
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 
+from griptape_nodes_library.video import public_video_url_mixin
 from griptape_nodes_library.video.ltx_video_extend import LTXVideoExtend
 from griptape_nodes_library.video.ltx_video_retake import LTXVideoRetake
-from griptape_nodes_library.video.public_video_url_mixin import MAX_VIDEO_FILE_SIZE_BYTES
+from griptape_nodes_library.video.public_video_url_mixin import (
+    MAX_VIDEO_DATA_URI_SIZE_BYTES,
+    decoded_data_uri_size,
+)
 
 # Minimal valid base64 payload whose decoded size is well under the limit (~15 bytes).
 _SMALL_DATA_URI = "data:video/mp4;base64," + base64.b64encode(b"tiny video data").decode()
 
 # Large fake data URI whose decoded size exceeds the limit.
-# Formula used in the nodes: (b64_len // 4) * 3 - padding.
-# 'A' chars have no '=' padding. We need (b64_len // 4) * 3 > MAX_VIDEO_FILE_SIZE_BYTES.
-# b64_len must be a multiple of 4 for the formula to be consistent.
-_LARGE_B64_LEN = ((MAX_VIDEO_FILE_SIZE_BYTES // 3) + 1) * 4  # first multiple-of-4 that decodes to > MAX
+# Formula: (b64_len // 4) * 3 - padding. 'A' chars carry no '=' padding, and b64_len is a
+# multiple of 4, so decoded size == (b64_len // 4) * 3 > MAX_VIDEO_DATA_URI_SIZE_BYTES.
+_LARGE_B64_LEN = ((MAX_VIDEO_DATA_URI_SIZE_BYTES // 3) + 1) * 4
 _LARGE_DATA_URI = "data:video/mp4;base64," + "A" * _LARGE_B64_LEN
 
 _PUBLIC_URL = "https://storage.griptapecloud.com/bucket/video.mp4?sig=abc123"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers: decoded_data_uri_size
+# ---------------------------------------------------------------------------
+
+
+def test_decoded_data_uri_size_returns_decoded_byte_count() -> None:
+    payload = b"hello world, this is some video bytes"
+    data_uri = "data:video/mp4;base64," + base64.b64encode(payload).decode()
+    assert decoded_data_uri_size(data_uri) == len(payload)
+
+
+def test_decoded_data_uri_size_raises_on_malformed_uri() -> None:
+    """A data URI with no ',' separator is unmeasurable — must raise, not silently pass."""
+    with pytest.raises(ValueError, match="Malformed data URI"):
+        decoded_data_uri_size("data:video/mp4;base64-no-comma-here")
 
 
 # ---------------------------------------------------------------------------
@@ -43,7 +64,7 @@ async def test_retake_rejects_video_exceeding_size_limit(monkeypatch: pytest.Mon
     node.set_parameter_value("resolution", "1920x1080")
 
     monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: None)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_DATA_URI))
 
     with pytest.raises(ValueError, match="too large"):
@@ -59,7 +80,7 @@ async def test_retake_error_message_includes_size_and_limit(monkeypatch: pytest.
     node.set_parameter_value("resolution", "1920x1080")
 
     monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: None)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_DATA_URI))
 
     with pytest.raises(ValueError) as exc_info:
@@ -67,7 +88,7 @@ async def test_retake_error_message_includes_size_and_limit(monkeypatch: pytest.
 
     message = str(exc_info.value)
     assert "MB" in message
-    assert str(MAX_VIDEO_FILE_SIZE_BYTES // (1024 * 1024)) in message
+    assert str(MAX_VIDEO_DATA_URI_SIZE_BYTES // (1024 * 1024)) in message
 
 
 @pytest.mark.asyncio
@@ -79,7 +100,7 @@ async def test_retake_accepts_video_within_size_limit(monkeypatch: pytest.Monkey
     node.set_parameter_value("resolution", "1920x1080")
 
     monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: None)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_SMALL_DATA_URI))
 
     payload = await node._build_payload()
@@ -87,7 +108,7 @@ async def test_retake_accepts_video_within_size_limit(monkeypatch: pytest.Monkey
 
 
 # ---------------------------------------------------------------------------
-# LTXVideoRetake — presigned URL path (tier 1)
+# LTXVideoRetake — public-URL path (tier 1)
 # ---------------------------------------------------------------------------
 
 
@@ -101,47 +122,18 @@ async def test_retake_uses_public_url_when_available(monkeypatch: pytest.MonkeyP
 
     prepare_mock = AsyncMock()
     monkeypatch.setattr(node, "_validate_video_input", lambda _video: None)
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: _PUBLIC_URL)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: _PUBLIC_URL)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", prepare_mock)
 
     payload = await node._build_payload()
 
     assert payload["video_uri"] == _PUBLIC_URL
-    prepare_mock.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_retake_resolve_to_public_url_returns_https_url_directly(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_resolve_to_public_url returns any https URL as-is."""
-    node = LTXVideoRetake(name="Retake")
-    result = node._resolve_to_public_url(VideoUrlArtifact(_PUBLIC_URL))
-    assert result == _PUBLIC_URL
-
-
-@pytest.mark.asyncio
-async def test_retake_resolve_to_public_url_returns_none_for_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
-    """_resolve_to_public_url returns None for localhost URLs so they fall through to base64."""
-    node = LTXVideoRetake(name="Retake")
-    result = node._resolve_to_public_url(VideoUrlArtifact("http://localhost:9999/static/video.mp4?token=abc"))
-    assert result is None
-
-
-@pytest.mark.asyncio
-async def test_retake_resolve_to_public_url_returns_none_for_data_uri(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """_resolve_to_public_url returns None for data URIs (skip to base64 path)."""
-    node = LTXVideoRetake(name="Retake")
-    result = node._resolve_to_public_url(_SMALL_DATA_URI)
-    assert result is None
+    prepare_mock.assert_not_called()  # base64 path skipped entirely
 
 
 # ---------------------------------------------------------------------------
 # LTXVideoExtend — base64 fallback path (tier 2)
 # ---------------------------------------------------------------------------
-
-_LARGE_EXTEND_B64_LEN = ((MAX_VIDEO_FILE_SIZE_BYTES // 3) + 1) * 4
-_LARGE_EXTEND_DATA_URI = "data:video/mp4;base64," + "A" * _LARGE_EXTEND_B64_LEN
 
 
 @pytest.mark.asyncio
@@ -152,8 +144,8 @@ async def test_extend_rejects_video_exceeding_size_limit(monkeypatch: pytest.Mon
     node.set_parameter_value("duration", 2)
     node.set_parameter_value("context", 1)
 
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
-    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_EXTEND_DATA_URI))
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_LARGE_DATA_URI))
 
     with pytest.raises(ValueError, match="too large"):
         await node._build_payload()
@@ -167,7 +159,7 @@ async def test_extend_accepts_video_within_size_limit(monkeypatch: pytest.Monkey
     node.set_parameter_value("duration", 2)
     node.set_parameter_value("context", 1)
 
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: None)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: None)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", AsyncMock(return_value=_SMALL_DATA_URI))
 
     payload = await node._build_payload()
@@ -175,7 +167,7 @@ async def test_extend_accepts_video_within_size_limit(monkeypatch: pytest.Monkey
 
 
 # ---------------------------------------------------------------------------
-# LTXVideoExtend — presigned URL path (tier 1)
+# LTXVideoExtend — public-URL path (tier 1)
 # ---------------------------------------------------------------------------
 
 
@@ -188,13 +180,85 @@ async def test_extend_uses_public_url_when_available(monkeypatch: pytest.MonkeyP
     node.set_parameter_value("context", 1)
 
     prepare_mock = AsyncMock()
-    monkeypatch.setattr(node, "_resolve_to_public_url", lambda _video: _PUBLIC_URL)
+    monkeypatch.setattr(node, "_upload_video_to_public_url", lambda _video: _PUBLIC_URL)
     monkeypatch.setattr(node, "_prepare_video_data_uri_async", prepare_mock)
 
     payload = await node._build_payload()
 
     assert payload["video_uri"] == _PUBLIC_URL
     prepare_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _upload_video_to_public_url — routing + fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_upload_passes_through_remote_https_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An already-public remote https URL is handed to LTX as-is — no upload attempted."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    ctor = MagicMock()
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", ctor)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact(_PUBLIC_URL))
+
+    assert result == _PUBLIC_URL
+    ctor.assert_not_called()
+
+
+def test_upload_uploads_localhost_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A localhost URL is not publicly reachable, so it is uploaded to Griptape Cloud."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    helper.get_public_url_for_parameter.return_value = _PUBLIC_URL
+    monkeypatch.setattr(public_video_url_mixin, "PublicArtifactUrlParameter", MagicMock(return_value=helper))
+    monkeypatch.setattr(node, "set_parameter_value", lambda *_args, **_kwargs: None)
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("http://localhost:9999/static/video.mp4?token=abc"))
+
+    assert result == _PUBLIC_URL
+    assert node._pending_video_uploads  # tracked for cleanup
+
+
+def test_upload_falls_back_to_none_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the cloud upload raises, resolution degrades to base64 (returns None), not an error."""
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    monkeypatch.setattr(
+        public_video_url_mixin,
+        "PublicArtifactUrlParameter",
+        MagicMock(side_effect=RuntimeError("no cloud creds")),
+    )
+
+    result = node._upload_video_to_public_url(VideoUrlArtifact("http://localhost:9999/static/video.mp4"))
+
+    assert result is None
+    assert not node._pending_video_uploads
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_video_uploads — deletes artifacts and removes scratch parameters
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_deletes_artifacts_and_removes_scratch_params() -> None:
+    node = LTXVideoRetake(name="Retake")
+    node._reset_video_uploads()
+
+    helper = MagicMock()
+    node._pending_video_uploads.append((helper, "_video_upload_deadbeef"))
+
+    with patch.object(node, "remove_parameter_element_by_name") as remove_mock:
+        node._cleanup_video_uploads()
+
+    helper.delete_uploaded_artifact.assert_called_once()
+    remove_mock.assert_called_once_with("_video_upload_deadbeef")
+    assert node._pending_video_uploads == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

LTX retake and extend send video as a base64 data URI, inflating payload size by ~33%. LTX's nginx rejects bodies above ~23 MB (~17 MB on disk), but the only signal users received was an opaque "client error: proxy client error" after a billed round-trip (griptape-ai/griptape-cloud#2137).

Three-part fix:

- **Presigned URL tier** (`PublicVideoUrlMixin._resolve_to_public_url`): in Griptape Cloud deployments, `CreateStaticFileDownloadUrlFromPathRequest` returns a real signed S3/Azure URL that LTX can fetch server-side — bypassing the payload limit entirely. Localhost and loopback URLs are excluded (detected via `urlparse` hostname check, not a substring match) so local dev always falls through to tier 2.

- **Pre-flight size check** (tier 2 fallback): after base64-encoding the video, the decoded byte count `((b64_len // 4) * 3 - padding)` is compared against `MAX_VIDEO_FILE_SIZE_BYTES = 16 MB`. If exceeded, a descriptive `ValueError` is raised before the proxy call — no billing impact.

- **Failure-edge propagation**: `LTXVideoRetake` and `LTXVideoExtend` had `_handle_api_key_validation_error` overrides that accidentally dropped the `_handle_failure_exception` call, causing silent no-output failures when credentials were absent. The overrides are removed; `logger.error` is added to the base class so all proxy nodes log consistently and the `SuccessFailureNode` failure edge fires correctly.

## Changes

- `griptape_nodes_library/video/public_video_url_mixin.py` — new; `PublicVideoUrlMixin` + `MAX_VIDEO_FILE_SIZE_BYTES`
- `griptape_nodes_library/video/ltx_video_retake.py` — inherit mixin, two-tier payload build, remove override
- `griptape_nodes_library/video/ltx_video_extend.py` — same
- `griptape_nodes_library/proxy/griptape_proxy_node.py` — add `logger.error` to base `_handle_api_key_validation_error`
- `tests/unit/video/test_ltx_video_size_check.py` — new; 12 tests covering both tiers, size boundary, and failure-edge propagation

## Test plan

- [ ] `uv run pytest tests/unit/video/test_ltx_video_size_check.py -v` — all 12 pass
- [ ] Manual: LTX Video Retake with a small local video file submits successfully (base64 path)
- [ ] Manual: LTX Video Retake with an oversized local file raises a clear size error before the proxy call