### PR TITLE
feat(access): filter video model dropdowns through OFFER_MODEL

### DIFF
--- a/griptape_nodes_library/video/grok_video_edit.py
+++ b/griptape_nodes_library/video/grok_video_edit.py
@@ -9,7 +9,6 @@ from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 
@@ -32,8 +31,10 @@ class GrokVideoEdit(GriptapeProxyNode):
         - result_details (str): Details about the edit result or error
     """
 
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
+    # Migrates values saved before the dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Grok Imagine Video": "grok-imagine-video",
+        "gtc_grok_imagine_video": "grok-imagine-video",
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -41,14 +42,20 @@ class GrokVideoEdit(GriptapeProxyNode):
         self.category = "API Nodes"
         self.description = "Edit videos using Grok video models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Video",
-                tooltip="Select the Grok video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Video"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="grok-imagine-video",
+            tooltip="Select the Grok video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["grok-imagine-video"],
+            default_model="grok-imagine-video",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -152,18 +159,10 @@ class GrokVideoEdit(GriptapeProxyNode):
             return None
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Video"
-        base_model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{base_model_id}:edit"
+        return f"{self._get_selected_model_id()}:edit"
 
     def _get_payload_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Video"
-        return self.MODEL_NAME_MAP.get(model_name, model_name)
-
-    def _get_catalog_model_id(self) -> str:
-        # The catalog declares the bare provider id (no `:edit` suffix), so
-        # resolve the declaration against the un-suffixed id.
-        return self._get_payload_model_id()
+        return self._get_selected_model_id() or "grok-imagine-video"
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = super().validate_before_node_run() or []

--- a/griptape_nodes_library/video/grok_video_generation.py
+++ b/griptape_nodes_library/video/grok_video_generation.py
@@ -40,8 +40,10 @@ class GrokVideoGeneration(GriptapeProxyNode):
         - result_details (str): Details about the generation result or error
     """
 
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
+    # Migrates values saved before the dropdown stored the provider's own model id.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Grok Imagine Video": "grok-imagine-video",
+        "gtc_grok_imagine_video": "grok-imagine-video",
     }
 
     MIN_DURATION: ClassVar[int] = 1
@@ -63,14 +65,20 @@ class GrokVideoGeneration(GriptapeProxyNode):
         self.category = "API Nodes"
         self.description = "Generate videos using Grok video models via Griptape model proxy"
 
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="Grok Imagine Video",
-                tooltip="Select the Grok video model to use",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["Grok Imagine Video"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="grok-imagine-video",
+            tooltip="Select the Grok video model to use",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["grok-imagine-video"],
+            default_model="grok-imagine-video",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -203,18 +211,10 @@ class GrokVideoGeneration(GriptapeProxyNode):
             return None
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Video"
-        base_model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{base_model_id}:generate"
+        return f"{self._get_selected_model_id()}:generate"
 
     def _get_payload_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "Grok Imagine Video"
-        return self.MODEL_NAME_MAP.get(model_name, model_name)
-
-    def _get_catalog_model_id(self) -> str:
-        # The catalog declares the bare provider id (no `:generate` suffix), so
-        # resolve the declaration against the un-suffixed id.
-        return self._get_payload_model_id()
+        return self._get_selected_model_id() or "grok-imagine-video"
 
     def validate_before_node_run(self) -> list[Exception] | None:
         exceptions = super().validate_before_node_run() or []

--- a/griptape_nodes_library/video/kling_image_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_image_to_video_generation.py
@@ -72,17 +72,27 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         - result_details (str): Details about the generation result or error
     """
 
-    # Map user-facing names to provider model IDs
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Kling v3.0": "kling-v3",
-        "Kling v2.6": "kling-v2-6",
-        "Kling v2.5 Turbo": "kling-v2-5-turbo",
-        "Kling v2.1 Master": "kling-v2-1-master",
-        "Kling v2.1": "kling-v2-1",
-        "Kling v2 Master": "kling-v2-master",
-        "Kling v1.6": "kling-v1-6",
-        "Kling v1.5": "kling-v1-5",
+    # Migrates values saved before the dropdown stored the provider's own model id: old
+    # display labels and catalog keys.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Kling v1": "kling-v1",
+        "Kling v1.5": "kling-v1-5",
+        "Kling v1.6": "kling-v1-6",
+        "Kling v2 Master": "kling-v2-master",
+        "Kling v2.1": "kling-v2-1",
+        "Kling v2.1 Master": "kling-v2-1-master",
+        "Kling v2.5 Turbo": "kling-v2-5-turbo",
+        "Kling v2.6": "kling-v2-6",
+        "Kling v3.0": "kling-v3",
+        "gtc_kling_v1": "kling-v1",
+        "gtc_kling_v1_5": "kling-v1-5",
+        "gtc_kling_v1_6": "kling-v1-6",
+        "gtc_kling_v2_1": "kling-v2-1",
+        "gtc_kling_v2_1_master": "kling-v2-1-master",
+        "gtc_kling_v2_5_turbo": "kling-v2-5-turbo",
+        "gtc_kling_v2_6": "kling-v2-6",
+        "gtc_kling_v2_master": "kling-v2-master",
+        "gtc_kling_v3": "kling-v3",
     }
 
     # Model capability definitions
@@ -151,29 +161,31 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model_name",
-                default_value="Kling v3.0",
-                tooltip="Model Name for generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={
-                    Options(
-                        choices=[
-                            "Kling v3.0",
-                            "Kling v2.6",
-                            "Kling v2.5 Turbo",
-                            "Kling v2.1 Master",
-                            "Kling v2.1",
-                            "Kling v2 Master",
-                            "Kling v1.6",
-                            "Kling v1.5",
-                            "Kling v1",
-                        ]
-                    )
-                },
-                ui_options={"display_name": "Model"},
-            )
+        model_name_param = ParameterString(
+            name="model_name",
+            default_value="kling-v3",
+            tooltip="Model Name for generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_name_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_name_param,
+            model_choices=[
+                "kling-v3",
+                "kling-v2-6",
+                "kling-v2-5-turbo",
+                "kling-v2-1-master",
+                "kling-v2-1",
+                "kling-v2-master",
+                "kling-v1-6",
+                "kling-v1-5",
+                "kling-v1",
+            ],
+            default_model="kling-v3",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         # Prompts
@@ -376,7 +388,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        self._update_parameter_visibility_for_model(self.get_parameter_value("model_name") or "Kling v3.0")
+        self._update_parameter_visibility_for_model(self.get_parameter_value("model_name") or "kling-v3")
         self._update_multi_shot_parameter_visibility()
 
         self.set_initial_node_size(height=1145)
@@ -398,8 +410,8 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
     def _update_duration_choices(self) -> None:
         """Update duration dropdown based on current model and image_tail state."""
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v3"
+        model_id = model_name
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
         new_durations = list(capabilities.get("durations", [5, 10]))
         # kling-v1: end frame restricts to 5s only
@@ -413,7 +425,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility based on selected model."""
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_id = model_name
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
         # Show mask features for all models
@@ -466,7 +478,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
     def _update_mode_dependent_features(self) -> None:
         """Show/hide features that depend on the current mode (e.g. sound for kling-v2-6)."""
         model_name = self.get_parameter_value("model_name") or ""
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_id = model_name
         if model_id == "kling-v2-6":
             mode = self.get_parameter_value("mode") or MODE_PRO
             if mode == MODE_PRO:
@@ -487,8 +499,8 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
     def _update_multi_shot_parameter_visibility(self) -> None:
         """Toggle prompt and shot inputs for v3 multi-shot configurations."""
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v3"
+        model_id = model_name
         if model_id != V3_MODEL_ID:
             return
 
@@ -586,9 +598,7 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
 
         Appends :image2video modality to the model name.
         """
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:image2video"
+        return f"{self._get_selected_model_id()}:image2video"
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Kling API.
@@ -596,8 +606,8 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         Returns:
             dict: The request payload (model field excluded, handled by base class)
         """
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v2-6"
+        model_id = model_name
 
         # Normalize image parameters before processing
         image_input = normalize_artifact_input(
@@ -930,8 +940,8 @@ class KlingImageToVideoGeneration(GriptapeProxyNode):
         exceptions = super().validate_before_node_run() or []
 
         # Get parameter values
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v2-6"
+        model_id = model_name
         image = self.get_parameter_value("image")
         image_tail = self.get_parameter_value("image_tail")
         prompt = self.get_parameter_value("prompt") or ""

--- a/griptape_nodes_library/video/kling_omni_video_generation.py
+++ b/griptape_nodes_library/video/kling_omni_video_generation.py
@@ -42,15 +42,13 @@ BASE_MODE_CHOICES = [MODE_STD, MODE_PRO]
 DEFAULT_MODE = MODE_PRO
 
 
-MODEL_NAME_MAP: dict[str, dict[str, str]] = {
-    "Kling Omni": {
-        "api_model_id": "kling-video-o1:omnivideo",
-        "payload_model_name": "kling-video-o1",
-    },
-    "Kling v3.0 Omni": {
-        "api_model_id": "kling-v3-omni:omnivideo",
-        "payload_model_name": "kling-v3-omni",
-    },
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels, catalog display names, and catalog keys.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Kling Omni": "kling-video-o1",
+    "Kling v3.0 Omni": "kling-v3-omni",
+    "gtc_kling_v3_omni": "kling-v3-omni",
+    "gtc_kling_video_o1_omni": "kling-video-o1",
 }
 MODEL_CAPABILITIES: dict[str, dict[str, Any]] = {
     "kling-video-o1": {
@@ -77,7 +75,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
     images, and videos. Use <<<element_1>>>, <<<image_1>>>, <<<video_1>>> in prompts.
 
     Inputs:
-        - model_name (str): Model selection ("Kling Omni" or "Kling v3.0 Omni")
+        - model_name (str): Model selection ("kling-video-o1" or "kling-v3-omni")
         - multi_shot (bool): Enable multi-prompt mode (default: False)
         - prompt (str): Text prompt with optional templates (max 2500 chars, required when multi_shot=False)
         - shot_count (int): Number of shots in multi-shot mode (1-6, required when multi_shot=True)
@@ -108,15 +106,21 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model_name",
-                default_value="Kling v3.0 Omni",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=list(MODEL_NAME_MAP.keys()))},
-                ui_options={"display_name": "Model"},
-            )
+        model_name_param = ParameterString(
+            name="model_name",
+            default_value="kling-v3-omni",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "Model"},
+        )
+        self.add_parameter(model_name_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_name_param,
+            model_choices=["kling-video-o1", "kling-v3-omni"],
+            default_model="kling-v3-omni",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -323,9 +327,8 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         if parameter.name in {"model_name", "reference_video", "end_frame_image"}:
             self._update_mode_choices()
             # Update duration choices inline (WAN pattern)
-            model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
-            model_config = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])
-            capabilities = MODEL_CAPABILITIES.get(model_config["payload_model_name"], {})
+            model_name = self.get_parameter_value("model_name") or "kling-v3-omni"
+            capabilities = MODEL_CAPABILITIES.get(model_name, {})
             has_reference_video = bool(self.get_parameter_value("reference_video"))
             has_end_frame = bool(self.get_parameter_value("end_frame_image"))
             new_durations = list(capabilities.get("durations", list(range(3, 11))))
@@ -356,9 +359,8 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
 
     def _get_supported_modes(self) -> list[str]:
         """Return the valid mode choices for the selected model and inputs."""
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
-        model_config = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])
-        capabilities = MODEL_CAPABILITIES.get(model_config["payload_model_name"], {"modes": BASE_MODE_CHOICES})
+        model_name = self.get_parameter_value("model_name") or "kling-v3-omni"
+        capabilities = MODEL_CAPABILITIES.get(model_name, {"modes": BASE_MODE_CHOICES})
         supported_modes = list(capabilities.get("modes", BASE_MODE_CHOICES))
 
         if self.get_parameter_value("reference_video") and not capabilities.get(
@@ -414,10 +416,9 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation.
 
-        Converts user-facing model name to provider API model ID.
+        Builds the URL-path model id from the current selection's provider id.
         """
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
-        return MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])["api_model_id"]
+        return f"{self._get_selected_model_id()}:omnivideo"
 
     def _build_customize_multi_prompt_payload(self, shot_count: Any) -> list[dict[str, Any]]:
         """Build multi_prompt payload from shot input parameters."""
@@ -517,8 +518,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         Returns:
             dict: The request payload (model field excluded, handled by base class)
         """
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
-        model_config = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])
+        model_name = self.get_parameter_value("model_name") or "kling-v3-omni"
         prompt = (self.get_parameter_value("prompt") or "").strip()
         multi_shot = bool(self.get_parameter_value("multi_shot"))
         shot_count = self.get_parameter_value("shot_count") or 1
@@ -543,7 +543,7 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
         duration = self.get_parameter_value("duration") or 5
 
         payload: dict[str, Any] = {
-            "model_name": model_config["payload_model_name"],
+            "model_name": model_name,
             "mode": mode,
             "aspect_ratio": aspect_ratio,
             "duration": int(duration),
@@ -760,8 +760,8 @@ class KlingOmniVideoGeneration(GriptapeProxyNode):
             )
 
         # kling-video-o1: text-to-video and start-frame-only generation restrict to 5s or 10s
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0 Omni"
-        payload_model = MODEL_NAME_MAP.get(model_name, MODEL_NAME_MAP["Kling v3.0 Omni"])["payload_model_name"]
+        model_name = self.get_parameter_value("model_name") or "kling-v3-omni"
+        payload_model = model_name
         capabilities = MODEL_CAPABILITIES.get(payload_model, {})
 
         if payload_model == "kling-video-o1":

--- a/griptape_nodes_library/video/kling_text_to_video_generation.py
+++ b/griptape_nodes_library/video/kling_text_to_video_generation.py
@@ -59,14 +59,21 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         - result_details (str): Details about the generation result or error
     """
 
-    # Map user-facing names to provider model IDs
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Kling v3.0": "kling-v3",
-        "Kling v2.6": "kling-v2-6",
-        "Kling v2.5 Turbo": "kling-v2-5-turbo",
-        "Kling v2.1 Master": "kling-v2-1-master",
-        "Kling v2 Master": "kling-v2-master",
+    # Migrates values saved before the dropdown stored the provider's own model id: old
+    # display labels and catalog keys.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Kling v1.6": "kling-v1-6",
+        "Kling v2 Master": "kling-v2-master",
+        "Kling v2.1 Master": "kling-v2-1-master",
+        "Kling v2.5 Turbo": "kling-v2-5-turbo",
+        "Kling v2.6": "kling-v2-6",
+        "Kling v3.0": "kling-v3",
+        "gtc_kling_v1_6": "kling-v1-6",
+        "gtc_kling_v2_1_master": "kling-v2-1-master",
+        "gtc_kling_v2_5_turbo": "kling-v2-5-turbo",
+        "gtc_kling_v2_6": "kling-v2-6",
+        "gtc_kling_v2_master": "kling-v2-master",
+        "gtc_kling_v3": "kling-v3",
     }
 
     # Model capability definitions
@@ -114,25 +121,27 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
-        self.add_parameter(
-            ParameterString(
-                name="model_name",
-                default_value="Kling v3.0",
-                tooltip="Model Name",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={
-                    Options(
-                        choices=[
-                            "Kling v3.0",
-                            "Kling v2.6",
-                            "Kling v2.5 Turbo",
-                            "Kling v2.1 Master",
-                            "Kling v2 Master",
-                            "Kling v1.6",
-                        ]
-                    )
-                },
-            )
+        model_name_param = ParameterString(
+            name="model_name",
+            default_value="kling-v3",
+            tooltip="Model Name",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_name_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_name_param,
+            model_choices=[
+                "kling-v3",
+                "kling-v2-6",
+                "kling-v2-5-turbo",
+                "kling-v2-1-master",
+                "kling-v2-master",
+                "kling-v1-6",
+            ],
+            default_model="kling-v3",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         # INPUTS / PROPERTIES
@@ -310,7 +319,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        self._update_parameter_visibility_for_model(self.get_parameter_value("model_name") or "Kling v3.0")
+        self._update_parameter_visibility_for_model(self.get_parameter_value("model_name") or "kling-v3")
         self._update_multi_shot_parameter_visibility()
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
@@ -321,7 +330,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             self._update_parameter_visibility_for_model(value)
             self._update_multi_shot_parameter_visibility()
             # Update duration choices inline (WAN pattern)
-            model_id = self.MODEL_NAME_MAP.get(str(value), str(value))
+            model_id = str(value)
             capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
             new_durations = capabilities.get("durations", [5, 10])
             current_duration = self.get_parameter_value("duration")
@@ -336,7 +345,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility based on selected model."""
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_id = model_name
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
         modes = capabilities.get("modes", BASE_MODE_CHOICES)
 
@@ -387,7 +396,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
     def _update_mode_dependent_features(self) -> None:
         """Show/hide features that depend on the current mode (e.g. sound for kling-v2-6)."""
         model_name = self.get_parameter_value("model_name") or ""
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_id = model_name
         if model_id == "kling-v2-6":
             mode = self.get_parameter_value("mode") or MODE_PRO
             if mode == MODE_PRO:
@@ -399,8 +408,8 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
     def _update_multi_shot_parameter_visibility(self) -> None:
         """Toggle prompt and shot inputs for v3 multi-shot configurations."""
-        model_name = self.get_parameter_value("model_name") or "Kling v3.0"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v3"
+        model_id = model_name
         if model_id != V3_MODEL_ID:
             return
 
@@ -459,9 +468,7 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
         Appends :text2video modality to the model name.
         """
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
-        return f"{model_id}:text2video"
+        return f"{self._get_selected_model_id()}:text2video"
 
     def _build_customize_multi_prompt_payload(self, shot_count: int) -> list[dict[str, Any]]:
         """Build multi_prompt payload from shot input parameters."""
@@ -633,8 +640,8 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             dict: The request payload (model field excluded, handled by base class)
         """
         prompt = self.get_parameter_value("prompt") or ""
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v2-6"
+        model_id = model_name
         negative_prompt = self.get_parameter_value("negative_prompt") or ""
         cfg_scale = self.get_parameter_value("cfg_scale")
         mode = self.get_parameter_value("mode") or DEFAULT_MODE
@@ -732,8 +739,8 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
 
         # Validate prompt is provided
         prompt = self.get_parameter_value("prompt") or ""
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v2-6"
+        model_id = model_name
         multi_shot = bool(self.get_parameter_value("multi_shot"))
         shot_type = self.get_parameter_value("shot_type") or "customize"
         shot_count = self.get_parameter_value("shot_count") or 1
@@ -767,8 +774,8 @@ class KlingTextToVideoGeneration(GriptapeProxyNode):
             )
 
         # Validate model-specific constraints
-        model_name = self.get_parameter_value("model_name") or "Kling v2.6"
-        model_id = self.MODEL_NAME_MAP.get(model_name, model_name)
+        model_name = self.get_parameter_value("model_name") or "kling-v2-6"
+        model_id = model_name
         mode = self.get_parameter_value("mode") or DEFAULT_MODE
         aspect_ratio = self.get_parameter_value("aspect_ratio") or "16:9"
 

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -26,9 +26,13 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["LTXAudioToVideoGeneration"]
 
-MODEL_MAPPING = {
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
+    "gtc_ltx_2_pro": "ltx-2-pro",
 }
 
 
@@ -58,14 +62,20 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="LTX 2 Pro",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2.3 Pro"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="ltx-2-pro",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-pro", "ltx-2-3-pro"],
+            default_model="ltx-2-pro",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
         self.add_parameter(
             ParameterString(
@@ -177,7 +187,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         """Get and process all parameters, including audio and image conversion."""
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model": self.get_parameter_value("model") or "LTX 2 Pro",
+            "model": self.get_parameter_value("model") or "ltx-2-pro",
             "audio_uri": await self._prepare_audio_data_url_async(self.get_parameter_value("audio")),
             "image_uri": await self._prepare_image_data_url_async(self.get_parameter_value("image")),
             "resolution": self.get_parameter_value("resolution") or "1920x1080",
@@ -185,9 +195,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:audio-to-video"
+        return f"{self._get_selected_model_id()}:audio-to-video"
 
     async def _prepare_audio_data_url_async(self, audio_input: Any) -> str | None:
         """Convert audio input to a base64 data URL."""
@@ -399,7 +407,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
             msg = f"{self.name} requires a prompt to generate video."
             raise ValueError(msg)
 
-        model_id = MODEL_MAPPING.get(params["model"], "ltx-2-pro")
+        model_id = params["model"]
         payload: dict[str, Any] = {
             "audio_uri": params["audio_uri"],
             "prompt": params["prompt"].strip(),

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -22,12 +22,17 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["LTXImageToVideoGeneration"]
 
-# Model mapping from display names to API model IDs
-MODEL_MAPPING = {
-    "LTX 2 Pro": "ltx-2-pro",
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2 Fast": "ltx-2-fast",
-    "LTX 2.3 Pro": "ltx-2-3-pro",
+    "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Fast": "ltx-2-3-fast",
+    "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_fast": "ltx-2-3-fast",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
+    "gtc_ltx_2_fast": "ltx-2-fast",
+    "gtc_ltx_2_pro": "ltx-2-pro",
 }
 
 # Camera motion options
@@ -107,14 +112,20 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="LTX 2.3 Fast",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="ltx-2-3-fast",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-pro", "ltx-2-fast", "ltx-2-3-pro", "ltx-2-3-fast"],
+            default_model="ltx-2-3-fast",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
         self.add_parameter(
             ParameterString(
@@ -216,7 +227,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        self._update_parameter_visibility_for_model("LTX 2 Fast")
+        self._update_parameter_visibility_for_model("ltx-2-fast")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Handle parameter value changes to show/hide dependent parameters."""
@@ -224,12 +235,12 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
 
         # Update parameter options when model, resolution, or fps changes
         if parameter.name in ("model", "resolution", "fps"):
-            model_name = self.get_parameter_value("model") or "LTX 2 Fast"
+            model_name = self.get_parameter_value("model") or "ltx-2-fast"
             self._update_parameter_visibility_for_model(model_name)
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility and options based on selected model."""
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
+        model_id = model_name
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
         # Get available resolutions
@@ -271,7 +282,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         """Get and process all parameters, including image conversion."""
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model": self.get_parameter_value("model") or "LTX 2 Fast",
+            "model": self.get_parameter_value("model") or "ltx-2-fast",
             "image_uri": await self._prepare_image_data_url_async(self.get_parameter_value("image")),
             "resolution": self.get_parameter_value("resolution") or "1920x1080",
             "duration": self.get_parameter_value("duration") or 6,
@@ -283,14 +294,12 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:image-to-video"
+        return f"{self._get_selected_model_id()}:image-to-video"
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""
         model_display_name = params["model"]
-        model_id = MODEL_MAPPING.get(model_display_name, "ltx-2-fast")
+        model_id = model_display_name
         resolution = params["resolution"]
         fps = params["fps"]
         duration = params["duration"]
@@ -346,7 +355,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
             raise ValueError(validation_error)
 
         # Map display name to model ID (without modality)
-        model_id = MODEL_MAPPING.get(params["model"], "ltx-2-fast")
+        model_id = params["model"]
 
         payload: dict[str, Any] = {
             "image_uri": params["image_uri"],

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -20,12 +20,17 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["LTXTextToVideoGeneration"]
 
-# Model mapping from display names to API model IDs
-MODEL_MAPPING = {
-    "LTX 2 Pro": "ltx-2-pro",
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2 Fast": "ltx-2-fast",
-    "LTX 2.3 Pro": "ltx-2-3-pro",
+    "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Fast": "ltx-2-3-fast",
+    "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_fast": "ltx-2-3-fast",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
+    "gtc_ltx_2_fast": "ltx-2-fast",
+    "gtc_ltx_2_pro": "ltx-2-pro",
 }
 
 # Camera motion options
@@ -104,14 +109,20 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="LTX 2.3 Fast",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="ltx-2-3-fast",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-pro", "ltx-2-fast", "ltx-2-3-pro", "ltx-2-3-fast"],
+            default_model="ltx-2-3-fast",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -202,7 +213,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        self._update_parameter_visibility_for_model("LTX 2 Fast")
+        self._update_parameter_visibility_for_model("ltx-2-fast")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Handle parameter value changes to show/hide dependent parameters."""
@@ -210,12 +221,12 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
 
         # Update parameter options when model, resolution, or fps changes
         if parameter.name in ("model", "resolution", "fps"):
-            model_name = self.get_parameter_value("model") or "LTX 2 Fast"
+            model_name = self.get_parameter_value("model") or "ltx-2-fast"
             self._update_parameter_visibility_for_model(model_name)
 
     def _update_parameter_visibility_for_model(self, model_name: str) -> None:
         """Update parameter visibility and options based on selected model."""
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
+        model_id = model_name
         capabilities = self.MODEL_CAPABILITIES.get(model_id, {})
 
         # Get available resolutions
@@ -256,7 +267,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
     def _get_parameters(self) -> dict[str, Any]:
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model": self.get_parameter_value("model") or "LTX 2 Fast",
+            "model": self.get_parameter_value("model") or "ltx-2-fast",
             "resolution": self.get_parameter_value("resolution") or "1920x1080",
             "duration": self.get_parameter_value("duration") or 6,
             "fps": self.get_parameter_value("fps") or 25,
@@ -267,14 +278,12 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "LTX 2 Fast"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-fast")
-        return f"{model_id}:text-to-video"
+        return f"{self._get_selected_model_id()}:text-to-video"
 
     def _validate_model_params(self, params: dict[str, Any]) -> str | None:
         """Validate that the model-resolution-fps-duration combination is supported."""
         model_display_name = params["model"]
-        model_id = MODEL_MAPPING.get(model_display_name, "ltx-2-fast")
+        model_id = model_display_name
         resolution = params["resolution"]
         fps = params["fps"]
         duration = params["duration"]
@@ -321,8 +330,8 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         if validation_error:
             raise ValueError(validation_error)
 
-        # Map display name to model ID (without modality)
-        model_id = MODEL_MAPPING.get(params["model"], "ltx-2-fast")
+        # Model id is already the bare id the API expects (without modality).
+        model_id = params["model"]
 
         payload: dict[str, Any] = {
             "prompt": params["prompt"].strip(),

--- a/griptape_nodes_library/video/ltx_video_extend.py
+++ b/griptape_nodes_library/video/ltx_video_extend.py
@@ -28,11 +28,16 @@ MIN_CONTEXT_DURATION = 0
 DEFAULT_CONTEXT_DURATION = 1
 MAX_CONTEXT_DURATION = 20
 
-MODEL_MAPPING = {
+DEFAULT_MODEL = "ltx-2-3-pro"
+
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
+    "gtc_ltx_2_pro": "ltx-2-pro",
 }
-DEFAULT_MODEL = "LTX 2.3 Pro"
 
 
 class LTXVideoExtend(GriptapeProxyNode):
@@ -65,14 +70,20 @@ class LTXVideoExtend(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value=DEFAULT_MODEL,
-                tooltip="Model to use for video extension",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=list(MODEL_MAPPING.keys()))},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Model to use for video extension",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-pro", "ltx-2-3-pro"],
+            default_model=DEFAULT_MODEL,
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -201,9 +212,7 @@ class LTXVideoExtend(GriptapeProxyNode):
             self._update_context_badge(value)
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or DEFAULT_MODEL
-        model_id = MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
-        return f"{model_id}:extend"
+        return f"{self._get_selected_model_id()}:extend"
 
     async def _prepare_video_data_uri_async(self, video_input: Any) -> str | None:
         """Convert video input to a base64 data URI."""
@@ -268,7 +277,7 @@ class LTXVideoExtend(GriptapeProxyNode):
             "video_uri": video_data_uri,
             "duration": duration,
             "mode": params["mode"],
-            "model": MODEL_MAPPING.get(params["model"], MODEL_MAPPING[DEFAULT_MODEL]),
+            "model": params["model"],
         }
 
         prompt = params["prompt"].strip()

--- a/griptape_nodes_library/video/ltx_video_retake.py
+++ b/griptape_nodes_library/video/ltx_video_retake.py
@@ -28,9 +28,13 @@ MAX_VIDEO_DURATION = 21
 MIN_RETAKE_DURATION = 2.0
 RETAKE_SEGMENT_LENGTH = 2
 
-MODEL_MAPPING = {
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
+    "gtc_ltx_2_pro": "ltx-2-pro",
 }
 
 SUPPORTED_RESOLUTIONS = ("1920x1080", "2560x1440", "3840x2160")
@@ -67,14 +71,20 @@ class LTXVideoRetake(GriptapeProxyNode):
         # INPUTS / PROPERTIES
 
         # Model parameter (retake supports pro-tier LTX models)
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="LTX 2 Pro",
-                tooltip="Model to use for video retake",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2.3 Pro"])},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="ltx-2-pro",
+            tooltip="Model to use for video retake",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-pro", "ltx-2-3-pro"],
+            default_model="ltx-2-pro",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
         self.add_parameter(
             ParameterString(
@@ -351,16 +361,14 @@ class LTXVideoRetake(GriptapeProxyNode):
     def _get_parameters(self) -> dict[str, Any]:
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model": self.get_parameter_value("model") or "LTX 2 Pro",
+            "model": self.get_parameter_value("model") or "ltx-2-pro",
             "retake_segment": self.get_parameter_value("retake_segment") or [0.0, 2.0],
             "mode": self.get_parameter_value("mode") or "replace_audio_and_video",
             "resolution": self.get_parameter_value("resolution") or DEFAULT_RESOLUTION,
         }
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "LTX 2 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-pro")
-        return f"{model_id}:retake"
+        return f"{self._get_selected_model_id()}:retake"
 
     def _validate_video_input(self, video: Any) -> str | None:
         """Validate video is provided and doesn't exceed duration limits."""
@@ -467,7 +475,7 @@ class LTXVideoRetake(GriptapeProxyNode):
             "duration": duration,
             "prompt": params["prompt"].strip(),
             "mode": params["mode"],
-            "model": MODEL_MAPPING.get(params["model"], "ltx-2-pro"),
+            "model": params["model"],
             "resolution": resolution,
         }
 

--- a/griptape_nodes_library/video/ltx_video_to_video_hdr.py
+++ b/griptape_nodes_library/video/ltx_video_to_video_hdr.py
@@ -10,7 +10,6 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
-from griptape_nodes.traits.options import Options
 
 # static_ffmpeg is dynamically installed by the library loader at runtime
 from static_ffmpeg import run  # type: ignore[import-untyped]
@@ -22,8 +21,11 @@ logger = logging.getLogger("griptape_nodes")
 
 __all__ = ["LTXVideoToVideoHDR"]
 
-MODEL_MAPPING = {
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES = {
     "LTX 2.3 Pro": "ltx-2-3-pro",
+    "gtc_ltx_2_3_pro": "ltx-2-3-pro",
 }
 
 # Input frame-count limits per LTX HDR upscale docs, keyed by billing tier.
@@ -60,14 +62,20 @@ class LTXVideoToVideoHDR(GriptapeProxyNode):
         # INPUTS / PROPERTIES
 
         # Model parameter — HDR upscale is only offered on ltx-2-3-pro per the pricing page.
-        self.add_parameter(
-            ParameterString(
-                name="model",
-                default_value="LTX 2.3 Pro",
-                tooltip="Model to use for video-to-video HDR upscale",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=list(MODEL_MAPPING.keys()))},
-            )
+        model_param = ParameterString(
+            name="model",
+            default_value="ltx-2-3-pro",
+            tooltip="Model to use for video-to-video HDR upscale",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        self.add_parameter(model_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_param,
+            model_choices=["ltx-2-3-pro"],
+            default_model="ltx-2-3-pro",
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -115,9 +123,7 @@ class LTXVideoToVideoHDR(GriptapeProxyNode):
         self.set_initial_node_size(height=400)
 
     def _get_api_model_id(self) -> str:
-        model_name = self.get_parameter_value("model") or "LTX 2.3 Pro"
-        model_id = MODEL_MAPPING.get(model_name, "ltx-2-3-pro")
-        return f"{model_id}:video-to-video-hdr"
+        return f"{self._get_selected_model_id()}:video-to-video-hdr"
 
     @staticmethod
     def _extract_input_video_url(video_input: Any) -> str | None:

--- a/griptape_nodes_library/video/minimax_hailuo_video_generation.py
+++ b/griptape_nodes_library/video/minimax_hailuo_video_generation.py
@@ -78,37 +78,46 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
         },
     }
 
-    # Map user-facing names to provider model IDs
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Hailuo 2.3 (TTV & ITV)": "MiniMax-Hailuo-2.3",
+    # Migrates values saved before the dropdown stored the provider's own model id: old
+    # display labels and catalog keys.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "Hailuo 02": "MiniMax-Hailuo-02",
         "Hailuo 02 (TTV & ITV)": "MiniMax-Hailuo-02",
+        "Hailuo 2.3": "MiniMax-Hailuo-2.3",
+        "Hailuo 2.3 (TTV & ITV)": "MiniMax-Hailuo-2.3",
+        "Hailuo 2.3 Fast": "MiniMax-Hailuo-2.3-Fast",
         "Hailuo 2.3 Fast (ITV)": "MiniMax-Hailuo-2.3-Fast",
+        "gtc_minimax_hailuo_02": "MiniMax-Hailuo-02",
+        "gtc_minimax_hailuo_2_3": "MiniMax-Hailuo-2.3",
+        "gtc_minimax_hailuo_2_3_fast": "MiniMax-Hailuo-2.3-Fast",
     }
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value="Hailuo 2.3 (TTV & ITV)",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "model",
-                    "hide": False,
-                },
-                traits={
-                    Options(
-                        choices=[
-                            "Hailuo 2.3 (TTV & ITV)",
-                            "Hailuo 02 (TTV & ITV)",
-                            "Hailuo 2.3 Fast (ITV)",
-                        ]
-                    )
-                },
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value="MiniMax-Hailuo-2.3",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "model",
+                "hide": False,
+            },
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=[
+                "MiniMax-Hailuo-2.3",
+                "MiniMax-Hailuo-02",
+                "MiniMax-Hailuo-2.3-Fast",
+            ],
+            default_model="MiniMax-Hailuo-2.3",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -230,9 +239,8 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        default_model = "Hailuo 2.3 (TTV & ITV)"
-        default_provider_model_id = self._get_provider_model_id(default_model)
-        default_capabilities = self.MODEL_CAPABILITIES.get(default_provider_model_id, {})
+        default_model = "MiniMax-Hailuo-2.3"
+        default_capabilities = self.MODEL_CAPABILITIES.get(default_model, {})
 
         # Show/hide last_frame_image based on default model
         if default_capabilities.get("supports_last_frame", False):
@@ -251,11 +259,8 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
         super().after_value_set(parameter, value)
 
         if parameter.name == "model_id":
-            # Convert friendly name to provider model ID
-            provider_model_id = self._get_provider_model_id(value)
-
             # Show/hide last_frame_image parameter only for 02 model
-            capabilities = self.MODEL_CAPABILITIES.get(provider_model_id, {})
+            capabilities = self.MODEL_CAPABILITIES.get(value, {})
             show_last_frame = capabilities.get("supports_last_frame", False)
             if show_last_frame:
                 self.show_parameter_by_name("last_frame_image")
@@ -273,9 +278,7 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
         await super()._process_generation()
 
     def _get_parameters(self) -> dict[str, Any]:
-        raw_model_id = self.get_parameter_value("model_id") or "Hailuo 2.3 (TTV & ITV)"
-        # Convert friendly name to provider model ID
-        model_id = self._get_provider_model_id(raw_model_id)
+        model_id = self.get_parameter_value("model_id") or "MiniMax-Hailuo-2.3"
 
         return {
             "prompt": self.get_parameter_value("prompt") or "",
@@ -288,18 +291,8 @@ class MinimaxHailuoVideoGeneration(GriptapeProxyNode):
             "last_frame_image": self.get_parameter_value("last_frame_image"),
         }
 
-    @classmethod
-    def _get_provider_model_id(cls, user_facing_name: str) -> str:
-        """Convert user-facing model name to provider model ID.
-
-        Falls back to the input value if it's not in the mapping (for backwards compatibility
-        with saved flows that may have old model IDs).
-        """
-        return cls.MODEL_NAME_MAP.get(user_facing_name, user_facing_name)
-
     def _get_api_model_id(self) -> str:
-        raw_model_id = self.get_parameter_value("model_id") or "Hailuo 2.3 (TTV & ITV)"
-        return self._get_provider_model_id(raw_model_id)
+        return self.get_parameter_value("model_id") or "MiniMax-Hailuo-2.3"
 
     async def _build_payload(self) -> dict[str, Any]:  # noqa: C901
         """Build the request payload for MiniMax Hailuo API."""

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -48,9 +48,9 @@ __all__ = ["Seedance20VideoGeneration"]
 INPUT_MODE_TEXT_ONLY = "Text Only"
 INPUT_MODE_FIRST_LAST_FRAME = "First/Last Frame"
 INPUT_MODE_MULTIMODAL_REFERENCES = "Multimodal References"
-MODEL_NAME_SEEDANCE_2_0 = "Seedance 2.0"
-MODEL_NAME_SEEDANCE_2_0_FAST = "Seedance 2.0 Fast"
-MODEL_NAME_SEEDANCE_2_0_MINI = "Seedance 2.0 Mini"
+MODEL_NAME_SEEDANCE_2_0 = "dreamina-seedance-2-0-260128"
+MODEL_NAME_SEEDANCE_2_0_FAST = "dreamina-seedance-2-0-fast-260128"
+MODEL_NAME_SEEDANCE_2_0_MINI = "dreamina-seedance-2-0-mini-260615"
 SEEDANCE_2_0_MODEL_ID = "dreamina-seedance-2-0-260128"
 SEEDANCE_2_0_FAST_MODEL_ID = "dreamina-seedance-2-0-fast-260128"
 SEEDANCE_2_0_MINI_MODEL_ID = "dreamina-seedance-2-0-mini-260615"
@@ -177,10 +177,15 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         - result_details (str): Details about the result or error
     """
 
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        MODEL_NAME_SEEDANCE_2_0_FAST: SEEDANCE_2_0_FAST_MODEL_ID,
-        MODEL_NAME_SEEDANCE_2_0_MINI: SEEDANCE_2_0_MINI_MODEL_ID,
-        MODEL_NAME_SEEDANCE_2_0: SEEDANCE_2_0_MODEL_ID,
+    # Migrates values saved before the dropdown stored the provider's own model id: old
+    # display labels and catalog keys.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
+        "Seedance 2.0": MODEL_NAME_SEEDANCE_2_0,
+        "Seedance 2.0 Fast": MODEL_NAME_SEEDANCE_2_0_FAST,
+        "Seedance 2.0 Mini": MODEL_NAME_SEEDANCE_2_0_MINI,
+        "gtc_seedance_2_0": MODEL_NAME_SEEDANCE_2_0,
+        "gtc_seedance_2_0_fast": MODEL_NAME_SEEDANCE_2_0_FAST,
+        "gtc_seedance_2_0_mini": MODEL_NAME_SEEDANCE_2_0_MINI,
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -194,23 +199,25 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         self._pending_asset_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
         # Model selection
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=MODEL_NAME_SEEDANCE_2_0,
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={"display_name": "Model", "hide": False},
-                traits={
-                    Options(
-                        choices=[
-                            MODEL_NAME_SEEDANCE_2_0,
-                            MODEL_NAME_SEEDANCE_2_0_FAST,
-                            MODEL_NAME_SEEDANCE_2_0_MINI,
-                        ]
-                    )
-                },
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=MODEL_NAME_SEEDANCE_2_0,
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={"display_name": "Model", "hide": False},
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=[
+                MODEL_NAME_SEEDANCE_2_0,
+                MODEL_NAME_SEEDANCE_2_0_FAST,
+                MODEL_NAME_SEEDANCE_2_0_MINI,
+            ],
+            default_model=MODEL_NAME_SEEDANCE_2_0,
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         # Input mode selector
@@ -543,8 +550,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
 
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation."""
-        raw_model_id = self.get_parameter_value("model_id") or MODEL_NAME_SEEDANCE_2_0
-        return self.MODEL_NAME_MAP.get(raw_model_id, raw_model_id)
+        return self.get_parameter_value("model_id") or MODEL_NAME_SEEDANCE_2_0
 
     async def _process_generation(self) -> None:
         self._pending_asset_uploads = []
@@ -582,8 +588,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         return exceptions if exceptions else None
 
     def _get_parameters(self) -> dict[str, Any]:
-        raw_model_id = self.get_parameter_value("model_id") or MODEL_NAME_SEEDANCE_2_0
-        model_id = self.MODEL_NAME_MAP.get(raw_model_id, raw_model_id)
+        model_id = self.get_parameter_value("model_id") or MODEL_NAME_SEEDANCE_2_0
         first_frame = normalize_artifact_input(
             self.get_parameter_value("first_frame"),
             ImageUrlArtifact,

--- a/griptape_nodes_library/video/seedance_video_generation.py
+++ b/griptape_nodes_library/video/seedance_video_generation.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from typing import Any, ClassVar
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMessage, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
@@ -15,7 +15,6 @@ from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File, FileLoadError
-from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.media import coerce_media_url_or_data_uri
@@ -54,20 +53,19 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
         - result_details (str): Details about the generation result or error
     """
 
-    # Map user-facing names to provider model IDs
-    MODEL_NAME_MAP: ClassVar[dict[str, str]] = {
-        "Seedance 1.5 Pro": "seedance-1-5-pro-251215",
+    # Migrates values saved before the dropdown stored the provider's own model id: old
+    # display labels, catalog keys, and models retired in favor of a current choice.
+    LEGACY_MODEL_VALUES: ClassVar[dict[str, str]] = {
         "Seedance 1.0 Pro": "seedance-1-0-pro-250528",
         "Seedance 1.0 Pro Fast": "seedance-1-0-pro-fast-251015",
-    }
-
-    # Deprecated models and their replacements (covers both friendly names and raw provider IDs
-    # so saved workflows in either format are migrated)
-    DEPRECATED_MODELS: ClassVar[dict[str, str]] = {
-        "Seedance 1.0 Lite T2V": "Seedance 1.0 Pro Fast",
-        "seedance-1-0-lite-t2v-250428": "Seedance 1.0 Pro Fast",
-        "Seedance 1.0 Lite I2V": "Seedance 1.0 Pro Fast",
-        "seedance-1-0-lite-i2v-250428": "Seedance 1.0 Pro Fast",
+        "Seedance 1.5 Pro": "seedance-1-5-pro-251215",
+        "gtc_seedance_1_0_pro": "seedance-1-0-pro-250528",
+        "gtc_seedance_1_0_pro_fast": "seedance-1-0-pro-fast-251015",
+        "gtc_seedance_1_5_pro": "seedance-1-5-pro-251215",
+        "Seedance 1.0 Lite T2V": "seedance-1-0-pro-fast-251015",
+        "seedance-1-0-lite-t2v-250428": "seedance-1-0-pro-fast-251015",
+        "Seedance 1.0 Lite I2V": "seedance-1-0-pro-fast-251015",
+        "seedance-1-0-lite-i2v-250428": "seedance-1-0-pro-fast-251015",
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -76,43 +74,28 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
         self.description = "Generate video via Seedance through Griptape Cloud model proxy"
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value="Seedance 1.5 Pro",
-                tooltip="Model to use for video generation",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "Model",
-                    "hide": False,
-                },
-                traits={
-                    Options(
-                        choices=[
-                            "Seedance 1.5 Pro",
-                            "Seedance 1.0 Pro",
-                            "Seedance 1.0 Pro Fast",
-                        ]
-                    )
-                },
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value="seedance-1-5-pro-251215",
+            tooltip="Model to use for video generation",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "Model",
+                "hide": False,
+            },
         )
-
-        self.add_node_element(
-            ParameterMessage(
-                name="model_deprecation_notice",
-                title="Model Deprecation Notice",
-                variant="info",
-                value="",
-                traits={
-                    Button(
-                        full_width=True,
-                        on_click=lambda _, __: self.hide_message_by_name("model_deprecation_notice"),
-                    )
-                },
-                button_text="Dismiss",
-                hide=True,
-            )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=[
+                "seedance-1-5-pro-251215",
+                "seedance-1-0-pro-250528",
+                "seedance-1-0-pro-fast-251015",
+            ],
+            default_model="seedance-1-5-pro-251215",
+            deprecated_values=self.LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -233,26 +216,7 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
         )
 
         # Set initial parameter visibility based on default model
-        default_provider_model_id = self._get_provider_model_id("Seedance 1.5 Pro")
-        self._update_parameter_visibility(default_provider_model_id)
-
-    def before_value_set(self, parameter: Parameter, value: Any) -> Any:
-        """Migrate deprecated model selections to their replacement."""
-        if parameter.name == "model_id" and isinstance(value, str) and value in self.DEPRECATED_MODELS:
-            replacement = self.DEPRECATED_MODELS[value]
-            message = self.get_message_by_name_or_element_id("model_deprecation_notice")
-            if message is None:
-                raise RuntimeError("model_deprecation_notice message element not found")  # noqa: TRY003, EM101
-            message.value = (
-                f"The '{value}' model has been deprecated. The model has been updated to '{replacement}'. "
-                "Please save your workflow to apply this change."
-            )
-            self.show_message_by_name("model_deprecation_notice")
-            value = replacement
-        elif parameter.name == "model_id" and isinstance(value, str):
-            self.hide_message_by_name("model_deprecation_notice")
-
-        return super().before_value_set(parameter, value)
+        self._update_parameter_visibility("seedance-1-5-pro-251215")
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         """Handle parameter value changes to show/hide dependent parameters based on model capabilities.
@@ -263,8 +227,7 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
         - seedance-1-0-pro-fast-251015: i2v with first frame only, text-to-video
         """
         if parameter.name == "model_id":
-            provider_model_id = self._get_provider_model_id(value)
-            self._update_parameter_visibility(provider_model_id)
+            self._update_parameter_visibility(value)
 
         return super().after_value_set(parameter, value)
 
@@ -289,19 +252,16 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
     def _get_api_model_id(self) -> str:
         """Get the API model ID for this generation.
 
-        Converts user-facing model name to provider model ID.
+        The stored dropdown value is already the provider's model id.
         """
-        raw_model_id = self.get_parameter_value("model_id") or "Seedance 1.5 Pro"
-        return self._get_provider_model_id(raw_model_id)
+        return self.get_parameter_value("model_id") or "seedance-1-5-pro-251215"
 
     def _log(self, message: str) -> None:
         with suppress(Exception):
             logger.info(message)
 
     def _get_parameters(self) -> dict[str, Any]:
-        raw_model_id = self.get_parameter_value("model_id") or "Seedance 1.5 Pro"
-        # Convert friendly name to provider model ID
-        model_id = self._get_provider_model_id(raw_model_id)
+        model_id = self.get_parameter_value("model_id") or "seedance-1-5-pro-251215"
 
         return {
             "prompt": self.get_parameter_value("prompt") or "",
@@ -314,15 +274,6 @@ class SeedanceVideoGeneration(GriptapeProxyNode):
             "camerafixed": self.get_parameter_value("camerafixed"),
             "generate_audio": self.get_parameter_value("generate_audio"),
         }
-
-    @classmethod
-    def _get_provider_model_id(cls, user_facing_name: str) -> str:
-        """Convert user-facing model name to provider model ID.
-
-        Falls back to the input value if it's not in the mapping (for backwards compatibility
-        with saved flows that may have old model IDs).
-        """
-        return cls.MODEL_NAME_MAP.get(user_facing_name, user_facing_name)
 
     async def _build_payload(self) -> dict[str, Any]:
         """Build the request payload for Seedance API (without model field)."""

--- a/griptape_nodes_library/video/veo3_video_generation.py
+++ b/griptape_nodes_library/video/veo3_video_generation.py
@@ -31,13 +31,6 @@ logger = logging.getLogger("griptape_nodes")
 __all__ = ["Veo3VideoGeneration"]
 
 
-class ModelName(StrEnum):
-    VEO_3_1 = "Veo 3.1"
-    VEO_3_1_FAST = "Veo 3.1 Fast"
-    VEO_3_0 = "Veo 3.0"
-    VEO_3_0_FAST = "Veo 3.0 Fast"
-
-
 class ModelId(StrEnum):
     VEO_3_1_GENERATE_001 = "veo-3.1-generate-001"
     VEO_3_1_FAST_GENERATE_001 = "veo-3.1-fast-generate-001"
@@ -45,12 +38,17 @@ class ModelId(StrEnum):
     VEO_3_0_FAST_GENERATE_001 = "veo-3.0-fast-generate-001"
 
 
-# Model mapping from human-friendly names to API model IDs
-MODEL_MAPPING = {
-    ModelName.VEO_3_1.value: ModelId.VEO_3_1_GENERATE_001,
-    ModelName.VEO_3_1_FAST.value: ModelId.VEO_3_1_FAST_GENERATE_001,
-    ModelName.VEO_3_0.value: ModelId.VEO_3_0_GENERATE_001,
-    ModelName.VEO_3_0_FAST.value: ModelId.VEO_3_0_FAST_GENERATE_001,
+# Migrates values saved before the dropdown stored the provider's own model id: old
+# display labels and catalog keys.
+LEGACY_MODEL_VALUES: dict[str, str] = {
+    "Veo 3.0": ModelId.VEO_3_0_GENERATE_001.value,
+    "Veo 3.0 Fast": ModelId.VEO_3_0_FAST_GENERATE_001.value,
+    "Veo 3.1": ModelId.VEO_3_1_GENERATE_001.value,
+    "Veo 3.1 Fast": ModelId.VEO_3_1_FAST_GENERATE_001.value,
+    "gtc_veo_3_0": ModelId.VEO_3_0_GENERATE_001.value,
+    "gtc_veo_3_0_fast": ModelId.VEO_3_0_FAST_GENERATE_001.value,
+    "gtc_veo_3_1": ModelId.VEO_3_1_GENERATE_001.value,
+    "gtc_veo_3_1_fast": ModelId.VEO_3_1_FAST_GENERATE_001.value,
 }
 
 
@@ -90,26 +88,28 @@ class Veo3VideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
 
         # INPUTS / PROPERTIES
-        self.add_parameter(
-            ParameterString(
-                name="model_id",
-                default_value=ModelName.VEO_3_1.value,
-                tooltip="Model id to call via proxy",
-                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                ui_options={
-                    "display_name": "model",
-                },
-                traits={
-                    Options(
-                        choices=[
-                            ModelName.VEO_3_1.value,
-                            ModelName.VEO_3_1_FAST.value,
-                            ModelName.VEO_3_0.value,
-                            ModelName.VEO_3_0_FAST.value,
-                        ]
-                    )
-                },
-            )
+        model_id_param = ParameterString(
+            name="model_id",
+            default_value=ModelId.VEO_3_1_GENERATE_001.value,
+            tooltip="Model id to call via proxy",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            ui_options={
+                "display_name": "model",
+            },
+        )
+        self.add_parameter(model_id_param)
+        # License-policy dropdown: the component adds Options + refresh Button traits and
+        # marks the models the license denies; the proxy base refuses a denied selection.
+        self._install_model_access(
+            parameter=model_id_param,
+            model_choices=[
+                ModelId.VEO_3_1_GENERATE_001.value,
+                ModelId.VEO_3_1_FAST_GENERATE_001.value,
+                ModelId.VEO_3_0_GENERATE_001.value,
+                ModelId.VEO_3_0_FAST_GENERATE_001.value,
+            ],
+            default_model=ModelId.VEO_3_1_GENERATE_001.value,
+            deprecated_values=LEGACY_MODEL_VALUES,
         )
 
         self.add_parameter(
@@ -293,18 +293,20 @@ class Veo3VideoGeneration(GriptapeProxyNode):
         # Set initial parameter visibility based on default model
         self._initialize_parameter_visibility()
 
-    def _map_api_model_id(self, friendly_name: str) -> ModelId | str:
-        """Map friendly model name to API model ID."""
-        mapped_model = MODEL_MAPPING.get(friendly_name, friendly_name)
+    def _map_api_model_id(self, model_id: str) -> ModelId | str:
+        """Coerce the stored model id (already the provider's own id) to a `ModelId`.
 
+        Returns the raw string unchanged when it names no known `ModelId`, so an
+        unrecognized selection still reaches the API rather than being dropped.
+        """
         try:
-            return ModelId(mapped_model)
+            return ModelId(model_id)
         except ValueError:
-            return mapped_model
+            return model_id
 
     def _initialize_parameter_visibility(self) -> None:
         """Initialize parameter visibility based on default model selection."""
-        default_model = self.get_parameter_value("model_id") or ModelName.VEO_3_1.value
+        default_model = self.get_parameter_value("model_id") or ModelId.VEO_3_1_GENERATE_001.value
         self._update_parameter_visibility_for_model(default_model)
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
@@ -405,7 +407,7 @@ class Veo3VideoGeneration(GriptapeProxyNode):
 
         return {
             "prompt": self.get_parameter_value("prompt") or "",
-            "model_id": self.get_parameter_value("model_id") or ModelName.VEO_3_1.value,
+            "model_id": self.get_parameter_value("model_id") or ModelId.VEO_3_1_GENERATE_001.value,
             "negative_prompt": self.get_parameter_value("negative_prompt") or "",
             "image": self.get_parameter_value("start_frame"),
             "last_frame": self.get_parameter_value("last_frame"),
@@ -421,7 +423,7 @@ class Veo3VideoGeneration(GriptapeProxyNode):
         }
 
     def _get_api_model_id(self) -> str:
-        model_id = self.get_parameter_value("model_id") or ModelName.VEO_3_1.value
+        model_id = self.get_parameter_value("model_id") or ModelId.VEO_3_1_GENERATE_001.value
         api_model_id = self._map_api_model_id(model_id)
         return api_model_id.value if isinstance(api_model_id, ModelId) else api_model_id
 
@@ -439,11 +441,7 @@ class Veo3VideoGeneration(GriptapeProxyNode):
             ModelId.VEO_3_1_GENERATE_001,
             ModelId.VEO_3_1_FAST_GENERATE_001,
         }:
-            msg = (
-                f"{self.name}: lastFrame parameter is only supported by "
-                f"{ModelName.VEO_3_1.value} and {ModelName.VEO_3_1_FAST.value} models. "
-                f"Current model: {model_id}"
-            )
+            msg = f"{self.name}: lastFrame parameter is only supported by Veo 3.1 and Veo 3.1 Fast models."
             raise ValueError(msg)
 
         # referenceImages are only supported by veo-3.1-generate-001
@@ -451,10 +449,7 @@ class Veo3VideoGeneration(GriptapeProxyNode):
         has_reference_images = reference_images and len(reference_images) > 0
         if has_reference_images:
             if api_model_id != ModelId.VEO_3_1_GENERATE_001:
-                msg = (
-                    f"{self.name}: referenceImages parameter is only supported by "
-                    f"{ModelName.VEO_3_1.value} model. Current model: {model_id}"
-                )
+                msg = f"{self.name}: referenceImages parameter is only supported by Veo 3.1 model."
                 raise ValueError(msg)
 
             # When referenceImages are provided, duration must be 8 seconds

--- a/tests/unit/test_proxy_model_access.py
+++ b/tests/unit/test_proxy_model_access.py
@@ -87,6 +87,21 @@ NODE_MODEL_CASES: list[tuple[str, str, str, str]] = [
     ("GoogleImageGeneration", "gtc_gemini_3_1_flash_image", "gemini-3.1-flash-image", "model"),
     ("OpenAiImageGeneration", "gtc_gpt_image_1", "gpt-image-1", "model"),
     ("WorldLabsWorldGeneration", "gtc_marble_1_0_draft", "marble-1.0-draft", "model"),
+    ("SeedanceVideoGeneration", "gtc_seedance_1_0_pro_fast", "seedance-1-0-pro-fast-251015", "model_id"),
+    ("Seedance20VideoGeneration", "gtc_seedance_2_0_fast", "dreamina-seedance-2-0-fast-260128", "model_id"),
+    ("GrokVideoGeneration", "gtc_grok_imagine_video", "grok-imagine-video", "model"),  # only declared model
+    ("GrokVideoEdit", "gtc_grok_imagine_video", "grok-imagine-video", "model"),  # only declared model
+    ("MinimaxHailuoVideoGeneration", "gtc_minimax_hailuo_2_3_fast", "MiniMax-Hailuo-2.3-Fast", "model_id"),
+    ("KlingTextToVideoGeneration", "gtc_kling_v2_6", "kling-v2-6", "model_name"),
+    ("KlingImageToVideoGeneration", "gtc_kling_v1_5", "kling-v1-5", "model_name"),
+    ("KlingOmniVideoGeneration", "gtc_kling_video_o1_omni", "kling-video-o1", "model_name"),
+    ("Veo3VideoGeneration", "gtc_veo_3_0_fast", "veo-3.0-fast-generate-001", "model_id"),
+    ("LTXTextToVideoGeneration", "gtc_ltx_2_pro", "ltx-2-pro", "model"),
+    ("LTXImageToVideoGeneration", "gtc_ltx_2_3_pro", "ltx-2-3-pro", "model"),
+    ("LTXAudioToVideoGeneration", "gtc_ltx_2_3_pro", "ltx-2-3-pro", "model"),
+    ("LTXVideoExtend", "gtc_ltx_2_pro", "ltx-2-pro", "model"),
+    ("LTXVideoRetake", "gtc_ltx_2_3_pro", "ltx-2-3-pro", "model"),
+    ("LTXVideoToVideoHDR", "gtc_ltx_2_3_pro", "ltx-2-3-pro", "model"),  # only declared model
 ]
 
 


### PR DESCRIPTION
Routes the fifteen remaining video node model dropdowns through the helper from #507.

Part of #432.

<!-- stack map: hand-maintained while `main`'s merge queue keeps the native stack UI unavailable -->
### Stack

Review and merge bottom to top. Trunk: `main`; each PR's base is the branch below it.

1. #507 — feat(access): add license-filtered model dropdown plumbing
2. #509 — feat(access): filter config driver model dropdowns through OFFER_MODEL
3. #510 — feat(access): filter proxy model dropdowns through OFFER_MODEL
4. #512 — feat(access): filter video model dropdowns through OFFER_MODEL  ⬅ **this PR**
5. #517 — feat(access): filter agent and task model dropdowns through OFFER_MODEL
