### PR TITLE
fix(access): keep catalog model ids bare on suffixed proxy nodes

### DIFF
--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -7,7 +7,6 @@ from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
-from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
@@ -102,11 +101,11 @@ class TranscribeAudio(GriptapeProxyNode):
             ui_options={"display_name": "audio transcription model"},
         )
         self.add_parameter(model_param)
-        # License-policy helper: adds Options + refresh Button traits, applies per-row
-        # decoration + badge, exposes query_for_denial, and relocates the stored value
-        # to a permitted alternative if DEFAULT_MODEL is denied.
-        self._model_access = ModelAccessComponent(
-            node=self,
+        # License-policy dropdown: the component adds Options + refresh Button traits,
+        # marks the models the license denies, and relocates the stored value to a
+        # permitted alternative if DEFAULT_MODEL is denied. The proxy base class
+        # refuses to submit a denied selection.
+        self._install_model_access(
             parameter=model_param,
             model_choices=MODEL_CHOICES,
             default_model=DEFAULT_MODEL,
@@ -250,8 +249,6 @@ class TranscribeAudio(GriptapeProxyNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        if parameter.name == "model":
-            self._model_access.on_value_changed(value)
         if parameter.name == "response_format":
             if value == "verbose_json":
                 self.show_parameter_by_name("segments")
@@ -318,18 +315,6 @@ class TranscribeAudio(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for OpenAI audio transcription."""
-        # License-policy runtime gate. SuccessFailure idiom: route the denial
-        # through _set_status_results and return an empty payload so the outer
-        # proxy pipeline sees was_successful=False rather than an exception.
-        # Runs BEFORE the proxy's own INVOKE_MODEL gate so a denied model fails
-        # immediately instead of after payload construction.
-        model_value = self.get_parameter_value("model")
-        denial = self._model_access.query_for_denial(model_value)
-        if denial is not None:
-            self._set_safe_defaults()
-            self._set_status_results(was_successful=False, result_details=denial.reason())
-            return {}
-
         audio_value = self.get_parameter_value("audio")
         if audio_value is None:
             msg = "No audio provided. Please connect an audio source."

--- a/griptape_nodes_library/config/base_driver.py
+++ b/griptape_nodes_library/config/base_driver.py
@@ -6,6 +6,8 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+from griptape_nodes_library.utils.model_access import ModelDropdownAccess
+
 
 class BaseDriver(DataNode):
     """Base class for driver nodes that need to manage parameters and validate configuration.
@@ -28,6 +30,11 @@ class BaseDriver(DataNode):
             driver = BaseDriver(name="ExampleDriver")
         """
         super().__init__(**kwargs)
+
+        # Set by `_install_model_access` on subclasses whose model parameter is a
+        # license-filtered dropdown; stays None on the ones offering free text or a
+        # dynamically fetched list.
+        self._model_access: ModelDropdownAccess | None = None
 
         self.add_parameter(
             Parameter(
@@ -109,6 +116,63 @@ class BaseDriver(DataNode):
     # -----------------------------------------------------------------------------
     # Internal Helper Methods
     # -----------------------------------------------------------------------------
+
+    def _install_model_access(
+        self,
+        *,
+        model_choices: list[str],
+        default_model: str,
+        param: str = "model",
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        """Turn the named model parameter into a license-filtered dropdown.
+
+        Stands in for `_update_option_choices` on driver nodes: the component owns
+        the `Options` trait (so the parameter must not already carry one), adds an
+        inline refresh button, marks the models the caller's license denies, and
+        moves the stored value off a denied default. The declared default is still
+        applied here, so the parameter reads the same as it did before adoption.
+
+        Args:
+            model_choices: The models the node offers, in dropdown order.
+            default_model: The choice to select by default; must be in `model_choices`.
+            param: Name of the parameter to decorate.
+            provider_model_id_by_choice: Choice -> catalog `provider_model_id` map,
+                needed only when the choices are display labels rather than
+                provider ids.
+        """
+        if default_model not in model_choices:
+            msg = f"Default model '{default_model}' is not one of the offered choices."
+            raise ValueError(msg)
+        parameter = self.get_parameter_by_name(param)
+        if parameter is None:
+            msg = f"Cannot install model access on '{type(self).__name__}': no '{param}' parameter."
+            raise ValueError(msg)
+
+        parameter.default_value = default_model
+        self.set_parameter_value(param, default_model)
+        self._model_access = ModelDropdownAccess(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            provider_model_id_by_choice=provider_model_id_by_choice,
+        )
+
+    def _raise_if_model_denied(self) -> None:
+        """Fail closed rather than hand a downstream node a driver the license denies.
+
+        Called at the top of `process` on nodes with a license-filtered dropdown;
+        no-ops on the nodes that never installed one.
+        """
+        if self._model_access is not None:
+            self._model_access.raise_if_selection_denied()
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Keep the model dropdown's denial badge in step with the selection."""
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+        return super().after_value_set(parameter, value)
 
     def _display_api_key_message(self, service_name: str, api_key_env_var: str, api_key_url: str | None) -> None:
         """Checks if the API key exists in the node configuration, displays a message if not.

--- a/griptape_nodes_library/config/image/base_image_driver.py
+++ b/griptape_nodes_library/config/image/base_image_driver.py
@@ -62,7 +62,8 @@ class BaseImageDriver(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses call `_install_model_access`
+        # to offer a license-filtered dropdown of their models.
         self.add_parameter(
             Parameter(
                 name="model",
@@ -71,7 +72,6 @@ class BaseImageDriver(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
         self.add_parameter(

--- a/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -95,7 +95,6 @@ class AmazonBedrockPrompt(BasePrompt):
         # a dropdown, we'll provide just a text field for the user to enter the model name
         # and set the default to the first model in the list.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/876
-        self._remove_options_trait(param="model")
         param = self.get_parameter_by_name("model")
         if param is not None:
             param.default_value = MODEL_CHOICES[0]

--- a/griptape_nodes_library/config/prompt/base_prompt.py
+++ b/griptape_nodes_library/config/prompt/base_prompt.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from griptape.drivers.prompt.dummy import DummyPromptDriver
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.base_driver import BaseDriver
 
@@ -31,7 +30,8 @@ class BasePrompt(BaseDriver):
     - Defines common LLM parameters accessible via `self.parameter_values`.
     - Provides `_get_common_driver_args` to easily collect arguments for drivers based on base parameters.
     - Provides `_validate_api_key` to standardize API key validation logic.
-    - Provides `_update_option_choices` to set driver-specific model lists for the 'model' parameter.
+    - Provides `_install_model_access` to turn the 'model' parameter into a
+      license-filtered dropdown of driver-specific models.
     Note: The `process` method in this base class creates a `DummyPromptDriver`
     primarily to establish the output socket type. It does not utilize the
     configuration parameters defined herein. Direct use of `BasePrompt` is
@@ -71,7 +71,10 @@ class BasePrompt(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses either call
+        # `_install_model_access` to offer a license-filtered dropdown of their
+        # models, or add their own trait when the choices are theirs to manage
+        # (a free-text field, or a list fetched from the provider at runtime).
         self.add_parameter(
             Parameter(
                 name="model",
@@ -80,7 +83,6 @@ class BasePrompt(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
 

--- a/griptape_nodes_library/config/prompt/openai_prompt.py
+++ b/griptape_nodes_library/config/prompt/openai_prompt.py
@@ -9,6 +9,7 @@ node configuration, and instantiates the `OpenAiPromptDriver`.
 
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 
@@ -68,6 +69,12 @@ class OpenAiPrompt(BasePrompt):
         import openai
 
         available_models = [model.id for model in openai.Client().models.list().data]
+        # This node offers whatever models the account can see rather than a
+        # declared list, so it owns the dropdown trait instead of routing through
+        # `_install_model_access`.
+        model_param = self.get_parameter_by_name("model")
+        if model_param is not None:
+            model_param.add_trait(Options(choices=available_models))
         self._update_option_choices(
             param="model", choices=available_models, default=available_models[0] if available_models else ""
         )

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -8,7 +8,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import suppress
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpx
@@ -22,7 +22,11 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key, resolve_proxy_base
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
+from griptape_nodes_library.utils.model_access import ModelDropdownAccess
 from griptape_nodes_library.utils.model_invocation import declare_model_invocation
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -79,6 +83,10 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._user_auth_info: str | None = None
         self._api_key_provider: ProxyAuthProviderParameter | None = None
         self._initialize_api_key_provider()
+
+        # Set by `_install_model_access` on subclasses whose model selection is a
+        # license-filtered dropdown; stays None on the ones bound to a single model.
+        self._model_access: ModelDropdownAccess | None = None
 
         default_timeout = self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
         self.add_parameter(
@@ -156,6 +164,39 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         super().after_value_set(parameter, value)
         if self._api_key_provider:
             self._api_key_provider.after_value_set(parameter, value)
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+
+    def _install_model_access(
+        self,
+        *,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        """Turn an already-added model parameter into a license-filtered dropdown.
+
+        The component owns the parameter's `Options` trait, so pass a parameter
+        built without one; it also adds an inline refresh button, marks the models
+        the caller's license denies, and moves the stored value off a denied
+        default. `_submit_and_poll` then refuses to submit a denied selection.
+
+        Args:
+            parameter: The model parameter, already added to this node.
+            model_choices: The models the node offers, in dropdown order.
+            default_model: The choice selected by default.
+            provider_model_id_by_choice: Choice -> catalog `provider_model_id` map,
+                needed only when the choices are display labels rather than
+                provider ids.
+        """
+        self._model_access = ModelDropdownAccess(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            provider_model_id_by_choice=provider_model_id_by_choice,
+        )
 
     def _prepare_user_auth_info(self) -> None:
         self.register_user_auth_info(None)
@@ -605,6 +646,12 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         error_msg = f"{self.name}: No model ID provided"
         self._set_status_results(was_successful=False, result_details=error_msg)
 
+    def _handle_denied_model(self, denial: CheckpointDenial) -> None:
+        """Handle a dropdown selection the license policy does not permit."""
+        self._set_safe_defaults()
+        error_msg = f"{self.name}: {denial.reason()}"
+        self._set_status_results(was_successful=False, result_details=error_msg)
+
     def _handle_submission_error(self, e: RuntimeError) -> None:
         """Handle generation submission errors."""
         self._set_safe_defaults()
@@ -640,6 +687,15 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         if not api_model_id:
             self._handle_missing_model_id()
             return None
+
+        # Re-check the dropdown selection against the license policy: it may have
+        # been permitted when the node was built and denied since. Runs before the
+        # invocation declaration so the failure carries the dropdown's own reason.
+        if self._model_access is not None:
+            selection_denial = self._model_access.selection_denial()
+            if selection_denial is not None:
+                self._handle_denied_model(selection_denial)
+                return None
 
         # Declare the invocation so the engine's permission layer can gate it
         # before any network call. The proxy still enforces server-side; this is

--- a/griptape_nodes_library/utils/model_access.py
+++ b/griptape_nodes_library/utils/model_access.py
@@ -1,0 +1,134 @@
+"""License-policy wiring for the library's model-selection dropdowns.
+
+The engine's ``ModelAccessComponent`` decorates a model dropdown with the
+caller's entitlement, badges a denied selection, and answers "is this selection
+permitted right now?" at run time. It keys every lookup on the dropdown value,
+which it expects to be the catalog's ``provider_model_id``.
+
+Many nodes here instead offer artist-facing labels (``"Kling v3.0"``,
+``"Seedream 4.5"``) and translate to the provider id when they build their
+request. Those labels are the values the parameter stores, so they cannot be
+swapped for provider ids: ``Options`` converts any value outside ``choices`` to
+``choices[0]`` before ``before_value_set`` runs, so a rename would silently
+repoint every saved workflow at the first model in the list.
+``MappedModelAccessComponent`` closes that gap by keying the component's
+snapshot under the label as well, so decoration, badges, and runtime queries all
+work off the value the parameter actually holds.
+
+``ModelDropdownAccess`` is what node base classes hold: the component plus the
+parameter it owns, so a base class can forward value changes and query the
+current selection without every node repeating that bookkeeping.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.exe_types.param_components.model_access_component import _AccessSnapshot
+    from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+
+__all__ = ["MappedModelAccessComponent", "ModelDropdownAccess"]
+
+
+class MappedModelAccessComponent(ModelAccessComponent):
+    """A model-access component for a dropdown whose choices are display labels.
+
+    ``provider_model_id_by_choice`` maps each dropdown choice to the
+    ``provider_model_id`` the library catalog declares for it -- the same id the
+    node sends upstream. Choices missing from the map keep the base class's
+    behavior and resolve as provider ids, so a dropdown that mixes labels and
+    raw ids still works.
+    """
+
+    def __init__(
+        self,
+        *,
+        node: BaseNode,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str],
+    ) -> None:
+        # Assigned before the base constructor because that constructor fetches
+        # the first snapshot, which `_fetch_snapshot` re-keys through this map.
+        self._provider_model_id_by_choice = dict(provider_model_id_by_choice)
+        super().__init__(
+            node=node,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+        )
+
+    def _fetch_snapshot(self) -> _AccessSnapshot:
+        """Index the engine's verdicts under the dropdown labels as well as the provider ids."""
+        snapshot = super()._fetch_snapshot()
+        for choice, provider_model_id in self._provider_model_id_by_choice.items():
+            catalog_id = snapshot.catalog_id_by_provider_id.get(provider_model_id)
+            if catalog_id is not None:
+                snapshot.catalog_id_by_provider_id[choice] = catalog_id
+            denial = snapshot.denial_by_provider_id.get(provider_model_id)
+            if denial is not None:
+                snapshot.denial_by_provider_id[choice] = denial
+        return snapshot
+
+
+class ModelDropdownAccess:
+    """One node's license-filtered model dropdown.
+
+    Owns the ``ModelAccessComponent`` and remembers which parameter it decorates
+    so a node base class can forward ``after_value_set`` and query the current
+    selection generically. Nodes reach the component itself through
+    ``component`` when they need its dropdown-level API (``model_choices``,
+    ``pick_permitted_default``, ``reinstall_options``).
+    """
+
+    def __init__(
+        self,
+        *,
+        node: BaseNode,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        self._node = node
+        self._parameter_name = parameter.name
+        self.component: ModelAccessComponent
+        if provider_model_id_by_choice:
+            self.component = MappedModelAccessComponent(
+                node=node,
+                parameter=parameter,
+                model_choices=model_choices,
+                default_model=default_model,
+                provider_model_id_by_choice=provider_model_id_by_choice,
+            )
+        else:
+            self.component = ModelAccessComponent(
+                node=node,
+                parameter=parameter,
+                model_choices=model_choices,
+                default_model=default_model,
+            )
+
+    @property
+    def parameter_name(self) -> str:
+        """Name of the parameter this dropdown decorates."""
+        return self._parameter_name
+
+    def on_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Track the badge for this dropdown; ignore every other parameter on the node."""
+        if parameter.name == self._parameter_name:
+            self.component.on_value_changed(value)
+
+    def selection_denial(self) -> CheckpointDenial | None:
+        """The current selection's verdict, or ``None`` when it is permitted."""
+        return self.component.query_for_denial(self._node.get_parameter_value(self._parameter_name))
+
+    def raise_if_selection_denied(self) -> None:
+        """Raise ``RuntimeError`` when the current selection is not permitted."""
+        self.component.raise_if_denied(self._node.get_parameter_value(self._parameter_name))

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -586,9 +586,12 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         Appends :image2video modality to the model name.
         """
+        return f"{self._get_catalog_model_id()}:image2video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:image2video` suffix).
         model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:image2video"
+        return self.MODEL_NAME_MAP.get(model_name, model_name)
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Kling API.

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -459,9 +459,12 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
         Appends :text2video modality to the model name.
         """
+        return f"{self._get_catalog_model_id()}:text2video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:text2video` suffix).
         model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:text2video"
+        return self.MODEL_NAME_MAP.get(model_name, model_name)
 
     def _build_customize_multi_prompt_payload(self, shot_count: int) -> list[dict[str, Any]]:
         """Build multi_prompt payload from shot input parameters."""

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -185,9 +185,12 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:audio-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:audio-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:audio-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-pro")
 
     async def _prepare_audio_data_url_async(self, audio_input: Any) -> str | None:
         """Convert audio input to a base64 data URL."""

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -283,9 +283,12 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:image-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:image-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:image-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-fast")
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -267,9 +267,12 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:text-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:text-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:text-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-fast")
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -201,9 +201,12 @@ class LTXVideoExtend(GriptapeProxyNode):
             self._update_context_badge(value)
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:extend"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:extend` suffix).
         model_name = self.get_parameter_value("model") or DEFAULT_MODEL
-        model_id = MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
-        return f"{model_id}:extend"
+        return MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
 
     async def _prepare_video_data_uri_async(self, video_input: Any) -> str | None:
         """Convert video input to a base64 data URI."""

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -358,9 +358,12 @@ class LTXVideoRetake(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:retake"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:retake` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:retake"
+        return MODEL_MAPPING.get(model_name, "ltx-2-pro")
 
     def _validate_video_input(self, video: Any) -> str | None:
         """Validate video is provided and doesn't exceed duration limits."""

--- a/griptape_nodes_library/video/ltx_video_to_video_hdr.py
+++ b/griptape_nodes_library/video/ltx_video_to_video_hdr.py
@@ -115,9 +115,12 @@ class LTXVideoToVideoHDR(GriptapeProxyNode):
         self.set_initial_node_size(height=400)
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:video-to-video-hdr"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:video-to-video-hdr` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2.3 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-3-pro")
-        return f"{model_id}:video-to-video-hdr"
+        return MODEL_MAPPING.get(model_name, "ltx-2-3-pro")
 
     @staticmethod
     def _extract_input_video_url(video_input: Any) -> str | None:

--- a/tests/unit/test_griptape_proxy_node_catalog_id.py
+++ b/tests/unit/test_griptape_proxy_node_catalog_id.py
@@ -16,6 +16,14 @@ from griptape_nodes_library.image.grok_image_generation import GrokImageGenerati
 from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.video.grok_video_edit import GrokVideoEdit
 from griptape_nodes_library.video.grok_video_generation import GrokVideoGeneration
+from griptape_nodes_library.video.kling_image_to_video_generation import KlingImageToVideoGeneration
+from griptape_nodes_library.video.kling_text_to_video_generation import KlingTextToVideoGeneration
+from griptape_nodes_library.video.ltx_audio_to_video_generation import LTXAudioToVideoGeneration
+from griptape_nodes_library.video.ltx_image_to_video_generation import LTXImageToVideoGeneration
+from griptape_nodes_library.video.ltx_text_to_video_generation import LTXTextToVideoGeneration
+from griptape_nodes_library.video.ltx_video_extend import LTXVideoExtend
+from griptape_nodes_library.video.ltx_video_retake import LTXVideoRetake
+from griptape_nodes_library.video.ltx_video_to_video_hdr import LTXVideoToVideoHDR
 
 # (node class, bare catalog provider id, suffixed url-path id)
 GROK_NODES = [
@@ -28,6 +36,33 @@ GROK_NODES = [
 
 @pytest.mark.parametrize(("node_class", "bare_id", "suffixed_id"), GROK_NODES)
 def test_grok_catalog_id_is_bare_provider_id(
+    node_class: type[GriptapeProxyNode], bare_id: str, suffixed_id: str
+) -> None:
+    node = node_class(name=node_class.__name__)
+
+    # The URL-path id keeps the operation suffix; the catalog id must not, so it
+    # matches the bare `provider_model_id` declared in the catalog.
+    assert node._get_api_model_id() == suffixed_id
+    assert node._get_catalog_model_id() == bare_id
+
+
+# (node class, bare catalog provider id, suffixed url-path id) for each node's default
+# dropdown selection. The bare ids are cross-checked against the `model_usage` ids each
+# node declares in griptape_nodes_library.json's `model_catalog` metadata.
+SUFFIXED_NODES = [
+    (LTXTextToVideoGeneration, "ltx-2-3-fast", "ltx-2-3-fast:text-to-video"),
+    (LTXImageToVideoGeneration, "ltx-2-3-fast", "ltx-2-3-fast:image-to-video"),
+    (LTXAudioToVideoGeneration, "ltx-2-pro", "ltx-2-pro:audio-to-video"),
+    (LTXVideoExtend, "ltx-2-3-pro", "ltx-2-3-pro:extend"),
+    (LTXVideoRetake, "ltx-2-pro", "ltx-2-pro:retake"),
+    (LTXVideoToVideoHDR, "ltx-2-3-pro", "ltx-2-3-pro:video-to-video-hdr"),
+    (KlingTextToVideoGeneration, "kling-v3", "kling-v3:text2video"),
+    (KlingImageToVideoGeneration, "kling-v3", "kling-v3:image2video"),
+]
+
+
+@pytest.mark.parametrize(("node_class", "bare_id", "suffixed_id"), SUFFIXED_NODES)
+def test_suffixed_catalog_id_is_bare_provider_id(
     node_class: type[GriptapeProxyNode], bare_id: str, suffixed_id: str
 ) -> None:
     node = node_class(name=node_class.__name__)

--- a/tests/unit/utils/test_model_access.py
+++ b/tests/unit/utils/test_model_access.py
@@ -1,0 +1,197 @@
+"""Unit tests for the library's model-dropdown access wiring.
+
+`MappedModelAccessComponent` exists for dropdowns whose choices are display
+labels rather than the catalog's `provider_model_id`. These tests stub the
+engine's access query so the mapping, the decoration it drives, and the runtime
+denial lookup are all exercised against known verdicts. The component's own
+behavior (badges, refresh button, fail-closed snapshot) is covered in the engine
+test suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.retained_mode.events.access_events import (
+    ModelAccessVerdict,
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.model_access import MappedModelAccessComponent, ModelDropdownAccess
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+# Dropdown labels this library's proxy nodes show, and the provider ids they map to.
+PROVIDER_MODEL_ID_BY_CHOICE = {
+    "Kling v3.0": "kling-v3",
+    "Kling v2.6": "kling-v2-6",
+}
+MODEL_CHOICES = list(PROVIDER_MODEL_ID_BY_CHOICE)
+CATALOG_ID_BY_PROVIDER_MODEL_ID = {
+    "kling-v3": "gtc_kling_v3",
+    "kling-v2-6": "gtc_kling_v2_6",
+}
+DENIAL = CheckpointDenial(failures=(CheckpointFailure(detail="Kling v3 is not in your plan."),))
+
+
+class _ModelNode(DataNode):
+    """Minimal node to hang a model parameter off of."""
+
+    def process(self) -> None:
+        return None
+
+
+@pytest.fixture
+def stub_access_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer every access query with `kling-v3` denied and `kling-v2-6` allowed."""
+    original_handle_request = GriptapeNodes.handle_request
+
+    def handle_request(request: RequestPayload, **kwargs: Any) -> ResultPayload:
+        if not isinstance(request, QueryModelAccessForNodeRequest):
+            return original_handle_request(request, **kwargs)
+        provider_model_ids = list(CATALOG_ID_BY_PROVIDER_MODEL_ID)
+        if request.candidate_model_ids is not None:
+            provider_model_ids = [
+                provider_model_id
+                for provider_model_id, catalog_id in CATALOG_ID_BY_PROVIDER_MODEL_ID.items()
+                if catalog_id in request.candidate_model_ids
+            ]
+        return QueryModelAccessForNodeResultSuccess(
+            result_details="stubbed access query",
+            verdicts=[
+                ModelAccessVerdict(
+                    model_id=CATALOG_ID_BY_PROVIDER_MODEL_ID[provider_model_id],
+                    provider_model_id=provider_model_id,
+                    denial=DENIAL if provider_model_id == "kling-v3" else None,
+                )
+                for provider_model_id in provider_model_ids
+            ],
+        )
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", handle_request)
+
+
+def _build_node_with_dropdown(*, default_model: str) -> tuple[_ModelNode, Parameter]:
+    node = _ModelNode(name="ModelNode")
+    parameter = Parameter(
+        name="model_name",
+        type="str",
+        default_value=default_model,
+        tooltip="Model to use",
+    )
+    node.add_parameter(parameter)
+    node.set_parameter_value("model_name", default_model)
+    return node, parameter
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_denied_label_is_decorated_and_queried_by_label() -> None:
+    """A denied provider id flags the dropdown row keyed by its display label."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    component = MappedModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    rows = {row["name"]: row for row in parameter.ui_options["data"]}
+    assert rows["Kling v3.0"].get("icon") == "shield-off"
+    assert "icon" not in rows["Kling v2.6"]
+
+    # The runtime query resolves the label to its catalog id and returns the denial.
+    assert component.query_for_denial("Kling v3.0") is not None
+    assert component.query_for_denial("Kling v2.6") is None
+    # Provider ids still resolve, so a raw-id value saved in an older workflow works.
+    assert component.query_for_denial("kling-v3") is not None
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_denied_default_label_relocates_to_a_permitted_choice() -> None:
+    """A denied default moves the stored value to a permitted label, not a provider id."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v3.0")
+    MappedModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v3.0",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    assert node.get_parameter_value("model_name") == "Kling v2.6"
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_dropdown_access_installs_traits_and_reads_the_selection() -> None:
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    assert isinstance(access.component, MappedModelAccessComponent)
+    assert parameter.find_elements_by_type(Options)
+    assert parameter.find_elements_by_type(Button)
+    assert access.parameter_name == "model_name"
+
+    assert access.selection_denial() is None
+    node.set_parameter_value("model_name", "Kling v3.0")
+    denial = access.selection_denial()
+    assert denial is not None
+    assert "not in your plan" in denial.reason()
+    with pytest.raises(RuntimeError, match="not permitted"):
+        access.raise_if_selection_denied()
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_dropdown_access_without_a_mapping_uses_the_engine_component() -> None:
+    """Provider-id dropdowns need no mapping, so they get the engine component itself."""
+    node = _ModelNode(name="ModelNode")
+    parameter = Parameter(name="model", type="str", default_value="kling-v2-6", tooltip="Model to use")
+    node.add_parameter(parameter)
+    node.set_parameter_value("model", "kling-v2-6")
+
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=list(CATALOG_ID_BY_PROVIDER_MODEL_ID),
+        default_model="kling-v2-6",
+    )
+
+    assert not isinstance(access.component, MappedModelAccessComponent)
+    node.set_parameter_value("model", "kling-v3")
+    assert access.selection_denial() is not None
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_on_value_set_ignores_other_parameters() -> None:
+    """Badge tracking is scoped to the dropdown the component owns."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    other = Parameter(name="prompt", type="str", default_value="", tooltip="Prompt")
+    node.add_parameter(other)
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    access.on_value_set(other, "Kling v3.0")
+    assert parameter.get_badge() is None
+
+    access.on_value_set(parameter, "Kling v3.0")
+    assert parameter.get_badge() is not None


### PR DESCRIPTION
The LTX and Kling text/image-to-video nodes decorate their model id with an operation suffix for the proxy URL path (e.g. `ltx-2-pro:retake`) and declared that suffixed id to the permission layer, where it matched no catalog entry, so a policy keyed on catalog ids never fired. Each of the eight nodes now resolves the bare provider id for its declaration.

Part of #432.

<!-- stack map: hand-maintained while `main`'s merge queue keeps the native stack UI unavailable -->
### Stack

Review and merge bottom to top. Trunk: `main`; each PR's base is the branch below it.

1. #507 — feat(access): add license-filtered model dropdown plumbing
2. #508 — fix(access): keep catalog model ids bare on suffixed proxy nodes  ⬅ **this PR**
3. #509 — feat(access): filter config driver model dropdowns through OFFER_MODEL
4. #510 — feat(access): filter provider-id proxy model dropdowns through OFFER_MODEL
5. #511 — feat(access): filter labeled image and world model dropdowns through OFFER_MODEL
6. #512 — feat(access): filter labeled video model dropdowns through OFFER_MODEL
7. #513 — fix(access): resolve Kling Omni's catalog model id
8. #515 — refactor(access): store catalog model keys in every model dropdown
