### PR TITLE
feat(access): filter proxy model dropdowns through OFFER_MODEL

### DIFF
--- a/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
+++ b/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
@@ -23,6 +23,14 @@ __all__ = ["ElevenLabsTextToSpeechGeneration"]
 
 PROMPT_TRUNCATE_LENGTH = 100
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Eleven Multilingual v2": "eleven_multilingual_v2",
+    "Eleven v3": "eleven_v3",
+    "gtc_eleven_multilingual_v2": "eleven_multilingual_v2",
+    "gtc_eleven_v3": "eleven_v3",
+}
+
 # Voice preset mapping - friendly names to Eleven Labs voice IDs (sorted alphabetically)
 VOICE_PRESET_MAP = {  # spellchecker:disable-line
     "Alexandra": "kdmDKE6EkgrWrrykO9Qt",  # spellchecker:disable-line
@@ -64,15 +72,21 @@ class ElevenLabsTextToSpeechGeneration(GriptapeProxyNode):
 
         # INPUTS / PROPERTIES
         # Model Selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="eleven_v3",
-                tooltip="Select the Eleven Labs text-to-speech model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["eleven_multilingual_v2", "eleven_v3"])},
-                ui_options={"display_name": "Model"},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="eleven_v3",
+            tooltip="Select the Eleven Labs text-to-speech model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["eleven_multilingual_v2", "eleven_v3"],
+            default_model="eleven_v3",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Text input
@@ -268,10 +282,6 @@ class ElevenLabsTextToSpeechGeneration(GriptapeProxyNode):
 
         return super().after_value_set(parameter, value)
 
-    def _get_api_model_id(self) -> str:
-        """Get the API model ID for this generation."""
-        return self.get_parameter_value("model") or "eleven_v3"
-
     def _log(self, message: str) -> None:
         with suppress(Exception):
             logger.info(message)
@@ -294,7 +304,7 @@ class ElevenLabsTextToSpeechGeneration(GriptapeProxyNode):
         elif voice_preset:
             voice_id = VOICE_PRESET_MAP.get(voice_preset)
 
-        model = self.get_parameter_value("model") or "eleven_v3"
+        model = self._get_selected_model_id() or "eleven_v3"
         params = {"text": text, "model_id": model}
 
         # Add optional parameters if they have values

--- a/griptape_nodes_library/image/flux_2_image_generation.py
+++ b/griptape_nodes_library/image/flux_2_image_generation.py
@@ -37,16 +37,35 @@ MAX_IMAGE_DIMENSION = 8192  # Any image wider than this will be >4MP anyways
 # Output format options
 OUTPUT_FORMAT_OPTIONS = ["jpeg", "png"]
 
-# Model mapping from user-friendly names to API model IDs
-MODEL_MAPPING = {
-    "Flux.2 [pro]": "flux-2-pro",
+# Model options, in catalog order
+MODEL_OPTIONS = [
+    "flux-2-pro",
+    "flux-2-flex",
+    "flux-2-max",
+    "flux-2-klein-4b",
+    "flux-2-klein-9b",
+]
+DEFAULT_MODEL = MODEL_OPTIONS[0]
+
+# Migrates values saved before this dropdown stored the provider's own model id (friendly
+# labels and catalog keys alike).
+LEGACY_MODEL_VALUES = {
+    "FLUX.2 [flex]": "flux-2-flex",
+    "FLUX.2 [klein] 4B": "flux-2-klein-4b",
+    "FLUX.2 [klein] 9B": "flux-2-klein-9b",
+    "FLUX.2 [max]": "flux-2-max",
+    "FLUX.2 [pro]": "flux-2-pro",
     "Flux.2 [flex]": "flux-2-flex",
-    "Flux.2 [max]": "flux-2-max",
     "Flux.2 [klein] 4B": "flux-2-klein-4b",
     "Flux.2 [klein] 9B": "flux-2-klein-9b",
+    "Flux.2 [max]": "flux-2-max",
+    "Flux.2 [pro]": "flux-2-pro",
+    "gtc_flux_2_flex": "flux-2-flex",
+    "gtc_flux_2_klein_4b": "flux-2-klein-4b",
+    "gtc_flux_2_klein_9b": "flux-2-klein-9b",
+    "gtc_flux_2_max": "flux-2-max",
+    "gtc_flux_2_pro": "flux-2-pro",
 }
-MODEL_OPTIONS = list(MODEL_MAPPING.keys())
-DEFAULT_MODEL = MODEL_OPTIONS[0]
 
 # Safety tolerance options
 SAFETY_TOLERANCE_OPTIONS = ["least restrictive", "moderate", "most restrictive"]
@@ -89,14 +108,20 @@ class Flux2ImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Flux models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Select the Flux model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Select the Flux model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Core parameters
@@ -261,27 +286,15 @@ class Flux2ImageGeneration(GriptapeProxyNode):
                 self.set_parameter_value("input_images", updated_list)
 
         if parameter.name == "model":
-            # Map friendly name to API model ID
-            model_value = str(value) if value is not None else ""
-            api_model_id = MODEL_MAPPING.get(model_value, model_value)
+            # The provider's own model id decides whether flex-only fields (steps,
+            # guidance) apply.
+            api_model_id = self._get_selected_model_id()
             if api_model_id == "flux-2-flex":
                 self.show_parameter_by_name("steps")
                 self.show_parameter_by_name("guidance")
             else:
                 self.hide_parameter_by_name("steps")
                 self.hide_parameter_by_name("guidance")
-
-    def _get_api_model_id(self) -> str:
-        """Get the API model ID for this generation.
-
-        Maps friendly model names to API model IDs.
-
-        Returns:
-            str: The API model ID to use in the API request
-        """
-        model = self.get_parameter_value("model") or DEFAULT_MODEL
-        model_str = str(model) if model is not None else DEFAULT_MODEL
-        return MODEL_MAPPING.get(model_str, model_str)
 
     def _parse_safety_tolerance(self, value: str | None) -> int:
         """Parse safety tolerance integer from preset string value.
@@ -363,7 +376,7 @@ class Flux2ImageGeneration(GriptapeProxyNode):
         }
 
         # Add steps and guidance for flex model
-        api_model_id = self._get_api_model_id()
+        api_model_id = self._get_selected_model_id()
         if api_model_id == "flux-2-flex":
             payload["steps"] = self.get_parameter_value("steps") or MAX_STEPS_FLEX
             payload["guidance"] = self.get_parameter_value("guidance") or DEFAULT_GUIDANCE_FLEX

--- a/griptape_nodes_library/image/flux_image_generation.py
+++ b/griptape_nodes_library/image/flux_image_generation.py
@@ -39,6 +39,12 @@ OUTPUT_FORMAT_OPTIONS = ["jpeg", "png"]
 # Model options
 MODEL_OPTIONS = ["flux-kontext-pro"]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "FLUX Kontext Pro": "flux-kontext-pro",
+    "gtc_flux_kontext_pro": "flux-kontext-pro",
+}
+
 # Safety tolerance options
 SAFETY_TOLERANCE_OPTIONS = ["least restrictive", "moderate", "most restrictive"]
 
@@ -83,14 +89,20 @@ class FluxImageGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate images using Flux models via API (supports user-provided API keys via proxy)"
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="flux-kontext-pro",
-                tooltip="Select the Flux model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="flux-kontext-pro",
+            tooltip="Select the Flux model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="flux-kontext-pro",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Core parameters
@@ -258,9 +270,6 @@ class FluxImageGeneration(GriptapeProxyNode):
 
     def preprocess(self) -> None:
         self._seed_parameter.preprocess()
-
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or "flux-kontext-pro"
 
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()

--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -44,25 +44,25 @@ class GoogleImageGeneration(GriptapeProxyNode):
 
     SERVICE_NAME = "Griptape"
     API_KEY_NAME = "GT_CLOUD_API_KEY"
-    DEFAULT_MODEL: ClassVar[str] = "Nano Banana Pro"
-    SUPPORTED_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
-        "Nano Banana Pro": "gemini-3-pro-image",
+    DEFAULT_MODEL: ClassVar[str] = "gemini-3-pro-image"
+    MODEL_OPTIONS: ClassVar[list[str]] = ["gemini-3-pro-image", "gemini-3.1-flash-image"]
+    # Migrates values saved before this dropdown stored the provider's own model id
+    # (friendly labels and catalog keys alike).
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Nano Banana 2": "gemini-3.1-flash-image",
-    }
-    DEPRECATED_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
+        "Nano Banana Pro": "gemini-3-pro-image",
+        "gtc_gemini_3_1_flash_image": "gemini-3.1-flash-image",
+        "gtc_gemini_3_pro_image": "gemini-3-pro-image",
+        # Folded in from this node's own retired DEPRECATED_MODELS_TO_API_MODELS dict.
         "nano-banana-3-pro": "gemini-3-pro-image",
     }
-    ALL_MODELS_TO_API_MODELS: ClassVar[dict[str, str]] = {
-        **SUPPORTED_MODELS_TO_API_MODELS,
-        **DEPRECATED_MODELS_TO_API_MODELS,
-    }
     IMAGE_SIZE_OPTIONS: ClassVar[dict[str, list[str]]] = {
-        "Nano Banana Pro": ["1K", "2K", "4K"],
-        "Nano Banana 2": ["512", "1K", "2K", "4K"],
+        "gemini-3-pro-image": ["1K", "2K", "4K"],
+        "gemini-3.1-flash-image": ["512", "1K", "2K", "4K"],
     }
     ASPECT_RATIO_OPTIONS: ClassVar[dict[str, list[str]]] = {
-        "Nano Banana Pro": ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
-        "Nano Banana 2": [
+        "gemini-3-pro-image": ["1:1", "3:2", "2:3", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"],
+        "gemini-3.1-flash-image": [
             "1:1",
             "1:4",
             "1:8",
@@ -86,21 +86,23 @@ class GoogleImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Google Gemini models via Griptape Cloud model proxy"
 
         # Model ID
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=self.DEFAULT_MODEL,
-                tooltip="Model id to call via proxy",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "Model",
-                },
-                traits={
-                    Options(
-                        choices=list(self.SUPPORTED_MODELS_TO_API_MODELS.keys()),
-                    )
-                },
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=self.DEFAULT_MODEL,
+            tooltip="Model id to call via proxy",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "Model",
+            },
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=self.MODEL_OPTIONS,
+            default_model=self.DEFAULT_MODEL,
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         # Prompt
@@ -300,7 +302,7 @@ class GoogleImageGeneration(GriptapeProxyNode):
             self._update_option_choices("aspect_ratio", new_ratios, default_ratio)
 
             # Show Google Image Search only for Nano Banana 2
-            if value == "Nano Banana 2":
+            if value == "gemini-3.1-flash-image":
                 self.show_parameter_by_name("use_google_image_search")
             else:
                 self.hide_parameter_by_name("use_google_image_search")
@@ -379,7 +381,7 @@ class GoogleImageGeneration(GriptapeProxyNode):
                 parts.append({"inlineData": {"mimeType": mime_type, "data": image_data}})
 
         payload = {
-            "model": self.ALL_MODELS_TO_API_MODELS.get(self.get_parameter_value("model")),
+            "model": self._get_selected_model_id(),
             "contents": [{"parts": parts}],
             "generationConfig": {
                 "responseModalities": ["TEXT", "IMAGE"],
@@ -399,10 +401,6 @@ class GoogleImageGeneration(GriptapeProxyNode):
             payload["tools"] = [{"google_search": {}}]
 
         return payload
-
-    def _get_api_model_id(self) -> str:
-        model = self.get_parameter_value("model")
-        return self.ALL_MODELS_TO_API_MODELS.get(model) or ""
 
     async def _build_payload(self) -> dict[str, Any]:
         return await self._get_parameters()

--- a/griptape_nodes_library/image/grok_image_edit.py
+++ b/griptape_nodes_library/image/grok_image_edit.py
@@ -41,29 +41,41 @@ class GrokImageEdit(GriptapeProxyNode):
         - result_details (str): Details about the generation result or error
     """
 
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Grok Imagine Image": "grok-imagine-image",
-    }
-
     MIN_IMAGES: ClassVar[int] = 1
     MAX_IMAGES: ClassVar[int] = 10
     QUALITY_OPTIONS: ClassVar[list[str]] = ["low", "medium", "high"]
 
     RESOLUTION_OPTIONS: ClassVar[list[str]] = ["1k", "2k"]
 
+    # Migrates values saved before this dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "Grok Imagine Image": "grok-imagine-image",
+        "gtc_grok_imagine_image": "grok-imagine-image",
+        # Folded in from GrokImageGeneration's retired DEPRECATED_MODELS dict; this
+        # node's own removed _supports_quality check compared against the same value.
+        "Grok 2 Image": "grok-imagine-image",
+        "grok-2-image-1212": "grok-imagine-image",
+    }
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Edit images using Grok image models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Image",
-                tooltip="Select the Grok image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Image"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="grok-imagine-image",
+            tooltip="Select the Grok image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["grok-imagine-image"],
+            default_model="grok-imagine-image",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -152,26 +164,6 @@ class GrokImageEdit(GriptapeProxyNode):
             result_details_placeholder="Editing status and details will appear here.",
             parameter_group_initially_collapsed=True,
         )
-        self._initialize_parameter_visibility()
-
-    def _initialize_parameter_visibility(self) -> None:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Image"
-        if self._supports_quality(model_name):
-            self.show_parameter_by_name("quality")
-        else:
-            self.hide_parameter_by_name("quality")
-
-    @staticmethod
-    def _supports_quality(model_name: str) -> bool:
-        return model_name != "Grok 2 Image"
-
-    def after_value_set(self, parameter: Any, value: Any) -> None:
-        if parameter.name == "model":
-            if self._supports_quality(value):
-                self.show_parameter_by_name("quality")
-            else:
-                self.hide_parameter_by_name("quality")
-        return super().after_value_set(parameter, value)
 
     @staticmethod
     def _has_media_value(value: Any) -> bool:
@@ -223,18 +215,9 @@ class GrokImageEdit(GriptapeProxyNode):
                 self.hide_parameter_by_name(param_name)
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Image"
-        base_model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{base_model_id}:edit"
-
-    def _get_payload_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Image"
-        return self.MODEL_NAME_MAP.get(model_name, model_name)
-
-    def _get_catalog_model_id(self) -> str:
-        # The catalog declares the bare provider id (no `:edit` suffix), so
-        # resolve the declaration against the un-suffixed id.
-        return self._get_payload_model_id()
+        # Decorate the resolved provider id with the URL-path operation suffix the
+        # proxy expects; the catalog declares the bare id (see _get_catalog_model_id).
+        return f"{self._get_selected_model_id()}:edit"
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = super().validate_before_node_run() or []
@@ -257,18 +240,17 @@ class GrokImageEdit(GriptapeProxyNode):
         prompt = (self.get_parameter_value("prompt") or "").strip()
         n_value = int(self.get_parameter_value("n") or 1)
         resolution = self.get_parameter_value("resolution") or "1k"
-        api_model_id = self._get_payload_model_id()
+        api_model_id = self._get_selected_model_id()
         image_data_uri = await self._prepare_image_data_uri(self.get_parameter_value("image"))
 
         payload: dict[str, Any] = {
             "model": api_model_id,
             "prompt": prompt,
             "n": n_value,
+            "quality": self.get_parameter_value("quality") or "medium",
             "resolution": resolution,
             "response_format": "url",
         }
-        if self._supports_quality(self.get_parameter_value("model") or "Grok Imagine Image"):
-            payload["quality"] = self.get_parameter_value("quality") or "medium"
 
         if image_data_uri:
             payload["image"] = {"url": image_data_uri}

--- a/griptape_nodes_library/image/grok_image_generation.py
+++ b/griptape_nodes_library/image/grok_image_generation.py
@@ -5,14 +5,13 @@ from contextlib import suppress
 from typing import Any, ClassVar
 
 from griptape.artifacts import ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File
-from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
@@ -20,13 +19,6 @@ from griptape_nodes_library.proxy import GriptapeProxyNode
 logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["GrokImageGeneration"]
-
-# Deprecated models and their replacements (covers both friendly names and raw provider IDs
-# so saved workflows in either format are migrated)
-DEPRECATED_MODELS = {
-    "Grok 2 Image": "Grok Imagine Image",
-    "grok-2-image-1212": "Grok Imagine Image",
-}
 
 
 class GrokImageGeneration(GriptapeProxyNode):
@@ -48,10 +40,6 @@ class GrokImageGeneration(GriptapeProxyNode):
         - was_successful (bool): Whether the generation succeeded
         - result_details (str): Details about the generation result or error
     """
-
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Grok Imagine Image": "grok-imagine-image",
-    }
 
     MIN_IMAGES: ClassVar[int] = 1
     MAX_IMAGES: ClassVar[int] = 10
@@ -76,36 +64,34 @@ class GrokImageGeneration(GriptapeProxyNode):
 
     RESOLUTION_OPTIONS: ClassVar[list[str]] = ["1k", "2k"]
 
+    # Migrates values saved before this dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "Grok Imagine Image": "grok-imagine-image",
+        "gtc_grok_imagine_image": "grok-imagine-image",
+        # Folded in from this node's own retired DEPRECATED_MODELS dict.
+        "Grok 2 Image": "grok-imagine-image",
+        "grok-2-image-1212": "grok-imagine-image",
+    }
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate images using Grok image models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Image",
-                tooltip="Select the Grok image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Image"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="grok-imagine-image",
+            tooltip="Select the Grok image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
         )
-
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecation Notice",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["grok-imagine-image"],
+            default_model="grok-imagine-image",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -194,24 +180,6 @@ class GrokImageGeneration(GriptapeProxyNode):
             parameter_group_initially_collapsed=True,
         )
 
-    def before_value_set(self, parameter: Parameter, value: Any) -> Any:
-        """Migrate deprecated model selections to their replacement."""
-        if parameter.name == "model" and isinstance(value, str) and value in DEPRECATED_MODELS:
-            replacement = DEPRECATED_MODELS[value]
-            message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-            if message is None:
-                raise RuntimeError("model_deprecation_notice message element not found")  # noqa: TRY003, EM101
-            message.value = (
-                f"The '{value}' model has been deprecated. The model has been updated to '{replacement}'. "
-                "Please save your workflow to apply this change."
-            )
-            self.show_message_by_name("model_deprecation_notice")
-            value = replacement
-        elif parameter.name == "model" and isinstance(value, str):
-            self.hide_message_by_name("model_deprecation_notice")
-
-        return super().before_value_set(parameter, value)
-
     def _show_image_output_parameters(self, count: int) -> None:
         for i in range(1, 11):
             param_name = "image_url" if i == 1 else f"image_url_{i}"
@@ -221,18 +189,9 @@ class GrokImageGeneration(GriptapeProxyNode):
                 self.hide_parameter_by_name(param_name)
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Image"
-        base_model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{base_model_id}:generate"
-
-    def _get_payload_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Image"
-        return self.MODEL_NAME_MAP.get(model_name, model_name)
-
-    def _get_catalog_model_id(self) -> str:
-        # The catalog declares the bare provider id (no `:generate` suffix), so
-        # resolve the declaration against the un-suffixed id.
-        return self._get_payload_model_id()
+        # Decorate the resolved provider id with the URL-path operation suffix the
+        # proxy expects; the catalog declares the bare id (see _get_catalog_model_id).
+        return f"{self._get_selected_model_id()}:generate"
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = super().validate_before_node_run() or []
@@ -252,7 +211,7 @@ class GrokImageGeneration(GriptapeProxyNode):
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "1:1"
         n_value = int(self.get_parameter_value("n") or 1)
         resolution = self.get_parameter_value("resolution") or "1k"
-        api_model_id = self._get_payload_model_id()
+        api_model_id = self._get_selected_model_id()
 
         payload: dict[str, Any] = {
             "model": api_model_id,

--- a/griptape_nodes_library/image/openai_image_generation.py
+++ b/griptape_nodes_library/image/openai_image_generation.py
@@ -26,22 +26,24 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["OpenAiImageGeneration"]
 
-GPT_IMAGE_1_MODEL_ID = "gpt-image-1"
-GPT_IMAGE_1_5_MODEL_ID = "gpt-image-1.5"
-GPT_IMAGE_2_MODEL_ID = "gpt-image-2"
-
-GPT_IMAGE_1_MODEL_NAME = "GPT Image 1"
-GPT_IMAGE_1_5_MODEL_NAME = "GPT Image 1.5"
-GPT_IMAGE_2_MODEL_NAME = "GPT Image 2"
+GPT_IMAGE_1_MODEL_KEY = "gpt-image-1"
+GPT_IMAGE_1_5_MODEL_KEY = "gpt-image-1.5"
+GPT_IMAGE_2_MODEL_KEY = "gpt-image-2"
+MODEL_CHOICES = [GPT_IMAGE_1_MODEL_KEY, GPT_IMAGE_1_5_MODEL_KEY, GPT_IMAGE_2_MODEL_KEY]
 
 
 class OpenAiImageGeneration(GriptapeProxyNode):
     """Generate images using OpenAI GPT Image models via Griptape model proxy."""
 
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        GPT_IMAGE_1_MODEL_NAME: GPT_IMAGE_1_MODEL_ID,
-        GPT_IMAGE_1_5_MODEL_NAME: GPT_IMAGE_1_5_MODEL_ID,
-        GPT_IMAGE_2_MODEL_NAME: GPT_IMAGE_2_MODEL_ID,
+    # Migrates values saved before this dropdown stored the provider's own model id
+    # (friendly labels and catalog keys alike).
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "GPT Image 1": GPT_IMAGE_1_MODEL_KEY,
+        "GPT Image 1.5": GPT_IMAGE_1_5_MODEL_KEY,
+        "GPT Image 2": GPT_IMAGE_2_MODEL_KEY,
+        "gtc_gpt_image_1": GPT_IMAGE_1_MODEL_KEY,
+        "gtc_gpt_image_1_5": GPT_IMAGE_1_5_MODEL_KEY,
+        "gtc_gpt_image_2": GPT_IMAGE_2_MODEL_KEY,
     }
     GPT_IMAGE_SIZE_OPTIONS: ClassVar[list[str]] = ["1024x1024", "1024x1536", "1536x1024"]
     GPT_IMAGE_2_CUSTOM_SIZE: ClassVar[str] = "custom"
@@ -64,22 +66,22 @@ class OpenAiImageGeneration(GriptapeProxyNode):
     # Only gpt-image-1 supports transparent backgrounds; gpt-image-1.5 and gpt-image-2 reject
     # background="transparent" at the API level.
     BACKGROUND_OPTIONS_BY_MODEL: ClassVar[dict[str, list[str]]] = {
-        GPT_IMAGE_1_MODEL_NAME: ["auto", "opaque", "transparent"],
-        GPT_IMAGE_1_5_MODEL_NAME: ["auto", "opaque"],
-        GPT_IMAGE_2_MODEL_NAME: ["auto", "opaque"],
+        GPT_IMAGE_1_MODEL_KEY: ["auto", "opaque", "transparent"],
+        GPT_IMAGE_1_5_MODEL_KEY: ["auto", "opaque"],
+        GPT_IMAGE_2_MODEL_KEY: ["auto", "opaque"],
     }
     MODERATION_OPTIONS: ClassVar[list[str]] = ["auto", "low"]
     OUTPUT_FORMAT_OPTIONS: ClassVar[list[str]] = ["png", "jpeg", "webp"]
     MAX_REFERENCE_IMAGES: ClassVar[int] = 16
     MAX_REFERENCE_IMAGES_BY_MODEL: ClassVar[dict[str, int]] = {
-        GPT_IMAGE_1_MODEL_NAME: MAX_REFERENCE_IMAGES,
-        GPT_IMAGE_1_5_MODEL_NAME: MAX_REFERENCE_IMAGES,
-        GPT_IMAGE_2_MODEL_NAME: MAX_REFERENCE_IMAGES,
+        GPT_IMAGE_1_MODEL_KEY: MAX_REFERENCE_IMAGES,
+        GPT_IMAGE_1_5_MODEL_KEY: MAX_REFERENCE_IMAGES,
+        GPT_IMAGE_2_MODEL_KEY: MAX_REFERENCE_IMAGES,
     }
     MIN_IMAGES: ClassVar[int] = 1
     MAX_IMAGES: ClassVar[int] = 10
     MAX_PROMPT_LENGTH: ClassVar[int] = 32_000
-    DEFAULT_MODEL: ClassVar[str] = GPT_IMAGE_2_MODEL_NAME
+    DEFAULT_MODEL: ClassVar[str] = GPT_IMAGE_2_MODEL_KEY
     DEFAULT_OUTPUT_FORMAT: ClassVar[str] = "png"
     DEFAULT_OUTPUT_FILENAME_BASE: ClassVar[str] = "openai_image"
     DEFAULT_INPUT_IMAGE_MIME_TYPE: ClassVar[str] = "image/png"
@@ -99,14 +101,20 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         # PublicArtifactUrlParameter tracked here so it can be cleaned up after the run.
         self._pending_reference_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=self.DEFAULT_MODEL,
-                tooltip="Select the OpenAI image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=list(self.MODEL_NAME_MAP.keys()))},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=self.DEFAULT_MODEL,
+            tooltip="Select the OpenAI image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_CHOICES,
+            default_model=self.DEFAULT_MODEL,
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -278,20 +286,13 @@ class OpenAiImageGeneration(GriptapeProxyNode):
 
     @classmethod
     def _size_choices_for_model(cls, model_name: str) -> list[str]:
-        if model_name == GPT_IMAGE_2_MODEL_NAME:
+        if model_name == GPT_IMAGE_2_MODEL_KEY:
             return list(cls.GPT_IMAGE_2_SIZE_OPTIONS)
         return list(cls.GPT_IMAGE_SIZE_OPTIONS)
 
     @classmethod
     def _background_choices_for_model(cls, model_name: str) -> list[str]:
         return list(cls.BACKGROUND_OPTIONS_BY_MODEL.get(model_name, cls.BACKGROUND_OPTIONS))
-
-    def _get_payload_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or self.DEFAULT_MODEL
-        return self.MODEL_NAME_MAP[model_name]
-
-    def _get_api_model_id(self) -> str:
-        return self._get_payload_model_id()
 
     def _show_image_output_parameters(self, count: int) -> None:
         for i in range(1, self.MAX_IMAGES + 1):
@@ -319,7 +320,7 @@ class OpenAiImageGeneration(GriptapeProxyNode):
             return
 
         # GPT Image 2 accepts any in-range WIDTHxHEIGHT, so don't clobber a custom size.
-        if model_name == GPT_IMAGE_2_MODEL_NAME and isinstance(current_size, str):
+        if model_name == GPT_IMAGE_2_MODEL_KEY and isinstance(current_size, str):
             match = self.GPT_IMAGE_2_SIZE_PATTERN.fullmatch(current_size.strip())
             if match is not None and not self._validate_gpt_image_2_size(current_size.strip()):
                 self._sync_custom_size_visibility(model_name, current_size)
@@ -349,7 +350,7 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         self.publish_update_to_parameter("background", choices[0])
 
     def _sync_custom_size_visibility(self, model_name: str, size_value: Any) -> None:
-        show_custom = model_name == GPT_IMAGE_2_MODEL_NAME and size_value == self.GPT_IMAGE_2_CUSTOM_SIZE
+        show_custom = model_name == GPT_IMAGE_2_MODEL_KEY and size_value == self.GPT_IMAGE_2_CUSTOM_SIZE
         for param_name in ("custom_width", "custom_height"):
             if show_custom:
                 self.show_parameter_by_name(param_name)
@@ -468,12 +469,11 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         size = self._resolve_effective_size()
         if not size:
             exceptions.append(ValueError(f"{self.name}: Size is required for image generation."))
-        elif (
-            model_name in {GPT_IMAGE_1_MODEL_NAME, GPT_IMAGE_1_5_MODEL_NAME} and size not in self.GPT_IMAGE_SIZE_OPTIONS
-        ):
+        elif model_name in {GPT_IMAGE_1_MODEL_KEY, GPT_IMAGE_1_5_MODEL_KEY} and size not in self.GPT_IMAGE_SIZE_OPTIONS:
             valid_sizes = ", ".join(self.GPT_IMAGE_SIZE_OPTIONS)
-            exceptions.append(ValueError(f"{self.name}: {model_name} size must be one of: {valid_sizes}."))
-        elif model_name == GPT_IMAGE_2_MODEL_NAME:
+            display_name = "GPT Image 1" if model_name == GPT_IMAGE_1_MODEL_KEY else "GPT Image 1.5"
+            exceptions.append(ValueError(f"{self.name}: {display_name} size must be one of: {valid_sizes}."))
+        elif model_name == GPT_IMAGE_2_MODEL_KEY:
             exceptions.extend(self._validate_gpt_image_2_size(size))
 
         input_images = self._get_input_images_value()
@@ -481,7 +481,7 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         if len(input_images) > max_reference_images:
             exceptions.append(
                 ValueError(
-                    f"{self.name}: {model_name} supports up to {max_reference_images} reference images; "
+                    f"{self.name}: this model supports up to {max_reference_images} reference images; "
                     f"received {len(input_images)}."
                 )
             )
@@ -520,7 +520,7 @@ class OpenAiImageGeneration(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
-            "model": self._get_payload_model_id(),
+            "model": self._get_selected_model_id(),
             "prompt": (self.get_parameter_value("prompt") or "").strip(),
             "size": self._resolve_effective_size(),
             "n": int(self.get_parameter_value("n") or 1),

--- a/griptape_nodes_library/image/qwen_image_edit.py
+++ b/griptape_nodes_library/image/qwen_image_edit.py
@@ -16,7 +16,6 @@ from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_list
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
@@ -35,6 +34,16 @@ MODEL_OPTIONS = [
     "qwen-image-edit-plus",
     "qwen-image-edit-plus-2025-10-30",
 ]
+
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Qwen Image Edit": "qwen-image-edit",
+    "Qwen Image Edit Plus": "qwen-image-edit-plus",
+    "Qwen Image Edit Plus (2025-10-30)": "qwen-image-edit-plus-2025-10-30",
+    "gtc_qwen_image_edit": "qwen-image-edit",
+    "gtc_qwen_image_edit_plus": "qwen-image-edit-plus",
+    "gtc_qwen_image_edit_plus_2025_10_30": "qwen-image-edit-plus-2025-10-30",
+}
 
 # Response status constants
 STATUS_FAILED = "Failed"
@@ -87,14 +96,20 @@ class QwenImageEdit(GriptapeProxyNode):
         self.description = "Edit images using Qwen image editing models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="qwen-image-edit-plus",
-                tooltip="Select the Qwen image editing model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="qwen-image-edit-plus",
+            tooltip="Select the Qwen image editing model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="qwen-image-edit-plus",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Editing instruction parameter
@@ -247,9 +262,6 @@ class QwenImageEdit(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()
 
@@ -268,7 +280,7 @@ class QwenImageEdit(GriptapeProxyNode):
 
         # Flatten structure - parameters should be at top level for MultiModalConversation.call()
         payload = {
-            "model": params["model"],
+            "model": self._get_selected_model_id(),
             "messages": [{"role": "user", "content": content}],
             "n": params["num_images"],
             "watermark": params["watermark"],

--- a/griptape_nodes_library/image/qwen_image_generation.py
+++ b/griptape_nodes_library/image/qwen_image_generation.py
@@ -34,6 +34,14 @@ SIZE_OPTIONS = ["1328*1328", "1664*928", "1472*1140", "1140*1472", "928*1664"]
 # Model options
 MODEL_OPTIONS = ["qwen-image", "qwen-image-plus"]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Qwen Image": "qwen-image",
+    "Qwen Image Plus": "qwen-image-plus",
+    "gtc_qwen_image": "qwen-image",
+    "gtc_qwen_image_plus": "qwen-image-plus",
+}
+
 # Response status constants
 STATUS_FAILED = "Failed"
 STATUS_ERROR = "Error"
@@ -73,16 +81,22 @@ class QwenImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Qwen models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            Parameter(
-                name="model",
-                input_types=["str"],
-                type="str",
-                default_value="qwen-image",
-                tooltip="Select the Qwen model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = Parameter(
+            name="model",
+            input_types=["str"],
+            type="str",
+            default_value="qwen-image",
+            tooltip="Select the Qwen model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="qwen-image",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Core parameters
@@ -187,9 +201,6 @@ class QwenImageGeneration(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()
 
@@ -198,7 +209,7 @@ class QwenImageGeneration(GriptapeProxyNode):
 
         # Flatten structure - parameters should be at top level for MultiModalConversation.call()
         payload = {
-            "model": params["model"],
+            "model": self._get_selected_model_id(),
             "messages": [{"role": "user", "content": content}],
             "size": params["size"],
             "prompt_extend": params["prompt_upsampling"],

--- a/griptape_nodes_library/image/seedream_image_generation.py
+++ b/griptape_nodes_library/image/seedream_image_generation.py
@@ -13,7 +13,6 @@ from griptape_nodes.exe_types.core_types import (
     Parameter,
     ParameterGroup,
     ParameterList,
-    ParameterMessage,
     ParameterMode,
 )
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
@@ -22,7 +21,6 @@ from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_list
 from PIL import Image
@@ -36,16 +34,9 @@ __all__ = ["SeedreamImageGeneration"]
 # Define constant for prompt truncation length
 PROMPT_TRUNCATE_LENGTH = 100
 
-# Model mapping from user-facing names to API model IDs
-MODEL_NAME_MAP = {
-    "Seedream 5.0 Lite": "seedream-5-0-260128",
-    "Seedream 4.5": "seedream-4-5-251128",
-    "Seedream 4.0": "seedream-4-0-250828",
-}
-
-# Size options for different models (using friendly names)
+# Size options for different models, keyed by the provider's own model id
 SIZE_OPTIONS = {
-    "Seedream 5.0 Lite": [
+    "seedream-5-0-260128": [
         "2K",
         "3K",
         "2048x2048",
@@ -65,7 +56,7 @@ SIZE_OPTIONS = {
         "3744x2496",
         "4704x2016",
     ],
-    "Seedream 4.5": [
+    "seedream-4-5-251128": [
         "2K",
         "4K",
         "2560x1440",
@@ -76,7 +67,7 @@ SIZE_OPTIONS = {
         "2160x4096",
         "4096x4096",
     ],
-    "Seedream 4.0": [
+    "seedream-4-0-250828": [
         "1K",
         "2K",
         "4K",
@@ -91,20 +82,29 @@ SIZE_OPTIONS = {
     ],
 }
 
-# Maximum number of input images for models that support multiple images (using friendly names)
+# Maximum number of input images for models that support multiple images, keyed by the provider's own model id
 MAX_IMAGES_PER_MODEL = {
-    "Seedream 5.0 Lite": 14,
-    "Seedream 4.5": 14,
-    "Seedream 4.0": 10,
+    "seedream-5-0-260128": 14,
+    "seedream-4-5-251128": 14,
+    "seedream-4-0-250828": 10,
 }
 
-# Deprecated models and their replacements (covers both friendly names and raw provider IDs
-# so saved workflows in either format are migrated)
-DEPRECATED_MODELS = {
-    "Seedream 3.0 T2I": "Seedream 5.0 Lite",
-    "seedream-3-0-t2i-250415": "Seedream 5.0 Lite",
-    "Seedream 3.0 I2I": "Seedream 4.0",
-    "seededit-3-0-i2i-250628": "Seedream 4.0",
+# Migrates values saved before this dropdown stored the provider's own model id (friendly
+# labels and catalog keys alike).
+LEGACY_MODEL_VALUES = {
+    "Seedream 4.0": "seedream-4-0-250828",
+    "Seedream 4.5": "seedream-4-5-251128",
+    "Seedream 5.0 Lite": "seedream-5-0-260128",
+    "gtc_seedream_4_0": "seedream-4-0-250828",
+    "gtc_seedream_4_5": "seedream-4-5-251128",
+    "gtc_seedream_5_0_lite": "seedream-5-0-260128",
+    # Folded in from this node's own retired DEPRECATED_MODELS dict.
+    "Seedream 3.0 T2I": "seedream-5-0-260128",
+    "seedream-3-0-t2i-250415": "seedream-5-0-260128",
+    "Seedream 3.0 I2I": "seedream-4-0-250828",
+    "seededit-3-0-i2i-250628": "seedream-4-0-250828",
+    # Found stored in a shipped workflow template; never appeared in DEPRECATED_MODELS.
+    "seedream-4.5": "seedream-4-5-251128",
 }
 
 
@@ -146,39 +146,24 @@ class SeedreamImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Seedream models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Seedream 4.5",
-                tooltip="Select the Seedream model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={
-                    Options(
-                        choices=[
-                            "Seedream 5.0 Lite",
-                            "Seedream 4.5",
-                            "Seedream 4.0",
-                        ]
-                    )
-                },
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="seedream-4-5-251128",
+            tooltip="Select the Seedream model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
         )
-
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecation Notice",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=[
+                "seedream-5-0-260128",
+                "seedream-4-5-251128",
+                "seedream-4-0-250828",
+            ],
+            default_model="seedream-4-5-251128",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Core parameters
@@ -222,7 +207,7 @@ class SeedreamImageGeneration(GriptapeProxyNode):
                 default_value="2K",
                 tooltip="Image size specification",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=SIZE_OPTIONS["Seedream 4.5"])},
+                traits={Options(choices=SIZE_OPTIONS["seedream-4-5-251128"])},
             )
         )
 
@@ -319,35 +304,17 @@ class SeedreamImageGeneration(GriptapeProxyNode):
 
     def _initialize_parameter_visibility(self) -> None:
         """Initialize parameter visibility based on default model selection."""
-        default_model = self.get_parameter_value("model") or "Seedream 4.5"
+        default_model = self.get_parameter_value("model") or "seedream-4-5-251128"
         # Show output_format only for Seedream 5.0 Lite
-        if default_model == "Seedream 5.0 Lite":
+        if default_model == "seedream-5-0-260128":
             self.show_parameter_by_name("output_format")
             self.show_parameter_by_name("optimize_prompt_mode")
-        elif default_model == "Seedream 4.0":
+        elif default_model == "seedream-4-0-250828":
             self.hide_parameter_by_name("output_format")
             self.show_parameter_by_name("optimize_prompt_mode")
-        else:  # Seedream 4.5
+        else:  # seedream-4-5-251128
             self.hide_parameter_by_name("output_format")
             self.hide_parameter_by_name("optimize_prompt_mode")
-
-    def before_value_set(self, parameter: Parameter, value: Any) -> Any:
-        """Migrate deprecated model selections to their replacement."""
-        if parameter.name == "model" and isinstance(value, str) and value in DEPRECATED_MODELS:
-            replacement = DEPRECATED_MODELS[value]
-            message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-            if message is None:
-                raise RuntimeError("model_deprecation_notice message element not found")  # noqa: TRY003, EM101
-            message.value = (
-                f"The '{value}' model has been deprecated. The model has been updated to '{replacement}'. "
-                "Please save your workflow to apply this change."
-            )
-            self.show_message_by_name("model_deprecation_notice")
-            value = replacement
-        elif parameter.name == "model" and isinstance(value, str):
-            self.hide_message_by_name("model_deprecation_notice")
-
-        return super().before_value_set(parameter, value)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Update size options and parameter visibility based on parameter changes."""
@@ -362,34 +329,26 @@ class SeedreamImageGeneration(GriptapeProxyNode):
 
         return super().after_value_set(parameter, value)
 
-    def _get_api_model_id(self) -> str:
-        """Get the API model ID for this generation.
-
-        Converts friendly model name to API model ID.
-        """
-        model = self.get_parameter_value("model") or "Seedream 4.5"
-        return MODEL_NAME_MAP.get(model, model)
-
     def _update_model_parameters(self, model: str) -> None:
         """Update parameters and UI based on selected model."""
         new_choices = SIZE_OPTIONS[model]
         current_size = self.get_parameter_value("size")
 
         # Show output_format only for Seedream 5.0 Lite
-        if model == "Seedream 5.0 Lite":
+        if model == "seedream-5-0-260128":
             self.show_parameter_by_name("output_format")
             self.show_parameter_by_name("optimize_prompt_mode")
-        elif model == "Seedream 4.0":
+        elif model == "seedream-4-0-250828":
             self.hide_parameter_by_name("output_format")
             self.show_parameter_by_name("optimize_prompt_mode")
-        else:  # Seedream 4.5
+        else:  # seedream-4-5-251128
             self.hide_parameter_by_name("output_format")
             self.hide_parameter_by_name("optimize_prompt_mode")
 
         if current_size in new_choices:
             self._update_option_choices("size", new_choices, current_size)
         else:
-            default_size = "1K" if model == "Seedream 4.0" else "2K"
+            default_size = "1K" if model == "seedream-4-0-250828" else "2K"
             default_size = default_size if default_size in new_choices else new_choices[0]
             self._update_option_choices("size", new_choices, default_size)
 
@@ -484,7 +443,7 @@ class SeedreamImageGeneration(GriptapeProxyNode):
         images = normalize_artifact_list(images, ImageUrlArtifact, accepted_types=(ImageArtifact,))
 
         return {
-            "model": self.get_parameter_value("model") or "Seedream 4.5",
+            "model": self.get_parameter_value("model") or "seedream-4-5-251128",
             "prompt": self.get_parameter_value("prompt") or "",
             "images": images,
             "size": self.get_parameter_value("size") or "2K",
@@ -533,10 +492,10 @@ class SeedreamImageGeneration(GriptapeProxyNode):
         payload["sequential_image_generation_options"] = params["sequential_image_generation_options"]
 
         # Add output_format for Seedream 5.0 Lite
-        if model == "Seedream 5.0 Lite":
+        if model == "seedream-5-0-260128":
             payload["output_format"] = params.get("output_format", "jpeg")
             payload["optimize_prompt_options"] = {"mode": params.get("optimize_prompt_mode", "standard")}
-        elif model == "Seedream 4.0":
+        elif model == "seedream-4-0-250828":
             payload["optimize_prompt_options"] = {"mode": params.get("optimize_prompt_mode", "standard")}
 
     async def _add_multi_image_payload_fields(self, payload: dict[str, Any], params: dict[str, Any]) -> None:

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -20,13 +20,18 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["WanImageGeneration"]
 
-# Model mapping from user-friendly names to API model IDs
-MODEL_MAPPING = {
-    "Wan 2.7 Image Pro": "wan2.7-image-pro",
-    "Wan 2.7 Image": "wan2.7-image",
-}
-MODEL_OPTIONS = list(MODEL_MAPPING.keys())
+# Model options, in catalog order
+MODEL_OPTIONS = ["wan2.7-image-pro", "wan2.7-image"]
 DEFAULT_MODEL = MODEL_OPTIONS[0]
+
+# Migrates values saved before this dropdown stored the provider's own model id (friendly
+# labels and catalog keys alike).
+LEGACY_MODEL_VALUES = {
+    "Wan 2.7 Image": "wan2.7-image",
+    "Wan 2.7 Image Pro": "wan2.7-image-pro",
+    "gtc_wan_2_7_image": "wan2.7-image",
+    "gtc_wan_2_7_image_pro": "wan2.7-image-pro",
+}
 
 # Size options
 SIZE_OPTIONS = ["1K", "2K", "4K"]
@@ -62,14 +67,20 @@ class WanImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Wan 2.7 models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Select the Wan model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Select the Wan model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Core parameters
@@ -174,11 +185,6 @@ class WanImageGeneration(GriptapeProxyNode):
             result_details_placeholder="Generation status and details will appear here.",
             parameter_group_initially_collapsed=True,
         )
-
-    def _get_api_model_id(self) -> str:
-        """Map friendly model name to API model ID."""
-        model = self.get_parameter_value("model") or DEFAULT_MODEL
-        return MODEL_MAPPING.get(str(model), str(model))
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Wan image generation.

--- a/griptape_nodes_library/splat/world_labs_world_generation.py
+++ b/griptape_nodes_library/splat/world_labs_world_generation.py
@@ -29,16 +29,21 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["WorldLabsWorldGeneration"]
 
-# Model options
-MODEL_OPTIONS = ["Marble 1.1 Plus", "Marble 1.1", "Marble 1.0", "Marble 1.0 Draft"]
-DEFAULT_MODEL = "Marble 1.1"
+# Model options, in catalog order
+MODEL_OPTIONS = ["marble-1.1-plus", "marble-1.1", "marble-1.0", "marble-1.0-draft"]
+DEFAULT_MODEL = "marble-1.1"
 
-# Model ID mapping
-MODEL_ID_MAP = {
-    "Marble 1.1 Plus": "marble-1.1-plus",
-    "Marble 1.1": "marble-1.1",
+# Migrates values saved before this dropdown stored the provider's own model id (friendly
+# labels and catalog keys alike).
+LEGACY_MODEL_VALUES = {
     "Marble 1.0": "marble-1.0",
     "Marble 1.0 Draft": "marble-1.0-draft",
+    "Marble 1.1": "marble-1.1",
+    "Marble 1.1 Plus": "marble-1.1-plus",
+    "gtc_marble_1_0": "marble-1.0",
+    "gtc_marble_1_0_draft": "marble-1.0-draft",
+    "gtc_marble_1_1": "marble-1.1",
+    "gtc_marble_1_1_plus": "marble-1.1-plus",
 }
 
 # Input type options
@@ -90,15 +95,21 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
         self.description = "Generate 3D worlds using World Labs Marble via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Marble model: 1.1 Plus (variable pricing, larger worlds), 1.1 (standard), 1.0 (previous), 1.0 Draft (fast/cheaper)",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-                ui_options={"display_name": "Model"},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Marble model: 1.1 Plus (variable pricing, larger worlds), 1.1 (standard), 1.0 (previous), 1.0 Draft (fast/cheaper)",
+            allow_output=False,
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Input type selector
@@ -374,12 +385,6 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
             "seed": self._seed_parameter.get_seed(),
         }
 
-    def _get_api_model_id(self) -> str:
-        """Map friendly model name to backend model ID."""
-        params = self._get_parameters()
-        model_name = params.get("model", DEFAULT_MODEL)
-        return MODEL_ID_MAP.get(model_name, "marble-1.1")
-
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Handle parameter changes and update visibility."""
         super().after_value_set(parameter, value)
@@ -435,7 +440,7 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
         # Build top-level request
         payload: dict[str, Any] = {
             "world_prompt": world_prompt,
-            "model": self._get_api_model_id(),
+            "model": self._get_selected_model_id(),
         }
 
         # Add optional parameters

--- a/griptape_nodes_library/video/omnihuman_subject_detection.py
+++ b/griptape_nodes_library/video/omnihuman_subject_detection.py
@@ -12,7 +12,6 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key
@@ -45,6 +44,11 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
     MODEL_IDS: ClassVar[list[str]] = [
         "omnihuman-1-5-subject-detection",
     ]
+    # Migrates values saved before the dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "OmniHuman 1.5 Subject Detection": "omnihuman-1-5-subject-detection",
+        "gtc_omnihuman_1_5_subject_detection": "omnihuman-1-5-subject-detection",
+    }
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -52,14 +56,20 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
         self.description = "Detect subjects and generate masks using OmniHuman Subject Detection via Griptape Cloud"
 
         # INPUTS
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=self.MODEL_IDS[0],
-                tooltip="Model identifier to use for detection",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=self.MODEL_IDS[0],
+            tooltip="Model identifier to use for detection",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model=self.MODEL_IDS[0],
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self._public_image_url_parameter = PublicArtifactUrlParameter(
@@ -125,11 +135,8 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model_id") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
-        model_id = self.get_parameter_value("model_id")
+        provider_model_id = self._get_selected_model_id()
         image_value = extract_image_url(self.get_parameter_value("image_url"))
         if not image_value:
             msg = "Image URL is required"
@@ -140,7 +147,7 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
         image_url = self._public_image_url_parameter.get_public_url_for_parameter()
 
         return {
-            "req_key": self._get_req_key(model_id),
+            "req_key": self._get_req_key(provider_model_id),
             "image_url": image_url,
         }
 

--- a/griptape_nodes_library/video/omnihuman_subject_recognition.py
+++ b/griptape_nodes_library/video/omnihuman_subject_recognition.py
@@ -12,7 +12,6 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key
@@ -45,6 +44,11 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
     MODEL_IDS: ClassVar[list[str]] = [
         "omnihuman-1-5-subject-recognition",
     ]
+    # Migrates values saved before the dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "OmniHuman 1.5 Subject Recognition": "omnihuman-1-5-subject-recognition",
+        "gtc_omnihuman_1_5_subject_recognition": "omnihuman-1-5-subject-recognition",
+    }
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -52,14 +56,20 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
         self.description = "Identify subjects in images using OmniHuman Subject Recognition via Griptape Cloud"
 
         # INPUTS
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=self.MODEL_IDS[0],
-                tooltip="Model identifier to use for recognition",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=self.MODEL_IDS[0],
+            tooltip="Model identifier to use for recognition",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model=self.MODEL_IDS[0],
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self._public_image_url_parameter = PublicArtifactUrlParameter(
@@ -115,11 +125,8 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model_id") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
-        model_id = self.get_parameter_value("model_id")
+        provider_model_id = self._get_selected_model_id()
         image_value = extract_image_url(self.get_parameter_value("image_url"))
         if not image_value:
             msg = "Image URL is required"
@@ -130,7 +137,7 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
         image_url = self._public_image_url_parameter.get_public_url_for_parameter()
 
         return {
-            "req_key": self._get_req_key(model_id),
+            "req_key": self._get_req_key(provider_model_id),
             "image_url": image_url,
         }
 

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -22,7 +22,6 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.options import Options
 from PIL import Image
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
@@ -71,6 +70,13 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
         "omnihuman-1-0",
         "omnihuman-1-5",
     ]
+    # Migrates values saved before the dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "OmniHuman 1.0": "omnihuman-1-0",
+        "OmniHuman 1.5": "omnihuman-1-5",
+        "gtc_omnihuman_1_0": "omnihuman-1-0",
+        "gtc_omnihuman_1_5": "omnihuman-1-5",
+    }
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -79,14 +85,20 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
 
         # INPUTS
         # add model_id parameter with fixed value
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value="omnihuman-1-5",
-                tooltip="Model identifier to use for generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value="omnihuman-1-5",
+            tooltip="Model identifier to use for generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model="omnihuman-1-5",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
         self.add_parameter(
             ParameterString(
@@ -199,7 +211,8 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
         parameter: Parameter,
         value: Any,
     ) -> None:
-        # if the model_id parameter is omnihuman-1-0, remove seed, fast_mode, and prompt parameters
+        super().after_value_set(parameter, value)
+        # if the model_id parameter is OmniHuman 1.0, remove seed, fast_mode, and prompt parameters
         if parameter.name == "model_id" and value == "omnihuman-1-0":
             self.hide_parameter_by_name("seed")
             self.hide_parameter_by_name("fast_mode")
@@ -344,8 +357,6 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
         seed = self.get_parameter_value("seed")
         fast_mode = self.get_parameter_value("fast_mode")
 
-        model_id = self.get_parameter_value("model_id")
-
         if not image_input:
             msg = "image_url parameter is required."
             raise ValueError(msg)
@@ -381,7 +392,7 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
                     mask_urls.append(mask_url)
 
         body = {
-            "req_key": self._get_req_key(model_id),
+            "req_key": self._get_req_key(self._get_selected_model_id()),
             "image_url": image_url,
             "audio_url": audio_url,
             "mask_url": "; ".join(mask_urls) if mask_urls else None,
@@ -430,7 +441,7 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
             return []
 
     def _get_req_key(self, model_id: str) -> str:
-        """Get the request key based on model_id."""
+        """Get the request key based on the upstream provider's model id."""
         if model_id == "omnihuman-1-0":
             return "realman_avatar_picture_omni_cv"
         if model_id == "omnihuman-1-5":
@@ -445,9 +456,6 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."
             raise ValueError(msg)
         return api_key
-
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model_id") or ""
 
     async def _build_payload(self) -> dict[str, Any]:
         params = await self._get_parameters()

--- a/griptape_nodes_library/video/sora_video_generation.py
+++ b/griptape_nodes_library/video/sora_video_generation.py
@@ -28,10 +28,18 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["SoraVideoGeneration"]
 
-# Size options for different models
+# Size options for different models, keyed by the provider's own model id
 SIZE_OPTIONS = {
     "sora-2": ["1280x720", "720x1280"],
     "sora-2-pro": ["1280x720", "720x1280", "1024x1792", "1792x1024"],
+}
+
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Sora 2": "sora-2",
+    "Sora 2 Pro": "sora-2-pro",
+    "gtc_sora_2": "sora-2",
+    "gtc_sora_2_pro": "sora-2-pro",
 }
 
 
@@ -66,17 +74,23 @@ class SoraVideoGeneration(GriptapeProxyNode):
         self.description = "Generate video via Sora 2 through Griptape Cloud model proxy"
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="sora-2",
-                tooltip="Sora model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "Model",
-                },
-                traits={Options(choices=["sora-2", "sora-2-pro"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="sora-2",
+            tooltip="Sora model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "Model",
+            },
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["sora-2", "sora-2-pro"],
+            default_model="sora-2",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
         self.add_parameter(
             ParameterString(
@@ -217,14 +231,11 @@ class SoraVideoGeneration(GriptapeProxyNode):
 
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model": self.get_parameter_value("model") or "sora-2",
+            "model": self._get_selected_model_id() or "sora-2",
             "seconds": seconds_value,
             "size": self.get_parameter_value("size") or "720x1280",
             "start_frame": self.get_parameter_value("start_frame"),
         }
-
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or "sora-2"
 
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -32,6 +32,14 @@ MODEL_OPTIONS = [
     "wan2.2-animate-move",
 ]
 
+# Migrates values saved before the dropdown stored catalog keys.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Wan 2.2 Animate Mix": "wan2.2-animate-mix",
+    "Wan 2.2 Animate Move": "wan2.2-animate-move",
+    "gtc_wan_2_2_animate_mix": "wan2.2-animate-mix",
+    "gtc_wan_2_2_animate_move": "wan2.2-animate-move",
+}
+
 # Mode options
 MODE_OPTIONS = [
     "wan-std",
@@ -93,14 +101,20 @@ class WanAnimateGeneration(GriptapeProxyNode):
         self.description = "Generate animated videos from images using WAN Animate models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=MODEL_OPTIONS[0],
-                tooltip="Select the WAN Animate model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=MODEL_OPTIONS[0],
+            tooltip="Select the WAN Animate model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=MODEL_OPTIONS[0],
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
         # Mode selection
         self.add_parameter(
@@ -265,9 +279,6 @@ class WanAnimateGeneration(GriptapeProxyNode):
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."
             raise ValueError(msg)
         return api_key
-
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
 
     async def _build_payload(self) -> dict[str, Any]:
         params = await self._get_parameters()

--- a/griptape_nodes_library/video/wan_image_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_image_to_video_generation.py
@@ -42,6 +42,22 @@ MODEL_OPTIONS = [
     "wanx2.1-i2v-turbo",
 ]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Wan 2.1 I2V Plus": "wanx2.1-i2v-plus",
+    "Wan 2.1 I2V Turbo": "wanx2.1-i2v-turbo",
+    "Wan 2.2 I2V Flash": "wan2.2-i2v-flash",
+    "Wan 2.2 I2V Plus": "wan2.2-i2v-plus",
+    "Wan 2.5 I2V Preview": "wan2.5-i2v-preview",
+    "Wan 2.6 I2V": "wan2.6-i2v",
+    "gtc_wan_2_2_i2v_flash": "wan2.2-i2v-flash",
+    "gtc_wan_2_2_i2v_plus": "wan2.2-i2v-plus",
+    "gtc_wan_2_5_i2v_preview": "wan2.5-i2v-preview",
+    "gtc_wan_2_6_i2v": "wan2.6-i2v",
+    "gtc_wanx_2_1_i2v_plus": "wanx2.1-i2v-plus",
+    "gtc_wanx_2_1_i2v_turbo": "wanx2.1-i2v-turbo",
+}
+
 # Model-specific configurations
 MODEL_CONFIGS = {
     "wan2.6-i2v": {
@@ -138,14 +154,20 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from images using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-i2v",
-                tooltip="Select the WAN image-to-video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-i2v",
+            tooltip="Select the WAN image-to-video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-i2v",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Prompt parameter (optional)
@@ -459,9 +481,6 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()
 
@@ -477,7 +496,7 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
 
         # Build flattened payload (all params at top level)
         payload = {
-            "model": params["model"],
+            "model": self._get_selected_model_id(),
             "img_url": img_url,
             "resolution": params["resolution"],
             "duration": params["duration"],

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -38,6 +38,12 @@ MODEL_OPTIONS = [
     "wan2.6-r2v",
 ]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Wan 2.6 R2V": "wan2.6-r2v",
+    "gtc_wan_2_6_r2v": "wan2.6-r2v",
+}
+
 # Size options organized by resolution tier
 SIZE_OPTIONS_720P = [
     "1280*720",  # 16:9
@@ -120,14 +126,20 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from reference videos using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-r2v",
-                tooltip="Select the WAN reference-to-video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-r2v",
+            tooltip="Select the WAN reference-to-video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-r2v",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Prompt parameter
@@ -437,9 +449,6 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
             msg = f"{self.name} is missing {self.API_KEY_NAME}. Ensure it's set in the environment/config."
             raise ValueError(msg)
         return api_key
-
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
 
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()

--- a/griptape_nodes_library/video/wan_text_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_text_to_video_generation.py
@@ -39,6 +39,20 @@ MODEL_OPTIONS = [
     "wanx2.1-t2v-plus",
 ]
 
+# Migrates values saved before the dropdown stored the provider's own model id.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Wan 2.1 T2V Plus": "wanx2.1-t2v-plus",
+    "Wan 2.1 T2V Turbo": "wanx2.1-t2v-turbo",
+    "Wan 2.2 T2V Plus": "wan2.2-t2v-plus",
+    "Wan 2.5 T2V Preview": "wan2.5-t2v-preview",
+    "Wan 2.6 T2V": "wan2.6-t2v",
+    "gtc_wan_2_2_t2v_plus": "wan2.2-t2v-plus",
+    "gtc_wan_2_5_t2v_preview": "wan2.5-t2v-preview",
+    "gtc_wan_2_6_t2v": "wan2.6-t2v",
+    "gtc_wanx_2_1_t2v_plus": "wanx2.1-t2v-plus",
+    "gtc_wanx_2_1_t2v_turbo": "wanx2.1-t2v-turbo",
+}
+
 # Model-specific configurations
 MODEL_CONFIGS = {
     "wan2.6-t2v": {
@@ -123,14 +137,20 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from text using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-t2v",
-                tooltip="Select the WAN model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-t2v",
+            tooltip="Select the WAN model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-t2v",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         # Prompt parameter
@@ -409,9 +429,6 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
             raise ValueError(msg)
         return api_key
 
-    def _get_api_model_id(self) -> str:
-        return self.get_parameter_value("model") or ""
-
     async def _build_payload(self) -> dict[str, Any]:
         params = self._get_parameters()
 
@@ -421,7 +438,7 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
 
         # Build flattened payload (all params at top level)
         payload = {
-            "model": params["model"],
+            "model": self._get_selected_model_id(),
             "prompt": params["prompt"],
             "resolution": params["size"],
             "duration": params["duration"],

--- a/tests/unit/image/test_openai_image_generation.py
+++ b/tests/unit/image/test_openai_image_generation.py
@@ -3,22 +3,25 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from griptape.artifacts import ImageArtifact
 from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
     PublicArtifactUrlParameter,
 )
+from griptape_nodes.node_library.library_registry import LibraryRegistry
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.image.openai_image_generation import (
-    GPT_IMAGE_1_MODEL_NAME,
-    GPT_IMAGE_2_MODEL_ID,
-    GPT_IMAGE_2_MODEL_NAME,
+    GPT_IMAGE_1_MODEL_KEY,
+    GPT_IMAGE_2_MODEL_KEY,
     OpenAiImageGeneration,
 )
 from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
+
+LIBRARY_NAME = "Griptape Nodes Library"
 
 
 def _is_param_hidden(node: OpenAiImageGeneration, name: str) -> bool:
@@ -35,7 +38,18 @@ def _has_size_badge(node: OpenAiImageGeneration) -> bool:
 
 @pytest.fixture
 def node(griptape_nodes: GriptapeNodes) -> OpenAiImageGeneration:  # noqa: ARG002
-    return OpenAiImageGeneration(name="OpenAI Image Generation")
+    """Construct through the library so its metadata carries `library` / `node_type`.
+
+    `_get_selected_model_id()` resolves the dropdown's catalog key
+    through the node's declared models, which requires that metadata; a bare
+    `OpenAiImageGeneration(name=...)` construction leaves it unset and
+    resolution would return `""`.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return cast(
+        "OpenAiImageGeneration",
+        library.create_node(node_type="OpenAiImageGeneration", name="OpenAI Image Generation"),
+    )
 
 
 @pytest.mark.asyncio
@@ -389,10 +403,10 @@ def test_default_model_omits_transparent_background(node: OpenAiImageGeneration)
 
 
 def test_switching_to_unsupported_model_resets_transparent_background(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_KEY)
     node.set_parameter_value("background", "transparent")
 
-    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY)
 
     assert node.get_parameter_value("background") == "auto"
 
@@ -400,19 +414,19 @@ def test_switching_to_unsupported_model_resets_transparent_background(node: Open
 def test_switching_to_supported_model_preserves_opaque_background(node: OpenAiImageGeneration) -> None:
     node.set_parameter_value("background", "opaque")
 
-    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_KEY)
 
     assert node.get_parameter_value("background") == "opaque"
 
 
-def test_default_model_uses_display_name(node: OpenAiImageGeneration) -> None:
-    assert node.get_parameter_value("model") == GPT_IMAGE_2_MODEL_NAME
+def test_default_model_uses_catalog_key(node: OpenAiImageGeneration) -> None:
+    assert node.get_parameter_value("model") == GPT_IMAGE_2_MODEL_KEY
 
 
-def test_payload_model_id_translates_display_name(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+def test_provider_model_id_resolves_from_catalog_key(node: OpenAiImageGeneration) -> None:
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY)
 
-    assert node._get_payload_model_id() == GPT_IMAGE_2_MODEL_ID
+    assert node._get_selected_model_id() == "gpt-image-2"
 
 
 def test_size_choices_include_custom_for_gpt_image_2(node: OpenAiImageGeneration) -> None:
@@ -420,7 +434,7 @@ def test_size_choices_include_custom_for_gpt_image_2(node: OpenAiImageGeneration
 
 
 def test_size_choices_omit_custom_for_legacy_models(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_KEY)
     assert "custom" not in _size_choices(node)
 
 
@@ -449,7 +463,7 @@ def test_switching_off_custom_size_hides_dimension_inputs(node: OpenAiImageGener
 
 def test_switching_to_legacy_model_hides_custom_size_inputs(node: OpenAiImageGeneration) -> None:
     node.set_parameter_value("size", "custom")
-    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_1_MODEL_KEY)
 
     assert _is_param_hidden(node, "custom_width")
     assert _is_param_hidden(node, "custom_height")
@@ -481,7 +495,7 @@ def test_custom_dimension_snaps_to_multiple_of_16(
 
 @pytest.mark.asyncio
 async def test_build_payload_combines_custom_dimensions(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY)
     node.set_parameter_value("prompt", "A panoramic image")
     node.set_parameter_value("size", "custom")
     node.set_parameter_value("custom_width", 2048)
@@ -493,7 +507,7 @@ async def test_build_payload_combines_custom_dimensions(node: OpenAiImageGenerat
 
 
 def test_validate_runs_against_custom_dimensions(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY)
     node.set_parameter_value("prompt", "A red circle")
     node.set_parameter_value("size", "custom")
     node.set_parameter_value("custom_width", 3840)
@@ -506,7 +520,7 @@ def test_validate_runs_against_custom_dimensions(node: OpenAiImageGeneration) ->
 
 
 def test_validate_accepts_valid_custom_dimensions(node: OpenAiImageGeneration) -> None:
-    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME)
+    node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY)
     node.set_parameter_value("prompt", "A red circle")
     node.set_parameter_value("size", "custom")
     node.set_parameter_value("custom_width", 2048)
@@ -521,7 +535,7 @@ def test_initial_setup_sync_restores_custom_size_visibility(
     """Workflow load uses initial_setup=True, which skips after_value_set. Visibility must still sync."""
     fresh_node = OpenAiImageGeneration(name="OpenAI Image Generation Loaded")
 
-    fresh_node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME, initial_setup=True)
+    fresh_node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY, initial_setup=True)
     fresh_node.set_parameter_value("size", "custom", initial_setup=True)
 
     assert not _is_param_hidden(fresh_node, "custom_width")
@@ -535,7 +549,7 @@ def test_initial_setup_does_not_snap_custom_dimensions(
     """Workflow load must not mutate persisted custom_width/height values."""
     fresh_node = OpenAiImageGeneration(name="OpenAI Image Generation Loaded")
 
-    fresh_node.set_parameter_value("model", GPT_IMAGE_2_MODEL_NAME, initial_setup=True)
+    fresh_node.set_parameter_value("model", GPT_IMAGE_2_MODEL_KEY, initial_setup=True)
     fresh_node.set_parameter_value("size", "custom", initial_setup=True)
     fresh_node.set_parameter_value("custom_width", 1000, initial_setup=True)
 

--- a/tests/unit/test_proxy_model_access.py
+++ b/tests/unit/test_proxy_model_access.py
@@ -1,0 +1,264 @@
+"""Tests that the proxy nodes wire their model dropdown through
+``ModelAccessComponent``.
+
+Every proxy node under ``griptape_nodes_library`` that offers a choice of
+models routes its ``model``/``model_id`` parameter through
+``GriptapeProxyNode._install_model_access``, which hands the parameter to a
+``ModelAccessComponent``: the component owns the ``Options`` + refresh
+``Button`` traits, decorates each row with the caller's license entitlement,
+and gates ``_submit_and_poll`` against the current policy. These tests cover
+that wiring and the runtime gate across every node that installs it; the
+component's own behavior is covered in the engine test suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointDenial,
+    CheckpointFailure,
+)
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.image.seedream_image_generation import SeedreamImageGeneration
+from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.video.sora_video_generation import SoraVideoGeneration
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+LIBRARY_NAME = "Griptape Nodes Library"
+
+type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | None]
+
+# (node type, catalog model id to deny, provider model id the dropdown offers
+# for it, model parameter name). The dropdown stores the provider id, so the
+# row the denial decorates is named by that id, while the license-policy hook
+# still keys on the catalog id it gates on. The denied id is deliberately not
+# the node's default everywhere it can be, so the ModelAccessComponent
+# constructor's default-relocation logic (which moves the stored value off a
+# denied default) never fires and can't confuse these assertions.
+# OmnihumanSubjectRecognition, OmnihumanSubjectDetection,
+# WanReferenceToVideoGeneration, FluxImageGeneration, TranscribeAudio, GrokImageGeneration,
+# GrokImageEdit, GrokVideoGeneration, GrokVideoEdit, and LTXVideoToVideoHDR each declare
+# exactly one model, so their only choice is necessarily also their default.
+# TopazImageEnhance's "operation" dropdown does not install model access (its models
+# are chosen implicitly by the operation, not offered as a license-gated choice), so
+# it has no case here.
+NODE_MODEL_CASES: list[tuple[str, str, str, str]] = [
+    ("TranscribeAudio", "gtc_whisper_1", "whisper-1", "model"),  # only declared model
+    ("ElevenLabsTextToSpeechGeneration", "gtc_eleven_multilingual_v2", "eleven_multilingual_v2", "model"),
+    (
+        "OmnihumanSubjectRecognition",
+        "gtc_omnihuman_1_5_subject_recognition",
+        "omnihuman-1-5-subject-recognition",
+        "model_id",
+    ),  # only declared model
+    (
+        "OmnihumanSubjectDetection",
+        "gtc_omnihuman_1_5_subject_detection",
+        "omnihuman-1-5-subject-detection",
+        "model_id",
+    ),  # only declared model
+    ("OmnihumanVideoGeneration", "gtc_omnihuman_1_0", "omnihuman-1-0", "model_id"),
+    ("SoraVideoGeneration", "gtc_sora_2_pro", "sora-2-pro", "model"),
+    ("WanTextToVideoGeneration", "gtc_wan_2_5_t2v_preview", "wan2.5-t2v-preview", "model"),
+    ("WanImageToVideoGeneration", "gtc_wan_2_5_i2v_preview", "wan2.5-i2v-preview", "model"),
+    ("WanAnimateGeneration", "gtc_wan_2_2_animate_move", "wan2.2-animate-move", "model"),
+    ("WanReferenceToVideoGeneration", "gtc_wan_2_6_r2v", "wan2.6-r2v", "model"),  # only declared model
+    ("FluxImageGeneration", "gtc_flux_kontext_pro", "flux-kontext-pro", "model"),  # only declared model
+    ("QwenImageGeneration", "gtc_qwen_image_plus", "qwen-image-plus", "model"),
+    ("QwenImageEdit", "gtc_qwen_image_edit", "qwen-image-edit", "model"),
+    ("SeedreamImageGeneration", "gtc_seedream_4_0", "seedream-4-0-250828", "model"),
+    ("GrokImageGeneration", "gtc_grok_imagine_image", "grok-imagine-image", "model"),  # only declared model
+    ("GrokImageEdit", "gtc_grok_imagine_image", "grok-imagine-image", "model"),  # only declared model
+    ("Flux2ImageGeneration", "gtc_flux_2_flex", "flux-2-flex", "model"),
+    ("WanImageGeneration", "gtc_wan_2_7_image", "wan2.7-image", "model"),
+    ("GoogleImageGeneration", "gtc_gemini_3_1_flash_image", "gemini-3.1-flash-image", "model"),
+    ("OpenAiImageGeneration", "gtc_gpt_image_1", "gpt-image-1", "model"),
+    ("WorldLabsWorldGeneration", "gtc_marble_1_0_draft", "marble-1.0-draft", "model"),
+]
+
+
+def _create_node(node_type: str) -> BaseNode:
+    """Create a node through the library so its metadata carries `library` / `node_type`.
+
+    The engine's model-access query reads those two metadata keys to resolve a
+    node's declared models; a bare `NodeClass(name=...)` construction does not
+    set them and would leave the dropdown undecorated.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return library.create_node(node_type=node_type, name=node_type)
+
+
+def _deny_hook(action: CheckpointAction, subject_id: str) -> AuthorizationHook:
+    """Build a hook that denies one action against one catalog model id, else allows."""
+
+    def hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        if checkpoint.action == action and checkpoint.subject_id == subject_id:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="denied for test"),))
+        return None
+
+    return hook
+
+
+@pytest.fixture
+def authorization_hook() -> Iterator[Callable[[AuthorizationHook], None]]:
+    """Register an authorization hook for the test, guaranteed removed afterward."""
+    registered: list[AuthorizationHook] = []
+
+    def register(hook: AuthorizationHook) -> None:
+        GriptapeNodes.EventManager().add_authorization_hook(hook)
+        registered.append(hook)
+
+    try:
+        yield register
+    finally:
+        for hook in registered:
+            GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+
+@pytest.mark.parametrize(
+    ("node_type", "param_name"),
+    [(case[0], case[3]) for case in NODE_MODEL_CASES],
+    ids=[case[0] for case in NODE_MODEL_CASES],
+)
+def test_model_param_wired_to_model_access_component(node_type: str, param_name: str) -> None:
+    node = cast("GriptapeProxyNode", _create_node(node_type))
+
+    assert node._model_access is not None
+    assert isinstance(node._model_access, ModelAccessComponent)
+    assert node._model_access.parameter_name == param_name
+
+    model_param = node.get_parameter_by_name(param_name)
+    assert model_param is not None
+    # The component installs the Options dropdown and a refresh Button.
+    assert model_param.find_elements_by_type(Options)
+    assert model_param.find_elements_by_type(Button)
+    # Per-row decoration the frontend uses to flag denied models.
+    ui_options = model_param.ui_options
+    assert ui_options.get("dropdown_row_icons") is True
+    assert ui_options.get("dropdown_row_subtitles") is True
+    assert isinstance(ui_options.get("data"), list)
+    assert ui_options["data"]
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "denied_provider_id", "param_name"), NODE_MODEL_CASES)
+def test_denied_model_row_carries_denial_icon(
+    node_type: str,
+    denied_catalog_id: str,
+    denied_provider_id: str,
+    param_name: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    # Registered before construction so the component's constructor-time snapshot
+    # already carries the denial, and decorates the row on the first build.
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node = _create_node(node_type)
+
+    model_param = node.get_parameter_by_name(param_name)
+    assert model_param is not None
+    data = model_param.ui_options["data"]
+    assert data
+
+    for row in data:
+        if row["name"] == denied_provider_id:
+            assert row.get("icon") == "shield-off"
+        else:
+            assert row.get("icon") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_and_poll_gates_on_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_submit_and_poll` re-checks the selection against the current policy.
+
+    Construct the node BEFORE registering the deny hook, so the component's
+    constructor-time snapshot is clean and doesn't relocate the stored value
+    off the about-to-be-denied selection. Only one representative node
+    (SoraVideoGeneration) is exercised here: the gate itself lives in
+    `GriptapeProxyNode._submit_and_poll`, shared by every adopting node, so this
+    isn't re-checked per node.
+    """
+    node = cast("SoraVideoGeneration", _create_node("SoraVideoGeneration"))
+    node.set_parameter_value("model", "sora-2-pro")
+
+    async def fake_build_payload() -> dict[str, Any]:
+        return {}
+
+    submit_calls: list[dict[str, Any]] = []
+
+    async def fake_submit_generation(payload: dict[str, Any], headers: dict[str, str], api_model_id: str) -> None:
+        submit_calls.append({"payload": payload, "headers": headers, "api_model_id": api_model_id})
+        # None short-circuits `_submit_and_poll` before it reaches the poll loop,
+        # which this test has no interest in exercising.
+        return None
+
+    monkeypatch.setattr(node, "_build_payload", fake_build_payload)
+    monkeypatch.setattr(node, "_submit_generation", fake_submit_generation)
+
+    hook = _deny_hook(CheckpointAction.OFFER_MODEL, "gtc_sora_2_pro")
+    GriptapeNodes.EventManager().add_authorization_hook(hook)
+    try:
+        result = await node._submit_and_poll({})
+    finally:
+        GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+    assert result is None
+    assert node.parameter_output_values.get("was_successful") is False
+    assert "denied for test" in node.parameter_output_values.get("result_details", "")
+    assert submit_calls == []
+
+    # Mirror case: with the hook removed, the same selection is permitted again
+    # and the flow reaches `_submit_generation`.
+    await node._submit_and_poll({})
+
+    assert len(submit_calls) == 1
+    assert submit_calls[0]["api_model_id"] == "sora-2-pro"
+
+
+def test_legacy_dropdown_value_migrates_and_resolves_denial_at_runtime(
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    """A legacy value assigned to a migrated node's dropdown is rewritten to its provider model id.
+
+    `ModelAccessComponent` registers a converter on the parameter, so assigning
+    one of its `deprecated_values` keys (an artist-facing label the dropdown
+    used to store, before it adopted the provider model id convention) rewrites
+    the stored value to the canonical provider id on the way in. A runtime
+    query against the current selection then resolves through to the catalog
+    id the policy denies, same as if the provider id had been assigned
+    directly. The hook is registered AFTER construction so this exercises
+    `selection_denial()`'s live re-check, not the constructor-time snapshot or
+    its default-relocation logic.
+    """
+    node = cast("SeedreamImageGeneration", _create_node("SeedreamImageGeneration"))
+    assert node._model_access is not None
+
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, "gtc_seedream_5_0_lite"))
+
+    node.set_parameter_value("model", "Seedream 5.0 Lite")
+    assert node._model_access.selection_denial() is not None
+
+    node.set_parameter_value("model", "Seedream 4.5")
+    assert node._model_access.selection_denial() is None
+
+
+def test_topaz_image_enhance_operation_has_no_model_access() -> None:
+    """TopazImageEnhance's `operation` dropdown does not install `ModelAccessComponent`.
+
+    The dropdown was deliberately reverted to a plain operation switch (denoise /
+    enhance / sharpen), not a license-gated model choice, so it has no case in
+    `NODE_MODEL_CASES`. Guard that reverting stays reverted.
+    """
+    node = cast("GriptapeProxyNode", _create_node("TopazImageEnhance"))
+    assert node._model_access is None


### PR DESCRIPTION
Routes the twenty proxy node model dropdowns (image, audio, world, and the Wan / Omnihuman / Sora video families) through the helper from #507.

Part of #432.

<!-- stack map: hand-maintained while `main`'s merge queue keeps the native stack UI unavailable -->
### Stack

Review and merge bottom to top. Trunk: `main`; each PR's base is the branch below it.

1. #507 — feat(access): add license-filtered model dropdown plumbing
2. #509 — feat(access): filter config driver model dropdowns through OFFER_MODEL
3. #510 — feat(access): filter proxy model dropdowns through OFFER_MODEL  ⬅ **this PR**
4. #512 — feat(access): filter video model dropdowns through OFFER_MODEL
5. #517 — feat(access): filter agent and task model dropdowns through OFFER_MODEL
