### PR TITLE
feat(load-text): add .edl to supported text extensions

### DIFF
--- a/griptape_nodes_library/utils/file_utils.py
+++ b/griptape_nodes_library/utils/file_utils.py
@@ -5,6 +5,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 # Supported text file extensions (based on LoadText node)
 SUPPORTED_TEXT_EXTENSIONS = {
     ".txt",
+    ".edl",
     ".md",
     ".csv",
     ".json",

--- a/tests/unit/text/test_load_text.py
+++ b/tests/unit/text/test_load_text.py
@@ -75,3 +75,13 @@ class TestLoadTextProcess:
             node.process()
 
         mock_loader_cls.assert_not_called()
+
+    def test_edl_reads_as_plain_text(self, node: LoadText) -> None:
+        """EDL files (plain ASCII) should be read via File.read_text(), not PdfLoader."""
+        node.parameter_values["path"] = "cut_list.edl"
+
+        with patch.object(File, "read_text", return_value="TITLE: MY_EDL\nFCM: DROP FRAME\n") as mock_read:
+            node.process()
+
+        mock_read.assert_called_once()
+        assert node.parameter_output_values["output"] == "TITLE: MY_EDL\nFCM: DROP FRAME\n"


### PR DESCRIPTION
## Summary

- Adds `.edl` to `SUPPORTED_TEXT_EXTENSIONS` in `file_utils.py` so the Load Text node's file picker accepts EDL files
- EDL files (CMX3600 and similar) are plain ASCII — no new parsing branch needed; they fall through to `File.read_text()` like any other non-PDF format
- Adds a targeted test confirming `.edl` is handled as plain text

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)