### PR TITLE
feat(access): filter labeled image and world model dropdowns through OFFER_MODEL

### DIFF
--- a/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
+++ b/griptape_nodes_library/audio/eleven_labs_text_to_speech.py
@@ -64,15 +64,20 @@ class ElevenLabsTextToSpeechGeneration(GriptapeProxyNode):
 
         # INPUTS / PROPERTIES
         # Model Selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="eleven_v3",
-                tooltip="Select the Eleven Labs text-to-speech model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["eleven_multilingual_v2", "eleven_v3"])},
-                ui_options={"display_name": "Model"},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="eleven_v3",
+            tooltip="Select the Eleven Labs text-to-speech model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["eleven_multilingual_v2", "eleven_v3"],
+            default_model="eleven_v3",
         )
 
         # Text input

--- a/griptape_nodes_library/audio/transcribe_audio.py
+++ b/griptape_nodes_library/audio/transcribe_audio.py
@@ -7,7 +7,6 @@ from griptape.artifacts import TextArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.memory.structure import Run
 from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
-from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
@@ -102,11 +101,11 @@ class TranscribeAudio(GriptapeProxyNode):
             ui_options={"display_name": "audio transcription model"},
         )
         self.add_parameter(model_param)
-        # License-policy helper: adds Options + refresh Button traits, applies per-row
-        # decoration + badge, exposes query_for_denial, and relocates the stored value
-        # to a permitted alternative if DEFAULT_MODEL is denied.
-        self._model_access = ModelAccessComponent(
-            node=self,
+        # License-policy dropdown: the component adds Options + refresh Button traits,
+        # marks the models the license denies, and relocates the stored value to a
+        # permitted alternative if DEFAULT_MODEL is denied. The proxy base class
+        # refuses to submit a denied selection.
+        self._install_model_access(
             parameter=model_param,
             model_choices=MODEL_CHOICES,
             default_model=DEFAULT_MODEL,
@@ -250,8 +249,6 @@ class TranscribeAudio(GriptapeProxyNode):
         )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
-        if parameter.name == "model":
-            self._model_access.on_value_changed(value)
         if parameter.name == "response_format":
             if value == "verbose_json":
                 self.show_parameter_by_name("segments")
@@ -318,18 +315,6 @@ class TranscribeAudio(GriptapeProxyNode):
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for OpenAI audio transcription."""
-        # License-policy runtime gate. SuccessFailure idiom: route the denial
-        # through _set_status_results and return an empty payload so the outer
-        # proxy pipeline sees was_successful=False rather than an exception.
-        # Runs BEFORE the proxy's own INVOKE_MODEL gate so a denied model fails
-        # immediately instead of after payload construction.
-        model_value = self.get_parameter_value("model")
-        denial = self._model_access.query_for_denial(model_value)
-        if denial is not None:
-            self._set_safe_defaults()
-            self._set_status_results(was_successful=False, result_details=denial.reason())
-            return {}
-
         audio_value = self.get_parameter_value("audio")
         if audio_value is None:
             msg = "No audio provided. Please connect an audio source."

--- a/griptape_nodes_library/config/base_driver.py
+++ b/griptape_nodes_library/config/base_driver.py
@@ -6,6 +6,8 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+from griptape_nodes_library.utils.model_access import ModelDropdownAccess
+
 
 class BaseDriver(DataNode):
     """Base class for driver nodes that need to manage parameters and validate configuration.
@@ -28,6 +30,11 @@ class BaseDriver(DataNode):
             driver = BaseDriver(name="ExampleDriver")
         """
         super().__init__(**kwargs)
+
+        # Set by `_install_model_access` on subclasses whose model parameter is a
+        # license-filtered dropdown; stays None on the ones offering free text or a
+        # dynamically fetched list.
+        self._model_access: ModelDropdownAccess | None = None
 
         self.add_parameter(
             Parameter(
@@ -109,6 +116,63 @@ class BaseDriver(DataNode):
     # -----------------------------------------------------------------------------
     # Internal Helper Methods
     # -----------------------------------------------------------------------------
+
+    def _install_model_access(
+        self,
+        *,
+        model_choices: list[str],
+        default_model: str,
+        param: str = "model",
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        """Turn the named model parameter into a license-filtered dropdown.
+
+        Stands in for `_update_option_choices` on driver nodes: the component owns
+        the `Options` trait (so the parameter must not already carry one), adds an
+        inline refresh button, marks the models the caller's license denies, and
+        moves the stored value off a denied default. The declared default is still
+        applied here, so the parameter reads the same as it did before adoption.
+
+        Args:
+            model_choices: The models the node offers, in dropdown order.
+            default_model: The choice to select by default; must be in `model_choices`.
+            param: Name of the parameter to decorate.
+            provider_model_id_by_choice: Choice -> catalog `provider_model_id` map,
+                needed only when the choices are display labels rather than
+                provider ids.
+        """
+        if default_model not in model_choices:
+            msg = f"Default model '{default_model}' is not one of the offered choices."
+            raise ValueError(msg)
+        parameter = self.get_parameter_by_name(param)
+        if parameter is None:
+            msg = f"Cannot install model access on '{type(self).__name__}': no '{param}' parameter."
+            raise ValueError(msg)
+
+        parameter.default_value = default_model
+        self.set_parameter_value(param, default_model)
+        self._model_access = ModelDropdownAccess(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            provider_model_id_by_choice=provider_model_id_by_choice,
+        )
+
+    def _raise_if_model_denied(self) -> None:
+        """Fail closed rather than hand a downstream node a driver the license denies.
+
+        Called at the top of `process` on nodes with a license-filtered dropdown;
+        no-ops on the nodes that never installed one.
+        """
+        if self._model_access is not None:
+            self._model_access.raise_if_selection_denied()
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Keep the model dropdown's denial badge in step with the selection."""
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+        return super().after_value_set(parameter, value)
 
     def _display_api_key_message(self, service_name: str, api_key_env_var: str, api_key_url: str | None) -> None:
         """Checks if the API key exists in the node configuration, displays a message if not.

--- a/griptape_nodes_library/config/image/base_image_driver.py
+++ b/griptape_nodes_library/config/image/base_image_driver.py
@@ -62,7 +62,8 @@ class BaseImageDriver(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses call `_install_model_access`
+        # to offer a license-filtered dropdown of their models.
         self.add_parameter(
             Parameter(
                 name="model",
@@ -71,7 +72,6 @@ class BaseImageDriver(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
         self.add_parameter(

--- a/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
+++ b/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
@@ -37,8 +37,8 @@ class GriptapeCloudImage(BaseImageDriver):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Griptape Cloud specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Griptape Cloud's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Update the 'size' parameter for Griptape Cloud specifics.
         self._update_option_choices(param="image_size", choices=AVAILABLE_SIZES, default=str(DEFAULT_SIZE))
@@ -92,6 +92,9 @@ class GriptapeCloudImage(BaseImageDriver):
     def process(self) -> None:
         # Get the parameters from the node
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments

--- a/griptape_nodes_library/config/image/grok_image_driver.py
+++ b/griptape_nodes_library/config/image/grok_image_driver.py
@@ -25,8 +25,8 @@ class GrokImage(BaseImageDriver):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Grok's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # remove the 'size' parameter
         self.remove_parameter_element_by_name("image_size")
@@ -34,6 +34,9 @@ class GrokImage(BaseImageDriver):
     def process(self) -> None:
         # Get the parameters from the node
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments

--- a/griptape_nodes_library/config/image/openai_image_driver.py
+++ b/griptape_nodes_library/config/image/openai_image_driver.py
@@ -110,8 +110,8 @@ class OpenAiImage(BaseImageDriver):
             )
         )
 
-        # Update the parameters  for OpenAI specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer OpenAI's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
         self._update_option_choices(param="image_size", choices=GPT_IMAGE_SIZES, default=DEFAULT_SIZE)
 
     def _set_parameter_visibility(self, names: str | list[str], *, visible: bool) -> None:
@@ -186,6 +186,9 @@ class OpenAiImage(BaseImageDriver):
     def process(self) -> None:
         # Get the parameters from the node
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BaseImageDriver to get common driver arguments

--- a/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
+++ b/griptape_nodes_library/config/prompt/amazon_bedrock_prompt.py
@@ -95,7 +95,6 @@ class AmazonBedrockPrompt(BasePrompt):
         # a dropdown, we'll provide just a text field for the user to enter the model name
         # and set the default to the first model in the list.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/876
-        self._remove_options_trait(param="model")
         param = self.get_parameter_by_name("model")
         if param is not None:
             param.default_value = MODEL_CHOICES[0]

--- a/griptape_nodes_library/config/prompt/anthropic_prompt.py
+++ b/griptape_nodes_library/config/prompt/anthropic_prompt.py
@@ -75,8 +75,8 @@ class AnthropicPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Anthropic specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Anthropic's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Add deprecation notice message element right after model parameter
         self.add_node_element(
@@ -137,6 +137,9 @@ class AnthropicPrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt. This gets temperature, stream,

--- a/griptape_nodes_library/config/prompt/base_prompt.py
+++ b/griptape_nodes_library/config/prompt/base_prompt.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from griptape.drivers.prompt.dummy import DummyPromptDriver
 from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.base_driver import BaseDriver
 
@@ -31,7 +30,8 @@ class BasePrompt(BaseDriver):
     - Defines common LLM parameters accessible via `self.parameter_values`.
     - Provides `_get_common_driver_args` to easily collect arguments for drivers based on base parameters.
     - Provides `_validate_api_key` to standardize API key validation logic.
-    - Provides `_update_option_choices` to set driver-specific model lists for the 'model' parameter.
+    - Provides `_install_model_access` to turn the 'model' parameter into a
+      license-filtered dropdown of driver-specific models.
     Note: The `process` method in this base class creates a `DummyPromptDriver`
     primarily to establish the output socket type. It does not utilize the
     configuration parameters defined herein. Direct use of `BasePrompt` is
@@ -71,7 +71,10 @@ class BasePrompt(BaseDriver):
                 ui_options={"is_full_width": True, "multiline": True, "hide": True},
             )
         )
-        # Parameter for model selection. Subclasses should populate the 'choices'.
+        # Parameter for model selection. Subclasses either call
+        # `_install_model_access` to offer a license-filtered dropdown of their
+        # models, or add their own trait when the choices are theirs to manage
+        # (a free-text field, or a list fetched from the provider at runtime).
         self.add_parameter(
             Parameter(
                 name="model",
@@ -80,7 +83,6 @@ class BasePrompt(BaseDriver):
                 output_type="str",
                 default_value="",
                 tooltip="Select the model you want to use from the available options.",
-                traits={Options(choices=[])},
             )
         )
 

--- a/griptape_nodes_library/config/prompt/cohere_prompt.py
+++ b/griptape_nodes_library/config/prompt/cohere_prompt.py
@@ -44,8 +44,8 @@ class CoherePrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Anthropic specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Cohere's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Replace `min_p` with `top_p` for Cohere.
         self._replace_param_by_name(
@@ -72,6 +72,9 @@ class CoherePrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt. This gets temperature, stream,

--- a/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
+++ b/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
@@ -62,15 +62,12 @@ class GriptapeCloudPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Griptape Cloud specifics.
+        # Offer Griptape Cloud's models as a license-filtered dropdown.
         models, default_model = self._list_models()
         logger.debug(f"All models on Griptape Cloud: {models}")
         logger.debug(f"Default model on Griptape Cloud: {default_model}")
 
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
-        model_param = self.get_parameter_by_name("model")
-        if model_param is not None:
-            model_param.ui_options = {"data": MODEL_CHOICES_ARGS}
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Remove the 'seed' parameter as it's not directly used by GriptapeCloudPromptDriver.
         self.remove_parameter_element_by_name("seed")
@@ -151,6 +148,9 @@ class GriptapeCloudPrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.

--- a/griptape_nodes_library/config/prompt/grok_prompt.py
+++ b/griptape_nodes_library/config/prompt/grok_prompt.py
@@ -49,8 +49,8 @@ class GrokPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Grok specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Grok's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Remove `top_k` parameter as it's not used by Grok.
         self.remove_parameter_element_by_name("seed")
@@ -74,6 +74,9 @@ class GrokPrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.

--- a/griptape_nodes_library/config/prompt/groq_prompt.py
+++ b/griptape_nodes_library/config/prompt/groq_prompt.py
@@ -61,8 +61,8 @@ class GroqPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for Groq specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer Groq's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Remove the 'seed' parameter as it's not directly used by GroqPromptDriver.
         self.remove_parameter_element_by_name("seed")
@@ -88,6 +88,9 @@ class GroqPrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.

--- a/griptape_nodes_library/config/prompt/nim_prompt.py
+++ b/griptape_nodes_library/config/prompt/nim_prompt.py
@@ -66,8 +66,8 @@ class NimPrompt(BasePrompt):
 
         # --- Customize Inherited Parameters ---
 
-        # Update the 'model' parameter for NVIDIA specifics.
-        self._update_option_choices(param="model", choices=MODEL_CHOICES, default=DEFAULT_MODEL)
+        # Offer NVIDIA's models as a license-filtered dropdown.
+        self._install_model_access(model_choices=MODEL_CHOICES, default_model=DEFAULT_MODEL)
 
         # Remove the 'seed' parameter
         self.remove_parameter_element_by_name("seed")
@@ -93,6 +93,9 @@ class NimPrompt(BasePrompt):
         """
         # Retrieve all parameter values set on the node UI or via input connections.
         params = self.parameter_values
+
+        # A model the license denies must not reach a downstream node as a driver.
+        self._raise_if_model_denied()
 
         # --- Get Common Driver Arguments ---
         # Use the helper method from BasePrompt to get args like temperature, stream, max_attempts, etc.

--- a/griptape_nodes_library/config/prompt/openai_prompt.py
+++ b/griptape_nodes_library/config/prompt/openai_prompt.py
@@ -9,6 +9,7 @@ node configuration, and instantiates the `OpenAiPromptDriver`.
 
 from griptape.drivers.prompt.openai import OpenAiChatPromptDriver as GtOpenAiChatPromptDriver
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
 
@@ -68,6 +69,12 @@ class OpenAiPrompt(BasePrompt):
         import openai
 
         available_models = [model.id for model in openai.Client().models.list().data]
+        # This node offers whatever models the account can see rather than a
+        # declared list, so it owns the dropdown trait instead of routing through
+        # `_install_model_access`.
+        model_param = self.get_parameter_by_name("model")
+        if model_param is not None:
+            model_param.add_trait(Options(choices=available_models))
         self._update_option_choices(
             param="model", choices=available_models, default=available_models[0] if available_models else ""
         )

--- a/griptape_nodes_library/image/flux_2_image_generation.py
+++ b/griptape_nodes_library/image/flux_2_image_generation.py
@@ -89,14 +89,20 @@ class Flux2ImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Flux models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Select the Flux model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Select the Flux model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            provider_model_id_by_choice=MODEL_MAPPING,
         )
 
         # Core parameters

--- a/griptape_nodes_library/image/flux_image_generation.py
+++ b/griptape_nodes_library/image/flux_image_generation.py
@@ -83,14 +83,19 @@ class FluxImageGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate images using Flux models via API (supports user-provided API keys via proxy)"
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="flux-kontext-pro",
-                tooltip="Select the Flux model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="flux-kontext-pro",
+            tooltip="Select the Flux model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="flux-kontext-pro",
         )
 
         # Core parameters

--- a/griptape_nodes_library/image/google_image_generation.py
+++ b/griptape_nodes_library/image/google_image_generation.py
@@ -86,21 +86,23 @@ class GoogleImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Google Gemini models via Griptape Cloud model proxy"
 
         # Model ID
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=self.DEFAULT_MODEL,
-                tooltip="Model id to call via proxy",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "Model",
-                },
-                traits={
-                    Options(
-                        choices=list(self.SUPPORTED_MODELS_TO_API_MODELS.keys()),
-                    )
-                },
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=self.DEFAULT_MODEL,
+            tooltip="Model id to call via proxy",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "Model",
+            },
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=list(self.SUPPORTED_MODELS_TO_API_MODELS.keys()),
+            default_model=self.DEFAULT_MODEL,
+            provider_model_id_by_choice=self.SUPPORTED_MODELS_TO_API_MODELS,
         )
 
         # Prompt

--- a/griptape_nodes_library/image/grok_image_edit.py
+++ b/griptape_nodes_library/image/grok_image_edit.py
@@ -56,14 +56,20 @@ class GrokImageEdit(GriptapeProxyNode):
         self.category = "API Nodes"
         self.description = "Edit images using Grok image models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Image",
-                tooltip="Select the Grok image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Image"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="Grok Imagine Image",
+            tooltip="Select the Grok image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["Grok Imagine Image"],
+            default_model="Grok Imagine Image",
+            provider_model_id_by_choice=self.MODEL_NAME_MAP,
         )
 
         self.add_parameter(

--- a/griptape_nodes_library/image/grok_image_generation.py
+++ b/griptape_nodes_library/image/grok_image_generation.py
@@ -81,14 +81,20 @@ class GrokImageGeneration(GriptapeProxyNode):
         self.category = "API Nodes"
         self.description = "Generate images using Grok image models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Image",
-                tooltip="Select the Grok image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Image"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="Grok Imagine Image",
+            tooltip="Select the Grok image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["Grok Imagine Image"],
+            default_model="Grok Imagine Image",
+            provider_model_id_by_choice=self.MODEL_NAME_MAP,
         )
 
         self.add_node_element(

--- a/griptape_nodes_library/image/openai_image_generation.py
+++ b/griptape_nodes_library/image/openai_image_generation.py
@@ -99,14 +99,20 @@ class OpenAiImageGeneration(GriptapeProxyNode):
         # PublicArtifactUrlParameter tracked here so it can be cleaned up after the run.
         self._pending_reference_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=self.DEFAULT_MODEL,
-                tooltip="Select the OpenAI image model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=list(self.MODEL_NAME_MAP.keys()))},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=self.DEFAULT_MODEL,
+            tooltip="Select the OpenAI image model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=list(self.MODEL_NAME_MAP.keys()),
+            default_model=self.DEFAULT_MODEL,
+            provider_model_id_by_choice=self.MODEL_NAME_MAP,
         )
 
         self.add_parameter(

--- a/griptape_nodes_library/image/qwen_image_edit.py
+++ b/griptape_nodes_library/image/qwen_image_edit.py
@@ -16,7 +16,6 @@ from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_list
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
@@ -87,14 +86,19 @@ class QwenImageEdit(GriptapeProxyNode):
         self.description = "Edit images using Qwen image editing models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="qwen-image-edit-plus",
-                tooltip="Select the Qwen image editing model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="qwen-image-edit-plus",
+            tooltip="Select the Qwen image editing model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="qwen-image-edit-plus",
         )
 
         # Editing instruction parameter

--- a/griptape_nodes_library/image/qwen_image_generation.py
+++ b/griptape_nodes_library/image/qwen_image_generation.py
@@ -73,16 +73,21 @@ class QwenImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Qwen models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            Parameter(
-                name="model",
-                input_types=["str"],
-                type="str",
-                default_value="qwen-image",
-                tooltip="Select the Qwen model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = Parameter(
+            name="model",
+            input_types=["str"],
+            type="str",
+            default_value="qwen-image",
+            tooltip="Select the Qwen model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="qwen-image",
         )
 
         # Core parameters

--- a/griptape_nodes_library/image/seedream_image_generation.py
+++ b/griptape_nodes_library/image/seedream_image_generation.py
@@ -146,22 +146,24 @@ class SeedreamImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Seedream models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Seedream 4.5",
-                tooltip="Select the Seedream model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={
-                    Options(
-                        choices=[
-                            "Seedream 5.0 Lite",
-                            "Seedream 4.5",
-                            "Seedream 4.0",
-                        ]
-                    )
-                },
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="Seedream 4.5",
+            tooltip="Select the Seedream model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=[
+                "Seedream 5.0 Lite",
+                "Seedream 4.5",
+                "Seedream 4.0",
+            ],
+            default_model="Seedream 4.5",
+            provider_model_id_by_choice=MODEL_NAME_MAP,
         )
 
         self.add_node_element(

--- a/griptape_nodes_library/image/topaz_image_enhance.py
+++ b/griptape_nodes_library/image/topaz_image_enhance.py
@@ -42,6 +42,10 @@ OPERATION_OPTIONS = [
     "tool",
 ]
 
+# The catalog declares one model per operation (topaz-<operation>); operation is this
+# node's catalog-model dimension, not the per-operation `model` variant list below.
+OPERATION_MODEL_ID_MAP = {operation: f"topaz-{operation}" for operation in OPERATION_OPTIONS}
+
 ENHANCE_MODELS = {
     "Standard V2": [
         "face_enhancement",
@@ -295,14 +299,20 @@ class TopazImageEnhance(GriptapeProxyNode):
         self.description = "Enhance images using Topaz Labs models via Griptape model proxy"
 
         # Operation selection
-        self.add_parameter(
-            ParameterString(
-                name="operation",
-                default_value="enhance",
-                tooltip="Type of image enhancement operation",
-                allow_output=False,
-                traits={Options(choices=OPERATION_OPTIONS)},
-            )
+        operation_param = ParameterString(
+            name="operation",
+            default_value="enhance",
+            tooltip="Type of image enhancement operation",
+            allow_output=False,
+        )
+        self.add_parameter(operation_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=operation_param,
+            model_choices=OPERATION_OPTIONS,
+            default_model="enhance",
+            provider_model_id_by_choice=OPERATION_MODEL_ID_MAP,
         )
 
         # Model selection - will be dynamically updated based on operation

--- a/griptape_nodes_library/image/wan_image_generation.py
+++ b/griptape_nodes_library/image/wan_image_generation.py
@@ -62,14 +62,20 @@ class WanImageGeneration(GriptapeProxyNode):
         self.description = "Generate images using Wan 2.7 models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Select the Wan model to use",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Select the Wan model to use",
+            allow_output=False,
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            provider_model_id_by_choice=MODEL_MAPPING,
         )
 
         # Core parameters

--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -8,7 +8,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import suppress
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import httpx
@@ -22,7 +22,11 @@ from griptape_nodes.exe_types.param_types.parameter_string import ParameterStrin
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key, resolve_proxy_base
 from griptape_nodes_library.proxy.proxy_api_key_providers import get_proxy_api_key_provider_config
 from griptape_nodes_library.proxy.proxy_auth_provider_parameter import ProxyAuthProviderParameter
+from griptape_nodes_library.utils.model_access import ModelDropdownAccess
 from griptape_nodes_library.utils.model_invocation import declare_model_invocation
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -79,6 +83,10 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         self._user_auth_info: str | None = None
         self._api_key_provider: ProxyAuthProviderParameter | None = None
         self._initialize_api_key_provider()
+
+        # Set by `_install_model_access` on subclasses whose model selection is a
+        # license-filtered dropdown; stays None on the ones bound to a single model.
+        self._model_access: ModelDropdownAccess | None = None
 
         default_timeout = self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
         self.add_parameter(
@@ -156,6 +164,39 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         super().after_value_set(parameter, value)
         if self._api_key_provider:
             self._api_key_provider.after_value_set(parameter, value)
+        if self._model_access is not None:
+            self._model_access.on_value_set(parameter, value)
+
+    def _install_model_access(
+        self,
+        *,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        """Turn an already-added model parameter into a license-filtered dropdown.
+
+        The component owns the parameter's `Options` trait, so pass a parameter
+        built without one; it also adds an inline refresh button, marks the models
+        the caller's license denies, and moves the stored value off a denied
+        default. `_submit_and_poll` then refuses to submit a denied selection.
+
+        Args:
+            parameter: The model parameter, already added to this node.
+            model_choices: The models the node offers, in dropdown order.
+            default_model: The choice selected by default.
+            provider_model_id_by_choice: Choice -> catalog `provider_model_id` map,
+                needed only when the choices are display labels rather than
+                provider ids.
+        """
+        self._model_access = ModelDropdownAccess(
+            node=self,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+            provider_model_id_by_choice=provider_model_id_by_choice,
+        )
 
     def _prepare_user_auth_info(self) -> None:
         self.register_user_auth_info(None)
@@ -605,6 +646,12 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         error_msg = f"{self.name}: No model ID provided"
         self._set_status_results(was_successful=False, result_details=error_msg)
 
+    def _handle_denied_model(self, denial: CheckpointDenial) -> None:
+        """Handle a dropdown selection the license policy does not permit."""
+        self._set_safe_defaults()
+        error_msg = f"{self.name}: {denial.reason()}"
+        self._set_status_results(was_successful=False, result_details=error_msg)
+
     def _handle_submission_error(self, e: RuntimeError) -> None:
         """Handle generation submission errors."""
         self._set_safe_defaults()
@@ -640,6 +687,15 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         if not api_model_id:
             self._handle_missing_model_id()
             return None
+
+        # Re-check the dropdown selection against the license policy: it may have
+        # been permitted when the node was built and denied since. Runs before the
+        # invocation declaration so the failure carries the dropdown's own reason.
+        if self._model_access is not None:
+            selection_denial = self._model_access.selection_denial()
+            if selection_denial is not None:
+                self._handle_denied_model(selection_denial)
+                return None
 
         # Declare the invocation so the engine's permission layer can gate it
         # before any network call. The proxy still enforces server-side; this is

--- a/griptape_nodes_library/splat/world_labs_world_generation.py
+++ b/griptape_nodes_library/splat/world_labs_world_generation.py
@@ -90,15 +90,21 @@ class WorldLabsWorldGeneration(GriptapeProxyNode):
         self.description = "Generate 3D worlds using World Labs Marble via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Marble model: 1.1 Plus (variable pricing, larger worlds), 1.1 (standard), 1.0 (previous), 1.0 Draft (fast/cheaper)",
-                allow_output=False,
-                traits={Options(choices=MODEL_OPTIONS)},
-                ui_options={"display_name": "Model"},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Marble model: 1.1 Plus (variable pricing, larger worlds), 1.1 (standard), 1.0 (previous), 1.0 Draft (fast/cheaper)",
+            allow_output=False,
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=DEFAULT_MODEL,
+            provider_model_id_by_choice=MODEL_ID_MAP,
         )
 
         # Input type selector

--- a/griptape_nodes_library/utils/model_access.py
+++ b/griptape_nodes_library/utils/model_access.py
@@ -1,0 +1,134 @@
+"""License-policy wiring for the library's model-selection dropdowns.
+
+The engine's ``ModelAccessComponent`` decorates a model dropdown with the
+caller's entitlement, badges a denied selection, and answers "is this selection
+permitted right now?" at run time. It keys every lookup on the dropdown value,
+which it expects to be the catalog's ``provider_model_id``.
+
+Many nodes here instead offer artist-facing labels (``"Kling v3.0"``,
+``"Seedream 4.5"``) and translate to the provider id when they build their
+request. Those labels are the values the parameter stores, so they cannot be
+swapped for provider ids: ``Options`` converts any value outside ``choices`` to
+``choices[0]`` before ``before_value_set`` runs, so a rename would silently
+repoint every saved workflow at the first model in the list.
+``MappedModelAccessComponent`` closes that gap by keying the component's
+snapshot under the label as well, so decoration, badges, and runtime queries all
+work off the value the parameter actually holds.
+
+``ModelDropdownAccess`` is what node base classes hold: the component plus the
+parameter it owns, so a base class can forward value changes and query the
+current selection without every node repeating that bookkeeping.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.exe_types.param_components.model_access_component import _AccessSnapshot
+    from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
+
+__all__ = ["MappedModelAccessComponent", "ModelDropdownAccess"]
+
+
+class MappedModelAccessComponent(ModelAccessComponent):
+    """A model-access component for a dropdown whose choices are display labels.
+
+    ``provider_model_id_by_choice`` maps each dropdown choice to the
+    ``provider_model_id`` the library catalog declares for it -- the same id the
+    node sends upstream. Choices missing from the map keep the base class's
+    behavior and resolve as provider ids, so a dropdown that mixes labels and
+    raw ids still works.
+    """
+
+    def __init__(
+        self,
+        *,
+        node: BaseNode,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str],
+    ) -> None:
+        # Assigned before the base constructor because that constructor fetches
+        # the first snapshot, which `_fetch_snapshot` re-keys through this map.
+        self._provider_model_id_by_choice = dict(provider_model_id_by_choice)
+        super().__init__(
+            node=node,
+            parameter=parameter,
+            model_choices=model_choices,
+            default_model=default_model,
+        )
+
+    def _fetch_snapshot(self) -> _AccessSnapshot:
+        """Index the engine's verdicts under the dropdown labels as well as the provider ids."""
+        snapshot = super()._fetch_snapshot()
+        for choice, provider_model_id in self._provider_model_id_by_choice.items():
+            catalog_id = snapshot.catalog_id_by_provider_id.get(provider_model_id)
+            if catalog_id is not None:
+                snapshot.catalog_id_by_provider_id[choice] = catalog_id
+            denial = snapshot.denial_by_provider_id.get(provider_model_id)
+            if denial is not None:
+                snapshot.denial_by_provider_id[choice] = denial
+        return snapshot
+
+
+class ModelDropdownAccess:
+    """One node's license-filtered model dropdown.
+
+    Owns the ``ModelAccessComponent`` and remembers which parameter it decorates
+    so a node base class can forward ``after_value_set`` and query the current
+    selection generically. Nodes reach the component itself through
+    ``component`` when they need its dropdown-level API (``model_choices``,
+    ``pick_permitted_default``, ``reinstall_options``).
+    """
+
+    def __init__(
+        self,
+        *,
+        node: BaseNode,
+        parameter: Parameter,
+        model_choices: list[str],
+        default_model: str,
+        provider_model_id_by_choice: dict[str, str] | None = None,
+    ) -> None:
+        self._node = node
+        self._parameter_name = parameter.name
+        self.component: ModelAccessComponent
+        if provider_model_id_by_choice:
+            self.component = MappedModelAccessComponent(
+                node=node,
+                parameter=parameter,
+                model_choices=model_choices,
+                default_model=default_model,
+                provider_model_id_by_choice=provider_model_id_by_choice,
+            )
+        else:
+            self.component = ModelAccessComponent(
+                node=node,
+                parameter=parameter,
+                model_choices=model_choices,
+                default_model=default_model,
+            )
+
+    @property
+    def parameter_name(self) -> str:
+        """Name of the parameter this dropdown decorates."""
+        return self._parameter_name
+
+    def on_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Track the badge for this dropdown; ignore every other parameter on the node."""
+        if parameter.name == self._parameter_name:
+            self.component.on_value_changed(value)
+
+    def selection_denial(self) -> CheckpointDenial | None:
+        """The current selection's verdict, or ``None`` when it is permitted."""
+        return self.component.query_for_denial(self._node.get_parameter_value(self._parameter_name))
+
+    def raise_if_selection_denied(self) -> None:
+        """Raise ``RuntimeError`` when the current selection is not permitted."""
+        self.component.raise_if_denied(self._node.get_parameter_value(self._parameter_name))

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -586,9 +586,12 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         Appends :image2video modality to the model name.
         """
+        return f"{self._get_catalog_model_id()}:image2video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:image2video` suffix).
         model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:image2video"
+        return self.MODEL_NAME_MAP.get(model_name, model_name)
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Kling API.

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -459,9 +459,12 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
         Appends :text2video modality to the model name.
         """
+        return f"{self._get_catalog_model_id()}:text2video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:text2video` suffix).
         model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:text2video"
+        return self.MODEL_NAME_MAP.get(model_name, model_name)
 
     def _build_customize_multi_prompt_payload(self, shot_count: int) -> list[dict[str, Any]]:
         """Build multi_prompt payload from shot input parameters."""

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -185,9 +185,12 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:audio-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:audio-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:audio-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-pro")
 
     async def _prepare_audio_data_url_async(self, audio_input: Any) -> str | None:
         """Convert audio input to a base64 data URL."""

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -283,9 +283,12 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:image-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:image-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:image-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-fast")
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -267,9 +267,12 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:text-to-video"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:text-to-video` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:text-to-video"
+        return MODEL_MAPPING.get(model_name, "ltx-2-fast")
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -201,9 +201,12 @@ class LTXVideoExtend(GriptapeProxyNode):
             self._update_context_badge(value)
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:extend"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:extend` suffix).
         model_name = self.get_parameter_value("model") or DEFAULT_MODEL
-        model_id = MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
-        return f"{model_id}:extend"
+        return MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
 
     async def _prepare_video_data_uri_async(self, video_input: Any) -> str | None:
         """Convert video input to a base64 data URI."""

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -358,9 +358,12 @@ class LTXVideoRetake(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:retake"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:retake` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:retake"
+        return MODEL_MAPPING.get(model_name, "ltx-2-pro")
 
     def _validate_video_input(self, video: Any) -> str | None:
         """Validate video is provided and doesn't exceed duration limits."""

--- a/griptape_nodes_library/video/ltx_video_to_video_hdr.py
+++ b/griptape_nodes_library/video/ltx_video_to_video_hdr.py
@@ -115,9 +115,12 @@ class LTXVideoToVideoHDR(GriptapeProxyNode):
         self.set_initial_node_size(height=400)
 
     def _get_api_model_id(self) -> str:
+        return f"{self._get_catalog_model_id()}:video-to-video-hdr"
+
+    def _get_catalog_model_id(self) -> str:
+        # The catalog declares the bare provider id (no `:video-to-video-hdr` suffix).
         model_name = self.get_parameter_value("model") or "LTX 2.3 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-3-pro")
-        return f"{model_id}:video-to-video-hdr"
+        return MODEL_MAPPING.get(model_name, "ltx-2-3-pro")
 
     @staticmethod
     def _extract_input_video_url(video_input: Any) -> str | None:

--- a/griptape_nodes_library/video/omnihuman_subject_detection.py
+++ b/griptape_nodes_library/video/omnihuman_subject_detection.py
@@ -12,7 +12,6 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key
@@ -52,14 +51,19 @@ class OmnihumanSubjectDetection(GriptapeProxyNode):
         self.description = "Detect subjects and generate masks using OmniHuman Subject Detection via Griptape Cloud"
 
         # INPUTS
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=self.MODEL_IDS[0],
-                tooltip="Model identifier to use for detection",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=self.MODEL_IDS[0],
+            tooltip="Model identifier to use for detection",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model=self.MODEL_IDS[0],
         )
 
         self._public_image_url_parameter = PublicArtifactUrlParameter(

--- a/griptape_nodes_library/video/omnihuman_subject_recognition.py
+++ b/griptape_nodes_library/video/omnihuman_subject_recognition.py
@@ -12,7 +12,6 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key
@@ -52,14 +51,19 @@ class OmnihumanSubjectRecognition(GriptapeProxyNode):
         self.description = "Identify subjects in images using OmniHuman Subject Recognition via Griptape Cloud"
 
         # INPUTS
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=self.MODEL_IDS[0],
-                tooltip="Model identifier to use for recognition",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=self.MODEL_IDS[0],
+            tooltip="Model identifier to use for recognition",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model=self.MODEL_IDS[0],
         )
 
         self._public_image_url_parameter = PublicArtifactUrlParameter(

--- a/griptape_nodes_library/video/omnihuman_video_generation.py
+++ b/griptape_nodes_library/video/omnihuman_video_generation.py
@@ -22,7 +22,6 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.options import Options
 from PIL import Image
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
@@ -79,14 +78,19 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
 
         # INPUTS
         # add model_id parameter with fixed value
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value="omnihuman-1-5",
-                tooltip="Model identifier to use for generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=self.MODEL_IDS)},
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value="omnihuman-1-5",
+            tooltip="Model identifier to use for generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=self.MODEL_IDS,
+            default_model="omnihuman-1-5",
         )
         self.add_parameter(
             ParameterString(
@@ -199,6 +203,7 @@ class OmnihumanVideoGeneration(GriptapeProxyNode):
         parameter: Parameter,
         value: Any,
     ) -> None:
+        super().after_value_set(parameter, value)
         # if the model_id parameter is omnihuman-1-0, remove seed, fast_mode, and prompt parameters
         if parameter.name == "model_id" and value == "omnihuman-1-0":
             self.hide_parameter_by_name("seed")

--- a/griptape_nodes_library/video/sora_video_generation.py
+++ b/griptape_nodes_library/video/sora_video_generation.py
@@ -66,17 +66,22 @@ class SoraVideoGeneration(GriptapeProxyNode):
         self.description = "Generate video via Sora 2 through Griptape Cloud model proxy"
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="sora-2",
-                tooltip="Sora model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "Model",
-                },
-                traits={Options(choices=["sora-2", "sora-2-pro"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="sora-2",
+            tooltip="Sora model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "Model",
+            },
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["sora-2", "sora-2-pro"],
+            default_model="sora-2",
         )
         self.add_parameter(
             ParameterString(

--- a/griptape_nodes_library/video/wan_animate_generation.py
+++ b/griptape_nodes_library/video/wan_animate_generation.py
@@ -93,14 +93,19 @@ class WanAnimateGeneration(GriptapeProxyNode):
         self.description = "Generate animated videos from images using WAN Animate models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=MODEL_OPTIONS[0],
-                tooltip="Select the WAN Animate model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=MODEL_OPTIONS[0],
+            tooltip="Select the WAN Animate model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model=MODEL_OPTIONS[0],
         )
         # Mode selection
         self.add_parameter(

--- a/griptape_nodes_library/video/wan_image_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_image_to_video_generation.py
@@ -138,14 +138,19 @@ class WanImageToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from images using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-i2v",
-                tooltip="Select the WAN image-to-video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-i2v",
+            tooltip="Select the WAN image-to-video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-i2v",
         )
 
         # Prompt parameter (optional)

--- a/griptape_nodes_library/video/wan_reference_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_reference_to_video_generation.py
@@ -120,14 +120,19 @@ class WanReferenceToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from reference videos using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-r2v",
-                tooltip="Select the WAN reference-to-video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-r2v",
+            tooltip="Select the WAN reference-to-video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-r2v",
         )
 
         # Prompt parameter

--- a/griptape_nodes_library/video/wan_text_to_video_generation.py
+++ b/griptape_nodes_library/video/wan_text_to_video_generation.py
@@ -123,14 +123,19 @@ class WanTextToVideoGeneration(GriptapeProxyNode):
         self.description = "Generate videos from text using WAN models via Griptape model proxy"
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="wan2.6-t2v",
-                tooltip="Select the WAN model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=MODEL_OPTIONS)},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="wan2.6-t2v",
+            tooltip="Select the WAN model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=MODEL_OPTIONS,
+            default_model="wan2.6-t2v",
         )
 
         # Prompt parameter

--- a/tests/unit/config/test_driver_model_access.py
+++ b/tests/unit/config/test_driver_model_access.py
@@ -1,0 +1,183 @@
+"""Tests that the config driver nodes wire their model dropdown through
+``ModelAccessComponent``.
+
+Every prompt/image driver node under ``griptape_nodes_library/config`` offers
+its model list via ``BaseDriver._install_model_access``, which hands the
+node's ``model`` parameter to a ``ModelAccessComponent``: the component owns
+the ``Options`` + refresh ``Button`` traits, decorates each row with the
+caller's license entitlement, and gates ``process()`` against the current
+policy. These tests cover that wiring and the runtime gate across every node
+that installs it; the component's own behavior is covered in the engine test
+suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import requests
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointDenial,
+    CheckpointFailure,
+)
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.config.base_driver import BaseDriver
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+LIBRARY_NAME = "Griptape Nodes Library"
+
+type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | None]
+
+# (node type, catalog model id to deny, dropdown value that id resolves to).
+# The denied id is deliberately not the node's default everywhere it can be,
+# so the ModelAccessComponent constructor's default-relocation logic (which
+# moves the stored value off a denied default) never fires and can't confuse
+# these assertions. CoherePrompt and GrokImage each declare exactly one model,
+# so their only choice is necessarily also their default.
+NODE_MODEL_CASES: list[tuple[str, str, str]] = [
+    ("AnthropicPrompt", "gtc_claude_haiku_4_5", "claude-haiku-4-5"),
+    ("CoherePrompt", "cohere_command_r_plus", "command-r-plus"),  # CoherePrompt's only declared model
+    ("GriptapeCloudPrompt", "gtc_claude_sonnet_4_6", "claude-sonnet-4-6"),
+    ("GrokPrompt", "xai_grok_3_mini_beta", "grok-3-mini-beta"),
+    ("GroqPrompt", "groq_llama_3_3_70b_versatile", "llama-3.3-70b-versatile"),
+    ("NimPrompt", "nim_gpt_oss_20b", "openai/gpt-oss-20b"),
+    ("GriptapeCloudImage", "gtc_gpt_image_1_5", "gpt-image-1.5"),
+    ("GrokImage", "xai_grok_2_image_1212", "grok-2-image-1212"),  # GrokImage's only declared model
+    ("OpenAiImage", "openai_dall_e_3", "dall-e-3"),
+]
+
+
+def _create_node(node_type: str) -> BaseNode:
+    """Create a node through the library so its metadata carries `library` / `node_type`.
+
+    The engine's model-access query reads those two metadata keys to resolve a
+    node's declared models; a bare `NodeClass(name=...)` construction does not
+    set them and would leave the dropdown undecorated.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return library.create_node(node_type=node_type, name=node_type)
+
+
+def _deny_hook(action: CheckpointAction, subject_id: str) -> AuthorizationHook:
+    """Build a hook that denies one action against one catalog model id, else allows."""
+
+    def hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        if checkpoint.action == action and checkpoint.subject_id == subject_id:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="denied for test"),))
+        return None
+
+    return hook
+
+
+class _FakeCloudModelsResponse:
+    """Stand-in for the `requests.Response` `GriptapeCloudPrompt._list_models` reads."""
+
+    def raise_for_status(self) -> None:
+        return
+
+    def json(self) -> dict[str, list[dict[str, Any]]]:
+        return {"models": [{"model_name": "gpt-4.1-mini", "default": True}]}
+
+
+@pytest.fixture(autouse=True)
+def _stub_griptape_cloud_model_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`GriptapeCloudPrompt.__init__` calls `_list_models`, which hits Griptape Cloud's
+    API over HTTP; stub `requests.get` so constructing the node never depends on network
+    access. The library loader reimports each node's module from its file path, so
+    patching the `GriptapeCloudPrompt` class imported here would miss the module
+    instance the library actually registers; `requests.get` is shared regardless.
+    """
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: _FakeCloudModelsResponse())  # noqa: ARG005
+
+
+@pytest.fixture
+def authorization_hook() -> Iterator[Callable[[AuthorizationHook], None]]:
+    """Register an authorization hook for the test, guaranteed removed afterward."""
+    registered: list[AuthorizationHook] = []
+
+    def register(hook: AuthorizationHook) -> None:
+        GriptapeNodes.EventManager().add_authorization_hook(hook)
+        registered.append(hook)
+
+    try:
+        yield register
+    finally:
+        for hook in registered:
+            GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+
+@pytest.mark.parametrize("node_type", [case[0] for case in NODE_MODEL_CASES])
+def test_model_param_wired_to_model_access_component(node_type: str) -> None:
+    node = cast("BaseDriver", _create_node(node_type))
+
+    assert node._model_access is not None
+    assert isinstance(node._model_access.component, ModelAccessComponent)
+
+    model_param = node.get_parameter_by_name("model")
+    assert model_param is not None
+    # The component installs the Options dropdown and a refresh Button.
+    assert model_param.find_elements_by_type(Options)
+    assert model_param.find_elements_by_type(Button)
+    # Per-row decoration the frontend uses to flag denied models.
+    ui_options = model_param.ui_options
+    assert ui_options.get("dropdown_row_icons") is True
+    assert ui_options.get("dropdown_row_subtitles") is True
+    assert isinstance(ui_options.get("data"), list)
+    assert ui_options["data"]
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "dropdown_value"), NODE_MODEL_CASES)
+def test_denied_model_row_carries_denial_icon(
+    node_type: str,
+    denied_catalog_id: str,
+    dropdown_value: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    # Registered before construction so the component's constructor-time snapshot
+    # already carries the denial, and decorates the row on the first build.
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node = _create_node(node_type)
+
+    model_param = node.get_parameter_by_name("model")
+    assert model_param is not None
+    data = model_param.ui_options["data"]
+    assert data
+
+    for row in data:
+        if row["name"] == dropdown_value:
+            assert row.get("icon") == "shield-off"
+        else:
+            assert row.get("icon") is None
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "dropdown_value"), NODE_MODEL_CASES)
+def test_process_raises_when_selected_model_is_denied(
+    node_type: str,
+    denied_catalog_id: str,
+    dropdown_value: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    """A denied model must not reach a downstream node as a driver.
+
+    Construct the node BEFORE registering the deny hook, so the component's
+    constructor-time snapshot is clean and doesn't relocate the stored value
+    off the about-to-be-denied selection.
+    """
+    node = _create_node(node_type)
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node.set_parameter_value("model", dropdown_value)
+
+    with pytest.raises(RuntimeError, match="is not permitted"):
+        node.process()

--- a/tests/unit/test_griptape_proxy_node_catalog_id.py
+++ b/tests/unit/test_griptape_proxy_node_catalog_id.py
@@ -16,6 +16,14 @@ from griptape_nodes_library.image.grok_image_generation import GrokImageGenerati
 from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.video.grok_video_edit import GrokVideoEdit
 from griptape_nodes_library.video.grok_video_generation import GrokVideoGeneration
+from griptape_nodes_library.video.kling_image_to_video_generation import KlingImageToVideoGeneration
+from griptape_nodes_library.video.kling_text_to_video_generation import KlingTextToVideoGeneration
+from griptape_nodes_library.video.ltx_audio_to_video_generation import LTXAudioToVideoGeneration
+from griptape_nodes_library.video.ltx_image_to_video_generation import LTXImageToVideoGeneration
+from griptape_nodes_library.video.ltx_text_to_video_generation import LTXTextToVideoGeneration
+from griptape_nodes_library.video.ltx_video_extend import LTXVideoExtend
+from griptape_nodes_library.video.ltx_video_retake import LTXVideoRetake
+from griptape_nodes_library.video.ltx_video_to_video_hdr import LTXVideoToVideoHDR
 
 # (node class, bare catalog provider id, suffixed url-path id)
 GROK_NODES = [
@@ -28,6 +36,33 @@ GROK_NODES = [
 
 @pytest.mark.parametrize(("node_class", "bare_id", "suffixed_id"), GROK_NODES)
 def test_grok_catalog_id_is_bare_provider_id(
+    node_class: type[GriptapeProxyNode], bare_id: str, suffixed_id: str
+) -> None:
+    node = node_class(name=node_class.__name__)
+
+    # The URL-path id keeps the operation suffix; the catalog id must not, so it
+    # matches the bare `provider_model_id` declared in the catalog.
+    assert node._get_api_model_id() == suffixed_id
+    assert node._get_catalog_model_id() == bare_id
+
+
+# (node class, bare catalog provider id, suffixed url-path id) for each node's default
+# dropdown selection. The bare ids are cross-checked against the `model_usage` ids each
+# node declares in griptape_nodes_library.json's `model_catalog` metadata.
+SUFFIXED_NODES = [
+    (LTXTextToVideoGeneration, "ltx-2-3-fast", "ltx-2-3-fast:text-to-video"),
+    (LTXImageToVideoGeneration, "ltx-2-3-fast", "ltx-2-3-fast:image-to-video"),
+    (LTXAudioToVideoGeneration, "ltx-2-pro", "ltx-2-pro:audio-to-video"),
+    (LTXVideoExtend, "ltx-2-3-pro", "ltx-2-3-pro:extend"),
+    (LTXVideoRetake, "ltx-2-pro", "ltx-2-pro:retake"),
+    (LTXVideoToVideoHDR, "ltx-2-3-pro", "ltx-2-3-pro:video-to-video-hdr"),
+    (KlingTextToVideoGeneration, "kling-v3", "kling-v3:text2video"),
+    (KlingImageToVideoGeneration, "kling-v3", "kling-v3:image2video"),
+]
+
+
+@pytest.mark.parametrize(("node_class", "bare_id", "suffixed_id"), SUFFIXED_NODES)
+def test_suffixed_catalog_id_is_bare_provider_id(
     node_class: type[GriptapeProxyNode], bare_id: str, suffixed_id: str
 ) -> None:
     node = node_class(name=node_class.__name__)

--- a/tests/unit/test_proxy_model_access.py
+++ b/tests/unit/test_proxy_model_access.py
@@ -28,6 +28,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes_library.image.seedream_image_generation import SeedreamImageGeneration
 from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
 from griptape_nodes_library.video.sora_video_generation import SoraVideoGeneration
 
@@ -45,8 +46,11 @@ type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | 
 # it can be, so the ModelAccessComponent constructor's default-relocation logic
 # (which moves the stored value off a denied default) never fires and can't
 # confuse these assertions. OmnihumanSubjectRecognition, OmnihumanSubjectDetection,
-# WanReferenceToVideoGeneration, FluxImageGeneration, and TranscribeAudio each
-# declare exactly one model, so their only choice is necessarily also their default.
+# WanReferenceToVideoGeneration, FluxImageGeneration, TranscribeAudio, GrokImageGeneration,
+# and GrokImageEdit each declare exactly one model, so their only choice is necessarily
+# also their default. SeedreamImageGeneration, GoogleImageGeneration, OpenAiImageGeneration,
+# WorldLabsWorldGeneration, and TopazImageEnhance offer artist-facing labels rather than
+# provider ids, so the dropdown value here is the label the node maps to the denied id.
 NODE_MODEL_CASES: list[tuple[str, str, str, str]] = [
     ("TranscribeAudio", "gtc_whisper_1", "whisper-1", "model"),  # only declared model
     ("ElevenLabsTextToSpeechGeneration", "gtc_eleven_multilingual_v2", "eleven_multilingual_v2", "model"),
@@ -71,6 +75,15 @@ NODE_MODEL_CASES: list[tuple[str, str, str, str]] = [
     ("FluxImageGeneration", "gtc_flux_kontext_pro", "flux-kontext-pro", "model"),  # only declared model
     ("QwenImageGeneration", "gtc_qwen_image_plus", "qwen-image-plus", "model"),
     ("QwenImageEdit", "gtc_qwen_image_edit", "qwen-image-edit", "model"),
+    ("SeedreamImageGeneration", "gtc_seedream_4_0", "Seedream 4.0", "model"),
+    ("GrokImageGeneration", "gtc_grok_imagine_image", "Grok Imagine Image", "model"),  # only declared model
+    ("GrokImageEdit", "gtc_grok_imagine_image", "Grok Imagine Image", "model"),  # only declared model
+    ("Flux2ImageGeneration", "gtc_flux_2_flex", "Flux.2 [flex]", "model"),
+    ("WanImageGeneration", "gtc_wan_2_7_image", "Wan 2.7 Image", "model"),
+    ("GoogleImageGeneration", "gtc_gemini_3_1_flash_image", "Nano Banana 2", "model"),
+    ("OpenAiImageGeneration", "gtc_gpt_image_1", "GPT Image 1", "model"),
+    ("WorldLabsWorldGeneration", "gtc_marble_1_0_draft", "Marble 1.0 Draft", "model"),
+    ("TopazImageEnhance", "gtc_topaz_sharpen", "sharpen", "operation"),
 ]
 
 
@@ -208,3 +221,26 @@ async def test_submit_and_poll_gates_on_denial(monkeypatch: pytest.MonkeyPatch) 
 
     assert len(submit_calls) == 1
     assert submit_calls[0]["api_model_id"] == "sora-2-pro"
+
+
+def test_mapped_dropdown_label_resolves_denial_at_runtime(
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    """A labeled dropdown's stored value is the artist-facing label, not the provider id.
+
+    `MappedModelAccessComponent` re-keys the snapshot's lookup tables under the label
+    as well as the provider id, so a runtime query against the label still resolves
+    through to the catalog id the policy denies. The hook is registered AFTER
+    construction so this exercises `selection_denial()`'s live re-check, not the
+    constructor-time snapshot or its default-relocation logic.
+    """
+    node = cast("SeedreamImageGeneration", _create_node("SeedreamImageGeneration"))
+    assert node._model_access is not None
+
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, "gtc_seedream_5_0_lite"))
+
+    node.set_parameter_value("model", "Seedream 5.0 Lite")
+    assert node._model_access.selection_denial() is not None
+
+    node.set_parameter_value("model", "Seedream 4.5")
+    assert node._model_access.selection_denial() is None

--- a/tests/unit/test_proxy_model_access.py
+++ b/tests/unit/test_proxy_model_access.py
@@ -1,0 +1,210 @@
+"""Tests that the proxy nodes wire their model dropdown through
+``ModelAccessComponent``.
+
+Every proxy node under ``griptape_nodes_library`` that offers a choice of
+models routes its ``model``/``model_id`` parameter through
+``GriptapeProxyNode._install_model_access``, which hands the parameter to a
+``ModelDropdownAccess``: the component owns the ``Options`` + refresh
+``Button`` traits, decorates each row with the caller's license entitlement,
+and gates ``_submit_and_poll`` against the current policy. These tests cover
+that wiring and the runtime gate across every node that installs it; the
+component's own behavior is covered in the engine test suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointDenial,
+    CheckpointFailure,
+)
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.proxy.griptape_proxy_node import GriptapeProxyNode
+from griptape_nodes_library.video.sora_video_generation import SoraVideoGeneration
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+LIBRARY_NAME = "Griptape Nodes Library"
+
+type AuthorizationHook = Callable[[AuthorizationCheckpoint], CheckpointDenial | None]
+
+# (node type, catalog model id to deny, dropdown value that id resolves to, model
+# parameter name). The denied id is deliberately not the node's default everywhere
+# it can be, so the ModelAccessComponent constructor's default-relocation logic
+# (which moves the stored value off a denied default) never fires and can't
+# confuse these assertions. OmnihumanSubjectRecognition, OmnihumanSubjectDetection,
+# WanReferenceToVideoGeneration, FluxImageGeneration, and TranscribeAudio each
+# declare exactly one model, so their only choice is necessarily also their default.
+NODE_MODEL_CASES: list[tuple[str, str, str, str]] = [
+    ("TranscribeAudio", "gtc_whisper_1", "whisper-1", "model"),  # only declared model
+    ("ElevenLabsTextToSpeechGeneration", "gtc_eleven_multilingual_v2", "eleven_multilingual_v2", "model"),
+    (
+        "OmnihumanSubjectRecognition",
+        "gtc_omnihuman_1_5_subject_recognition",
+        "omnihuman-1-5-subject-recognition",
+        "model_id",
+    ),  # only declared model
+    (
+        "OmnihumanSubjectDetection",
+        "gtc_omnihuman_1_5_subject_detection",
+        "omnihuman-1-5-subject-detection",
+        "model_id",
+    ),  # only declared model
+    ("OmnihumanVideoGeneration", "gtc_omnihuman_1_0", "omnihuman-1-0", "model_id"),
+    ("SoraVideoGeneration", "gtc_sora_2_pro", "sora-2-pro", "model"),
+    ("WanTextToVideoGeneration", "gtc_wan_2_5_t2v_preview", "wan2.5-t2v-preview", "model"),
+    ("WanImageToVideoGeneration", "gtc_wan_2_5_i2v_preview", "wan2.5-i2v-preview", "model"),
+    ("WanAnimateGeneration", "gtc_wan_2_2_animate_move", "wan2.2-animate-move", "model"),
+    ("WanReferenceToVideoGeneration", "gtc_wan_2_6_r2v", "wan2.6-r2v", "model"),  # only declared model
+    ("FluxImageGeneration", "gtc_flux_kontext_pro", "flux-kontext-pro", "model"),  # only declared model
+    ("QwenImageGeneration", "gtc_qwen_image_plus", "qwen-image-plus", "model"),
+    ("QwenImageEdit", "gtc_qwen_image_edit", "qwen-image-edit", "model"),
+]
+
+
+def _create_node(node_type: str) -> BaseNode:
+    """Create a node through the library so its metadata carries `library` / `node_type`.
+
+    The engine's model-access query reads those two metadata keys to resolve a
+    node's declared models; a bare `NodeClass(name=...)` construction does not
+    set them and would leave the dropdown undecorated.
+    """
+    library = LibraryRegistry.get_library(name=LIBRARY_NAME)
+    return library.create_node(node_type=node_type, name=node_type)
+
+
+def _deny_hook(action: CheckpointAction, subject_id: str) -> AuthorizationHook:
+    """Build a hook that denies one action against one catalog model id, else allows."""
+
+    def hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+        if checkpoint.action == action and checkpoint.subject_id == subject_id:
+            return CheckpointDenial(failures=(CheckpointFailure(detail="denied for test"),))
+        return None
+
+    return hook
+
+
+@pytest.fixture
+def authorization_hook() -> Iterator[Callable[[AuthorizationHook], None]]:
+    """Register an authorization hook for the test, guaranteed removed afterward."""
+    registered: list[AuthorizationHook] = []
+
+    def register(hook: AuthorizationHook) -> None:
+        GriptapeNodes.EventManager().add_authorization_hook(hook)
+        registered.append(hook)
+
+    try:
+        yield register
+    finally:
+        for hook in registered:
+            GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+
+@pytest.mark.parametrize(
+    ("node_type", "param_name"),
+    [(case[0], case[3]) for case in NODE_MODEL_CASES],
+    ids=[case[0] for case in NODE_MODEL_CASES],
+)
+def test_model_param_wired_to_model_access_component(node_type: str, param_name: str) -> None:
+    node = cast("GriptapeProxyNode", _create_node(node_type))
+
+    assert node._model_access is not None
+    assert isinstance(node._model_access.component, ModelAccessComponent)
+    assert node._model_access.parameter_name == param_name
+
+    model_param = node.get_parameter_by_name(param_name)
+    assert model_param is not None
+    # The component installs the Options dropdown and a refresh Button.
+    assert model_param.find_elements_by_type(Options)
+    assert model_param.find_elements_by_type(Button)
+    # Per-row decoration the frontend uses to flag denied models.
+    ui_options = model_param.ui_options
+    assert ui_options.get("dropdown_row_icons") is True
+    assert ui_options.get("dropdown_row_subtitles") is True
+    assert isinstance(ui_options.get("data"), list)
+    assert ui_options["data"]
+
+
+@pytest.mark.parametrize(("node_type", "denied_catalog_id", "dropdown_value", "param_name"), NODE_MODEL_CASES)
+def test_denied_model_row_carries_denial_icon(
+    node_type: str,
+    denied_catalog_id: str,
+    dropdown_value: str,
+    param_name: str,
+    authorization_hook: Callable[[AuthorizationHook], None],
+) -> None:
+    # Registered before construction so the component's constructor-time snapshot
+    # already carries the denial, and decorates the row on the first build.
+    authorization_hook(_deny_hook(CheckpointAction.OFFER_MODEL, denied_catalog_id))
+    node = _create_node(node_type)
+
+    model_param = node.get_parameter_by_name(param_name)
+    assert model_param is not None
+    data = model_param.ui_options["data"]
+    assert data
+
+    for row in data:
+        if row["name"] == dropdown_value:
+            assert row.get("icon") == "shield-off"
+        else:
+            assert row.get("icon") is None
+
+
+@pytest.mark.asyncio
+async def test_submit_and_poll_gates_on_denial(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_submit_and_poll` re-checks the selection against the current policy.
+
+    Construct the node BEFORE registering the deny hook, so the component's
+    constructor-time snapshot is clean and doesn't relocate the stored value
+    off the about-to-be-denied selection. Only one representative node
+    (SoraVideoGeneration) is exercised here: the gate itself lives in
+    `GriptapeProxyNode._submit_and_poll`, shared by every adopting node, so this
+    isn't re-checked per node.
+    """
+    node = cast("SoraVideoGeneration", _create_node("SoraVideoGeneration"))
+    node.set_parameter_value("model", "sora-2-pro")
+
+    async def fake_build_payload() -> dict[str, Any]:
+        return {}
+
+    submit_calls: list[dict[str, Any]] = []
+
+    async def fake_submit_generation(payload: dict[str, Any], headers: dict[str, str], api_model_id: str) -> None:
+        submit_calls.append({"payload": payload, "headers": headers, "api_model_id": api_model_id})
+        # None short-circuits `_submit_and_poll` before it reaches the poll loop,
+        # which this test has no interest in exercising.
+        return None
+
+    monkeypatch.setattr(node, "_build_payload", fake_build_payload)
+    monkeypatch.setattr(node, "_submit_generation", fake_submit_generation)
+
+    hook = _deny_hook(CheckpointAction.OFFER_MODEL, "gtc_sora_2_pro")
+    GriptapeNodes.EventManager().add_authorization_hook(hook)
+    try:
+        result = await node._submit_and_poll({})
+    finally:
+        GriptapeNodes.EventManager().remove_authorization_hook(hook)
+
+    assert result is None
+    assert node.parameter_output_values.get("was_successful") is False
+    assert "denied for test" in node.parameter_output_values.get("result_details", "")
+    assert submit_calls == []
+
+    # Mirror case: with the hook removed, the same selection is permitted again
+    # and the flow reaches `_submit_generation`.
+    await node._submit_and_poll({})
+
+    assert len(submit_calls) == 1
+    assert submit_calls[0]["api_model_id"] == "sora-2-pro"

--- a/tests/unit/utils/test_model_access.py
+++ b/tests/unit/utils/test_model_access.py
@@ -1,0 +1,197 @@
+"""Unit tests for the library's model-dropdown access wiring.
+
+`MappedModelAccessComponent` exists for dropdowns whose choices are display
+labels rather than the catalog's `provider_model_id`. These tests stub the
+engine's access query so the mapping, the decoration it drives, and the runtime
+denial lookup are all exercised against known verdicts. The component's own
+behavior (badges, refresh button, fail-closed snapshot) is covered in the engine
+test suite.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.retained_mode.events.access_events import (
+    ModelAccessVerdict,
+    QueryModelAccessForNodeRequest,
+    QueryModelAccessForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+from griptape_nodes.traits.button import Button
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.utils.model_access import MappedModelAccessComponent, ModelDropdownAccess
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+# Dropdown labels this library's proxy nodes show, and the provider ids they map to.
+PROVIDER_MODEL_ID_BY_CHOICE = {
+    "Kling v3.0": "kling-v3",
+    "Kling v2.6": "kling-v2-6",
+}
+MODEL_CHOICES = list(PROVIDER_MODEL_ID_BY_CHOICE)
+CATALOG_ID_BY_PROVIDER_MODEL_ID = {
+    "kling-v3": "gtc_kling_v3",
+    "kling-v2-6": "gtc_kling_v2_6",
+}
+DENIAL = CheckpointDenial(failures=(CheckpointFailure(detail="Kling v3 is not in your plan."),))
+
+
+class _ModelNode(DataNode):
+    """Minimal node to hang a model parameter off of."""
+
+    def process(self) -> None:
+        return None
+
+
+@pytest.fixture
+def stub_access_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Answer every access query with `kling-v3` denied and `kling-v2-6` allowed."""
+    original_handle_request = GriptapeNodes.handle_request
+
+    def handle_request(request: RequestPayload, **kwargs: Any) -> ResultPayload:
+        if not isinstance(request, QueryModelAccessForNodeRequest):
+            return original_handle_request(request, **kwargs)
+        provider_model_ids = list(CATALOG_ID_BY_PROVIDER_MODEL_ID)
+        if request.candidate_model_ids is not None:
+            provider_model_ids = [
+                provider_model_id
+                for provider_model_id, catalog_id in CATALOG_ID_BY_PROVIDER_MODEL_ID.items()
+                if catalog_id in request.candidate_model_ids
+            ]
+        return QueryModelAccessForNodeResultSuccess(
+            result_details="stubbed access query",
+            verdicts=[
+                ModelAccessVerdict(
+                    model_id=CATALOG_ID_BY_PROVIDER_MODEL_ID[provider_model_id],
+                    provider_model_id=provider_model_id,
+                    denial=DENIAL if provider_model_id == "kling-v3" else None,
+                )
+                for provider_model_id in provider_model_ids
+            ],
+        )
+
+    monkeypatch.setattr(GriptapeNodes, "handle_request", handle_request)
+
+
+def _build_node_with_dropdown(*, default_model: str) -> tuple[_ModelNode, Parameter]:
+    node = _ModelNode(name="ModelNode")
+    parameter = Parameter(
+        name="model_name",
+        type="str",
+        default_value=default_model,
+        tooltip="Model to use",
+    )
+    node.add_parameter(parameter)
+    node.set_parameter_value("model_name", default_model)
+    return node, parameter
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_denied_label_is_decorated_and_queried_by_label() -> None:
+    """A denied provider id flags the dropdown row keyed by its display label."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    component = MappedModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    rows = {row["name"]: row for row in parameter.ui_options["data"]}
+    assert rows["Kling v3.0"].get("icon") == "shield-off"
+    assert "icon" not in rows["Kling v2.6"]
+
+    # The runtime query resolves the label to its catalog id and returns the denial.
+    assert component.query_for_denial("Kling v3.0") is not None
+    assert component.query_for_denial("Kling v2.6") is None
+    # Provider ids still resolve, so a raw-id value saved in an older workflow works.
+    assert component.query_for_denial("kling-v3") is not None
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_denied_default_label_relocates_to_a_permitted_choice() -> None:
+    """A denied default moves the stored value to a permitted label, not a provider id."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v3.0")
+    MappedModelAccessComponent(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v3.0",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    assert node.get_parameter_value("model_name") == "Kling v2.6"
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_dropdown_access_installs_traits_and_reads_the_selection() -> None:
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    assert isinstance(access.component, MappedModelAccessComponent)
+    assert parameter.find_elements_by_type(Options)
+    assert parameter.find_elements_by_type(Button)
+    assert access.parameter_name == "model_name"
+
+    assert access.selection_denial() is None
+    node.set_parameter_value("model_name", "Kling v3.0")
+    denial = access.selection_denial()
+    assert denial is not None
+    assert "not in your plan" in denial.reason()
+    with pytest.raises(RuntimeError, match="not permitted"):
+        access.raise_if_selection_denied()
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_dropdown_access_without_a_mapping_uses_the_engine_component() -> None:
+    """Provider-id dropdowns need no mapping, so they get the engine component itself."""
+    node = _ModelNode(name="ModelNode")
+    parameter = Parameter(name="model", type="str", default_value="kling-v2-6", tooltip="Model to use")
+    node.add_parameter(parameter)
+    node.set_parameter_value("model", "kling-v2-6")
+
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=list(CATALOG_ID_BY_PROVIDER_MODEL_ID),
+        default_model="kling-v2-6",
+    )
+
+    assert not isinstance(access.component, MappedModelAccessComponent)
+    node.set_parameter_value("model", "kling-v3")
+    assert access.selection_denial() is not None
+
+
+@pytest.mark.usefixtures("stub_access_query")
+def test_on_value_set_ignores_other_parameters() -> None:
+    """Badge tracking is scoped to the dropdown the component owns."""
+    node, parameter = _build_node_with_dropdown(default_model="Kling v2.6")
+    other = Parameter(name="prompt", type="str", default_value="", tooltip="Prompt")
+    node.add_parameter(other)
+    access = ModelDropdownAccess(
+        node=node,
+        parameter=parameter,
+        model_choices=MODEL_CHOICES,
+        default_model="Kling v2.6",
+        provider_model_id_by_choice=PROVIDER_MODEL_ID_BY_CHOICE,
+    )
+
+    access.on_value_set(other, "Kling v3.0")
+    assert parameter.get_badge() is None
+
+    access.on_value_set(parameter, "Kling v3.0")
+    assert parameter.get_badge() is not None


### PR DESCRIPTION
Eight image and world-generation proxy nodes adopt the component. Their dropdowns store display labels rather than model identities, which #515 later resolves properly; this layer keeps them working via a mapping.

Part of #432.

<!-- stack map: hand-maintained while `main`'s merge queue keeps the native stack UI unavailable -->
### Stack

Review and merge bottom to top. Trunk: `main`; each PR's base is the branch below it.

1. #507 — feat(access): add license-filtered model dropdown plumbing
2. #508 — fix(access): keep catalog model ids bare on suffixed proxy nodes
3. #509 — feat(access): filter config driver model dropdowns through OFFER_MODEL
4. #510 — feat(access): filter provider-id proxy model dropdowns through OFFER_MODEL
5. #511 — feat(access): filter labeled image and world model dropdowns through OFFER_MODEL  ⬅ **this PR**
6. #512 — feat(access): filter labeled video model dropdowns through OFFER_MODEL
7. #513 — fix(access): resolve Kling Omni's catalog model id
8. #515 — refactor(access): store catalog model keys in every model dropdown
