### PR TITLE
feat: add Seedance 2.5 to the Seedance video generation node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -406,6 +406,12 @@
                 "provider_model_id": "dreamina-seedance-2-0-mini-260615",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               },
+              "gtc_seedance_2_5": {
+                "display_name": "Seedance 2.5",
+                "family": "Seedance",
+                "provider_model_id": "dreamina-seedance-2-5-260628",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
               "gtc_omnihuman_1_0": {
                 "display_name": "OmniHuman 1.0",
                 "family": "OmniHuman",
@@ -2413,7 +2419,7 @@
       "file_path": "griptape_nodes_library/video/seedance_2_0_video_generation.py",
       "metadata": {
         "category": "video",
-        "description": "Generate a video using Seedance 2.0 models with multimodal support via Griptape Cloud model proxy.",
+        "description": "Generate a video using Seedance 2.0 or Seedance 2.5 models with multimodal support via Griptape Cloud model proxy.",
         "display_name": "Seedance 2.0 Video Generation",
         "icon": "Sparkles",
         "group": "create",
@@ -2430,7 +2436,8 @@
             "model_ids": [
               "gtc_seedance_2_0",
               "gtc_seedance_2_0_fast",
-              "gtc_seedance_2_0_mini"
+              "gtc_seedance_2_0_mini",
+              "gtc_seedance_2_5"
             ]
           }
         ]

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -67,15 +67,19 @@ class SeedanceModelCapabilities:
     """Capabilities supported by a Seedance model variant, per the BytePlus model docs.
 
     All four variants (2.0, 2.0 Fast, 2.0 Mini, 2.5) support first+last frame i2v and
-    private-asset references. They differ in output resolution and maximum duration: standard
-    2.0 supports up to 4k; 2.0 Fast and 2.0 Mini top out at 720p; 2.5 supports 480p and 720p only.
-    The three 2.0 variants cap duration at 15 seconds; 2.5 extends that ceiling to 30 seconds.
+    private-asset references. They differ in output resolution, maximum duration, and reference
+    media budgets: standard 2.0 supports up to 4k; 2.0 Fast and 2.0 Mini top out at 720p; 2.5
+    supports 480p and 720p only. The three 2.0 variants cap duration at 15 seconds and allow up
+    to 9 reference images and 3 reference audio files; 2.5 extends the duration ceiling to 30
+    seconds and raises those budgets to 30 reference images and 10 reference audio files.
     """
 
     resolutions: tuple[str, ...]
     supports_last_frame: bool
     supports_private_assets: bool
     max_duration: int
+    max_reference_images: int
+    max_reference_audio: int
 
 
 # Single source of truth for per-model capabilities, keyed by provider model id. Adding a new
@@ -86,24 +90,32 @@ SEEDANCE_MODEL_CAPABILITIES: dict[str, SeedanceModelCapabilities] = {
         supports_last_frame=True,
         supports_private_assets=True,
         max_duration=15,
+        max_reference_images=9,
+        max_reference_audio=3,
     ),
     SEEDANCE_2_0_FAST_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p"),
         supports_last_frame=True,
         supports_private_assets=True,
         max_duration=15,
+        max_reference_images=9,
+        max_reference_audio=3,
     ),
     SEEDANCE_2_0_MINI_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p"),
         supports_last_frame=True,
         supports_private_assets=True,
         max_duration=15,
+        max_reference_images=9,
+        max_reference_audio=3,
     ),
     SEEDANCE_2_5_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p"),
         supports_last_frame=True,
         supports_private_assets=True,
         max_duration=30,
+        max_reference_images=30,
+        max_reference_audio=10,
     ),
 }
 
@@ -114,6 +126,8 @@ _DEFAULT_MODEL_CAPABILITIES = SeedanceModelCapabilities(
     supports_last_frame=True,
     supports_private_assets=False,
     max_duration=15,
+    max_reference_images=9,
+    max_reference_audio=3,
 )
 
 
@@ -125,6 +139,13 @@ def _get_model_capabilities(model_id: str) -> SeedanceModelCapabilities:
 def _duration_choices(max_duration: int) -> list[int]:
     """Build the duration Options choices for a model: smart selection plus its integer range."""
     return [DURATION_SMART, *range(MIN_DURATION, max_duration + 1)]
+
+
+# ParameterList.max_items is a static, read-only ceiling with no per-model update hook, so the
+# reference lists are sized to the most permissive model and the per-model limit is enforced in
+# _validate_parameters.
+MAX_REFERENCE_IMAGES = max(capabilities.max_reference_images for capabilities in SEEDANCE_MODEL_CAPABILITIES.values())
+MAX_REFERENCE_AUDIO = max(capabilities.max_reference_audio for capabilities in SEEDANCE_MODEL_CAPABILITIES.values())
 
 
 # Provider-asset (private asset) registration via the GTC proxy. Supported by all Seedance
@@ -174,14 +195,16 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
     """Generate a video using Seedance 2.0 and Seedance 2.5 models via Griptape Cloud model proxy.
 
     Supports the Seedance 2.0, Seedance 2.0 Fast, Seedance 2.0 Mini, and Seedance 2.5 models. All
-    four share the same feature set; they differ in output resolution and max duration: standard
-    2.0 supports up to 4k and 15s, Fast and Mini top out at 720p and 15s, and 2.5 tops out at 720p
-    but extends to 30s.
+    four share the same feature set; they differ in output resolution, max duration, and reference
+    media budgets: standard 2.0 supports up to 4k and 15s, Fast and Mini top out at 720p and 15s,
+    and 2.5 tops out at 720p but extends to 30s. The three 2.0 variants allow up to 9 reference
+    images and 3 reference audio files; 2.5 raises those budgets to 30 reference images and 10
+    reference audio files.
 
     Supports three input modes:
     - Text Only: Pure text-to-video generation (default)
     - First/Last Frame: Traditional i2v with first and/or last frame images
-    - Multimodal References: Up to 9 images + 3 videos + 3 audio files as references
+    - Multimodal References: Images + up to 3 videos + audio files as references (image and audio counts are model-dependent)
 
     Inputs:
         - prompt (str): Text prompt for the video
@@ -192,7 +215,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         - duration (int): Video duration in seconds (default: 5, range is model-dependent: 4-15 for 2.0/Fast/Mini, 4-30 for 2.5, or -1 for smart selection)
         - generate_audio (bool): Generate audio with video (default: False)
         - first_frame/last_frame: Optional frame images (First/Last Frame mode only)
-        - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal mode only)
+        - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal mode only; reference image and audio counts are model-dependent: 0-9 images/0-3 audio for 2.0/Fast/Mini, 0-30 images/0-10 audio for 2.5)
 
     Outputs:
         - generation_id (str): Griptape Cloud generation id
@@ -297,10 +320,10 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 name="reference_images",
                 input_types=["ImageUrlArtifact", "ImageArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_IMAGE]],
                 default_value=[],
-                tooltip="Optional reference images (0-9 images). Connect a Seedance Human Reference Asset to register an image as a private asset.",
+                tooltip="Optional reference images (0-9 for Seedance 2.0/Fast/Mini, 0-30 for Seedance 2.5). Connect a Seedance Human Reference Asset to register an image as a private asset.",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Images", "expander": True, "hide_property": True},
-                max_items=9,
+                max_items=MAX_REFERENCE_IMAGES,
             )
         )
 
@@ -370,10 +393,10 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 name="reference_audio",
                 input_types=["AudioArtifact", "AudioUrlArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_AUDIO]],
                 default_value=[],
-                tooltip="Optional reference audio (0-3 audio files, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported. Connect a Seedance Human Reference Asset to register audio as a private asset.",
+                tooltip="Optional reference audio (0-3 for Seedance 2.0/Fast/Mini, 0-10 for Seedance 2.5, 2-15s each, max 15s total). URLs, asset:// IDs, or base64/data URIs are supported. Connect a Seedance Human Reference Asset to register audio as a private asset.",
                 allowed_modes={ParameterMode.INPUT},
                 ui_options={"display_name": "Reference Audio", "expander": True, "hide_property": True},
-                max_items=3,
+                max_items=MAX_REFERENCE_AUDIO,
             )
         )
 
@@ -728,17 +751,22 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
         # Multimodal mode validation
         if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
+            model_capabilities = _get_model_capabilities(params["model_id"])
+
             # Audio requires at least one image or video
             if has_reference_audio and not (has_reference_images or has_reference_videos):
                 msg = (
-                    f"{self.name}: Seedance 2.0 requires at least one reference image or video when using audio. "
-                    "Audio cannot be used alone."
+                    f"{self.name}: the selected model requires at least one reference image or video when using "
+                    "audio. Audio cannot be used alone."
                 )
                 raise ValueError(msg)
 
             # Validate counts
-            if has_reference_images and len(params["reference_images"]) > 9:
-                msg = f"{self.name}: Seedance 2.0 supports up to 9 reference images, got {len(params['reference_images'])}."
+            if has_reference_images and len(params["reference_images"]) > model_capabilities.max_reference_images:
+                msg = (
+                    f"{self.name}: the selected model supports up to {model_capabilities.max_reference_images} "
+                    f"reference images, got {len(params['reference_images'])}."
+                )
                 raise ValueError(msg)
 
             if params.get("reference_video_2") and not params.get("reference_video_1"):
@@ -749,8 +777,11 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 msg = f"{self.name}: reference_video_3 requires reference_video_2 to be set first."
                 raise ValueError(msg)
 
-            if has_reference_audio and len(params["reference_audio"]) > 3:
-                msg = f"{self.name}: Seedance 2.0 supports up to 3 reference audio files, got {len(params['reference_audio'])}."
+            if has_reference_audio and len(params["reference_audio"]) > model_capabilities.max_reference_audio:
+                msg = (
+                    f"{self.name}: the selected model supports up to {model_capabilities.max_reference_audio} "
+                    f"reference audio files, got {len(params['reference_audio'])}."
+                )
                 raise ValueError(msg)
 
         # Validate duration range (model-dependent max; -1 requests smart selection)
@@ -895,10 +926,13 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
             self._log(f"{self.name} building multimodal content")
             supports_assets = self._private_assets_active(params["model_id"])
+            model_capabilities = _get_model_capabilities(params["model_id"])
             order_log: list[str] = []
 
             # Reference images (Image 1..N within this list, normal or private asset).
-            for idx, ref_image in enumerate(params.get("reference_images", [])[:9], start=1):
+            for idx, ref_image in enumerate(
+                params.get("reference_images", [])[: model_capabilities.max_reference_images], start=1
+            ):
                 if supports_assets and is_provider_asset_reference(ref_image):
                     asset_url = await self._append_private_asset(
                         ref_image, expected_kind=ASSET_KIND_IMAGE, label=f"reference image {idx}"
@@ -931,7 +965,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                     if not video_url:
                         msg = (
                             f"{self.name}: {ref_video['parameter_name']} only supports public URLs, uploaded asset URLs, "
-                            "or asset:// IDs. Seedance 2.0 does not accept video base64."
+                            "or asset:// IDs. Seedance does not accept video base64."
                         )
                         raise ValueError(msg)
                     content_list.append(
@@ -940,7 +974,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                     order_log.append(f"Video {idx}: reference")
 
             # Reference audio (Audio 1..N within this list, normal or private asset).
-            for idx, ref_audio in enumerate(params.get("reference_audio", [])[:3], start=1):
+            for idx, ref_audio in enumerate(
+                params.get("reference_audio", [])[: model_capabilities.max_reference_audio], start=1
+            ):
                 if supports_assets and is_provider_asset_reference(ref_audio):
                     asset_url = await self._append_private_asset(
                         ref_audio, expected_kind=ASSET_KIND_AUDIO, label=f"reference audio {idx}"

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -51,41 +51,59 @@ INPUT_MODE_MULTIMODAL_REFERENCES = "Multimodal References"
 MODEL_NAME_SEEDANCE_2_0 = "Seedance 2.0"
 MODEL_NAME_SEEDANCE_2_0_FAST = "Seedance 2.0 Fast"
 MODEL_NAME_SEEDANCE_2_0_MINI = "Seedance 2.0 Mini"
+MODEL_NAME_SEEDANCE_2_5 = "Seedance 2.5"
 SEEDANCE_2_0_MODEL_ID = "dreamina-seedance-2-0-260128"
 SEEDANCE_2_0_FAST_MODEL_ID = "dreamina-seedance-2-0-fast-260128"
 SEEDANCE_2_0_MINI_MODEL_ID = "dreamina-seedance-2-0-mini-260615"
+SEEDANCE_2_5_MODEL_ID = "dreamina-seedance-2-5-260628"
+# Duration bounds shared by every Seedance variant: the floor is fixed, the ceiling is per-model
+# (see SeedanceModelCapabilities.max_duration), and -1 requests the provider's smart selection.
+MIN_DURATION = 4
+DURATION_SMART = -1
 
 
 @dataclass(frozen=True)
 class SeedanceModelCapabilities:
-    """Capabilities supported by a Seedance 2.0 model variant, per the BytePlus model docs.
+    """Capabilities supported by a Seedance model variant, per the BytePlus model docs.
 
-    All three variants share the same feature set; they differ only in the output resolutions
-    they support (Fast and Mini top out at 720p, standard 2.0 adds 1080p and 4k).
+    All four variants (2.0, 2.0 Fast, 2.0 Mini, 2.5) support first+last frame i2v and
+    private-asset references. They differ in output resolution and maximum duration: standard
+    2.0 supports up to 4k; 2.0 Fast and 2.0 Mini top out at 720p; 2.5 supports 480p and 720p only.
+    The three 2.0 variants cap duration at 15 seconds; 2.5 extends that ceiling to 30 seconds.
     """
 
     resolutions: tuple[str, ...]
     supports_last_frame: bool
     supports_private_assets: bool
+    max_duration: int
 
 
 # Single source of truth for per-model capabilities, keyed by provider model id. Adding a new
-# variant is one row here. Values come straight from the BytePlus Seedance 2.0 capability matrix.
+# variant is one row here. Values come straight from the BytePlus Seedance capability matrix.
 SEEDANCE_MODEL_CAPABILITIES: dict[str, SeedanceModelCapabilities] = {
     SEEDANCE_2_0_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p", "1080p", "4k"),
         supports_last_frame=True,
         supports_private_assets=True,
+        max_duration=15,
     ),
     SEEDANCE_2_0_FAST_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p"),
         supports_last_frame=True,
         supports_private_assets=True,
+        max_duration=15,
     ),
     SEEDANCE_2_0_MINI_MODEL_ID: SeedanceModelCapabilities(
         resolutions=("480p", "720p"),
         supports_last_frame=True,
         supports_private_assets=True,
+        max_duration=15,
+    ),
+    SEEDANCE_2_5_MODEL_ID: SeedanceModelCapabilities(
+        resolutions=("480p", "720p"),
+        supports_last_frame=True,
+        supports_private_assets=True,
+        max_duration=30,
     ),
 }
 
@@ -95,6 +113,7 @@ _DEFAULT_MODEL_CAPABILITIES = SeedanceModelCapabilities(
     resolutions=("480p", "720p"),
     supports_last_frame=True,
     supports_private_assets=False,
+    max_duration=15,
 )
 
 
@@ -103,7 +122,12 @@ def _get_model_capabilities(model_id: str) -> SeedanceModelCapabilities:
     return SEEDANCE_MODEL_CAPABILITIES.get(model_id, _DEFAULT_MODEL_CAPABILITIES)
 
 
-# Provider-asset (private asset) registration via the GTC proxy. Supported by all Seedance 2.0
+def _duration_choices(max_duration: int) -> list[int]:
+    """Build the duration Options choices for a model: smart selection plus its integer range."""
+    return [DURATION_SMART, *range(MIN_DURATION, max_duration + 1)]
+
+
+# Provider-asset (private asset) registration via the GTC proxy. Supported by all Seedance
 # variants (see SEEDANCE_MODEL_CAPABILITIES), gated to Griptape auth (not BYOK).
 ASSET_PROVIDER = "byteplus_ark"
 ASSET_POLL_INTERVAL = 3  # seconds
@@ -147,11 +171,12 @@ def _normalize_audio_data_uri_subtype(data_uri: str) -> str:
 
 
 class Seedance20VideoGeneration(GriptapeProxyNode):
-    """Generate a video using Seedance 2.0 models via Griptape Cloud model proxy.
+    """Generate a video using Seedance 2.0 and Seedance 2.5 models via Griptape Cloud model proxy.
 
-    Supports the Seedance 2.0, Seedance 2.0 Fast, and Seedance 2.0 Mini models. All three share
-    the same feature set; they differ in output resolution: standard 2.0 supports up to 4k, while
-    Fast and Mini top out at 720p.
+    Supports the Seedance 2.0, Seedance 2.0 Fast, Seedance 2.0 Mini, and Seedance 2.5 models. All
+    four share the same feature set; they differ in output resolution and max duration: standard
+    2.0 supports up to 4k and 15s, Fast and Mini top out at 720p and 15s, and 2.5 tops out at 720p
+    but extends to 30s.
 
     Supports three input modes:
     - Text Only: Pure text-to-video generation (default)
@@ -162,9 +187,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         - prompt (str): Text prompt for the video
         - model_id (str): Model to use (default: Seedance 2.0)
         - input_mode (str): "Text Only", "First/Last Frame", or "Multimodal References" (default: Text Only)
-        - resolution (str): Output resolution (default: 720p, options: 480p, 720p, 1080p, 4k [1080p and 4k are Seedance 2.0 only])
+        - resolution (str): Output resolution (default: 720p, options: 480p, 720p, 1080p, 4k [1080p and 4k are Seedance 2.0 only, not Fast, Mini, or 2.5])
         - ratio (str): Output aspect ratio (default: adaptive)
-        - duration (int): Video duration in seconds (default: 5, range: 4-15 or -1 for smart)
+        - duration (int): Video duration in seconds (default: 5, range is model-dependent: 4-15 for 2.0/Fast/Mini, 4-30 for 2.5, or -1 for smart selection)
         - generate_audio (bool): Generate audio with video (default: False)
         - first_frame/last_frame: Optional frame images (First/Last Frame mode only)
         - reference_images/reference_video_1..3/reference_audio: Optional reference media (Multimodal mode only)
@@ -181,12 +206,13 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         MODEL_NAME_SEEDANCE_2_0_FAST: SEEDANCE_2_0_FAST_MODEL_ID,
         MODEL_NAME_SEEDANCE_2_0_MINI: SEEDANCE_2_0_MINI_MODEL_ID,
         MODEL_NAME_SEEDANCE_2_0: SEEDANCE_2_0_MODEL_ID,
+        MODEL_NAME_SEEDANCE_2_5: SEEDANCE_2_5_MODEL_ID,
     }
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.category = "API Nodes"
-        self.description = "Generate video via Seedance 2.0 through Griptape Cloud model proxy"
+        self.description = "Generate video via Seedance 2.0 or Seedance 2.5 through Griptape Cloud model proxy"
 
         # Transient (helper, scratch parameter name) pairs created while registering private
         # assets; the upload and the scratch parameter are both cleaned up in
@@ -207,6 +233,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                             MODEL_NAME_SEEDANCE_2_0,
                             MODEL_NAME_SEEDANCE_2_0_FAST,
                             MODEL_NAME_SEEDANCE_2_0_MINI,
+                            MODEL_NAME_SEEDANCE_2_5,
                         ]
                     )
                 },
@@ -371,9 +398,14 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             ParameterInt(
                 name="duration",
                 default_value=5,
-                tooltip="Video duration in seconds (4-15 or -1 for smart selection)",
+                tooltip=(
+                    "Video duration in seconds (4-15 for Seedance 2.0/Fast/Mini, 4-30 for Seedance 2.5, "
+                    "or -1 for smart selection)"
+                ),
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[-1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])},
+                traits={
+                    Options(choices=_duration_choices(_get_model_capabilities(SEEDANCE_2_0_MODEL_ID).max_duration))
+                },
             )
 
             ParameterBool(
@@ -466,6 +498,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         model_id = self._get_api_model_id()
 
         self._update_resolution_options(model_id)
+        self._update_duration_options(model_id)
 
         if input_mode == INPUT_MODE_MULTIMODAL_REFERENCES:
             # Show multimodal inputs, hide first/last frame
@@ -540,6 +573,23 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         current_resolution = self.get_parameter_value("resolution")
         if current_resolution not in available_resolutions:
             self.set_parameter_value("resolution", "720p")
+
+    def _update_duration_options(self, model_id: str) -> None:
+        """Update duration choices based on selected model (Seedance 2.5 extends the 15s cap to 30s)."""
+        duration_param = self.get_parameter_by_name("duration")
+        if duration_param is None:
+            return
+
+        available_durations = _duration_choices(_get_model_capabilities(model_id).max_duration)
+
+        existing_traits = duration_param.find_elements_by_type(Options)
+        if existing_traits:
+            duration_param.remove_trait(trait_type=existing_traits[0])
+        duration_param.add_trait(Options(choices=available_durations))
+
+        current_duration = self.get_parameter_value("duration")
+        if current_duration not in available_durations:
+            self.set_parameter_value("duration", 5)
 
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation."""
@@ -703,11 +753,16 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
                 msg = f"{self.name}: Seedance 2.0 supports up to 3 reference audio files, got {len(params['reference_audio'])}."
                 raise ValueError(msg)
 
-        # Validate duration range (4-15 or -1)
+        # Validate duration range (model-dependent max; -1 requests smart selection)
         duration = params.get("duration")
-        if duration is not None and duration != -1 and not (4 <= duration <= 15):
-            msg = f"{self.name}: Seedance 2.0 supports duration between 4-15 seconds or -1 for smart selection, got {duration}."
-            raise ValueError(msg)
+        if duration is not None and duration != DURATION_SMART:
+            max_duration = _get_model_capabilities(params["model_id"]).max_duration
+            if not (MIN_DURATION <= duration <= max_duration):
+                msg = (
+                    f"{self.name}: the selected model supports duration between {MIN_DURATION}-{max_duration} "
+                    f"seconds or {DURATION_SMART} for smart selection, got {duration}."
+                )
+                raise ValueError(msg)
 
         # 1080p is only supported on Seedance 2.0 (not Fast or Mini)
         if params.get("resolution") == "1080p" and not self._supports_1080p(params["model_id"]):
@@ -921,7 +976,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             # Text Only mode: no media inputs
             self._log(f"{self.name} text-only mode, no media inputs")
 
-    # --- Provider private-asset registration (Seedance 2.0 variants, Griptape auth only) -----
+    # --- Provider private-asset registration (Seedance variants, Griptape auth only) --------
 
     def _proxy_headers(self) -> dict[str, str]:
         """Bearer headers for the GTC proxy (same auth as the generation requests)."""

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -23,6 +23,7 @@ from griptape_nodes_library.video.seedance_2_0_video_generation import (
     SEEDANCE_2_0_FAST_MODEL_ID,
     SEEDANCE_2_0_MINI_MODEL_ID,
     SEEDANCE_2_0_MODEL_ID,
+    SEEDANCE_2_5_MODEL_ID,
     SEEDANCE_MODEL_CAPABILITIES,
     Seedance20VideoGeneration,
     _normalize_audio_data_uri_subtype,
@@ -85,9 +86,11 @@ async def test_build_payload_normalizes_local_frame_paths(monkeypatch: pytest.Mo
     assert all(str(last_frame) not in item["image_url"]["url"] for item in frame_entries)
 
 
-@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
+@pytest.mark.parametrize(
+    "model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID, SEEDANCE_2_5_MODEL_ID]
+)
 def test_all_models_support_last_frame(model_id: str) -> None:
-    # Per the BytePlus capability matrix, first+last frame i2v is supported by all three variants.
+    # Per the BytePlus capability matrix, first+last frame i2v is supported by all four variants.
     assert Seedance20VideoGeneration._supports_last_frame(model_id) is True
 
 
@@ -333,10 +336,12 @@ async def test_build_payload_uses_public_artifact_url_parameter_for_reference_vi
 # --- Private-asset reference gating (Seedance 2.0 only) -------------------------------------
 
 
-@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
+@pytest.mark.parametrize(
+    "model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID, SEEDANCE_2_5_MODEL_ID]
+)
 def test_all_models_support_private_assets(model_id: str) -> None:
-    # The GTC backend links provider assets for all Seedance 2.0 variant ids, so the node allows
-    # private-asset references on all three.
+    # The GTC backend links provider assets for all Seedance variant ids, so the node allows
+    # private-asset references on all four.
     assert Seedance20VideoGeneration._supports_private_assets(model_id) is True
 
 
@@ -347,22 +352,30 @@ def test_supports_4k_only_for_seedance_2_0() -> None:
     assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_MODEL_ID) is True
     assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_FAST_MODEL_ID) is False
     assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_0_MINI_MODEL_ID) is False
+    assert Seedance20VideoGeneration._supports_4k(SEEDANCE_2_5_MODEL_ID) is False
 
 
 def test_capability_table_matches_documented_matrix() -> None:
     # Regression guard on the single source of truth: values mirror the BytePlus capability matrix.
-    # All three variants support last_frame and private assets; only resolution ceiling differs.
+    # All four variants support last_frame and private assets; resolution ceiling and max_duration
+    # differ (the three 2.0 variants cap duration at 15s, 2.5 extends that to 30s).
     standard = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MODEL_ID]
     fast = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_FAST_MODEL_ID]
     mini = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MINI_MODEL_ID]
+    seedance_2_5 = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_5_MODEL_ID]
 
     assert standard.resolutions == ("480p", "720p", "1080p", "4k")
     assert fast.resolutions == ("480p", "720p")
     assert mini.resolutions == ("480p", "720p")
+    assert seedance_2_5.resolutions == ("480p", "720p")
 
-    for caps in (standard, fast, mini):
+    for caps in (standard, fast, mini, seedance_2_5):
         assert caps.supports_last_frame is True
         assert caps.supports_private_assets is True
+
+    for caps in (standard, fast, mini):
+        assert caps.max_duration == 15
+    assert seedance_2_5.max_duration == 30
 
 
 def test_seedance_2_0_offers_4k_resolution_choice() -> None:
@@ -400,6 +413,18 @@ def test_seedance_2_mini_omits_4k_resolution_choice() -> None:
     assert choices == ["480p", "720p"]
 
 
+def test_seedance_2_5_omits_4k_resolution_choice() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.5")
+    node._update_resolution_options(SEEDANCE_2_5_MODEL_ID)
+
+    resolution_param = _parameter_by_name(node, "resolution")
+    choices = resolution_param.find_elements_by_type(Options)[0].choices
+    assert "4k" not in choices
+    assert "1080p" not in choices
+    assert choices == ["480p", "720p"]
+
+
 @pytest.mark.parametrize("model_id", [SEEDANCE_2_0_FAST_MODEL_ID, SEEDANCE_2_0_MINI_MODEL_ID])
 def test_seedance_2_fast_and_mini_reject_4k_resolution(model_id: str) -> None:
     # The Options trait normally prevents selecting 4k on Fast/Mini via the UI, but resolution can
@@ -414,7 +439,86 @@ def test_seedance_2_fast_and_mini_reject_4k_resolution(model_id: str) -> None:
         node._validate_parameters(params)
 
 
-@pytest.mark.parametrize("model_name", ["Seedance 2.0", "Seedance 2.0 Fast", "Seedance 2.0 Mini"])
+@pytest.mark.parametrize("resolution", ["1080p", "4k"])
+def test_seedance_2_5_rejects_high_resolutions(resolution: str) -> None:
+    # Seedance 2.5 tops out at 720p (no 1080p, no 4k), same backstop as Fast/Mini.
+    node = Seedance20VideoGeneration(name="Seedance20")
+    params = node._get_parameters()
+    params["model_id"] = SEEDANCE_2_5_MODEL_ID
+    params["resolution"] = resolution
+
+    with pytest.raises(ValueError, match=f"does not support {resolution} resolution"):
+        node._validate_parameters(params)
+
+
+# --- Duration gating (model-dependent max) --------------------------------------------------
+
+
+def test_update_duration_options_reflects_selected_model_max() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+
+    node._update_duration_options(SEEDANCE_2_5_MODEL_ID)
+    seedance_2_5_choices = _parameter_by_name(node, "duration").find_elements_by_type(Options)[0].choices
+    assert 30 in seedance_2_5_choices
+    assert 31 not in seedance_2_5_choices
+
+    node._update_duration_options(SEEDANCE_2_0_MODEL_ID)
+    seedance_2_0_choices = _parameter_by_name(node, "duration").find_elements_by_type(Options)[0].choices
+    assert 15 in seedance_2_0_choices
+    assert 16 not in seedance_2_0_choices
+
+
+def test_seedance_2_5_accepts_duration_up_to_30_but_2_0_does_not() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    params = node._get_parameters()
+    params["model_id"] = SEEDANCE_2_5_MODEL_ID
+    params["duration"] = 30
+
+    # 30s validates on Seedance 2.5 (its documented ceiling)...
+    node._validate_parameters(params)
+
+    # ...but exceeds the 15s ceiling on Seedance 2.0.
+    params["model_id"] = SEEDANCE_2_0_MODEL_ID
+    with pytest.raises(ValueError, match="supports duration between"):
+        node._validate_parameters(params)
+
+
+@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_5_MODEL_ID])
+def test_duration_smart_selection_validates_on_all_models(model_id: str) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    params = node._get_parameters()
+    params["model_id"] = model_id
+    params["duration"] = -1
+
+    node._validate_parameters(params)
+
+
+@pytest.mark.parametrize("model_id", [SEEDANCE_2_0_MODEL_ID, SEEDANCE_2_5_MODEL_ID])
+def test_duration_below_minimum_rejected_on_all_models(model_id: str) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    params = node._get_parameters()
+    params["model_id"] = model_id
+    params["duration"] = 3
+
+    with pytest.raises(ValueError, match="supports duration between"):
+        node._validate_parameters(params)
+
+
+def test_switching_from_seedance_2_5_clamps_out_of_range_duration() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.5")
+    node.set_parameter_value("duration", 30)
+    assert node.get_parameter_value("duration") == 30
+
+    # Switching to Seedance 2.0 (15s max) must clamp the now out-of-range duration rather than
+    # leaving an invalid value selected.
+    node.set_parameter_value("model_id", "Seedance 2.0")
+
+    assert node.get_parameter_value("duration") != 30
+    assert node.get_parameter_value("duration") == 5
+
+
+@pytest.mark.parametrize("model_name", ["Seedance 2.0", "Seedance 2.0 Fast", "Seedance 2.0 Mini", "Seedance 2.5"])
 def test_all_models_accept_private_asset_reference(model_name: str) -> None:
     node = Seedance20VideoGeneration(name="Seedance20")
     node.set_parameter_value("model_id", model_name)

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -357,8 +357,10 @@ def test_supports_4k_only_for_seedance_2_0() -> None:
 
 def test_capability_table_matches_documented_matrix() -> None:
     # Regression guard on the single source of truth: values mirror the BytePlus capability matrix.
-    # All four variants support last_frame and private assets; resolution ceiling and max_duration
-    # differ (the three 2.0 variants cap duration at 15s, 2.5 extends that to 30s).
+    # All four variants support last_frame and private assets; resolution ceiling, max_duration,
+    # and reference budgets differ (the three 2.0 variants cap duration at 15s and allow up to 9
+    # reference images / 3 reference audio files; 2.5 extends duration to 30s and raises those
+    # budgets to 30 reference images / 10 reference audio files).
     standard = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MODEL_ID]
     fast = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_FAST_MODEL_ID]
     mini = SEEDANCE_MODEL_CAPABILITIES[SEEDANCE_2_0_MINI_MODEL_ID]
@@ -375,7 +377,101 @@ def test_capability_table_matches_documented_matrix() -> None:
 
     for caps in (standard, fast, mini):
         assert caps.max_duration == 15
+        assert caps.max_reference_images == 9
+        assert caps.max_reference_audio == 3
     assert seedance_2_5.max_duration == 30
+    assert seedance_2_5.max_reference_images == 30
+    assert seedance_2_5.max_reference_audio == 10
+
+
+# --- Reference image/audio budgets (model-dependent) ----------------------------------------
+
+
+def test_seedance_2_5_accepts_30_reference_images() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.5")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    _set_parameter_list_values(node, "reference_images", [f"https://public.example/img{i}.png" for i in range(30)])
+
+    # 30 reference images validates on Seedance 2.5 (its documented ceiling).
+    node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.parametrize("model_name", ["Seedance 2.0", "Seedance 2.0 Fast", "Seedance 2.0 Mini"])
+def test_seedance_2_0_variants_reject_10_reference_images(model_name: str) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", model_name)
+    node.set_parameter_value("input_mode", "Multimodal References")
+    _set_parameter_list_values(node, "reference_images", [f"https://public.example/img{i}.png" for i in range(10)])
+
+    with pytest.raises(ValueError, match="supports up to 9 reference images"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_seedance_2_5_rejects_31_reference_images() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    params = node._get_parameters()
+    params["model_id"] = SEEDANCE_2_5_MODEL_ID
+    params["input_mode"] = "Multimodal References"
+    params["reference_images"] = [f"https://public.example/img{i}.png" for i in range(31)]
+
+    with pytest.raises(ValueError, match="supports up to 30 reference images"):
+        node._validate_parameters(params)
+
+
+def test_seedance_2_5_accepts_10_reference_audio() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.5")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    # Audio cannot be used alone, so a reference image is included alongside the audio files.
+    _set_parameter_list_values(node, "reference_images", ["https://public.example/portrait.png"])
+    _set_parameter_list_values(node, "reference_audio", [f"https://public.example/clip{i}.wav" for i in range(10)])
+
+    node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.parametrize("model_name", ["Seedance 2.0", "Seedance 2.0 Fast", "Seedance 2.0 Mini"])
+def test_seedance_2_0_variants_reject_4_reference_audio(model_name: str) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", model_name)
+    node.set_parameter_value("input_mode", "Multimodal References")
+    _set_parameter_list_values(node, "reference_images", ["https://public.example/portrait.png"])
+    _set_parameter_list_values(node, "reference_audio", [f"https://public.example/clip{i}.wav" for i in range(4)])
+
+    with pytest.raises(ValueError, match="supports up to 3 reference audio files"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_list_max_items_equal_the_maximum_across_models() -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+
+    reference_images_param = _parameter_by_name(node, "reference_images")
+    reference_audio_param = _parameter_by_name(node, "reference_audio")
+
+    assert reference_images_param._max_items == 30
+    assert reference_audio_param._max_items == 10
+
+
+@pytest.mark.asyncio
+async def test_build_payload_truncates_reference_images_to_the_model_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    node = Seedance20VideoGeneration(name="Seedance20")
+    node.set_parameter_value("model_id", "Seedance 2.0 Fast")
+    node.set_parameter_value("input_mode", "Multimodal References")
+    node.set_parameter_value("prompt", "Reference many images")
+    _set_parameter_list_values(node, "reference_images", [f"https://public.example/img{i}.png" for i in range(12)])
+
+    async def fake_aread_data_uri(self: File, fallback_mime: str = "application/octet-stream") -> str:
+        return "data:image/png;base64,VALID_IMAGE"
+
+    monkeypatch.setattr(File, "aread_data_uri", fake_aread_data_uri)
+
+    payload = await node._build_payload()
+    reference_image_entries = [item for item in payload["content"] if item.get("role") == "reference_image"]
+
+    # Seedance 2.0 Fast caps reference images at 9, even though 12 were provided.
+    assert len(reference_image_entries) == 9
 
 
 def test_seedance_2_0_offers_4k_resolution_choice() -> None:


### PR DESCRIPTION
Requires https://github.com/griptape-ai/griptape-cloud/pull/2144 to test.