### PR TITLE
feat(access): filter config driver model dropdowns through OFFER_MODEL

### DIFF
--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -6,14 +6,12 @@ from typing import Any
 from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
-from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
@@ -28,14 +26,12 @@ __all__ = ["TranscribeAudio"]
 MODEL_CHOICES = ["whisper-1"]
 DEFAULT_MODEL = MODEL_CHOICES[0]
 
-# Deprecated models and their replacements (kept for backward-compat with saved graphs)
-DEPRECATED_MODELS = {
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Whisper 1": "whisper-1",
+    "gtc_whisper_1": "whisper-1",
     "gpt-4o-mini-transcribe": "whisper-1",
     "gpt-4o-transcribe": "whisper-1",
-}
-
-MODEL_MAPPING = {
-    "whisper-1": "whisper-1",
 }
 
 RESPONSE_FORMAT_CHOICES = ["json", "verbose_json"]
@@ -102,31 +98,15 @@ class TranscribeAudio(GriptapeProxyNode):
             ui_options={"display_name": "audio transcription model"},
         )
         self.add_parameter(model_param)
-        # License-policy helper: adds Options + refresh Button traits, applies per-row
-        # decoration + badge, exposes query_for_denial, and relocates the stored value
-        # to a permitted alternative if DEFAULT_MODEL is denied.
-        self._model_access = ModelAccessComponent(
-            node=self,
+        # License-policy dropdown: the component adds Options + refresh Button traits,
+        # marks the models the license denies, and relocates the stored value to a
+        # permitted alternative if DEFAULT_MODEL is denied. The proxy base class
+        # refuses to submit a denied selection.
+        self._install_model_access(
             parameter=model_param,
             model_choices=MODEL_CHOICES,
             default_model=DEFAULT_MODEL,
-        )
-
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecated",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -250,8 +230,6 @@ class TranscribeAudio(GriptapeProxyNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        if parameter.name == "model":
-            self._model_access.on_value_changed(value)
         if parameter.name == "response_format":
             if value == "verbose_json":
                 self.show_parameter_by_name("segments")
@@ -262,26 +240,6 @@ class TranscribeAudio(GriptapeProxyNode):
                 self.hide_parameter_by_name("detected_language")
                 self.hide_parameter_by_name("duration")
         return super().after_value_set(parameter, value)
-
-    def before_value_set(self, parameter: Parameter, value: Any) -> Any:
-        if parameter.name == "model" and isinstance(value, str) and value in DEPRECATED_MODELS:
-            replacement = DEPRECATED_MODELS[value]
-            message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-            if message is not None:
-                message.value = (
-                    f"The '{value}' model has been deprecated and replaced with '{replacement}'. "
-                    "Please save your workflow to apply this change."
-                )
-                self.show_message_by_name("model_deprecation_notice")
-            value = replacement
-        elif parameter.name == "model" and isinstance(value, str):
-            self.hide_message_by_name("model_deprecation_notice")
-        return super().before_value_set(parameter, value)
-
-    def _get_api_model_id(self) -> str:
-        """Get the API model ID for this generation."""
-        model = self.get_parameter_value("model") or DEFAULT_MODEL
-        return MODEL_MAPPING.get(str(model), str(model))
 
     async def _resolve_audio_data_uri(self, audio_value: Any) -> str | None:
         """Resolve an audio parameter value to a base64 data URI.
@@ -318,18 +276,6 @@ class TranscribeAudio(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for OpenAI audio transcription."""
-        # License-policy runtime gate. SuccessFailure idiom: route the denial
-        # through _set_status_results and return an empty payload so the outer
-        # proxy pipeline sees was_successful=False rather than an exception.
-        # Runs BEFORE the proxy's own INVOKE_MODEL gate so a denied model fails
-        # immediately instead of after payload construction.
-        model_value = self.get_parameter_value("model")
-        denial = self._model_access.query_for_denial(model_value)
-        if denial is not None:
-            self._set_safe_defaults()
-            self._set_status_results(was_successful=False, result_details=denial.reason())
-            return {}
-
         audio_value = self.get_parameter_value("audio")
         if audio_value is None:
             msg = "No audio provided. Please connect an audio source."

--- a/griptape_nodes_library/config/base_driver.py
+++ b/griptape_nodes_library/config/base_driver.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
@@ -28,6 +29,11 @@ class BaseDriver(DataNode):
             driver = BaseDriver(name="ExampleDriver")
         """
         super().__init__(**kwargs)
+
+        # Set by `_install_model_access` on subclasses whose model parameter is a
+        # license-filtered dropdown; stays None on the ones offering free text or a
+        # dynamically fetched list.
+        self._model_access: ModelAccessComponent | None = None
 
         self.add_parameter(
             Parameter(
@@ -109,6 +115,74 @@ class BaseDriver(DataNode):
     # -----------------------------------------------------------------------------
     # Internal Helper Methods
     # -----------------------------------------------------------------------------
+
+    def _install_model_access(
+        self,
+        *,
+        model_choices: list[str],
+        default_model: str,
+        param: str = "model",
+        deprecated_values: dict[str, str] | None = None,
+    ) -> None:
+        """Turn the named model parameter into a license-filtered dropdown.
+
+        Stands in for `_update_option_choices` on driver nodes: the component owns
+        the `Options` trait (so the parameter must not already carry one), adds an
+        inline refresh button, marks the models the caller's license denies, and
+        moves the stored value off a denied default. The declared default is still
+        applied here, so the parameter reads the same as it did before adoption.
+
+        Args:
+            model_choices: The provider model ids the node offers, in dropdown order.
+            default_model: The choice to select by default; must be in `model_choices`.
+            param: Name of the parameter to decorate.
+            deprecated_values: Legacy value -> canonical `model_choices` entry map,
+                needed only when the parameter used to store something other than
+                the provider's model id (an old display label, a catalog key).
+        """
+        if default_model not in model_choices:
+            msg = f"Default model '{default_model}' is not one of the offered choices."
+            raise ValueError(msg)
+        parameter = self.get_parameter_by_name(param)
+        if parameter is None:
+            msg = f"Cannot install model access on '{type(self).__name__}': no '{param}' parameter."
+            raise ValueError(msg)
+
+        parameter.default_value = default_model
+        self.set_parameter_value(param, default_model)
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            deprecated_values=deprecated_values,
+        )
+
+    def _get_selected_model_id(self) -> str:
+        """The provider model id the model dropdown currently stores.
+
+        The dropdown stores the provider's own id for the model, so a driver
+        built from this node's parameters passes the stored value upstream as-is.
+        Reading it through here keeps the parameter's name in one place.
+        """
+        if self._model_access is None:
+            return ""
+        return self._model_access.selected_value or ""
+
+    def _raise_if_model_denied(self) -> None:
+        """Fail closed rather than hand a downstream node a driver the license denies.
+
+        Called at the top of `process` on nodes with a license-filtered dropdown;
+        no-ops on the nodes that never installed one.
+        """
+        if self._model_access is not None:
+            self._model_access.raise_if_selection_denied()
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Keep the model dropdown's denial badge in step with the selection."""
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+        return super().after_value_set(parameter, value)
 
     def _display_api_key_message(self, service_name: str, api_key_env_var: str, api_key_url: str | None) -> None:
         """Checks if the API key exists in the node configuration, displays a message if not.

--- a/griptape_nodes_library/config/image/base_image_driver.py
+++ b/griptape_nodes_library/config/image/base_image_driver.py
@@ -62,7 +62,8 @@ class BaseImageDriver(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses call `_install_model_access`
+        # to offer a license-filtered dropdown of their models.
         self.add_parameter(
             Parameter(
                 name="model",
@@ -71,7 +72,6 @@ class BaseImageDriver(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
         self.add_parameter(

--- a/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
+++ b/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
@@ -1,11 +1,8 @@
-from typing import Any
-
 from griptape.drivers.image_generation.griptape_cloud import (
     GriptapeCloudImageGenerationDriver as GtGriptapeCloudImageGenerationDriver,
 )
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
+from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.image.base_image_driver import BaseImageDriver
@@ -20,8 +17,13 @@ DEFAULT_MODEL = MODEL_CHOICES[0]
 AVAILABLE_SIZES = ["1024x1024", "1536x1024", "1024x1536"]
 DEFAULT_SIZE = AVAILABLE_SIZES[0]
 
-# Deprecated models and their replacements
-DEPRECATED_MODELS = {
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "GPT Image 1 Mini": "gpt-image-1-mini",
+    "GPT Image 1.5": "gpt-image-1.5",
+    "gtc_gpt_image_1_5": "gpt-image-1.5",
+    "gtc_gpt_image_1_mini": "gpt-image-1-mini",
+    # Folded in from this node's own retired DEPRECATED_MODELS dict.
     "dall-e-3": "gpt-image-1-mini",
 }
 
@@ -37,28 +39,13 @@ class GriptapeCloudImage(BaseImageDriver):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Griptape Cloud specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Griptape Cloud's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # Update the 'size' parameter for Griptape Cloud specifics.
         self._update_option_choices(param="image_size", choices=AVAILABLE_SIZES, default=str(DEFAULT_SIZE))
-
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecation Notice",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
-        )
 
         # Add additional parameters specific to Griptape Cloud
         self.add_parameter(
@@ -71,27 +58,12 @@ class GriptapeCloudImage(BaseImageDriver):
             )
         )
 
-    def before_value_set(
-        self,
-        parameter: Parameter,
-        value: Any,
-    ) -> Any:
-        if parameter.name == "model" and isinstance(value, str) and value in DEPRECATED_MODELS:
-            replacement = DEPRECATED_MODELS[value]
-            message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-            if message is None:
-                raise RuntimeError("model_deprecation_notice message element not found")  # noqa: TRY003, EM101
-            message.value = f"The '{value}' model has been deprecated. The model has been updated to '{replacement}'. Please save your workflow to apply this change."
-            self.show_message_by_name("model_deprecation_notice")
-            value = replacement
-        elif parameter.name == "model" and isinstance(value, str):
-            self.hide_message_by_name("model_deprecation_notice")
-
-        return super().before_value_set(parameter, value)
-
     def process(self) -> None:
         # Get the parameters from the node
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments
@@ -102,6 +74,9 @@ class GriptapeCloudImage(BaseImageDriver):
 
         # Retrieve the mandatory API key.
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+
+        # The provider's own id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         specific_args["quality"] = self.get_parameter_value("quality")
 

--- a/griptape_nodes_library/config/image/grok_image_driver.py
+++ b/griptape_nodes_library/config/image/grok_image_driver.py
@@ -13,6 +13,12 @@ API_KEY_ENV_VAR = "GROK_API_KEY"
 MODEL_CHOICES = ["grok-2-image-1212"]
 DEFAULT_MODEL = MODEL_CHOICES[0]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "Grok 2 Image": "grok-2-image-1212",
+    "xai_grok_2_image_1212": "grok-2-image-1212",
+}
+
 
 class GrokImage(BaseImageDriver):
     """Node for OpenAI Image Generation Driver.
@@ -25,8 +31,10 @@ class GrokImage(BaseImageDriver):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Grok's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # remove the 'size' parameter
         self.remove_parameter_element_by_name("image_size")
@@ -34,6 +42,9 @@ class GrokImage(BaseImageDriver):
     def process(self) -> None:
         # Get the parameters from the node
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments
@@ -47,6 +58,9 @@ class GrokImage(BaseImageDriver):
 
         # Retrieve the mandatory API key.
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+
+        # The provider's own id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         all_kwargs = {**common_args, **specific_args}
 

--- a/griptape_nodes_library/config/image/openai_image_driver.py
+++ b/griptape_nodes_library/config/image/openai_image_driver.py
@@ -37,6 +37,16 @@ DEFAULT_SIZE = GPT_IMAGE_SIZES[0]
 DEFAULT_BACKGROUND = BACKGROUND_CHOICES[0]
 DEFAULT_MODERATION = MODERATION_CHOICES[0]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "DALL-E 2": "dall-e-2",
+    "DALL-E 3": "dall-e-3",
+    "GPT Image 1": "gpt-image-1",
+    "gtc_gpt_image_1": "gpt-image-1",
+    "openai_dall_e_2": "dall-e-2",
+    "openai_dall_e_3": "dall-e-3",
+}
+
 
 class OpenAiImage(BaseImageDriver):
     """Node for OpenAI Image Generation Driver.
@@ -110,8 +120,10 @@ class OpenAiImage(BaseImageDriver):
             )
         )
 
-        # Update the parameters  for OpenAI specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer OpenAI's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
         self._update_option_choices(param="image_size", choices=GPT_IMAGE_SIZES, default=DEFAULT_SIZE)
 
     def _set_parameter_visibility(self, names: str | list[str], *, visible: bool) -> None:
@@ -187,6 +199,9 @@ class OpenAiImage(BaseImageDriver):
         # Get the parameters from the node
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments
         common_args = self._get_common_driver_args(params)
@@ -198,7 +213,7 @@ class OpenAiImage(BaseImageDriver):
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
         model = self.get_parameter_value("model")
-        specific_args["model"] = model
+        specific_args["model"] = self._get_selected_model_id()
 
         if model == "dall-e-3":
             specific_args["style"] = self.get_parameter_value("style")

--- a/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -95,7 +95,6 @@ class AmazonBedrockPrompt(BasePrompt):
         # a dropdown, we'll provide just a text field for the user to enter the model name
         # and set the default to the first model in the list.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/876
-        self._remove_options_trait(param="model")
         param = self.get_parameter_by_name("model")
         if param is not None:
             param.default_value = MODEL_CHOICES[0]

--- a/griptape_nodes_library/config/prompt/anthropic_prompt.py
+++ b/griptape_nodes_library/config/prompt/anthropic_prompt.py
@@ -7,12 +7,8 @@ Anthropic specific model options, requires an Anthropic API key via
 node configuration, and instantiates the `GtAnthropicPromptDriver`.
 """
 
-from typing import Any
-
 from griptape.drivers.prompt.anthropic import AnthropicPromptDriver as GtAnthropicPromptDriver
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.traits.button import Button
 
 from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 
@@ -28,8 +24,14 @@ MODEL_CHOICES = [
 ]
 DEFAULT_MODEL = MODEL_CHOICES[1]  # claude-sonnet-4-6
 
-# Deprecated models and their replacements
-DEPRECATED_MODELS = {
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "Claude Haiku 4.5": "claude-haiku-4-5",
+    "Claude Opus 4.7": "claude-opus-4-7",
+    "Claude Sonnet 4.6": "claude-sonnet-4-6",
+    "gtc_claude_haiku_4_5": "claude-haiku-4-5",
+    "gtc_claude_opus_4_7": "claude-opus-4-7",
+    "gtc_claude_sonnet_4_6": "claude-sonnet-4-6",
     # Dated model versions
     "claude-3-5-sonnet-20241022": "claude-sonnet-4-6",
     "claude-3-5-sonnet-20240620": "claude-sonnet-4-6",
@@ -75,25 +77,9 @@ class AnthropicPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Anthropic specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
-
-        # Add deprecation notice message element right after model parameter
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecation Notice",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
+        # Offer Anthropic's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
         )
 
         # Replace `min_p` with `top_p` for Anthropic.
@@ -103,25 +89,6 @@ class AnthropicPrompt(BasePrompt):
 
         # Remove the 'seed' parameter as it's not directly used by AnthropicPromptDriver.
         self.remove_parameter_element_by_name("seed")
-
-    def before_value_set(
-        self,
-        parameter: Parameter,
-        value: Any,
-    ) -> Any:
-        if parameter.name == "model":
-            if isinstance(value, str) and value in DEPRECATED_MODELS:
-                replacement = DEPRECATED_MODELS[value]
-                message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-                if message is None:
-                    raise RuntimeError("model_deprecation_notice message element not found")  # noqa: TRY003, EM101
-                message.value = f"The '{value}' model has been deprecated. The model has been updated to '{replacement}'. Please save your workflow to apply this change."
-                self.show_message_by_name("model_deprecation_notice")
-                value = replacement
-            else:
-                self.hide_message_by_name("model_deprecation_notice")
-
-        return super().before_value_set(parameter, value)
 
     def process(self) -> None:
         """Processes the node configuration to create an AnthropicPromptDriver.
@@ -138,6 +105,9 @@ class AnthropicPrompt(BasePrompt):
         # Retrieve all parameter values set on the node.
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt. This gets temperature, stream,
         # max_attempts, max_tokens, use_native_tools, min_p, top_k if they are set.
@@ -149,8 +119,8 @@ class AnthropicPrompt(BasePrompt):
         # Retrieve the mandatory API key.
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
-        # Get the selected model.
-        specific_args["model"] = self.get_parameter_value("model")
+        # Get the upstream provider's id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         # Handle specific parameter conversions/logic for Anthropic driver
         # Anthropic uses 'top_p' and 'top_k' directly as kwargs.

--- a/griptape_nodes_library/config/prompt/base_prompt.py
+++ b/griptape_nodes_library/config/prompt/base_prompt.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from griptape.drivers.prompt.dummy import DummyPromptDriver
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.base_driver import BaseDriver
 
@@ -31,7 +30,8 @@ class BasePrompt(BaseDriver):
     - Defines common LLM parameters accessible via `self.parameter_values`.
     - Provides `_get_common_driver_args` to easily collect arguments for drivers based on base parameters.
     - Provides `_validate_api_key` to standardize API key validation logic.
-    - Provides `_update_option_choices` to set driver-specific model lists for the 'model' parameter.
+    - Provides `_install_model_access` to turn the 'model' parameter into a
+      license-filtered dropdown of driver-specific models.
     Note: The `process` method in this base class creates a `DummyPromptDriver`
     primarily to establish the output socket type. It does not utilize the
     configuration parameters defined herein. Direct use of `BasePrompt` is
@@ -71,7 +71,10 @@ class BasePrompt(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses either call
+        # `_install_model_access` to offer a license-filtered dropdown of their
+        # models, or add their own trait when the choices are theirs to manage
+        # (a free-text field, or a list fetched from the provider at runtime).
         self.add_parameter(
             Parameter(
                 name="model",
@@ -80,7 +83,6 @@ class BasePrompt(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
 

--- a/griptape_nodes_library/config/prompt/cohere_prompt.py
+++ b/griptape_nodes_library/config/prompt/cohere_prompt.py
@@ -20,6 +20,12 @@ API_KEY_ENV_VAR = "COHERE_API_KEY"
 MODEL_CHOICES = ["command-r-plus"]
 DEFAULT_MODEL = MODEL_CHOICES[0]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "Command R+": "command-r-plus",
+    "cohere_command_r_plus": "command-r-plus",
+}
+
 
 class CoherePrompt(BasePrompt):
     """Node for configuring and providing a Cohere Prompt Driver.
@@ -44,8 +50,10 @@ class CoherePrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Anthropic specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Cohere's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # Replace `min_p` with `top_p` for Cohere.
         self._replace_param_by_name(
@@ -73,6 +81,9 @@ class CoherePrompt(BasePrompt):
         # Retrieve all parameter values set on the node.
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt. This gets temperature, stream,
         # max_attempts, max_tokens, use_native_tools, min_p, top_k if they are set.
@@ -84,8 +95,8 @@ class CoherePrompt(BasePrompt):
         # Retrieve the mandatory API key.
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
-        # Get the selected model.
-        specific_args["model"] = self.get_parameter_value("model")
+        # Get the upstream provider's id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         # Handle parameters that go into 'extra_params' for Griptape Cloud.
         extra_params = {}

--- a/griptape_nodes_library/config/prompt/grok_prompt.py
+++ b/griptape_nodes_library/config/prompt/grok_prompt.py
@@ -17,8 +17,28 @@ from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 SERVICE = "Grok"
 API_KEY_URL = "https://console.x.ai"
 API_KEY_ENV_VAR = "GROK_API_KEY"
-MODEL_CHOICES = ["grok-3-beta", "grok-3-fast-beta", "grok-3-mini-beta", "grok-3-mini-fast-beta", "grok-2-vision-1212"]
+MODEL_CHOICES = [
+    "grok-3-beta",
+    "grok-3-fast-beta",
+    "grok-3-mini-beta",
+    "grok-3-mini-fast-beta",
+    "grok-2-vision-1212",
+]
 DEFAULT_MODEL = MODEL_CHOICES[0]
+
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "Grok 2 Vision": "grok-2-vision-1212",
+    "Grok 3 Beta": "grok-3-beta",
+    "Grok 3 Fast Beta": "grok-3-fast-beta",
+    "Grok 3 Mini Beta": "grok-3-mini-beta",
+    "Grok 3 Mini Fast Beta": "grok-3-mini-fast-beta",
+    "xai_grok_2_vision_1212": "grok-2-vision-1212",
+    "xai_grok_3_beta": "grok-3-beta",
+    "xai_grok_3_fast_beta": "grok-3-fast-beta",
+    "xai_grok_3_mini_beta": "grok-3-mini-beta",
+    "xai_grok_3_mini_fast_beta": "grok-3-mini-fast-beta",
+}
 
 
 class GrokPrompt(BasePrompt):
@@ -49,8 +69,10 @@ class GrokPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Grok specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Grok's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # Remove `top_k` parameter as it's not used by Grok.
         self.remove_parameter_element_by_name("seed")
@@ -75,6 +97,9 @@ class GrokPrompt(BasePrompt):
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.
         common_args = self._get_common_driver_args(params)
@@ -85,8 +110,8 @@ class GrokPrompt(BasePrompt):
         # Retrieve the mandatory API key.
         specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
 
-        # Get the selected model.
-        specific_args["model"] = self.get_parameter_value("model")
+        # Get the upstream provider's id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         # Handle parameters that go into 'extra_params' for Grok.
         extra_params = {}

--- a/griptape_nodes_library/config/prompt/groq_prompt.py
+++ b/griptape_nodes_library/config/prompt/groq_prompt.py
@@ -32,6 +32,30 @@ MODEL_CHOICES = [
 ]
 DEFAULT_MODEL = MODEL_CHOICES[0]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "Allam 2 7B": "allam-2-7b",
+    "DeepSeek R1 Distill Llama 70B": "deepseek-r1-distill-llama-70b",
+    "Gemma 2 9B IT": "gemma2-9b-it",
+    "Llama 3 70B 8192": "llama3-70b-8192",
+    "Llama 3 8B 8192": "llama3-8b-8192",
+    "Llama 3.1 8B Instant": "llama-3.1-8b-instant",
+    "Llama 3.3 70B Versatile": "llama-3.3-70b-versatile",
+    "Llama 4 Maverick 17B 128E Instruct": "meta-llama/llama-4-maverick-17b-128e-instruct",
+    "Llama 4 Scout 17B 16E Instruct": "meta-llama/llama-4-scout-17b-16e-instruct",
+    "Llama Guard 4 12B": "meta-llama/llama-guard-4-12b",
+    "groq_allam_2_7b": "allam-2-7b",
+    "groq_deepseek_r1_distill_llama_70b": "deepseek-r1-distill-llama-70b",
+    "groq_gemma2_9b_it": "gemma2-9b-it",
+    "groq_llama3_70b_8192": "llama3-70b-8192",
+    "groq_llama3_8b_8192": "llama3-8b-8192",
+    "groq_llama_3_1_8b_instant": "llama-3.1-8b-instant",
+    "groq_llama_3_3_70b_versatile": "llama-3.3-70b-versatile",
+    "groq_llama_4_maverick_17b_128e_instruct": "meta-llama/llama-4-maverick-17b-128e-instruct",
+    "groq_llama_4_scout_17b_16e_instruct": "meta-llama/llama-4-scout-17b-16e-instruct",
+    "groq_llama_guard_4_12b": "meta-llama/llama-guard-4-12b",
+}
+
 
 class GroqPrompt(BasePrompt):
     """Node for configuring and providing a Groq Chat Prompt Driver.
@@ -61,8 +85,10 @@ class GroqPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Groq specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Groq's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # Remove the 'seed' parameter as it's not directly used by GroqPromptDriver.
         self.remove_parameter_element_by_name("seed")
@@ -89,6 +115,9 @@ class GroqPrompt(BasePrompt):
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.
         common_args = self._get_common_driver_args(params)
@@ -102,8 +131,8 @@ class GroqPrompt(BasePrompt):
         # Set the base URL for the Groq API.
         specific_args["base_url"] = BASE_URL
 
-        # Get the selected model.
-        specific_args["model"] = self.get_parameter_value("model")
+        # Get the upstream provider's id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         # Handle parameters that go into 'extra_params' for Groq.
         extra_params = {}

--- a/griptape_nodes_library/config/prompt/nim_prompt.py
+++ b/griptape_nodes_library/config/prompt/nim_prompt.py
@@ -37,6 +37,40 @@ MODEL_CHOICES = [
 ]
 DEFAULT_MODEL = MODEL_CHOICES[0]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES = {
+    "DeepSeek V3.1": "deepseek-ai/deepseek-v3.1",
+    "GPT-OSS 120B": "openai/gpt-oss-120b",
+    "GPT-OSS 20B": "openai/gpt-oss-20b",
+    "Gemma 3 1B IT": "google/gemma-3-1b-it",
+    "Kimi K2 Instruct": "moonshotai/kimi-k2-instruct",
+    "Llama 3 8B Instruct": "meta/llama3-8b-instruct",
+    "Llama 3.1 Nemotron Nano VL 8B v1": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+    "Llama 3.2 11B Vision Instruct": "meta/llama-3.2-11b-vision-instruct",
+    "Llama 3.2 90B Vision Instruct": "meta/llama-3.2-90b-vision-instruct",
+    "Llama 3.3 Nemotron Super 49B v1.5": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "Llama 4 Maverick 17B 128E Instruct": "meta/llama-4-maverick-17b-128e-instruct",
+    "Llama 4 Scout 17B 16E Instruct": "meta/llama-4-scout-17b-16e-instruct",
+    "Magistral Small 2506": "mistralai/magistral-small-2506",
+    "Nemotron Nano 9B v2": "nvidia/nvidia-nemotron-nano-9b-v2",
+    "Teuken 7B Instruct Commercial v0.4": "opengpt-x/teuken-7b-instruct-commercial-v0.4",
+    "nim_deepseek_v3_1": "deepseek-ai/deepseek-v3.1",
+    "nim_gemma_3_1b_it": "google/gemma-3-1b-it",
+    "nim_gpt_oss_120b": "openai/gpt-oss-120b",
+    "nim_gpt_oss_20b": "openai/gpt-oss-20b",
+    "nim_kimi_k2_instruct": "moonshotai/kimi-k2-instruct",
+    "nim_llama3_8b_instruct": "meta/llama3-8b-instruct",
+    "nim_llama_3_1_nemotron_nano_vl_8b_v1": "nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
+    "nim_llama_3_2_11b_vision_instruct": "meta/llama-3.2-11b-vision-instruct",
+    "nim_llama_3_2_90b_vision_instruct": "meta/llama-3.2-90b-vision-instruct",
+    "nim_llama_3_3_nemotron_super_49b_v1_5": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+    "nim_llama_4_maverick_17b_128e_instruct": "meta/llama-4-maverick-17b-128e-instruct",
+    "nim_llama_4_scout_17b_16e_instruct": "meta/llama-4-scout-17b-16e-instruct",
+    "nim_magistral_small_2506": "mistralai/magistral-small-2506",
+    "nim_nemotron_nano_9b_v2": "nvidia/nvidia-nemotron-nano-9b-v2",
+    "nim_teuken_7b_instruct_commercial_v0_4": "opengpt-x/teuken-7b-instruct-commercial-v0.4",
+}
+
 
 class NimPrompt(BasePrompt):
     """Node for configuring and providing a NVIDIA Chat Prompt Driver.
@@ -66,8 +100,10 @@ class NimPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for NVIDIA specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer NVIDIA's models as a license-filtered dropdown.
+        self._install_model_access(
+            model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL, deprecated_values=LEGACY_MODEL_VALUES
+        )
 
         # Remove the 'seed' parameter
         self.remove_parameter_element_by_name("seed")
@@ -94,6 +130,9 @@ class NimPrompt(BasePrompt):
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
 
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
+
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.
         common_args = self._get_common_driver_args(params)
@@ -107,8 +146,8 @@ class NimPrompt(BasePrompt):
         # Set the base URL for the NVIDIA API.
         specific_args["base_url"] = BASE_URL
 
-        # Get the selected model.
-        specific_args["model"] = self.get_parameter_value("model")
+        # Get the upstream provider's id for the selected model.
+        specific_args["model"] = self._get_selected_model_id()
 
         # Handle parameters that go into 'extra_params' for NVIDIA.
         extra_params = {}

--- a/griptape_nodes_library/config/prompt/openai_prompt.py
+++ b/griptape_nodes_library/config/prompt/openai_prompt.py
@@ -9,6 +9,7 @@ node configuration, and instantiates the `OpenAiPromptDriver`.
 
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 
@@ -68,6 +69,12 @@ class OpenAiPrompt(BasePrompt):
         import openai
 
         available_models = [model.id for model in openai.Client().models.list().data]
+        # This node offers whatever models the account can see rather than a
+        # declared list, so it owns the dropdown trait instead of routing through
+        # `_install_model_access`.
+        model_param = self.get_parameter_by_name("model")
+        if model_param is not None:
+            model_param.add_trait(Options(choices=available_models))
         self._update_option_choices(
             param="model", choices=available_models, default=available_models[0] if available_models else ""
         )

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -8,12 +8,13 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import suppress
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpx
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import SuccessFailureNode
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
@@ -23,6 +24,9 @@ from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
 from griptape_nodes_library.utils.model_invocation import declare_model_invocation
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -79,6 +83,10 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._user_auth_info: str | None = None
         self._api_key_provider: ProxyAuthProviderParameter | None = None
         self._initialize_api_key_provider()
+
+        # Set by `_install_model_access` on subclasses whose model selection is a
+        # license-filtered dropdown; stays None on the ones bound to a single model.
+        self._model_access: ModelAccessComponent | None = None
 
         default_timeout = self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
         self.add_parameter(
@@ -156,6 +164,55 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         super().after_value_set(parameter, value)
         if self._api_key_provider:
             self._api_key_provider.after_value_set(parameter, value)
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+
+    def _install_model_access(
+        self,
+        *,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        deprecated_values: dict[str, str] | None = None,
+    ) -> None:
+        """Turn an already-added model parameter into a license-filtered dropdown.
+
+        The component owns the parameter's `Options` trait, so pass a parameter
+        built without one; it also adds an inline refresh button, marks the models
+        the caller's license denies, and moves the stored value off a denied
+        default. `_submit_and_poll` then refuses to submit a denied selection.
+
+        Args:
+            parameter: The model parameter, already added to this node.
+            model_choices: The provider model ids the node offers, in dropdown order.
+            default_model: The choice selected by default.
+            deprecated_values: Legacy value -> canonical `model_choices` entry map,
+                needed only when the parameter used to store something other than
+                the provider's model id (an old display label, a catalog key).
+        """
+        self._model_access = ModelAccessComponent(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            deprecated_values=deprecated_values,
+        )
+
+    def _get_selected_model_id(self) -> str:
+        """The provider model id the model dropdown currently stores.
+
+        The dropdown stores the provider's own id for the model, which is what a
+        node building a request URL or payload needs. Reading it through here
+        rather than by name keeps the parameter's name in one place: it is
+        `model` on most nodes but `model_name` or `model_id` on others.
+
+        Returns:
+            str: The stored provider model id, or `""` when there is no
+                model-access component installed or nothing is selected.
+        """
+        if self._model_access is None:
+            return ""
+        return self._model_access.selected_value or ""
 
     def _prepare_user_auth_info(self) -> None:
         self.register_user_auth_info(None)
@@ -245,29 +302,35 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation.
 
-        Subclasses can override this if they need to map friendly names to API IDs.
-        By default, returns the value of the 'model' parameter if it exists.
+        Subclasses can override this if they need to map the dropdown value to a
+        differently-shaped API ID (e.g. an operation suffix in the URL path). By
+        default, returns the dropdown's stored provider model id; falls back to
+        the raw 'model' parameter value when no model-access component is
+        installed.
 
         Returns:
             str: The model ID to use in the API request
         """
+        if self._model_access is not None:
+            return self._get_selected_model_id()
         return self.get_parameter_value("model") or ""
 
     def _get_catalog_model_id(self) -> str:
         """Get the model ID used to resolve this node's declared catalog model.
 
-        The permission/declaration layer matches on the catalog's
-        `provider_model_id`, which is the bare upstream model id. By default this
-        is the same value used in the API request URL (`_get_api_model_id()`).
+        The declaration layer resolves this through the catalog's
+        `provider_model_id`, so the bare stored value is what it needs. Falls
+        back to `_get_api_model_id()` when no model-access component is installed.
 
         Subclasses whose `_get_api_model_id()` decorates the id with an operation
-        suffix for the URL path (e.g. `grok-imagine-video:generate`) must override
-        this to return the bare provider id instead, or the catalog lookup will
-        fail to match and the invocation cannot be declared.
+        suffix for the URL path (e.g. `grok-imagine-video:generate`) do not need
+        to override this: the stored value is already the bare provider id.
 
         Returns:
             str: The model ID to match against declared catalog models
         """
+        if self._model_access is not None:
+            return self._get_selected_model_id()
         return self._get_api_model_id()
 
     def _validate_api_key(self) -> str:
@@ -605,6 +668,12 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         error_msg = f"{self.name}: No model ID provided"
         self._set_status_results(was_successful=False, result_details=error_msg)
 
+    def _handle_denied_model(self, denial: CheckpointDenial) -> None:
+        """Handle a dropdown selection the license policy does not permit."""
+        self._set_safe_defaults()
+        error_msg = f"{self.name}: {denial.reason()}"
+        self._set_status_results(was_successful=False, result_details=error_msg)
+
     def _handle_submission_error(self, e: RuntimeError) -> None:
         """Handle generation submission errors."""
         self._set_safe_defaults()
@@ -641,11 +710,20 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             self._handle_missing_model_id()
             return None
 
+        # Re-check the dropdown selection against the license policy: it may have
+        # been permitted when the node was built and denied since. Runs before the
+        # invocation declaration so the failure carries the dropdown's own reason.
+        if self._model_access is not None:
+            selection_denial = self._model_access.selection_denial()
+            if selection_denial is not None:
+                self._handle_denied_model(selection_denial)
+                return None
+
         # Declare the invocation so the engine's permission layer can gate it
         # before any network call. The proxy still enforces server-side; this is
         # the engine-side gate, so a denied invocation fails fast here. The
-        # declaration matches on the bare catalog id, which may differ from the
-        # URL-path id (e.g. when the latter carries an operation suffix).
+        # declaration resolves the bare provider model id, which may differ from
+        # the URL-path id (e.g. when the latter carries an operation suffix).
         declaration = await declare_model_invocation(self, self._get_catalog_model_id())
         if declaration.failed():
             self._set_safe_defaults()

--- a/griptape_nodes_library/utils/model_invocation.py
+++ b/griptape_nodes_library/utils/model_invocation.py
@@ -36,16 +36,20 @@ __all__ = [
 
 
 def resolve_catalog_model_id(node: BaseNode, api_model_id: str) -> str | None:
-    """Resolve the selected provider model id to its stable catalog key.
+    """Resolve a provider's model id to the stable catalog key the permission layer gates on.
 
-    The lookup is scoped to the node's own declared models, so the
-    provider_model_id -> stable key mapping is unambiguous: a node does not
-    declare the same upstream model under two catalog keys. Returns None
-    when the selection is not one of the node's declared catalog models.
+    `api_model_id` is the provider's own name for the model: either the value a
+    model dropdown stores, or a driver's `model` attribute read off whatever
+    concrete driver ended up installed. The lookup is scoped to the node's own
+    declared models.
+
+    The catalog permits two entries to share one `provider_model_id`, so an
+    ambiguous match resolves to nothing rather than gating against an arbitrary
+    one of them. Returns None in that case, and when `api_model_id` is not a
+    provider id this node declares.
     """
-    matches = [
-        resolved.model_id for resolved in get_declared_models(node) if resolved.model.provider_model_id == api_model_id
-    ]
+    declared = get_declared_models(node)
+    matches = [resolved.model_id for resolved in declared if resolved.model.provider_model_id == api_model_id]
     return matches[0] if len(matches) == 1 else None
 
 

--- a/griptape_nodes_library/utils/provider_selection_component.py
+++ b/griptape_nodes_library/utils/provider_selection_component.py
@@ -18,6 +18,17 @@ _GRIPTAPE_CLOUD_PROVIDER = ProviderConfig(name="griptape_cloud", type="griptape_
 
 
 class ProviderSelectionComponent:
+    """Swaps the model dropdown's choices between Griptape Cloud and a third-party provider.
+
+    The Griptape Cloud branch offers ``model_access``'s catalog model keys --
+    the same license-gated choices ``ModelAccessComponent`` decorates -- since
+    those are Griptape Cloud models. A third-party provider's models are not
+    catalog models: that branch offers whatever the provider itself reports
+    (``fetch_models_for_provider``) and is exempt from license gating. The two
+    id shapes are never interchangeable -- a catalog key must never be offered
+    for, or reach a driver through, the third-party branch, and vice versa.
+    """
+
     def __init__(
         self,
         node,
@@ -125,25 +136,36 @@ class ProviderSelectionComponent:
 
     def update_model_choices_for_provider(self, provider_name: str) -> None:
         if provider_name == "griptape_cloud":
+            # The component's own choices ARE catalog model keys; offer them as-is.
             default = self._model_access.pick_permitted_default() or self._default_model
             self._node._update_option_choices(param="model", choices=self._model_access.model_choices, default=default)
             # Restore the component's per-row license decoration and badge; the
             # _update_option_choices call above only refreshed choices and value.
             self._model_access.reinstall_options()
             return
+        # A third-party provider's models are not catalog models -- offer whatever the
+        # provider itself reports, never `self._gtc_model_choices` (those are catalog keys,
+        # meaningless and ungate-able for this provider's own driver).
         models = self.fetch_models_for_provider(provider_name)
-        default = models[0] if models else self._default_model
+        default = models[0] if models else ""
         self._node._update_option_choices(param="model", choices=models, default=default)
         param = self._node.get_parameter_by_name("model")
         if param:
             param.update_ui_options_key("data", [{"name": m, "icon": "", "args": {}} for m in models])
 
     def fetch_models_for_provider(self, provider_name: str) -> list[str]:
+        """Fetch a third-party provider's own model list.
+
+        Falls back to an empty list on failure or an unconfigured provider --
+        `self._gtc_model_choices` are catalog keys, not this provider's model
+        names, so they are never a valid substitute here: offering one would
+        risk it reaching this provider's driver unresolved.
+        """
         try:
             providers = self._fetch_providers()
             provider_config = next((p for p in providers if p.name == provider_name), None)
             if provider_config is None:
-                return self._gtc_model_choices
+                return []
             result = GriptapeNodes.handle_request(
                 ListProviderModelsRequest(
                     provider=provider_config.type,
@@ -152,7 +174,7 @@ class ProviderSelectionComponent:
                 )
             )
             if isinstance(result, ListProviderModelsResultSuccess):
-                return cast(ListProviderModelsResultSuccess, result).models or self._gtc_model_choices
+                return cast(ListProviderModelsResultSuccess, result).models or []
         except Exception:
             pass
-        return self._gtc_model_choices
+        return []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
   "asteval>=1.0.8",
   "color-matcher",
   "zstandard>=0.22.0",
-  "griptape-nodes-engine>=0.93.0",
+  "griptape-nodes-engine>=0.97.0",
   "lxml>=5.0.0",
 ]
 

--- a/tests/unit/config/test_driver_model_access.py
+++ b/tests/unit/config/test_driver_model_access.py
@@ -1,0 +1,184 @@
+"""Tests that the config driver nodes wire their model dropdown through
+``ModelAccessComponent``.
+
+Every prompt/image driver node under ``griptape_nodes_library/config`` offers
+its model list via ``BaseDriver._install_model_access``, which hands the
+node's ``model`` parameter to a ``ModelAccessComponent``: the component owns
+the ``Options`` + refresh ``Button`` traits, decorates each row with the
+caller's license entitlement, and gates ``process()`` against the current
+policy. These tests cover that wiring and the runtime gate across every node
+that installs it; the component's own behavior is covered in the engine test
+suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import requests
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointDenial,
+    CheckpointFailure,
+)
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.config.base_driver import BaseDriver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+LIBRARY_NAME = "Griptape Nodes Library"
+
+type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | None]
+
+# (node type, catalog model id to deny, provider model id the dropdown offers for
+# it). The dropdown stores the provider id, so the row the denial decorates is
+# named by that id, while the license-policy hook still keys on the catalog id
+# it gates on. The denied id is deliberately not the node's default everywhere
+# it can be, so the ModelAccessComponent constructor's default-relocation logic
+# (which moves the stored value off a denied default) never fires and can't
+# confuse these assertions. CoherePrompt and GrokImage each declare exactly one
+# model, so their only choice is necessarily also their default.
+NODE_MODEL_CASES: list[tuple[str, str, str]] = [
+    ("AnthropicPrompt", "gtc_claude_haiku_4_5", "claude-haiku-4-5"),
+    ("CoherePrompt", "cohere_command_r_plus", "command-r-plus"),  # CoherePrompt's only declared model
+    ("GrokPrompt", "xai_grok_3_mini_beta", "grok-3-mini-beta"),
+    ("GroqPrompt", "groq_llama_3_3_70b_versatile", "llama-3.3-70b-versatile"),
+    ("NimPrompt", "nim_gpt_oss_20b", "openai/gpt-oss-20b"),
+    ("GriptapeCloudImage", "gtc_gpt_image_1_5", "gpt-image-1.5"),
+    ("GrokImage", "xai_grok_2_image_1212", "grok-2-image-1212"),  # GrokImage's only declared model
+    ("OpenAiImage", "openai_dall_e_3", "dall-e-3"),
+]
+
+
+def _create_node(node_type: str) -> BaseNode:
+    """Create a node through the library so its metadata carries `library` / `node_type`.
+
+    The engine's model-access query reads those two metadata keys to resolve a
+    node's declared models; a bare `NodeClass(name=...)` construction does not
+    set them and would leave the dropdown undecorated.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return library.create_node(node_type=node_type, name=node_type)
+
+
+def _deny_hook(action: CheckpointAction, subject_id: str) -> AuthorizationHook:
+    """Build a hook that denies one action against one catalog model id, else allows."""
+
+    def hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        if checkpoint.action == action and checkpoint.subject_id == subject_id:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="denied for test"),))
+        return None
+
+    return hook
+
+
+class _FakeCloudModelsResponse:
+    """Stand-in for the `requests.Response` `GriptapeCloudPrompt._list_models` reads."""
+
+    def raise_for_status(self) -> None:
+        return
+
+    def json(self) -> dict[str, list[dict[str, Any]]]:
+        return {"models": [{"model_name": "gpt-4.1-mini", "default": True}]}
+
+
+@pytest.fixture(autouse=True)
+def _stub_griptape_cloud_model_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`GriptapeCloudPrompt.__init__` calls `_list_models`, which hits Griptape Cloud's
+    API over HTTP; stub `requests.get` so constructing the node never depends on network
+    access. The library loader reimports each node's module from its file path, so
+    patching the `GriptapeCloudPrompt` class imported here would miss the module
+    instance the library actually registers; `requests.get` is shared regardless.
+    """
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: _FakeCloudModelsResponse())  # noqa: ARG005
+
+
+@pytest.fixture
+def authorization_hook() -> Iterator[Callable[[AuthorizationHook], None]]:
+    """Register an authorization hook for the test, guaranteed removed afterward."""
+    registered: list[AuthorizationHook] = []
+
+    def register(hook: AuthorizationHook) -> None:
+        GriptapeNodes.EventManager().add_authorization_hook(hook)
+        registered.append(hook)
+
+    try:
+        yield register
+    finally:
+        for hook in registered:
+            GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+
+@pytest.mark.parametrize("node_type", [case[0] for case in NODE_MODEL_CASES])
+def test_model_param_wired_to_model_access_component(node_type: str) -> None:
+    node = cast("BaseDriver", _create_node(node_type))
+
+    assert node._model_access is not None
+    assert isinstance(node._model_access, ModelAccessComponent)
+
+    model_param = node.get_parameter_by_name("model")
+    assert model_param is not None
+    # The component installs the Options dropdown and a refresh Button.
+    assert model_param.find_elements_by_type(Options)
+    assert model_param.find_elements_by_type(Button)
+    # Per-row decoration the frontend uses to flag denied models.
+    ui_options = model_param.ui_options
+    assert ui_options.get("dropdown_row_icons") is True
+    assert ui_options.get("dropdown_row_subtitles") is True
+    assert isinstance(ui_options.get("data"), list)
+    assert ui_options["data"]
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "denied_provider_id"), NODE_MODEL_CASES)
+def test_denied_model_row_carries_denial_icon(
+    node_type: str,
+    denied_catalog_id: str,
+    denied_provider_id: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    # Registered before construction so the component's constructor-time snapshot
+    # already carries the denial, and decorates the row on the first build.
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node = _create_node(node_type)
+
+    model_param = node.get_parameter_by_name("model")
+    assert model_param is not None
+    data = model_param.ui_options["data"]
+    assert data
+
+    for row in data:
+        if row["name"] == denied_provider_id:
+            assert row.get("icon") == "shield-off"
+        else:
+            assert row.get("icon") is None
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "denied_provider_id"), NODE_MODEL_CASES)
+def test_process_raises_when_selected_model_is_denied(
+    node_type: str,
+    denied_catalog_id: str,
+    denied_provider_id: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    """A denied model must not reach a downstream node as a driver.
+
+    Construct the node BEFORE registering the deny hook, so the component's
+    constructor-time snapshot is clean and doesn't relocate the stored value
+    off the about-to-be-denied selection.
+    """
+    node = _create_node(node_type)
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node.set_parameter_value("model", denied_provider_id)
+
+    with pytest.raises(RuntimeError, match="is not permitted"):
+        node.process()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,18 @@ def run_test_in_isolated_env() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
+def stub_griptape_cloud_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Give PublicArtifactUrlParameter a Griptape Cloud credential to find.
+
+    Its constructor resolves a credential and raises if none is found, before it
+    ever reaches the bucket lookup that `stub_public_artifact_bucket_lookup`
+    patches. Unit tests never talk to Griptape Cloud, so the value only needs to
+    be present, not valid.
+    """
+    monkeypatch.setenv("GT_CLOUD_API_KEY", "test-key")
+
+
+@pytest.fixture(autouse=True)
 def stub_public_artifact_bucket_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
     """Prevent PublicArtifactUrlParameter from making HTTP calls to list buckets."""
     monkeypatch.setattr(

--- a/tests/unit/utils/test_model_access.py
+++ b/tests/unit/utils/test_model_access.py
@@ -1,0 +1,163 @@
+"""Unit tests for the library's model-dropdown access wiring.
+
+`ModelAccessComponent` decorates a node's model-selection parameter with an
+`Options` + refresh `Button` trait, per-row entitlement decoration, and
+runtime denial queries against the current selection. These tests stub the
+engine's access query so the decoration it drives, the runtime denial lookup,
+and the `deprecated_values` migration are all exercised against known
+verdicts. The component's own behavior (badges, refresh button, fail-closed
+snapshot) is covered in the engine test suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.retained_mode.events.access_events import (
+    ModelAccessVerdict,
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+# The dropdown stores provider model ids; the catalog keys the engine gates on stay
+# `gtc_*`. Kept deliberately distinct so a test cannot pass by conflating them.
+# `kling-v2-6` is first so that a migration landing on `kling-v3` cannot be
+# confused with `Options` snapping an unknown value to `choices[0]`.
+MODEL_CHOICES = ["kling-v2-6", "kling-v3"]
+CATALOG_ID_BY_CHOICE = {"kling-v3": "gtc_kling_v3", "kling-v2-6": "gtc_kling_v2_6"}
+DENIAL = CheckpointDenial(failures=(CheckpointFailure(detail="Kling v3 is not in your plan."),))
+
+
+class _ModelNode(DataNode):
+    """Minimal node to hang a model parameter off of."""
+
+    def process(self) -> None:
+        return None
+
+
+@pytest.fixture
+def stub_access_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer every access query with `kling-v3` denied and `kling-v2-6` allowed."""
+    original_handle_request = GriptapeNodes.handle_request
+
+    def handle_request(request: RequestPayload, **kwargs: Any) -> ResultPayload:
+        if not isinstance(request, QueryModelAccessForNodeRequest):
+            return original_handle_request(request, **kwargs)
+        choices = MODEL_CHOICES
+        if request.candidate_model_ids is not None:
+            catalog_ids = set(request.candidate_model_ids)
+            choices = [c for c in MODEL_CHOICES if CATALOG_ID_BY_CHOICE[c] in catalog_ids]
+        return QueryModelAccessForNodeResultSuccess(
+            result_details="stubbed access query",
+            verdicts=[
+                ModelAccessVerdict(
+                    model_id=CATALOG_ID_BY_CHOICE[choice],
+                    provider_model_id=choice,
+                    denial=DENIAL if choice == "kling-v3" else None,
+                )
+                for choice in choices
+            ],
+        )
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", handle_request)
+
+
+def _build_node_with_dropdown(*, default_model: str) -> tuple[_ModelNode, Parameter]:
+    node = _ModelNode(name="ModelNode")
+    parameter = Parameter(
+        name="model_name",
+        type="str",
+        default_value=default_model,
+        tooltip="Model to use",
+    )
+    node.add_parameter(parameter)
+    node.set_parameter_value("model_name", default_model)
+    return node, parameter
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_dropdown_access_installs_traits_and_reports_parameter_name() -> None:
+    node, parameter = _build_node_with_dropdown(default_model="kling-v2-6")
+    access = ModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="kling-v2-6",
+    )
+
+    assert parameter.find_elements_by_type(Options)
+    assert parameter.find_elements_by_type(Button)
+    assert access.parameter_name == "model_name"
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_on_value_set_ignores_other_parameters() -> None:
+    """Badge tracking is scoped to the dropdown the component owns."""
+    node, parameter = _build_node_with_dropdown(default_model="kling-v2-6")
+    other = Parameter(name="prompt", type="str", default_value="", tooltip="Prompt")
+    node.add_parameter(other)
+    access = ModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="kling-v2-6",
+    )
+
+    access.on_value_set(other, "kling-v3")
+    assert parameter.get_badge() is None
+
+    access.on_value_set(parameter, "kling-v3")
+    assert parameter.get_badge() is not None
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_selection_denial_and_raise_read_the_current_selection() -> None:
+    node, parameter = _build_node_with_dropdown(default_model="kling-v2-6")
+    access = ModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="kling-v2-6",
+    )
+
+    assert access.selection_denial() is None
+
+    node.set_parameter_value("model_name", "kling-v3")
+    assert access.selected_value == "kling-v3"
+    denial = access.selection_denial()
+    assert denial is not None
+    assert "not in your plan" in denial.reason()
+    with pytest.raises(RuntimeError, match="not permitted"):
+        access.raise_if_selection_denied()
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_deprecated_values_migrate_a_legacy_assignment_to_its_canonical_key() -> None:
+    """A legacy value the parameter stored before this convention migrates on assignment.
+
+    The migration target is deliberately NOT ``choices[0]``: ``Options`` rewrites
+    any value outside ``choices`` to ``choices[0]``, so a target of ``choices[0]``
+    would pass whether the value migrated or was simply snapped.
+    """
+    node, parameter = _build_node_with_dropdown(default_model="kling-v2-6")
+    ModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="kling-v2-6",
+        deprecated_values={"Kling v3": "kling-v3"},
+    )
+
+    node.set_parameter_value("model_name", "Kling v3")
+    assert node.get_parameter_value("model_name") == "kling-v3"


### PR DESCRIPTION
Routes the eight config driver nodes' model dropdowns through the helper from #507.

Part of #432.

<!-- stack map: hand-maintained while `main`'s merge queue keeps the native stack UI unavailable -->
### Stack

Review and merge bottom to top. Trunk: `main`; each PR's base is the branch below it.

1. #507 — feat(access): add license-filtered model dropdown plumbing
2. #509 — feat(access): filter config driver model dropdowns through OFFER_MODEL  ⬅ **this PR**
3. #510 — feat(access): filter proxy model dropdowns through OFFER_MODEL
4. #512 — feat(access): filter video model dropdowns through OFFER_MODEL
5. #517 — feat(access): filter agent and task model dropdowns through OFFER_MODEL
