### PR TITLE
feat: add a dedicated Seedance 2.5 video generation node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -406,6 +406,12 @@
                 "provider_model_id": "dreamina-seedance-2-0-mini-260615",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               },
+              "gtc_seedance_2_5": {
+                "display_name": "Seedance 2.5",
+                "family": "Seedance",
+                "provider_model_id": "dreamina-seedance-2-5-260628",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
               "gtc_omnihuman_1_0": {
                 "display_name": "OmniHuman 1.0",
                 "family": "OmniHuman",
@@ -2437,11 +2443,37 @@
       }
     },
     {
+      "class_name": "Seedance25VideoGeneration",
+      "file_path": "griptape_nodes_library/video/seedance_2_5_video_generation.py",
+      "metadata": {
+        "category": "video",
+        "description": "Generate a video using Seedance 2.5 with multimodal references, editing, and extension via Griptape Cloud model proxy.",
+        "display_name": "Seedance 2.5 Video Generation",
+        "icon": "Sparkles",
+        "group": "create",
+        "tags": [
+          "video",
+          "generation",
+          "ai",
+          "api",
+          "seedance"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_seedance_2_5"
+            ]
+          }
+        ]
+      }
+    },
+    {
       "class_name": "SeedanceHumanReferenceAsset",
       "file_path": "griptape_nodes_library/video/seedance_human_reference_asset.py",
       "metadata": {
         "category": "video/seedance",
-        "description": "Package an image, video, or audio as a private-asset reference for Seedance 2.0 human-reference inputs.",
+        "description": "Package an image, video, or audio as a private-asset reference for Seedance human-reference inputs.",
         "display_name": "Seedance Human Reference Asset",
         "icon": "Link",
         "group": "create",

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -141,6 +141,7 @@ _NODE_PROVIDER_CONFIGS = {
     "Rodin23DGeneration": RODIN,
     "SeedanceVideoGeneration": SEED,
     "Seedance20VideoGeneration": SEED,
+    "Seedance25VideoGeneration": SEED,
     "SeedreamImageGeneration": SEED,
     "SoraVideoGeneration": OPENAI,
     "TopazImageEnhance": TOPAZ,

--- a/griptape_nodes_library/video/seedance_2_0_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_0_video_generation.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-import asyncio
-import json as _json
 import logging
-from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any, ClassVar
-from urllib.parse import urljoin
-from uuid import uuid4
 
-import httpx
 from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
 from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
@@ -25,7 +19,6 @@ from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
 from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
 
@@ -35,11 +28,13 @@ from griptape_nodes_library.assets import (
     ASSET_KIND_VIDEO,
     ASSET_REFERENCE_TYPE_NAMES,
     get_provider_asset_kind,
-    get_provider_asset_value,
     is_provider_asset_reference,
 )
-from griptape_nodes_library.media import coerce_media_url_or_data_uri
-from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.video.seedance_common import (
+    SeedanceProxyNode,
+    coerce_video_url,
+    extract_video_url,
+)
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -103,50 +98,7 @@ def _get_model_capabilities(model_id: str) -> SeedanceModelCapabilities:
     return SEEDANCE_MODEL_CAPABILITIES.get(model_id, _DEFAULT_MODEL_CAPABILITIES)
 
 
-# Provider-asset (private asset) registration via the GTC proxy. Supported by all Seedance 2.0
-# variants (see SEEDANCE_MODEL_CAPABILITIES), gated to Griptape auth (not BYOK).
-ASSET_PROVIDER = "byteplus_ark"
-ASSET_POLL_INTERVAL = 3  # seconds
-ASSET_MAX_ATTEMPTS = 60  # ~3 min cap, independent of the generation timeout
-ASSET_STATUS_ACTIVE = "ACTIVE"
-ASSET_STATUS_FAILED = "FAILED"
-ASSET_STATUS_DELETED = "DELETED"
-# Skip provider-side moderation on private-asset ingestion (content is already moderated upstream).
-ASSET_MODERATION = {"Strategy": "Skip"}
-
-# Seedance only accepts audio data URIs whose subtype is exactly `wav` or `mp3` (per the BytePlus
-# docs). The local File/mimetypes layer emits other subtypes for the same formats (e.g. an .mp3
-# resolves to `audio/mpeg`, a .wav to `audio/x-wav`), which Seedance rejects as
-# "Invalid base64 audio_url". Map those aliases back to the accepted subtypes before sending.
-SEEDANCE_AUDIO_SUBTYPE_ALIASES = {
-    "mpeg": "mp3",
-    "mp3": "mp3",
-    "x-wav": "wav",
-    "wave": "wav",
-    "vnd.wave": "wav",
-    "wav": "wav",
-}
-
-
-def _normalize_audio_data_uri_subtype(data_uri: str) -> str:
-    """Rewrite an ``data:audio/<subtype>;base64,...`` URI to a Seedance-accepted subtype.
-
-    Returns the URI unchanged if it is not an audio data URI or the subtype has no known alias.
-    """
-    prefix = "data:audio/"
-    if not data_uri.startswith(prefix):
-        return data_uri
-    remainder = data_uri[len(prefix) :]
-    subtype, separator, rest = remainder.partition(";")
-    if not separator:
-        return data_uri
-    normalized_subtype = SEEDANCE_AUDIO_SUBTYPE_ALIASES.get(subtype.lower())
-    if normalized_subtype is None or normalized_subtype == subtype:
-        return data_uri
-    return f"{prefix}{normalized_subtype};{rest}"
-
-
-class Seedance20VideoGeneration(GriptapeProxyNode):
+class Seedance20VideoGeneration(SeedanceProxyNode):
     """Generate a video using Seedance 2.0 models via Griptape Cloud model proxy.
 
     Supports the Seedance 2.0, Seedance 2.0 Fast, and Seedance 2.0 Mini models. All three share
@@ -187,11 +139,6 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "API Nodes"
         self.description = "Generate video via Seedance 2.0 through Griptape Cloud model proxy"
-
-        # Transient (helper, scratch parameter name) pairs created while registering private
-        # assets; the upload and the scratch parameter are both cleaned up in
-        # _process_generation's finally block so they don't accumulate on the node across runs.
-        self._pending_asset_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
 
         # Model selection
         self.add_parameter(
@@ -554,18 +501,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             self._public_reference_video_parameter_1.delete_uploaded_artifact()
             self._public_reference_video_parameter_2.delete_uploaded_artifact()
             self._public_reference_video_parameter_3.delete_uploaded_artifact()
-            # Provider assets are reclaimed by the backend: a submitted generation deletes its
-            # linked assets on terminal state, and assets we register but never submit (e.g. a
-            # build failure after registration) are reclaimed by the backend's orphan sweeper.
-            # The transient GTC static-storage upload made to feed CreateProviderAsset is ours
-            # to clean up, along with the scratch parameter created to perform the upload (its
-            # name is unique per call, so leaving it would accumulate parameters on the node).
-            for helper, scratch_name in self._pending_asset_uploads:
-                with suppress(Exception):
-                    helper.delete_uploaded_artifact()
-                with suppress(Exception):
-                    self.remove_parameter_element_by_name(scratch_name)
-            self._pending_asset_uploads = []
+            self._cleanup_pending_asset_uploads()
 
     def validate_before_node_run(self) -> list[Exception] | None:
         """Validate parameters before execution."""
@@ -921,215 +857,9 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             # Text Only mode: no media inputs
             self._log(f"{self.name} text-only mode, no media inputs")
 
-    # --- Provider private-asset registration (Seedance 2.0 variants, Griptape auth only) -----
-
-    def _proxy_headers(self) -> dict[str, str]:
-        """Bearer headers for the GTC proxy (same auth as the generation requests)."""
-        return {"Authorization": f"Bearer {self._validate_api_key()}", "Content-Type": "application/json"}
-
-    async def _append_private_asset(self, ref: Any, *, expected_kind: str, label: str) -> str:
-        """Resolve a private-asset reference to an `asset://{asset_id}` URL.
-
-        Cross-checks the reference kind against the receiving input, obtains a public URL for
-        the media, registers it as a provider private asset via the proxy, and polls until ACTIVE.
-        """
-        actual_kind = get_provider_asset_kind(ref)
-        if actual_kind != expected_kind:
-            msg = (
-                f"{self.name}: {label} received a {actual_kind or 'unknown'} private-asset reference, "
-                f"but this input requires a {expected_kind} reference. "
-                f"Set the Seedance Human Reference Asset's Asset Kind to {expected_kind}."
-            )
-            raise ValueError(msg)
-
-        public_url = self._resolve_public_url_for_asset(ref, asset_kind=expected_kind)
-        headers = self._proxy_headers()
-        asset_id = await self._create_provider_asset(public_url, expected_kind, headers)
-        return f"asset://{asset_id}"
-
-    def _resolve_public_url_for_asset(self, ref: Any, *, asset_kind: str) -> str:
-        """Return a publicly fetchable URL for the reference's media.
-
-        Already-public http(s) URLs pass through. Otherwise the media is uploaded to GTC static
-        storage via a transient PublicArtifactUrlParameter (tracked for cleanup). CreateProviderAsset
-        requires a fetchable URL — data URIs / unresolvable inputs raise.
-        """
-        media_value = get_provider_asset_value(ref)
-        if not media_value:
-            msg = f"{self.name}: private-asset reference has no media value to register."
-            raise ValueError(msg)
-
-        if media_value.startswith(("http://", "https://")) and "localhost" not in media_value:
-            return media_value
-
-        artifact_type = {
-            ASSET_KIND_IMAGE: "ImageUrlArtifact",
-            ASSET_KIND_VIDEO: "VideoUrlArtifact",
-            ASSET_KIND_AUDIO: "AudioUrlArtifact",
-        }[asset_kind]
-
-        # Adding this scratch parameter during aprocess trips the strict-mode
-        # "parameter-mutation-during-aprocess" warning. That is expected and harmless here: the
-        # parameter is a transient, worker-local helper that only exists to feed the upload
-        # (PublicArtifactUrlParameter reads its value locally) and is removed before the run ends,
-        # so there is nothing for the orchestrator to stay in sync with.
-        scratch_name = f"_asset_upload_{uuid4().hex}"
-        helper = PublicArtifactUrlParameter(
-            node=self,
-            artifact_url_parameter=Parameter(
-                name=scratch_name,
-                input_types=[artifact_type],
-                type=artifact_type,
-                default_value="",
-                tooltip="",
-                allowed_modes={ParameterMode.PROPERTY},
-                hide=True,
-                hide_property=True,
-            ),
-        )
-        helper.add_input_parameters()
-        self._pending_asset_uploads.append((helper, scratch_name))
-        self.set_parameter_value(scratch_name, media_value)
-
-        public_url = helper.get_public_url_for_parameter()
-        if not (public_url.startswith(("http://", "https://")) and "localhost" not in public_url):
-            msg = (
-                f"{self.name}: could not obtain a public URL for the {asset_kind} private asset. "
-                "Provider asset registration requires a publicly fetchable URL (data URIs are not supported)."
-            )
-            raise RuntimeError(msg)
-        return public_url
-
-    async def _create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
-        """POST proxy/v2/assets and poll to ACTIVE; return the provider asset id."""
-        create_url = urljoin(self._proxy_base, "assets")
-        payload = {
-            "url": public_url,
-            "provider": ASSET_PROVIDER,
-            "provider_body": {"asset_type": asset_kind, "moderation": ASSET_MODERATION},
-        }
-        self._log(f"{self.name} registering {asset_kind} private asset via {create_url}")
-        try:
-            async with httpx.AsyncClient() as client:
-                response = await client.post(create_url, json=payload, headers=headers, timeout=60)
-                response.raise_for_status()
-                response_json = response.json()
-        except httpx.HTTPStatusError as e:
-            msg = f"{self.name}: failed to create private asset: HTTP {e.response.status_code} - {e.response.text}"
-            raise RuntimeError(msg) from e
-        except Exception as e:
-            msg = f"{self.name}: failed to create private asset: {e}"
-            raise RuntimeError(msg) from e
-
-        provider_asset_id = response_json.get("provider_asset_id")
-        if not provider_asset_id:
-            msg = f"{self.name}: CreateProviderAsset returned no provider_asset_id."
-            raise RuntimeError(msg)
-        return await self._poll_provider_asset(str(provider_asset_id), headers)
-
-    async def _poll_provider_asset(self, provider_asset_id: str, headers: dict[str, str]) -> str:
-        """Poll GET proxy/v2/assets/<id> until ACTIVE; return the provider asset id.
-
-        Transient errors (a network blip, a 5xx, or the eventual-consistency 404 right after the
-        asset id is minted) are logged and retried until attempts are exhausted, mirroring the
-        base class's generation poll. Only a terminal status (FAILED/DELETED) fails immediately.
-        """
-        get_url = urljoin(self._proxy_base, f"assets/{provider_asset_id}")
-        async with httpx.AsyncClient() as client:
-            for attempt in range(ASSET_MAX_ATTEMPTS):
-                try:
-                    response = await client.get(get_url, headers=headers, timeout=60)
-                    response.raise_for_status()
-                    result_json = response.json()
-                except Exception as e:
-                    # Transient — log and retry rather than aborting an otherwise-successful run.
-                    self._log(
-                        f"{self.name} error polling private asset {provider_asset_id} (attempt {attempt + 1}): {e}"
-                    )
-                    await asyncio.sleep(ASSET_POLL_INTERVAL)
-                    continue
-
-                status = result_json.get("status", "unknown")
-                self._log(f"{self.name} private asset {provider_asset_id} status: {status} (attempt {attempt + 1})")
-
-                if status == ASSET_STATUS_ACTIVE:
-                    asset_id = result_json.get("asset_id")
-                    if not asset_id:
-                        msg = f"{self.name}: private asset {provider_asset_id} is ACTIVE but no asset_id was returned."
-                        raise RuntimeError(msg)
-                    return str(asset_id)
-
-                if status in (ASSET_STATUS_FAILED, ASSET_STATUS_DELETED):
-                    detail = result_json.get("status_detail")
-                    msg = f"{self.name}: private asset {provider_asset_id} ended with status {status}: {detail}"
-                    raise RuntimeError(msg)
-
-                await asyncio.sleep(ASSET_POLL_INTERVAL)
-
-        msg = (
-            f"{self.name}: private asset {provider_asset_id} did not become ACTIVE within "
-            f"{ASSET_MAX_ATTEMPTS * ASSET_POLL_INTERVAL} seconds."
-        )
-        raise RuntimeError(msg)
-
-    async def _prepare_frame_url_async(self, frame_input: Any, *, frame_label: str) -> str | None:
-        """Convert frame input to a usable URL."""
-        if not frame_input:
-            self._log(f"{self.name} {frame_label} not provided")
-            return None
-
-        frame_url = coerce_media_url_or_data_uri(frame_input, kind="image")
-        if not frame_url:
-            self._log(
-                f"{self.name} {frame_label} could not be converted to an image URL or data URI. "
-                f"input_type={type(frame_input).__name__}, "
-                f"input_module={type(frame_input).__module__}, "
-                f"input_summary={self._summarize_image_input(frame_input)}"
-            )
-            return None
-
-        if frame_url.startswith("data:image/"):
-            self._log(f"{self.name} {frame_label} prepared as inline data URI")
-            return frame_url
-
-        try:
-            data_uri = await File(frame_url).aread_data_uri(fallback_mime="image/jpeg")
-            self._log(f"{self.name} {frame_label} loaded from file/URL into data URI")
-            return data_uri
-        except FileLoadError as e:
-            self._log(f"{self.name} {frame_label} failed to load from {frame_url}: {e}")
-            return None
-
-    async def _prepare_audio_url_async(self, audio_input: Any, *, audio_label: str) -> str | None:
-        if not audio_input:
-            self._log(f"{self.name} {audio_label} not provided")
-            return None
-
-        audio_url = coerce_media_url_or_data_uri(audio_input, kind="audio")
-        if not audio_url:
-            self._log(
-                f"{self.name} {audio_label} could not be converted to an audio URL or data URI. "
-                f"input_type={type(audio_input).__name__}, "
-                f"input_module={type(audio_input).__module__}, "
-                f"input_summary={self._summarize_image_input(audio_input)}"
-            )
-            return None
-
-        if audio_url.startswith(("data:audio/", "http://", "https://", "asset://")):
-            self._log(f"{self.name} {audio_label} prepared as direct audio URL/data URI")
-            return _normalize_audio_data_uri_subtype(audio_url)
-
-        try:
-            data_uri = await File(audio_url).aread_data_uri(fallback_mime="audio/wav")
-            self._log(f"{self.name} {audio_label} loaded from file into data URI")
-            return _normalize_audio_data_uri_subtype(data_uri)
-        except FileLoadError as e:
-            self._log(f"{self.name} {audio_label} failed to load from {audio_url}: {e}")
-            return None
-
     async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
         """Parse the result and set output parameters."""
-        extracted_url = self._extract_video_url(result_json)
+        extracted_url = extract_video_url(result_json)
         if not extracted_url:
             self.parameter_output_values["video_url"] = None
             self._set_status_results(
@@ -1141,103 +871,11 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         # Download and save video
         await self._download_and_save(extracted_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
 
-    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
-        """Extract error message from failed response."""
-        if not response_json:
-            return super()._extract_error_message(response_json)
-
-        parsed_provider_response = self._parse_provider_response(response_json.get("provider_response"))
-        if parsed_provider_response:
-            provider_error = parsed_provider_response.get("error")
-            if provider_error:
-                if isinstance(provider_error, dict):
-                    error_message = provider_error.get("message", "")
-                    details = f"{self.name} {error_message}"
-                    if error_code := provider_error.get("code"):
-                        details += f"\nError Code: {error_code}"
-                    if error_type := provider_error.get("type"):
-                        details += f"\nError Type: {error_type}"
-                    return details
-                return f"{self.name} Provider error: {provider_error}"
-
-        return super()._extract_error_message(response_json)
-
-    def _parse_provider_response(self, provider_response: Any) -> dict[str, Any] | None:
-        """Parse provider_response if it's a JSON string."""
-        if isinstance(provider_response, str):
-            try:
-                return _json.loads(provider_response)
-            except Exception:
-                return None
-        if isinstance(provider_response, dict):
-            return provider_response
-        return None
-
     def _set_safe_defaults(self) -> None:
         """Clear all output parameters on error."""
         self.parameter_output_values["generation_id"] = ""
         self.parameter_output_values["provider_response"] = None
         self.parameter_output_values["video_url"] = None
-
-    @staticmethod
-    def _extract_video_url(obj: dict[str, Any] | None) -> str | None:
-        if not obj:
-            return None
-        for key in ("url", "video_url", "output_url"):
-            val = obj.get(key) if isinstance(obj, dict) else None
-            if isinstance(val, str) and val.startswith("http"):
-                return val
-        for key in ("result", "data", "output", "outputs", "content", "task_result"):
-            nested = obj.get(key) if isinstance(obj, dict) else None
-            if isinstance(nested, dict):
-                url = Seedance20VideoGeneration._extract_video_url(nested)
-                if url:
-                    return url
-            elif isinstance(nested, list):
-                for item in nested:
-                    url = Seedance20VideoGeneration._extract_video_url(item if isinstance(item, dict) else None)
-                    if url:
-                        return url
-        return None
-
-    @staticmethod
-    def _coerce_video_url(val: Any) -> str | None:
-        """Convert video input to a Seedance-supported public URL or asset ID."""
-        if val is None:
-            return None
-
-        if isinstance(val, dict):
-            value = val.get("value")
-            if isinstance(value, str):
-                stripped = value.strip()
-                if stripped.startswith(("http://", "https://", "asset://")):
-                    return stripped
-            return None
-
-        if isinstance(val, str):
-            v = val.strip()
-            if not v:
-                return None
-            return v if v.startswith(("http://", "https://", "asset://")) else None
-
-        try:
-            to_dict = getattr(val, "to_dict", None)
-            if callable(to_dict):
-                serialized = to_dict()
-                if isinstance(serialized, dict):
-                    coerced = Seedance20VideoGeneration._coerce_video_url(serialized)
-                    if coerced:
-                        return coerced
-
-            v = getattr(val, "value", None)
-            if isinstance(v, str):
-                stripped = v.strip()
-                if stripped.startswith(("http://", "https://", "asset://")):
-                    return stripped
-        except Exception:  # noqa: S110
-            pass
-
-        return None
 
     def _get_reference_video_inputs(self, params: dict[str, Any]) -> list[dict[str, Any]]:
         return [
@@ -1247,7 +885,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         ]
 
     def _get_reference_video_url(self, parameter_name: str, value: Any) -> str | None:
-        direct_url = self._coerce_video_url(value)
+        direct_url = coerce_video_url(value)
         if direct_url:
             return direct_url
 
@@ -1266,7 +904,7 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
             self._log(f"{self.name} failed to prepare public URL for {parameter_name}: {e}")
             return None
 
-        return self._coerce_video_url(public_url)
+        return coerce_video_url(public_url)
 
     @staticmethod
     def _supports_last_frame(model_id: str) -> bool:
@@ -1297,24 +935,3 @@ class Seedance20VideoGeneration(GriptapeProxyNode):
         the user brings their own provider key (BYOK).
         """
         return self._supports_private_assets(model_id) and not self._is_byok_enabled()
-
-    @staticmethod
-    def _summarize_image_input(val: Any) -> str:
-        if val is None:
-            return "None"
-
-        if isinstance(val, str):
-            return f"str(len={len(val)})"
-
-        if isinstance(val, dict):
-            value = val.get("value")
-            value_summary = f"str(len={len(value)})" if isinstance(value, str) else type(value).__name__
-            return f"dict(type={val.get('type')}, value={value_summary})"
-
-        value_attr = getattr(val, "value", None)
-        if isinstance(value_attr, str):
-            return f"value=str(len={len(value_attr)})"
-        if value_attr is not None:
-            return f"value_type={type(value_attr).__name__}"
-
-        return repr(val)

--- a/griptape_nodes_library/video/seedance_2_5_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_5_video_generation.py
@@ -1,0 +1,980 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, ClassVar
+
+from griptape.artifacts import AudioArtifact, ImageArtifact, ImageUrlArtifact
+from griptape.artifacts.audio_url_artifact import AudioUrlArtifact
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterGroup, ParameterList, ParameterMode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.traits.options import Options
+from griptape_nodes.utils.artifact_normalization import normalize_artifact_input, normalize_artifact_list
+
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    ASSET_REFERENCE_TYPE_NAMES,
+    get_provider_asset_kind,
+    is_provider_asset_reference,
+)
+from griptape_nodes_library.video.seedance_common import (
+    SeedanceProxyNode,
+    coerce_video_url,
+    extract_video_url,
+)
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["Seedance25VideoGeneration"]
+
+SEEDANCE_2_5_MODEL_ID = "dreamina-seedance-2-5-260628"
+
+# Reference asset limits, per the BytePlus Seedance 2.5 docs. Each kind has its own cap and the
+# combined count across all three kinds is capped separately.
+MAX_REFERENCE_IMAGES = 30
+MAX_REFERENCE_VIDEOS = 10
+MAX_REFERENCE_AUDIO = 10
+MAX_TOTAL_REFERENCE_ASSETS = 50
+
+MIN_DURATION = 4
+MAX_DURATION = 30
+SMART_DURATION = -1
+
+RESOLUTION_CHOICES = ["480p", "720p"]
+OUTPUT_FORMAT_CHOICES = ["mp4", "mov"]
+DEFAULT_OUTPUT_FORMAT = "mp4"
+OUTPUT_FILENAME_BASE = "seedance_2_5_video"
+LAST_FRAME_FILENAME = "seedance_2_5_last_frame.png"
+
+ALL_RATIO_CHOICES = ("adaptive", "21:9", "16:9", "4:3", "1:1", "3:4", "9:16")
+ADAPTIVE_ONLY_RATIO_CHOICES = ("adaptive",)
+ALL_DURATION_CHOICES = (SMART_DURATION, *range(MIN_DURATION, MAX_DURATION + 1))
+SMART_ONLY_DURATION_CHOICES = (SMART_DURATION,)
+
+REFERENCE_IMAGES_PARAMETER = "reference_images"
+REFERENCE_VIDEOS_PARAMETER = "reference_videos"
+REFERENCE_AUDIO_PARAMETER = "reference_audio"
+REFERENCE_PARAMETERS = (REFERENCE_IMAGES_PARAMETER, REFERENCE_VIDEOS_PARAMETER, REFERENCE_AUDIO_PARAMETER)
+FRAME_PARAMETERS = ("first_frame", "last_frame")
+
+# Seedance 2.5 registers private assets through the Griptape Cloud proxy, the same as the 2.0 models.
+SUPPORTS_PRIVATE_ASSETS = True
+
+
+class SeedanceTask(StrEnum):
+    """The five task types Seedance 2.5 classifies a request into.
+
+    The provider infers the task from ``content.role`` plus the prompt's intent — there is no
+    ``task_type`` field — and applies per-task constraints to ``ratio`` and ``duration``. A
+    violation is reported asynchronously, after the task has queued, so this node makes the task
+    an explicit choice and validates its constraints before submitting.
+    """
+
+    TEXT_TO_VIDEO = "Text to Video"
+    FIRST_LAST_FRAME = "First/Last Frame"
+    REFERENCE_TO_VIDEO = "Reference to Video"
+    VIDEO_EDITING = "Video Editing"
+    VIDEO_EXTENSION = "Video Extension"
+
+
+@dataclass(frozen=True)
+class TaskConstraints:
+    """The provider constraints that apply to one Seedance 2.5 task type.
+
+    Args:
+        allows_frames: Whether first_frame/last_frame inputs belong to this task.
+        allows_references: Whether the reference image/video/audio lists belong to this task.
+        requires_reference_video: Whether at least one reference video is mandatory.
+        ratio_choices: The ``ratio`` values the provider accepts for this task.
+        duration_choices: The ``duration`` values the provider accepts for this task.
+        trigger_keywords: Words the prompt must contain for the provider to classify the request
+            as this task. Empty when the task needs no prompt trigger.
+    """
+
+    allows_frames: bool
+    allows_references: bool
+    requires_reference_video: bool
+    ratio_choices: tuple[str, ...]
+    duration_choices: tuple[int, ...]
+    trigger_keywords: tuple[str, ...]
+
+
+# Single source of truth for the per-task constraints, straight from the Seedance 2.5
+# task-specific constraints table. Adding a task type is one row here.
+TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
+    SeedanceTask.TEXT_TO_VIDEO: TaskConstraints(
+        allows_frames=False,
+        allows_references=False,
+        requires_reference_video=False,
+        ratio_choices=ALL_RATIO_CHOICES,
+        duration_choices=ALL_DURATION_CHOICES,
+        trigger_keywords=(),
+    ),
+    SeedanceTask.FIRST_LAST_FRAME: TaskConstraints(
+        allows_frames=True,
+        allows_references=False,
+        requires_reference_video=False,
+        # The output keeps the first frame's aspect ratio, so no ratio can be specified.
+        ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
+        duration_choices=ALL_DURATION_CHOICES,
+        trigger_keywords=(),
+    ),
+    SeedanceTask.REFERENCE_TO_VIDEO: TaskConstraints(
+        allows_frames=False,
+        allows_references=True,
+        requires_reference_video=False,
+        ratio_choices=ALL_RATIO_CHOICES,
+        duration_choices=ALL_DURATION_CHOICES,
+        trigger_keywords=(),
+    ),
+    SeedanceTask.VIDEO_EDITING: TaskConstraints(
+        allows_frames=False,
+        allows_references=True,
+        requires_reference_video=True,
+        # The output keeps the edited video's aspect ratio and duration.
+        ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
+        duration_choices=SMART_ONLY_DURATION_CHOICES,
+        trigger_keywords=("edit", "add", "delete", "remove", "modify", "replace", "change"),
+    ),
+    SeedanceTask.VIDEO_EXTENSION: TaskConstraints(
+        allows_frames=False,
+        allows_references=True,
+        requires_reference_video=True,
+        # The output keeps the extended video's aspect ratio.
+        ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
+        duration_choices=ALL_DURATION_CHOICES,
+        trigger_keywords=("extend", "continue"),
+    ),
+}
+
+PROMPT_TIPS_MESSAGE = (
+    "Reference assets are addressed positionally in the prompt: @Image 1, @Video 1, @Audio 1 "
+    "follow the order of the reference lists below.\n\n"
+    "Audio cues use special characters: () for music, <> for sound effects, {} for dialogue, "
+    "and 【】 for subtitles.\n\n"
+    "Video Editing and Video Extension are classified from the prompt, so the prompt must name "
+    "what you want done — e.g. 'Remove everyone in @Video 1 except the protagonist' or "
+    "'Extend @Video 1 backward'."
+)
+
+REFERENCE_VIDEO_UPLOAD_MESSAGE = (
+    "This node requires a public URL for each reference video.\n\n"
+    "Seedance does not accept video base64, so each reference video is uploaded to Griptape Cloud "
+    "static storage to obtain a temporary public URL, which the Seedance service then fetches. "
+    "The upload is deleted when the run finishes."
+)
+
+
+def _get_task_constraints(task: str) -> TaskConstraints:
+    """Return the constraint record for a task value, defaulting to the least restrictive task.
+
+    A task value can arrive over a connection, so an unrecognized value must not raise here —
+    ``_validate_parameters`` reports it with an actionable message instead.
+    """
+    for member in SeedanceTask:
+        if task == member:
+            return TASK_CONSTRAINTS[member]
+    return TASK_CONSTRAINTS[SeedanceTask.TEXT_TO_VIDEO]
+
+
+class Seedance25VideoGeneration(SeedanceProxyNode):
+    """Generate a video using Dreamina Seedance 2.5 via the Griptape Cloud model proxy.
+
+    Seedance 2.5 classifies each request into one of five task types from the media roles and the
+    prompt's intent, and locks `ratio`/`duration` per task. The `task` parameter makes that choice
+    explicit so the node can show the right inputs, narrow the settings to the values the provider
+    accepts, and reject a mismatched request before it is queued (the provider only reports task
+    constraint violations asynchronously, after the task starts processing).
+
+    Tasks:
+    - Text to Video: prompt only
+    - First/Last Frame: first and/or last frame images (ratio locked to adaptive)
+    - Reference to Video: up to 30 images + 10 videos + 10 audio clips as references
+    - Video Editing: edit a reference video (ratio locked to adaptive, duration locked to -1)
+    - Video Extension: extend a reference video (ratio locked to adaptive)
+
+    Inputs:
+        - prompt (str): Text prompt for the video
+        - task (str): One of the five Seedance 2.5 task types (default: Text to Video)
+        - resolution (str): Output resolution (default: 720p, options: 480p, 720p)
+        - ratio (str): Output aspect ratio (default: adaptive)
+        - duration (int): Video duration in seconds (4-30, or -1 to let the model choose)
+        - generate_audio (bool): Generate audio with video (default: False)
+        - output_format (str): Output container, mp4 or mov (default: mp4)
+        - watermark (bool): Add an "AI Generated" watermark (default: False)
+        - return_last_frame (bool): Also return the video's last frame as a PNG (default: False)
+        - first_frame/last_frame: Optional frame images (First/Last Frame task only)
+        - reference_images/reference_videos/reference_audio: Optional reference media
+
+    Outputs:
+        - generation_id (str): Griptape Cloud generation id
+        - provider_response (dict): Verbatim response from API
+        - video_url (VideoUrlArtifact): Saved static video URL
+        - last_frame_url (ImageUrlArtifact): Saved last frame, when return_last_frame is set
+        - was_successful (bool): Whether generation succeeded
+        - result_details (str): Details about the result or error
+    """
+
+    REFERENCE_ASSET_KINDS: ClassVar[dict[str, str]] = {
+        REFERENCE_IMAGES_PARAMETER: ASSET_KIND_IMAGE,
+        REFERENCE_VIDEOS_PARAMETER: ASSET_KIND_VIDEO,
+        REFERENCE_AUDIO_PARAMETER: ASSET_KIND_AUDIO,
+    }
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "API Nodes"
+        self.description = "Generate video via Seedance 2.5 through Griptape Cloud model proxy"
+
+        self.add_parameter(
+            ParameterString(
+                name="task",
+                default_value=SeedanceTask.TEXT_TO_VIDEO,
+                tooltip=(
+                    "Which Seedance 2.5 task to run. The provider infers this from the media roles and the "
+                    "prompt, and locks aspect ratio and duration per task, so choosing it here keeps the "
+                    "settings and inputs consistent with what the provider accepts."
+                ),
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                ui_options={"display_name": "Task"},
+                traits={Options(choices=[task.value for task in SeedanceTask])},
+            )
+        )
+
+        prompt_parameter = ParameterString(
+            name="prompt",
+            tooltip=(
+                "Text prompt for the video. Reference assets are addressed as @Image 1, @Video 1, @Audio 1 "
+                "in the order of the reference lists."
+            ),
+            multiline=True,
+            placeholder_text="Describe the video...",
+            allow_output=False,
+            ui_options={"display_name": "Prompt"},
+        )
+        self.add_parameter(prompt_parameter)
+        prompt_parameter.set_badge(variant="tip", title="Prompt Tips", message=PROMPT_TIPS_MESSAGE)
+
+        # First/Last Frame inputs
+        self.add_parameter(
+            ParameterImage(
+                name="first_frame",
+                default_value=None,
+                tooltip="Optional first frame image",
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+                ui_options={"display_name": "First Frame"},
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="last_frame",
+                default_value=None,
+                tooltip="Optional last frame image",
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+                ui_options={"display_name": "Last Frame"},
+            )
+        )
+
+        # Reference inputs
+        self.add_parameter(
+            ParameterList(
+                name=REFERENCE_IMAGES_PARAMETER,
+                input_types=["ImageUrlArtifact", "ImageArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_IMAGE]],
+                default_value=[],
+                tooltip=(
+                    f"Optional reference images (up to {MAX_REFERENCE_IMAGES}). Connect a Seedance Human "
+                    "Reference Asset to register an image as a private asset."
+                ),
+                allowed_modes={ParameterMode.INPUT},
+                ui_options={"display_name": "Reference Images", "expander": True, "hide_property": True},
+                child_prefix="Reference Image",
+                max_items=MAX_REFERENCE_IMAGES,
+            )
+        )
+
+        reference_videos = ParameterList(
+            name=REFERENCE_VIDEOS_PARAMETER,
+            input_types=["VideoUrlArtifact", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_VIDEO]],
+            type="VideoUrlArtifact",
+            default_value=[],
+            tooltip=(
+                f"Optional reference videos (up to {MAX_REFERENCE_VIDEOS}, 2-30s each and no more than 30s "
+                "combined). Seedance only accepts public URLs or uploaded asset URLs for videos. Connect a "
+                "Seedance Human Reference Asset to register a video as a private asset."
+            ),
+            allowed_modes={ParameterMode.INPUT},
+            ui_options={"display_name": "Reference Videos", "expander": True, "hide_property": True},
+            child_prefix="Reference Video",
+            max_items=MAX_REFERENCE_VIDEOS,
+        )
+        self.add_parameter(reference_videos)
+        reference_videos.set_badge(
+            variant="cloud-upload",
+            title="Media Upload",
+            message=REFERENCE_VIDEO_UPLOAD_MESSAGE,
+            hide_clear_button=False,
+        )
+
+        self.add_parameter(
+            ParameterList(
+                name=REFERENCE_AUDIO_PARAMETER,
+                input_types=["AudioArtifact", "AudioUrlArtifact", "str", ASSET_REFERENCE_TYPE_NAMES[ASSET_KIND_AUDIO]],
+                default_value=[],
+                tooltip=(
+                    f"Optional reference audio (up to {MAX_REFERENCE_AUDIO} clips, 2-30s each and no more than "
+                    "30s combined). URLs, asset:// IDs, or base64/data URIs are supported. Seedance 2.5 accepts "
+                    "audio without any image or video."
+                ),
+                allowed_modes={ParameterMode.INPUT},
+                ui_options={"display_name": "Reference Audio", "expander": True, "hide_property": True},
+                child_prefix="Reference Audio",
+                max_items=MAX_REFERENCE_AUDIO,
+            )
+        )
+
+        # Generation settings
+        with ParameterGroup(name="Generation Settings") as settings_group:
+            ParameterString(
+                name="resolution",
+                default_value="720p",
+                tooltip="Output resolution (480p or 720p)",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=list(RESOLUTION_CHOICES))},
+            )
+
+            ParameterString(
+                name="ratio",
+                default_value="adaptive",
+                tooltip=(
+                    "Output aspect ratio. Locked to adaptive for First/Last Frame, Video Editing, and Video "
+                    "Extension, where the output keeps the input's aspect ratio."
+                ),
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=list(ALL_RATIO_CHOICES))},
+            )
+
+            ParameterInt(
+                name="duration",
+                default_value=SMART_DURATION,
+                tooltip=(
+                    f"Video duration in seconds ({MIN_DURATION}-{MAX_DURATION}, or {SMART_DURATION} to let the "
+                    f"model choose). Locked to {SMART_DURATION} for Video Editing, where the output matches the "
+                    "edited video's duration."
+                ),
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=list(ALL_DURATION_CHOICES))},
+            )
+
+            ParameterBool(
+                name="generate_audio",
+                default_value=False,
+                tooltip="Generate audio with video",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+
+            ParameterString(
+                name="output_format",
+                default_value=DEFAULT_OUTPUT_FORMAT,
+                tooltip=(
+                    "Output container. mp4 is broadly compatible; mov preserves more color precision for "
+                    "post-production and is recommended for video editing and extension."
+                ),
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                traits={Options(choices=list(OUTPUT_FORMAT_CHOICES))},
+            )
+
+            ParameterBool(
+                name="watermark",
+                default_value=False,
+                tooltip='Add an "AI Generated" watermark to the lower-right corner of the video',
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+
+            ParameterBool(
+                name="return_last_frame",
+                default_value=False,
+                tooltip=(
+                    "Also return the video's last frame as a PNG. Useful for chaining runs: feed it into the "
+                    "next generation's first frame to continue a sequence."
+                ),
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+
+        self.add_node_element(settings_group)
+
+        # Outputs
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Verbatim response from API",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="video_url",
+                tooltip="Saved video as URL artifact",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+        self.add_parameter(
+            ParameterImage(
+                name="last_frame_url",
+                tooltip="Saved last frame of the generated video, when Return Last Frame is enabled",
+                allowed_modes={ParameterMode.OUTPUT},
+                settable=False,
+                hide=True,
+                ui_options={"display_name": "Last Frame Image"},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename=self._default_output_filename(DEFAULT_OUTPUT_FORMAT),
+        )
+        self._output_file.add_parameter()
+
+        self._last_frame_file = ProjectFileParameter(
+            node=self,
+            name="last_frame_file",
+            default_filename=LAST_FRAME_FILENAME,
+            ui_options={"hide": True},
+        )
+        self._last_frame_file.add_parameter()
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the video generation result or any errors",
+            result_details_placeholder="Generation status and details will appear here.",
+            parameter_group_initially_collapsed=True,
+        )
+
+        # Set initial visibility
+        self._update_parameter_visibility()
+
+    @staticmethod
+    def _default_output_filename(output_format: str) -> str:
+        return f"{OUTPUT_FILENAME_BASE}.{output_format}"
+
+    def set_parameter_value(self, param_name: str, value: Any, **kwargs: Any) -> None:
+        super().set_parameter_value(param_name, value, **kwargs)
+        if not kwargs.get("initial_setup", False):
+            return
+        # after_value_set is skipped during initial_setup (workflow load), but the UI still needs
+        # to reflect the loaded task and output format.
+        self._react_to_parameter_change(param_name, self.get_parameter_value(param_name), sync_only=True)
+
+    def after_value_set(self, parameter: Any, value: Any) -> None:
+        if parameter.name in FRAME_PARAMETERS:
+            artifact = normalize_artifact_input(value, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+            if artifact != value:
+                self.set_parameter_value(parameter.name, artifact)
+
+        if parameter.name == REFERENCE_IMAGES_PARAMETER and isinstance(value, list):
+            updated_list = normalize_artifact_list(value, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+            if updated_list != value:
+                self.set_parameter_value(REFERENCE_IMAGES_PARAMETER, updated_list)
+
+        if parameter.name == REFERENCE_AUDIO_PARAMETER and isinstance(value, list):
+            updated_list = normalize_artifact_list(value, AudioUrlArtifact, accepted_types=(AudioArtifact,))
+            if updated_list != value:
+                self.set_parameter_value(REFERENCE_AUDIO_PARAMETER, updated_list)
+
+        self._react_to_parameter_change(parameter.name, value, sync_only=False)
+        return super().after_value_set(parameter, value)
+
+    def _react_to_parameter_change(self, param_name: str, value: Any, *, sync_only: bool) -> None:
+        if param_name in {"task", "return_last_frame"}:
+            self._update_parameter_visibility()
+
+        if param_name == "output_format" and isinstance(value, str):
+            if not sync_only:
+                self._sync_output_filename(value)
+
+    def _sync_output_filename(self, output_format: str) -> None:
+        """Rewrite the output filename's extension to match the chosen container.
+
+        Only rewrites while the filename is still one of the format-derived defaults, so a
+        filename the user typed is never clobbered.
+        """
+        current_value = self.get_parameter_value("output_file")
+        default_filenames = {self._default_output_filename(fmt) for fmt in OUTPUT_FORMAT_CHOICES}
+        if current_value not in default_filenames:
+            return
+
+        updated_value = self._default_output_filename(output_format)
+        if current_value == updated_value:
+            return
+
+        self.set_parameter_value("output_file", updated_value)
+        self.publish_update_to_parameter("output_file", updated_value)
+
+    def _update_parameter_visibility(self) -> None:
+        """Show the inputs that belong to the selected task and lock the settings it constrains."""
+        task = self.get_parameter_value("task") or SeedanceTask.TEXT_TO_VIDEO
+        constraints = _get_task_constraints(task)
+
+        if constraints.allows_frames:
+            self.show_parameter_by_name(list(FRAME_PARAMETERS))
+        else:
+            self.hide_parameter_by_name(list(FRAME_PARAMETERS))
+
+        if constraints.allows_references:
+            self.show_parameter_by_name(list(REFERENCE_PARAMETERS))
+        else:
+            self.hide_parameter_by_name(list(REFERENCE_PARAMETERS))
+
+        self._update_option_choices_for_task("ratio", list(constraints.ratio_choices), fallback="adaptive")
+        self._update_option_choices_for_task("duration", list(constraints.duration_choices), fallback=SMART_DURATION)
+
+        if self.get_parameter_value("return_last_frame"):
+            self.show_parameter_by_name(["last_frame_url", "last_frame_file"])
+        else:
+            self.hide_parameter_by_name(["last_frame_url", "last_frame_file"])
+
+    def _update_option_choices_for_task(self, parameter_name: str, choices: list[Any], *, fallback: Any) -> None:
+        """Narrow a parameter's Options to the task's accepted values, coercing an invalid current value."""
+        parameter = self.get_parameter_by_name(parameter_name)
+        if parameter is None:
+            return
+
+        existing_traits = parameter.find_elements_by_type(Options)
+        if existing_traits:
+            parameter.remove_trait(trait_type=existing_traits[0])
+        parameter.add_trait(Options(choices=choices))
+
+        if self.get_parameter_value(parameter_name) not in choices:
+            self.set_parameter_value(parameter_name, fallback)
+
+    def _get_api_model_id(self) -> str:
+        return SEEDANCE_2_5_MODEL_ID
+
+    async def _process_generation(self) -> None:
+        self._pending_asset_uploads = []
+        try:
+            await super()._process_generation()
+        finally:
+            self._cleanup_pending_asset_uploads()
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Validate parameters before execution."""
+        exceptions = super().validate_before_node_run() or []
+
+        try:
+            self._validate_parameters(self._get_parameters())
+        except ValueError as e:
+            exceptions.append(e)
+
+        return exceptions if exceptions else None
+
+    def _get_parameters(self) -> dict[str, Any]:
+        first_frame = normalize_artifact_input(
+            self.get_parameter_value("first_frame"),
+            ImageUrlArtifact,
+            accepted_types=(ImageArtifact,),
+        )
+        last_frame = normalize_artifact_input(
+            self.get_parameter_value("last_frame"),
+            ImageUrlArtifact,
+            accepted_types=(ImageArtifact,),
+        )
+
+        reference_images = self.get_parameter_value(REFERENCE_IMAGES_PARAMETER) or []
+        normalized_reference_images = (
+            normalize_artifact_list(reference_images, ImageUrlArtifact, accepted_types=(ImageArtifact,))
+            if reference_images
+            else []
+        )
+        reference_audio = self.get_parameter_value(REFERENCE_AUDIO_PARAMETER) or []
+        normalized_reference_audio = (
+            normalize_artifact_list(reference_audio, AudioUrlArtifact, accepted_types=(AudioArtifact,))
+            if reference_audio
+            else []
+        )
+
+        return {
+            "prompt": self.get_parameter_value("prompt") or "",
+            "task": self.get_parameter_value("task") or SeedanceTask.TEXT_TO_VIDEO,
+            "resolution": self.get_parameter_value("resolution") or "720p",
+            "ratio": self.get_parameter_value("ratio") or "adaptive",
+            "duration": self.get_parameter_value("duration"),
+            "generate_audio": self.get_parameter_value("generate_audio"),
+            "output_format": self.get_parameter_value("output_format") or DEFAULT_OUTPUT_FORMAT,
+            "watermark": self.get_parameter_value("watermark"),
+            "return_last_frame": self.get_parameter_value("return_last_frame"),
+            "first_frame": first_frame,
+            "last_frame": last_frame,
+            REFERENCE_IMAGES_PARAMETER: normalized_reference_images,
+            # An empty list slot yields a falsy child value; drop those so counts and @Video N
+            # ordering reflect only the videos actually connected.
+            REFERENCE_VIDEOS_PARAMETER: [
+                value for value in self.get_parameter_value(REFERENCE_VIDEOS_PARAMETER) or [] if value
+            ],
+            REFERENCE_AUDIO_PARAMETER: normalized_reference_audio,
+        }
+
+    def _validate_parameters(self, params: dict[str, Any]) -> None:
+        """Validate the task, its media inputs, and its ratio/duration constraints."""
+        task = params["task"]
+        if task not in set(SeedanceTask):
+            supported = ", ".join(member.value for member in SeedanceTask)
+            msg = f"{self.name}: unknown task {task!r}. Supported tasks: {supported}."
+            raise ValueError(msg)
+
+        constraints = TASK_CONSTRAINTS[SeedanceTask(task)]
+
+        self._validate_media_matches_task(params, task, constraints)
+        self._validate_reference_counts(params)
+        self._validate_trigger_keywords(params, task, constraints)
+        self._validate_ratio_and_duration(params, task, constraints)
+
+        # Private-asset references require Griptape auth (not BYOK). Gate first so the user gets a
+        # specific message before the per-kind check.
+        self._validate_private_asset_auth(params)
+
+        # Private-asset reference kind must match the receiving input (early feedback; the
+        # authoritative check happens at build time in _append_private_asset).
+        if self._private_assets_active():
+            self._validate_private_asset_kinds(params)
+
+    def _validate_media_matches_task(self, params: dict[str, Any], task: str, constraints: TaskConstraints) -> None:
+        """Raise if media is connected to inputs the selected task does not use."""
+        has_frames = any(params.get(name) is not None for name in FRAME_PARAMETERS)
+        has_references = any(params.get(name) for name in REFERENCE_PARAMETERS)
+
+        if has_frames and not constraints.allows_frames:
+            msg = (
+                f"{self.name}: first_frame/last_frame inputs are only used by the "
+                f"{SeedanceTask.FIRST_LAST_FRAME.value} task. Switch the task to "
+                f"{SeedanceTask.FIRST_LAST_FRAME.value}, or clear the frame inputs."
+            )
+            raise ValueError(msg)
+
+        if has_references and not constraints.allows_references:
+            reference_tasks = ", ".join(
+                member.value for member in SeedanceTask if TASK_CONSTRAINTS[member].allows_references
+            )
+            msg = (
+                f"{self.name}: the reference image/video/audio inputs are only used by the "
+                f"{reference_tasks} tasks. Switch the task, or clear the reference inputs."
+            )
+            raise ValueError(msg)
+
+        if constraints.requires_reference_video and not params.get(REFERENCE_VIDEOS_PARAMETER):
+            msg = (
+                f"{self.name}: the {task} task requires at least one reference video — the video to "
+                f"{'edit' if task == SeedanceTask.VIDEO_EDITING else 'extend'}. Connect a video to "
+                "Reference Videos, or switch the task."
+            )
+            raise ValueError(msg)
+
+    def _validate_reference_counts(self, params: dict[str, Any]) -> None:
+        """Raise if any reference list exceeds the provider's cap for that kind.
+
+        The per-kind caps sum to MAX_TOTAL_REFERENCE_ASSETS, so satisfying all three also satisfies
+        the documented total cap; there is no separate total check to make.
+        """
+        caps = {
+            REFERENCE_IMAGES_PARAMETER: (MAX_REFERENCE_IMAGES, "reference images"),
+            REFERENCE_VIDEOS_PARAMETER: (MAX_REFERENCE_VIDEOS, "reference videos"),
+            REFERENCE_AUDIO_PARAMETER: (MAX_REFERENCE_AUDIO, "reference audio clips"),
+        }
+        for parameter_name, (cap, label) in caps.items():
+            count = len(params.get(parameter_name) or [])
+            if count > cap:
+                msg = f"{self.name}: Seedance 2.5 supports up to {cap} {label}, got {count}."
+                raise ValueError(msg)
+
+    def _validate_trigger_keywords(self, params: dict[str, Any], task: str, constraints: TaskConstraints) -> None:
+        """Raise if the prompt lacks a keyword the provider needs to classify this task.
+
+        Seedance 2.5 derives Video Editing and Video Extension from the prompt's intent, so a
+        prompt with no such wording is classified as a different task and rejected asynchronously.
+        """
+        if not constraints.trigger_keywords:
+            return
+
+        prompt = (params.get("prompt") or "").lower()
+        if any(keyword in prompt for keyword in constraints.trigger_keywords):
+            return
+
+        keywords = ", ".join(constraints.trigger_keywords)
+        msg = (
+            f"{self.name}: the {task} task is inferred from the prompt, which must say what to do to the "
+            f"reference video. Include at least one of: {keywords}."
+        )
+        raise ValueError(msg)
+
+    def _validate_ratio_and_duration(self, params: dict[str, Any], task: str, constraints: TaskConstraints) -> None:
+        """Raise if ratio or duration is outside what the provider accepts for this task.
+
+        The dropdowns are already narrowed per task, but either value can arrive over a connection.
+        """
+        ratio = params.get("ratio")
+        if ratio not in constraints.ratio_choices:
+            accepted = ", ".join(constraints.ratio_choices)
+            msg = (
+                f"{self.name}: the {task} task only supports ratio {accepted}, got {ratio!r}. "
+                "The output keeps the aspect ratio of its input."
+            )
+            raise ValueError(msg)
+
+        duration = params.get("duration")
+        if duration is None:
+            return
+        if duration not in constraints.duration_choices:
+            if constraints.duration_choices == SMART_ONLY_DURATION_CHOICES:
+                msg = (
+                    f"{self.name}: the {task} task only supports duration {SMART_DURATION}, got {duration}. "
+                    "The output duration matches the input video."
+                )
+            else:
+                msg = (
+                    f"{self.name}: Seedance 2.5 supports duration between {MIN_DURATION}-{MAX_DURATION} seconds "
+                    f"or {SMART_DURATION} to let the model choose, got {duration}."
+                )
+            raise ValueError(msg)
+
+    def _iter_reference_asset_checks(self, params: dict[str, Any]) -> list[tuple[Any, str]]:
+        """List (reference value, expected kind) pairs across all reference inputs."""
+        return [
+            (item, asset_kind)
+            for parameter_name, asset_kind in self.REFERENCE_ASSET_KINDS.items()
+            for item in params.get(parameter_name) or []
+        ]
+
+    def _validate_private_asset_auth(self, params: dict[str, Any]) -> None:
+        """Raise if a private-asset reference is connected while the node uses BYOK auth.
+
+        Provider assets are registered through the Griptape Cloud proxy on the org's behalf, so
+        they are unavailable when the user brings their own provider key.
+        """
+        if not self._is_byok_enabled():
+            return
+        for value, _ in self._iter_reference_asset_checks(params):
+            if is_provider_asset_reference(value):
+                msg = (
+                    f"{self.name}: private-asset references (Seedance Human Reference Asset) require "
+                    "Griptape authentication and are not available when using your own provider key. "
+                    "Switch off the customer key option, or remove the private-asset reference inputs."
+                )
+                raise ValueError(msg)
+
+    def _validate_private_asset_kinds(self, params: dict[str, Any]) -> None:
+        """Raise if a private-asset reference's kind doesn't match its receiving input."""
+        for value, expected_kind in self._iter_reference_asset_checks(params):
+            if is_provider_asset_reference(value):
+                actual_kind = get_provider_asset_kind(value)
+                if actual_kind != expected_kind:
+                    msg = (
+                        f"{self.name}: a {actual_kind or 'unknown'} private-asset reference is connected to a "
+                        f"{expected_kind} reference input. Set the Seedance Human Reference Asset's Asset Kind "
+                        f"to {expected_kind}, or connect it to the matching reference input."
+                    )
+                    raise ValueError(msg)
+
+    def _is_byok_enabled(self) -> bool:
+        """Whether the node is configured to use the customer's own key (BYOK) instead of Griptape auth."""
+        return bool(self._api_key_provider and self._api_key_provider.is_user_auth_enabled())
+
+    def _private_assets_active(self) -> bool:
+        """Whether private-asset registration applies for this run.
+
+        Requires Griptape auth: provider assets are registered through the Griptape Cloud proxy on
+        the org's behalf, which does not apply when the user brings their own provider key (BYOK).
+        """
+        return SUPPORTS_PRIVATE_ASSETS and not self._is_byok_enabled()
+
+    async def _build_payload(self) -> dict[str, Any]:
+        """Build the request payload for the Seedance 2.5 API."""
+        params = self._get_parameters()
+        self._log(
+            f"{self.name} parameter summary: "
+            f"model_id={SEEDANCE_2_5_MODEL_ID}, "
+            f"task={params['task']}, "
+            f"first_frame_present={params['first_frame'] is not None}, "
+            f"last_frame_present={params['last_frame'] is not None}, "
+            f"reference_images={len(params[REFERENCE_IMAGES_PARAMETER])}, "
+            f"reference_videos={len(params[REFERENCE_VIDEOS_PARAMETER])}, "
+            f"reference_audio={len(params[REFERENCE_AUDIO_PARAMETER])}"
+        )
+
+        payload: dict[str, Any] = {"model": SEEDANCE_2_5_MODEL_ID}
+        if params["resolution"]:
+            payload["resolution"] = params["resolution"]
+        if params["ratio"]:
+            payload["ratio"] = params["ratio"]
+        if params["duration"] is not None:
+            payload["duration"] = int(params["duration"])
+        if params["generate_audio"] is not None:
+            payload["generate_audio"] = bool(params["generate_audio"])
+        if params["output_format"]:
+            payload["output_format"] = params["output_format"]
+        if params["watermark"] is not None:
+            payload["watermark"] = bool(params["watermark"])
+        if params["return_last_frame"] is not None:
+            payload["return_last_frame"] = bool(params["return_last_frame"])
+
+        content_list: list[dict[str, Any]] = [{"type": "text", "text": params["prompt"].strip()}]
+        await self._add_media_inputs_async(content_list, params)
+        payload["content"] = content_list
+
+        return payload
+
+    async def _add_media_inputs_async(self, content_list: list[dict[str, Any]], params: dict[str, Any]) -> None:
+        """Append the selected task's media entries to the content list.
+
+        List order matters: it is what ``@Image N`` / ``@Video N`` / ``@Audio N`` in the prompt
+        resolve against.
+        """
+        task = SeedanceTask(params["task"])
+        constraints = TASK_CONSTRAINTS[task]
+
+        if constraints.allows_frames:
+            self._log(f"{self.name} building first/last-frame content")
+            for parameter_name in FRAME_PARAMETERS:
+                frame_url = await self._prepare_frame_url_async(params[parameter_name], frame_label=parameter_name)
+                if frame_url:
+                    content_list.append({"type": "image_url", "image_url": {"url": frame_url}, "role": parameter_name})
+            return
+
+        if not constraints.allows_references:
+            self._log(f"{self.name} text-only task, no media inputs")
+            return
+
+        self._log(f"{self.name} building multimodal reference content for {task.value}")
+        supports_assets = self._private_assets_active()
+        order_log: list[str] = []
+
+        for idx, ref_image in enumerate(params[REFERENCE_IMAGES_PARAMETER], start=1):
+            if supports_assets and is_provider_asset_reference(ref_image):
+                asset_url = await self._append_private_asset(
+                    ref_image, expected_kind=ASSET_KIND_IMAGE, label=f"reference image {idx}"
+                )
+                content_list.append({"type": "image_url", "image_url": {"url": asset_url}, "role": "reference_image"})
+                order_log.append(f"Image {idx}: private asset")
+            else:
+                ref_url = await self._prepare_frame_url_async(ref_image, frame_label="reference_image")
+                if ref_url:
+                    content_list.append({"type": "image_url", "image_url": {"url": ref_url}, "role": "reference_image"})
+                    order_log.append(f"Image {idx}: reference")
+
+        for idx, ref_video in enumerate(params[REFERENCE_VIDEOS_PARAMETER], start=1):
+            if supports_assets and is_provider_asset_reference(ref_video):
+                asset_url = await self._append_private_asset(
+                    ref_video, expected_kind=ASSET_KIND_VIDEO, label=f"reference video {idx}"
+                )
+                content_list.append({"type": "video_url", "video_url": {"url": asset_url}, "role": "reference_video"})
+                order_log.append(f"Video {idx}: private asset")
+            else:
+                video_url = self._get_reference_video_url(ref_video, label=f"reference video {idx}")
+                content_list.append({"type": "video_url", "video_url": {"url": video_url}, "role": "reference_video"})
+                order_log.append(f"Video {idx}: reference")
+
+        for idx, ref_audio in enumerate(params[REFERENCE_AUDIO_PARAMETER], start=1):
+            if supports_assets and is_provider_asset_reference(ref_audio):
+                asset_url = await self._append_private_asset(
+                    ref_audio, expected_kind=ASSET_KIND_AUDIO, label=f"reference audio {idx}"
+                )
+                content_list.append({"type": "audio_url", "audio_url": {"url": asset_url}, "role": "reference_audio"})
+                order_log.append(f"Audio {idx}: private asset")
+            else:
+                audio_url = await self._prepare_audio_url_async(ref_audio, audio_label="reference_audio")
+                if audio_url:
+                    content_list.append(
+                        {"type": "audio_url", "audio_url": {"url": audio_url}, "role": "reference_audio"}
+                    )
+                    order_log.append(f"Audio {idx}: reference")
+
+        if order_log:
+            self._log(f"{self.name} resolved reference order: " + "; ".join(order_log))
+
+    def _get_reference_video_url(self, value: Any, *, label: str) -> str:
+        """Resolve one reference video to a URL Seedance can fetch.
+
+        Public URLs and ``asset://`` IDs pass through; anything else is uploaded to Griptape Cloud
+        static storage for a temporary public URL, because Seedance does not accept video base64.
+        """
+        direct_url = coerce_video_url(value)
+        if direct_url:
+            return direct_url
+
+        try:
+            public_url = self._resolve_public_url_for_media(value, artifact_type="VideoUrlArtifact")
+        except Exception as e:
+            msg = f"{self.name}: failed to prepare a public URL for {label}: {e}"
+            raise ValueError(msg) from e
+
+        coerced_url = coerce_video_url(public_url)
+        if not coerced_url:
+            msg = (
+                f"{self.name}: {label} only supports public URLs, uploaded asset URLs, or asset:// IDs. "
+                "Seedance 2.5 does not accept video base64."
+            )
+            raise ValueError(msg)
+        return coerced_url
+
+    async def _parse_result(self, result_json: dict[str, Any], generation_id: str) -> None:
+        """Parse the result and set output parameters."""
+        extracted_url = extract_video_url(result_json)
+        if not extracted_url:
+            self.parameter_output_values["video_url"] = None
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"{self.name} generation completed but no video URL was found in the response.",
+            )
+            return
+
+        await self._download_and_save(extracted_url, "video_url", lambda v, n: VideoUrlArtifact(value=v, name=n))
+
+        if self.get_parameter_value("return_last_frame"):
+            await self._save_last_frame(result_json)
+
+    async def _save_last_frame(self, result_json: dict[str, Any]) -> None:
+        """Download the returned last frame, if any, into its own project file.
+
+        The video has already been saved at this point, so a missing or unretrievable last frame is
+        logged and leaves ``last_frame_url`` unset rather than failing the whole node.
+        """
+        content = result_json.get("content")
+        last_frame_url = content.get("last_frame_url") if isinstance(content, dict) else None
+        if not isinstance(last_frame_url, str) or not last_frame_url:
+            self._log(f"{self.name} return_last_frame was requested but the response contained no last frame URL")
+            return
+
+        try:
+            frame_bytes = await self._download_bytes_from_url(last_frame_url)
+            dest = self._last_frame_file.build_file()
+            saved = await dest.awrite_bytes(frame_bytes)
+        except Exception as e:
+            self._log(f"{self.name} failed to retrieve the last frame from {last_frame_url}: {e}")
+            return
+
+        self.parameter_output_values["last_frame_url"] = ImageUrlArtifact(value=saved.location, name=saved.name)
+        self._log(f"{self.name} saved last frame as {saved.name}")
+
+    def _set_safe_defaults(self) -> None:
+        """Clear all output parameters on error."""
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["video_url"] = None
+        self.parameter_output_values["last_frame_url"] = None

--- a/griptape_nodes_library/video/seedance_common.py
+++ b/griptape_nodes_library/video/seedance_common.py
@@ -1,0 +1,479 @@
+"""Shared plumbing for the Seedance video generation nodes.
+
+The Seedance 2.0 and 2.5 nodes talk to the same BytePlus endpoints through the same Griptape
+Cloud proxy, so everything that is about *the provider* rather than *the model* lives here:
+media coercion, audio-subtype normalization, provider response parsing, and the private-asset
+(``asset://``) registration flow. What differs per model version — task/input modes, capability
+tables, parameter layout, validation — stays in the node modules.
+
+`SeedanceProxyNode` is the shared base class. It carries the private-asset flow because that
+flow needs node state (the proxy base URL, the API key, the transient upload parameters it
+must tear down), while the stateless helpers are module-level functions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import logging
+from abc import ABC
+from contextlib import suppress
+from typing import Any
+from urllib.parse import urljoin
+from uuid import uuid4
+
+import httpx
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.files.file import File, FileLoadError
+
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    get_provider_asset_kind,
+    get_provider_asset_value,
+)
+from griptape_nodes_library.media import coerce_media_url_or_data_uri
+from griptape_nodes_library.proxy import GriptapeProxyNode
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = [
+    "ASSET_MAX_ATTEMPTS",
+    "ASSET_MODERATION",
+    "ASSET_POLL_INTERVAL",
+    "ASSET_PROVIDER",
+    "ASSET_STATUS_ACTIVE",
+    "ASSET_STATUS_DELETED",
+    "ASSET_STATUS_FAILED",
+    "SEEDANCE_AUDIO_SUBTYPE_ALIASES",
+    "SeedanceProxyNode",
+    "coerce_video_url",
+    "extract_video_url",
+    "normalize_audio_data_uri_subtype",
+    "parse_provider_response",
+    "summarize_media_input",
+]
+
+# Provider-asset (private asset) registration via the GTC proxy. Gated to Griptape auth (not BYOK).
+ASSET_PROVIDER = "byteplus_ark"
+ASSET_POLL_INTERVAL = 3  # seconds
+ASSET_MAX_ATTEMPTS = 60  # ~3 min cap, independent of the generation timeout
+ASSET_STATUS_ACTIVE = "ACTIVE"
+ASSET_STATUS_FAILED = "FAILED"
+ASSET_STATUS_DELETED = "DELETED"
+# Skip provider-side moderation on private-asset ingestion (content is already moderated upstream).
+ASSET_MODERATION = {"Strategy": "Skip"}
+
+# Artifact type name to wrap each asset kind in when uploading it for a public URL.
+_ASSET_KIND_ARTIFACT_TYPES = {
+    ASSET_KIND_IMAGE: "ImageUrlArtifact",
+    ASSET_KIND_VIDEO: "VideoUrlArtifact",
+    ASSET_KIND_AUDIO: "AudioUrlArtifact",
+}
+
+# Seedance only accepts audio data URIs whose subtype is exactly `wav` or `mp3` (per the BytePlus
+# docs). The local File/mimetypes layer emits other subtypes for the same formats (e.g. an .mp3
+# resolves to `audio/mpeg`, a .wav to `audio/x-wav`), which Seedance rejects as
+# "Invalid base64 audio_url". Map those aliases back to the accepted subtypes before sending.
+SEEDANCE_AUDIO_SUBTYPE_ALIASES = {
+    "mpeg": "mp3",
+    "mp3": "mp3",
+    "x-wav": "wav",
+    "wave": "wav",
+    "vnd.wave": "wav",
+    "wav": "wav",
+}
+
+
+def normalize_audio_data_uri_subtype(data_uri: str) -> str:
+    """Rewrite an ``data:audio/<subtype>;base64,...`` URI to a Seedance-accepted subtype.
+
+    Returns the URI unchanged if it is not an audio data URI or the subtype has no known alias.
+    """
+    prefix = "data:audio/"
+    if not data_uri.startswith(prefix):
+        return data_uri
+    remainder = data_uri[len(prefix) :]
+    subtype, separator, rest = remainder.partition(";")
+    if not separator:
+        return data_uri
+    normalized_subtype = SEEDANCE_AUDIO_SUBTYPE_ALIASES.get(subtype.lower())
+    if normalized_subtype is None or normalized_subtype == subtype:
+        return data_uri
+    return f"{prefix}{normalized_subtype};{rest}"
+
+
+def coerce_video_url(val: Any) -> str | None:
+    """Convert video input to a Seedance-supported public URL or asset ID."""
+    if val is None:
+        return None
+
+    if isinstance(val, dict):
+        value = val.get("value")
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.startswith(("http://", "https://", "asset://")):
+                return stripped
+        return None
+
+    if isinstance(val, str):
+        v = val.strip()
+        if not v:
+            return None
+        return v if v.startswith(("http://", "https://", "asset://")) else None
+
+    try:
+        to_dict = getattr(val, "to_dict", None)
+        if callable(to_dict):
+            serialized = to_dict()
+            if isinstance(serialized, dict):
+                coerced = coerce_video_url(serialized)
+                if coerced:
+                    return coerced
+
+        v = getattr(val, "value", None)
+        if isinstance(v, str):
+            stripped = v.strip()
+            if stripped.startswith(("http://", "https://", "asset://")):
+                return stripped
+    except Exception:  # noqa: S110
+        pass
+
+    return None
+
+
+def extract_video_url(obj: dict[str, Any] | None) -> str | None:
+    """Find the first http(s) video URL anywhere in a provider result payload."""
+    if not obj:
+        return None
+    for key in ("url", "video_url", "output_url"):
+        val = obj.get(key) if isinstance(obj, dict) else None
+        if isinstance(val, str) and val.startswith("http"):
+            return val
+    for key in ("result", "data", "output", "outputs", "content", "task_result"):
+        nested = obj.get(key) if isinstance(obj, dict) else None
+        if isinstance(nested, dict):
+            url = extract_video_url(nested)
+            if url:
+                return url
+        elif isinstance(nested, list):
+            for item in nested:
+                url = extract_video_url(item if isinstance(item, dict) else None)
+                if url:
+                    return url
+    return None
+
+
+def parse_provider_response(provider_response: Any) -> dict[str, Any] | None:
+    """Parse provider_response if it's a JSON string."""
+    if isinstance(provider_response, str):
+        try:
+            return _json.loads(provider_response)
+        except Exception:
+            return None
+    if isinstance(provider_response, dict):
+        return provider_response
+    return None
+
+
+def summarize_media_input(val: Any) -> str:
+    """Describe a media input's shape for logs without dumping base64 payloads."""
+    if val is None:
+        return "None"
+
+    if isinstance(val, str):
+        return f"str(len={len(val)})"
+
+    if isinstance(val, dict):
+        value = val.get("value")
+        value_summary = f"str(len={len(value)})" if isinstance(value, str) else type(value).__name__
+        return f"dict(type={val.get('type')}, value={value_summary})"
+
+    value_attr = getattr(val, "value", None)
+    if isinstance(value_attr, str):
+        return f"value=str(len={len(value_attr)})"
+    if value_attr is not None:
+        return f"value_type={type(value_attr).__name__}"
+
+    return repr(val)
+
+
+class SeedanceProxyNode(GriptapeProxyNode, ABC):
+    """Base class for Seedance video generation nodes.
+
+    Provides the media preparation and private-asset registration that every Seedance node
+    needs; subclasses own their parameters, validation, and payload shape.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+        # Transient (helper, scratch parameter name) pairs created while registering private
+        # assets; the upload and the scratch parameter are both cleaned up in
+        # _process_generation's finally block so they don't accumulate on the node across runs.
+        self._pending_asset_uploads: list[tuple[PublicArtifactUrlParameter, str]] = []
+
+    # --- Media preparation ------------------------------------------------------------------
+
+    async def _prepare_frame_url_async(self, frame_input: Any, *, frame_label: str) -> str | None:
+        """Convert frame input to a usable URL."""
+        if not frame_input:
+            self._log(f"{self.name} {frame_label} not provided")
+            return None
+
+        frame_url = coerce_media_url_or_data_uri(frame_input, kind="image")
+        if not frame_url:
+            self._log(
+                f"{self.name} {frame_label} could not be converted to an image URL or data URI. "
+                f"input_type={type(frame_input).__name__}, "
+                f"input_module={type(frame_input).__module__}, "
+                f"input_summary={summarize_media_input(frame_input)}"
+            )
+            return None
+
+        if frame_url.startswith("data:image/"):
+            self._log(f"{self.name} {frame_label} prepared as inline data URI")
+            return frame_url
+
+        try:
+            data_uri = await File(frame_url).aread_data_uri(fallback_mime="image/jpeg")
+            self._log(f"{self.name} {frame_label} loaded from file/URL into data URI")
+            return data_uri
+        except FileLoadError as e:
+            self._log(f"{self.name} {frame_label} failed to load from {frame_url}: {e}")
+            return None
+
+    async def _prepare_audio_url_async(self, audio_input: Any, *, audio_label: str) -> str | None:
+        """Convert audio input to a Seedance-accepted URL or data URI."""
+        if not audio_input:
+            self._log(f"{self.name} {audio_label} not provided")
+            return None
+
+        audio_url = coerce_media_url_or_data_uri(audio_input, kind="audio")
+        if not audio_url:
+            self._log(
+                f"{self.name} {audio_label} could not be converted to an audio URL or data URI. "
+                f"input_type={type(audio_input).__name__}, "
+                f"input_module={type(audio_input).__module__}, "
+                f"input_summary={summarize_media_input(audio_input)}"
+            )
+            return None
+
+        if audio_url.startswith(("data:audio/", "http://", "https://", "asset://")):
+            self._log(f"{self.name} {audio_label} prepared as direct audio URL/data URI")
+            return normalize_audio_data_uri_subtype(audio_url)
+
+        try:
+            data_uri = await File(audio_url).aread_data_uri(fallback_mime="audio/wav")
+            self._log(f"{self.name} {audio_label} loaded from file into data URI")
+            return normalize_audio_data_uri_subtype(data_uri)
+        except FileLoadError as e:
+            self._log(f"{self.name} {audio_label} failed to load from {audio_url}: {e}")
+            return None
+
+    # --- Provider private-asset registration (Griptape auth only) ---------------------------
+
+    def _proxy_headers(self) -> dict[str, str]:
+        """Bearer headers for the GTC proxy (same auth as the generation requests)."""
+        return {"Authorization": f"Bearer {self._validate_api_key()}", "Content-Type": "application/json"}
+
+    async def _append_private_asset(self, ref: Any, *, expected_kind: str, label: str) -> str:
+        """Resolve a private-asset reference to an `asset://{asset_id}` URL.
+
+        Cross-checks the reference kind against the receiving input, obtains a public URL for
+        the media, registers it as a provider private asset via the proxy, and polls until ACTIVE.
+        """
+        actual_kind = get_provider_asset_kind(ref)
+        if actual_kind != expected_kind:
+            msg = (
+                f"{self.name}: {label} received a {actual_kind or 'unknown'} private-asset reference, "
+                f"but this input requires a {expected_kind} reference. "
+                f"Set the Seedance Human Reference Asset's Asset Kind to {expected_kind}."
+            )
+            raise ValueError(msg)
+
+        public_url = self._resolve_public_url_for_asset(ref, asset_kind=expected_kind)
+        headers = self._proxy_headers()
+        asset_id = await self._create_provider_asset(public_url, expected_kind, headers)
+        return f"asset://{asset_id}"
+
+    def _resolve_public_url_for_asset(self, ref: Any, *, asset_kind: str) -> str:
+        """Return a publicly fetchable URL for the reference's media.
+
+        CreateProviderAsset requires a fetchable URL, so data URIs / unresolvable inputs raise.
+        """
+        media_value = get_provider_asset_value(ref)
+        if not media_value:
+            msg = f"{self.name}: private-asset reference has no media value to register."
+            raise ValueError(msg)
+
+        public_url = self._resolve_public_url_for_media(
+            media_value, artifact_type=_ASSET_KIND_ARTIFACT_TYPES[asset_kind]
+        )
+        if not (public_url.startswith(("http://", "https://")) and "localhost" not in public_url):
+            msg = (
+                f"{self.name}: could not obtain a public URL for the {asset_kind} private asset. "
+                "Provider asset registration requires a publicly fetchable URL (data URIs are not supported)."
+            )
+            raise RuntimeError(msg)
+        return public_url
+
+    def _resolve_public_url_for_media(self, media_value: Any, *, artifact_type: str) -> str:
+        """Upload media to GTC static storage through a transient parameter and return its URL.
+
+        Already-public http(s) URLs pass through untouched. PublicArtifactUrlParameter binds to a
+        named parameter, so a hidden scratch parameter is created per call and torn down together
+        with the upload by _cleanup_pending_asset_uploads.
+        """
+        # Media reaches this node as a URL string, an artifact, or a serialized artifact dict, and
+        # any of the three can already carry a public URL that needs no upload.
+        if isinstance(media_value, dict):
+            url = media_value.get("value")
+        else:
+            url = getattr(media_value, "value", media_value)
+        if not isinstance(url, str) or not url:
+            msg = f"{self.name}: cannot obtain a public URL for {media_value!r}, which carries no media path or URL."
+            raise ValueError(msg)
+        if url.startswith(("http://", "https://")) and "localhost" not in url:
+            return url
+
+        # Adding this scratch parameter during aprocess trips the strict-mode
+        # "parameter-mutation-during-aprocess" warning. That is expected and harmless here: the
+        # parameter is a transient, worker-local helper that only exists to feed the upload
+        # (PublicArtifactUrlParameter reads its value locally) and is removed before the run ends,
+        # so there is nothing for the orchestrator to stay in sync with.
+        scratch_name = f"_asset_upload_{uuid4().hex}"
+        helper = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=Parameter(
+                name=scratch_name,
+                input_types=[artifact_type],
+                type=artifact_type,
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.PROPERTY},
+                hide=True,
+                hide_property=True,
+            ),
+        )
+        helper.add_input_parameters()
+        self._pending_asset_uploads.append((helper, scratch_name))
+        self.set_parameter_value(scratch_name, url)
+
+        return helper.get_public_url_for_parameter()
+
+    async def _create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
+        """POST proxy/v2/assets and poll to ACTIVE; return the provider asset id."""
+        create_url = urljoin(self._proxy_base, "assets")
+        payload = {
+            "url": public_url,
+            "provider": ASSET_PROVIDER,
+            "provider_body": {"asset_type": asset_kind, "moderation": ASSET_MODERATION},
+        }
+        self._log(f"{self.name} registering {asset_kind} private asset via {create_url}")
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(create_url, json=payload, headers=headers, timeout=60)
+                response.raise_for_status()
+                response_json = response.json()
+        except httpx.HTTPStatusError as e:
+            msg = f"{self.name}: failed to create private asset: HTTP {e.response.status_code} - {e.response.text}"
+            raise RuntimeError(msg) from e
+        except Exception as e:
+            msg = f"{self.name}: failed to create private asset: {e}"
+            raise RuntimeError(msg) from e
+
+        provider_asset_id = response_json.get("provider_asset_id")
+        if not provider_asset_id:
+            msg = f"{self.name}: CreateProviderAsset returned no provider_asset_id."
+            raise RuntimeError(msg)
+        return await self._poll_provider_asset(str(provider_asset_id), headers)
+
+    async def _poll_provider_asset(self, provider_asset_id: str, headers: dict[str, str]) -> str:
+        """Poll GET proxy/v2/assets/<id> until ACTIVE; return the provider asset id.
+
+        Transient errors (a network blip, a 5xx, or the eventual-consistency 404 right after the
+        asset id is minted) are logged and retried until attempts are exhausted, mirroring the
+        base class's generation poll. Only a terminal status (FAILED/DELETED) fails immediately.
+        """
+        get_url = urljoin(self._proxy_base, f"assets/{provider_asset_id}")
+        async with httpx.AsyncClient() as client:
+            for attempt in range(ASSET_MAX_ATTEMPTS):
+                try:
+                    response = await client.get(get_url, headers=headers, timeout=60)
+                    response.raise_for_status()
+                    result_json = response.json()
+                except Exception as e:
+                    # Transient — log and retry rather than aborting an otherwise-successful run.
+                    self._log(
+                        f"{self.name} error polling private asset {provider_asset_id} (attempt {attempt + 1}): {e}"
+                    )
+                    await asyncio.sleep(ASSET_POLL_INTERVAL)
+                    continue
+
+                status = result_json.get("status", "unknown")
+                self._log(f"{self.name} private asset {provider_asset_id} status: {status} (attempt {attempt + 1})")
+
+                if status == ASSET_STATUS_ACTIVE:
+                    asset_id = result_json.get("asset_id")
+                    if not asset_id:
+                        msg = f"{self.name}: private asset {provider_asset_id} is ACTIVE but no asset_id was returned."
+                        raise RuntimeError(msg)
+                    return str(asset_id)
+
+                if status in (ASSET_STATUS_FAILED, ASSET_STATUS_DELETED):
+                    detail = result_json.get("status_detail")
+                    msg = f"{self.name}: private asset {provider_asset_id} ended with status {status}: {detail}"
+                    raise RuntimeError(msg)
+
+                await asyncio.sleep(ASSET_POLL_INTERVAL)
+
+        msg = (
+            f"{self.name}: private asset {provider_asset_id} did not become ACTIVE within "
+            f"{ASSET_MAX_ATTEMPTS * ASSET_POLL_INTERVAL} seconds."
+        )
+        raise RuntimeError(msg)
+
+    def _cleanup_pending_asset_uploads(self) -> None:
+        """Delete the transient uploads and scratch parameters minted during a run.
+
+        Provider assets are reclaimed by the backend: a submitted generation deletes its linked
+        assets on terminal state, and assets we register but never submit (e.g. a build failure
+        after registration) are reclaimed by the backend's orphan sweeper. The transient GTC
+        static-storage upload made to feed CreateProviderAsset is ours to clean up, along with the
+        scratch parameter created to perform the upload (its name is unique per call, so leaving it
+        would accumulate parameters on the node).
+        """
+        for helper, scratch_name in self._pending_asset_uploads:
+            with suppress(Exception):
+                helper.delete_uploaded_artifact()
+            with suppress(Exception):
+                self.remove_parameter_element_by_name(scratch_name)
+        self._pending_asset_uploads = []
+
+    # --- Provider error reporting ------------------------------------------------------------
+
+    def _extract_error_message(self, response_json: dict[str, Any]) -> str:
+        """Surface the BytePlus error object, which the proxy nests under provider_response."""
+        if not response_json:
+            return super()._extract_error_message(response_json)
+
+        parsed_provider_response = parse_provider_response(response_json.get("provider_response"))
+        if parsed_provider_response:
+            provider_error = parsed_provider_response.get("error")
+            if provider_error:
+                if isinstance(provider_error, dict):
+                    error_message = provider_error.get("message", "")
+                    details = f"{self.name} {error_message}"
+                    if error_code := provider_error.get("code"):
+                        details += f"\nError Code: {error_code}"
+                    if error_type := provider_error.get("type"):
+                        details += f"\nError Type: {error_type}"
+                    return details
+                return f"{self.name} Provider error: {provider_error}"
+
+        return super()._extract_error_message(response_json)

--- a/griptape_nodes_library/video/seedance_human_reference_asset.py
+++ b/griptape_nodes_library/video/seedance_human_reference_asset.py
@@ -47,18 +47,18 @@ _ACCESS_BADGE_TITLE = "Provider-asset access required"
 
 
 class SeedanceHumanReferenceAsset(DataNode):
-    """Package media as a private-asset reference for Seedance 2.0 human-reference inputs.
+    """Package media as a private-asset reference for Seedance human-reference inputs.
 
     Use this node for human-reference inputs (e.g. AIGC virtual-portrait images) that should be
-    registered as provider private assets, rather than plugging media directly into the
-    Seedance 2.0 reference inputs.
+    registered as provider private assets, rather than plugging media directly into a Seedance
+    node's reference inputs.
 
     Choose the asset kind (Image/Video/Audio) and supply the matching media. The node outputs a
     provider-asset reference carrying that media and kind; connect it into the matching reference
-    input on the Seedance 2.0 node (Reference Images, Reference Video, or Reference Audio). The
-    Seedance node registers the asset with the provider at generation time and references it via
-    `asset://{asset_id}`. Private-asset references are only supported by the Seedance 2.0 model
-    (not Seedance 2.0 Fast).
+    input on a Seedance video generation node (Reference Images, Reference Videos, or Reference
+    Audio). That node registers the asset with the provider at generation time and references it
+    via `asset://{asset_id}`. Private-asset references require Griptape authentication; they are
+    not available when the node uses your own provider key.
 
     Access to the provider-asset feature is org-gated. If the configured API key cannot use the
     provider-asset APIs, this node shows an error and asks an admin to request access from Foundry.
@@ -74,7 +74,7 @@ class SeedanceHumanReferenceAsset(DataNode):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.category = "video/seedance"
-        self.description = "Package media as a provider private-asset reference for Seedance 2.0"
+        self.description = "Package media as a provider private-asset reference for Seedance"
 
         self.add_parameter(
             ParameterString(
@@ -118,14 +118,14 @@ class SeedanceHumanReferenceAsset(DataNode):
         )
 
         # Output type/output_type is swapped per Asset Kind in _update_media_visibility so the
-        # connection (and edge color) matches the matching Seedance 2.0 reference input.
+        # connection (and edge color) matches the matching Seedance reference input.
         initial_type = reference_type_name_for_kind(ASSET_KIND_IMAGE)
         self._asset_reference_param = Parameter(
             name="asset_reference",
             type=initial_type,
             output_type=initial_type,
             default_value=None,
-            tooltip="The packaged private-asset reference. Connect into a Seedance 2.0 reference input.",
+            tooltip="The packaged private-asset reference. Connect into a Seedance reference input.",
             allowed_modes={ParameterMode.OUTPUT},
             settable=False,
             ui_options={"display_name": "Asset Reference", "pulse_on_run": True},
@@ -232,7 +232,7 @@ class SeedanceHumanReferenceAsset(DataNode):
                 self.hide_parameter_by_name(param_name)
 
         # Retype the output so the connection (and edge color) matches the receiving
-        # Seedance 2.0 reference input for this kind.
+        # Seedance reference input for this kind.
         reference_type = reference_type_name_for_kind(kind)
         self._asset_reference_param.type = reference_type
         self._asset_reference_param.output_type = reference_type

--- a/scripts/generate_test_workflows.py
+++ b/scripts/generate_test_workflows.py
@@ -876,6 +876,7 @@ def generate_advanced_workflow(cfg: dict) -> str:
 MANUAL_FLOW_INPUTS: dict[str, dict] = {
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_seedance_2_5.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }

--- a/tests/integration/SEEDANCE_TESTING.md
+++ b/tests/integration/SEEDANCE_TESTING.md
@@ -1,13 +1,13 @@
 # Seedance Video Generation Integration Tests
 
-This directory contains integration tests for the Seedance video generation node, including comprehensive tests for Seedance 2.0 features.
+This directory contains integration tests for the Seedance video generation nodes, including comprehensive tests for Seedance 2.0 features and the dedicated Seedance 2.5 node.
 
 ## Prerequisites
 
 1. **Local Griptape Cloud proxy running** at `http://localhost:8000`
 2. **ServiceModelConfig and ServiceModelConfigAuthDetails** configured in the local database:
    - Provider: BYTEPLUS_ARK
-   - Model IDs: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`
+   - Model IDs: `dreamina-seedance-2-0-260128`, `dreamina-seedance-2-0-fast-260128`, `dreamina-seedance-2-0-mini-260615`, `dreamina-seedance-2-5-260628`
    - API key configured
 
 ## Test Files
@@ -61,6 +61,36 @@ python tests/integration/test_seedance_2_0_features.py --test smart-duration
 python tests/integration/test_seedance_2_0_features.py --storage-backend gtc --test all
 ```
 
+### `test_seedance_2_5.py`
+
+Text-to-video test for the dedicated `Seedance25VideoGeneration` node. Seedance 2.5 has a single
+model, so there is no `model_id` to select — the `task` parameter is what shapes the request.
+
+**Usage:**
+
+```bash
+# Text to Video with the default prompt
+python tests/integration/test_seedance_2_5.py
+
+# Custom prompt
+python tests/integration/test_seedance_2_5.py --prompt "A cat walking"
+
+# GTC storage backend
+python tests/integration/test_seedance_2_5.py --storage-backend gtc
+```
+
+### `test_seedance_2_5_first_frame.py`
+
+First/Last Frame task driven from a `CreateColorBars` source image, with `output_format=mov` to
+exercise the 2.5-only container. Also covers the `ratio=adaptive` lock that this task requires.
+
+**Usage:**
+
+```bash
+python tests/integration/test_seedance_2_5_first_frame.py
+python tests/integration/test_seedance_2_5_first_frame.py --storage-backend gtc
+```
+
 ## Test Coverage
 
 ### Seedance 2.0 Standard
@@ -93,19 +123,33 @@ python tests/integration/test_seedance_2_0_features.py --storage-backend gtc --t
 - ✓ Audio generation
 - ✓ Best cost performance
 
+### Seedance 2.5 (`Seedance25VideoGeneration`)
+- ✓ Text to Video task
+- ✓ First/Last Frame task, `ratio` locked to adaptive
+- ✓ `mov` output format (2.5 only)
+- ✓ 480p/720p resolution (no 1080p/4k)
+- ✓ Duration 4-30 seconds
+- ✓ Smart duration (-1)
+
 ### Feature Validation
 - ✓ Parameter visibility based on model selection
 - ✓ 2.0 models show video/audio inputs
 - ✓ Duration range validation (4-15 or -1)
 - ✓ Resolution validation (1080p/4k are Seedance 2.0 standard only; Fast/Mini cap at 720p)
 - ✓ First/last frame supported on all three variants
+- ✓ 2.5 parameter visibility per task, and the per-task ratio/duration locks
 
 ### Future Tests (TODO)
-- [ ] Reference images (multimodal, 0-9 images)
-- [ ] Reference videos (0-3 videos)
-- [ ] Reference audio (0-3 audio files)
+- [ ] Reference images (2.0: 0-9 images; 2.5: 0-30)
+- [ ] Reference videos (2.0: 0-3 videos; 2.5: 0-10)
+- [ ] Reference audio (2.0: 0-3 audio files; 2.5: 0-10)
 - [ ] Validation: multimodal refs cannot mix with first/last frame
-- [ ] Validation: audio requires image/video
+- [ ] Validation: audio requires image/video (2.0 only — 2.5 accepts audio-only input)
+- [ ] 2.5 Reference to Video with one image + one video
+- [ ] 2.5 Video Editing and Video Extension (needs a 4-30s source video and a trigger keyword)
+- [ ] 2.5 `return_last_frame` output wiring
+- [ ] 2.5 deliberate constraint violation (Video Editing with `ratio=16:9`) to confirm the
+      client-side error fires before submission
 
 ## Debugging
 
@@ -123,7 +167,7 @@ If tests fail, check:
    docker exec -it griptape-cloud-web-1 python manage.py shell_plus
 
    # Check models
-   >>> ServiceModelConfig.objects.filter(model_name__contains='seedance-2-0')
+   >>> ServiceModelConfig.objects.filter(model_name__contains='seedance')
    ```
 
 3. **API key is valid:**

--- a/tests/integration/flow_inputs.py
+++ b/tests/integration/flow_inputs.py
@@ -22,6 +22,7 @@ FLOW_INPUTS: dict[str, dict] = {
     "test_elevenlabs_music_generation.py": {"Start Flow": {"prompt": "Upbeat jazz"}},
     "test_seedance_2_0.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_seedance_2_0_fast.py": {"Start Flow": {"prompt": "A ball bouncing"}},
+    "test_seedance_2_5.py": {"Start Flow": {"prompt": "A ball bouncing"}},
     "test_openai_image_generation_wide.py": {"Start Flow": {"prompt": "A red circle"}},
     "test_openai_image_generation_tall.py": {"Start Flow": {"prompt": "A red circle"}},
 }

--- a/tests/integration/test_seedance_2_5.py
+++ b/tests/integration/test_seedance_2_5.py
@@ -1,0 +1,227 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_seedance_2_5"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance25VideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# is_internal = true
+# ///
+"""Integration test for the Seedance 2.5 Text to Video task."""
+
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="main", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="Seedance25VideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Seedance25VideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    # Seedance 2.5 has one model, so the task selector is what shapes the request.
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="task", value="Text to Video"))
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="duration", value=4))
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Test the Seedance 2.5 Text to Video task")
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+
+    test_prompt = args.prompt or "A cat walking on a sunny beach, cinematic style"
+
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    else:
+        flow_input = {"Start Flow": {"prompt": test_prompt}}
+
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)

--- a/tests/integration/test_seedance_2_5_first_frame.py
+++ b/tests/integration/test_seedance_2_5_first_frame.py
@@ -1,0 +1,229 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_seedance_2_5_first_frame"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "CreateColorBars"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "Seedance25VideoGeneration"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# is_internal = true
+# ///
+"""Integration test for the Seedance 2.5 First/Last Frame task with a mov output."""
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="main", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    source_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="CreateColorBars",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Create Color Bars",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="Seedance25VideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Seedance25VideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    # First/Last Frame locks ratio to adaptive; mov is a Seedance 2.5-only output container.
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="task",
+                node_name=gen_node,
+                value="First/Last Frame",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=gen_node,
+                value="The color bars slowly drift to the left",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="duration", node_name=gen_node, value=4, initial_setup=True, is_output=False
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="output_format", node_name=gen_node, value="mov", initial_setup=True, is_output=False
+            )
+        )
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="image",
+            target_node_name=gen_node,
+            target_parameter_name="first_frame",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Test the Seedance 2.5 First/Last Frame task")
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    args = parser.parse_args()
+
+    workflow_output = execute_workflow(
+        input={}, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)

--- a/tests/unit/test_griptape_proxy_node_byok.py
+++ b/tests/unit/test_griptape_proxy_node_byok.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import inspect
 import logging
 from collections.abc import Iterator
 from pathlib import Path
@@ -14,8 +15,16 @@ from griptape_nodes_library.proxy import get_proxy_api_key_provider_config
 
 
 def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
+    """Yield every concrete GriptapeProxyNode subclass in the library, however deep.
+
+    Some nodes derive from an intermediate abstract base (e.g. SeedanceProxyNode) rather than
+    directly from GriptapeProxyNode, so the base names are resolved to a fixed point. Abstract
+    bases are skipped: they cannot be instantiated and it's their concrete subclasses that owe
+    the shared UI.
+    """
     library_root = Path(__file__).parents[2] / "griptape_nodes_library"
 
+    classes: list[tuple[str, str, set[str]]] = []
     for path in sorted(library_root.rglob("*.py")):
         module_rel_path = path.relative_to(library_root.parent)
         module_name = ".".join(module_rel_path.with_suffix("").parts)
@@ -24,11 +33,23 @@ def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
         for node in tree.body:
             if not isinstance(node, ast.ClassDef):
                 continue
+            base_names = {base.id for base in node.bases if isinstance(base, ast.Name)}
+            classes.append((node.name, module_name, base_names))
 
-            if not any(isinstance(base, ast.Name) and base.id == "GriptapeProxyNode" for base in node.bases):
-                continue
+    proxy_base_names = {"GriptapeProxyNode"}
+    while True:
+        matched = {name for name, _module, bases in classes if bases & proxy_base_names}
+        if matched <= proxy_base_names:
+            break
+        proxy_base_names |= matched
 
-            yield node.name, module_name
+    for class_name, module_name, base_names in classes:
+        if not base_names & proxy_base_names:
+            continue
+        node_class = getattr(importlib.import_module(module_name), class_name)
+        if inspect.isabstract(node_class):
+            continue
+        yield class_name, module_name
 
 
 PROXY_NODE_CLASSES = tuple(_iter_proxy_node_classes())

--- a/tests/unit/test_griptape_proxy_node_polling.py
+++ b/tests/unit/test_griptape_proxy_node_polling.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import importlib
+import inspect
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,16 @@ from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGener
 
 
 def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
+    """Yield every concrete GriptapeProxyNode subclass in the library, however deep.
+
+    Some nodes derive from an intermediate abstract base (e.g. SeedanceProxyNode) rather than
+    directly from GriptapeProxyNode, so the base names are resolved to a fixed point. Abstract
+    bases are skipped: they cannot be instantiated and it's their concrete subclasses that owe
+    the timeout parameter.
+    """
     library_root = Path(__file__).parents[2] / "griptape_nodes_library"
+
+    classes: list[tuple[str, str, set[str]]] = []
     for path in sorted(library_root.rglob("*.py")):
         module_rel_path = path.relative_to(library_root.parent)
         module_name = ".".join(module_rel_path.with_suffix("").parts)
@@ -21,9 +31,23 @@ def _iter_proxy_node_classes() -> Iterator[tuple[str, str]]:
         for node in tree.body:
             if not isinstance(node, ast.ClassDef):
                 continue
-            if not any(isinstance(base, ast.Name) and base.id == "GriptapeProxyNode" for base in node.bases):
-                continue
-            yield node.name, module_name
+            base_names = {base.id for base in node.bases if isinstance(base, ast.Name)}
+            classes.append((node.name, module_name, base_names))
+
+    proxy_base_names = {"GriptapeProxyNode"}
+    while True:
+        matched = {name for name, _module, bases in classes if bases & proxy_base_names}
+        if matched <= proxy_base_names:
+            break
+        proxy_base_names |= matched
+
+    for class_name, module_name, base_names in classes:
+        if not base_names & proxy_base_names:
+            continue
+        node_class = getattr(importlib.import_module(module_name), class_name)
+        if inspect.isabstract(node_class):
+            continue
+        yield class_name, module_name
 
 
 PROXY_NODE_CLASSES = tuple(_iter_proxy_node_classes())

--- a/tests/unit/video/test_seedance_2_0_video_generation.py
+++ b/tests/unit/video/test_seedance_2_0_video_generation.py
@@ -25,8 +25,8 @@ from griptape_nodes_library.video.seedance_2_0_video_generation import (
     SEEDANCE_2_0_MODEL_ID,
     SEEDANCE_MODEL_CAPABILITIES,
     Seedance20VideoGeneration,
-    _normalize_audio_data_uri_subtype,
 )
+from griptape_nodes_library.video.seedance_common import normalize_audio_data_uri_subtype
 
 
 def _set_parameter_list_values(node: Seedance20VideoGeneration, parameter_name: str, values: list[object]) -> None:
@@ -259,7 +259,7 @@ async def test_build_payload_includes_multimodal_video_url_and_audio_base64() ->
     ],
 )
 def test_normalize_audio_data_uri_subtype(data_uri: str, expected: str) -> None:
-    assert _normalize_audio_data_uri_subtype(data_uri) == expected
+    assert normalize_audio_data_uri_subtype(data_uri) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/unit/video/test_seedance_2_5_video_generation.py
+++ b/tests/unit/video/test_seedance_2_5_video_generation.py
@@ -1,0 +1,728 @@
+from __future__ import annotations
+
+import pytest
+from griptape.artifacts import ImageUrlArtifact
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterList, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.files.file import File
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.assets import (
+    ASSET_KIND_AUDIO,
+    ASSET_KIND_IMAGE,
+    ASSET_KIND_VIDEO,
+    create_provider_asset_reference,
+)
+from griptape_nodes_library.video.seedance_2_5_video_generation import (
+    ADAPTIVE_ONLY_RATIO_CHOICES,
+    ALL_DURATION_CHOICES,
+    ALL_RATIO_CHOICES,
+    MAX_REFERENCE_AUDIO,
+    MAX_REFERENCE_IMAGES,
+    MAX_REFERENCE_VIDEOS,
+    MAX_TOTAL_REFERENCE_ASSETS,
+    SEEDANCE_2_5_MODEL_ID,
+    SMART_DURATION,
+    Seedance25VideoGeneration,
+    SeedanceTask,
+)
+
+
+def _parameter_list_by_name(node: Seedance25VideoGeneration, parameter_name: str) -> ParameterList:
+    return next(
+        parameter
+        for parameter in node.parameters
+        if isinstance(parameter, ParameterList) and parameter.name == parameter_name
+    )
+
+
+def _set_parameter_list_values(node: Seedance25VideoGeneration, parameter_name: str, values: list[object]) -> None:
+    parameter_list = _parameter_list_by_name(node, parameter_name)
+    parameter_list.clear_list()
+    for value in values:
+        child = parameter_list.add_child_parameter()
+        node.set_parameter_value(child.name, value)
+
+
+def _parameter_by_name(node: Seedance25VideoGeneration, parameter_name: str):
+    return next(parameter for parameter in node.parameters if parameter.name == parameter_name)
+
+
+def _option_choices(node: Seedance25VideoGeneration, parameter_name: str) -> list:
+    parameter = _parameter_by_name(node, parameter_name)
+    return parameter.find_elements_by_type(Options)[0].choices
+
+
+def _editing_node(name: str = "Seedance25") -> Seedance25VideoGeneration:
+    """A node configured for a valid Video Editing run."""
+    node = Seedance25VideoGeneration(name=name)
+    node.set_parameter_value("task", SeedanceTask.VIDEO_EDITING)
+    node.set_parameter_value("prompt", "Remove everyone in @Video 1 except the protagonist")
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("https://public.example/reference.mp4")])
+    return node
+
+
+# --- Model id and task selector --------------------------------------------------------------
+
+
+def test_model_id_is_fixed_to_seedance_2_5() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert node._get_api_model_id() == SEEDANCE_2_5_MODEL_ID
+    assert node._get_catalog_model_id() == SEEDANCE_2_5_MODEL_ID
+
+
+def test_task_dropdown_offers_all_five_tasks() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert _option_choices(node, "task") == [task.value for task in SeedanceTask]
+
+
+def test_frame_inputs_remain_input_only() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert _parameter_by_name(node, "first_frame").allowed_modes == {ParameterMode.INPUT}
+    assert _parameter_by_name(node, "last_frame").allowed_modes == {ParameterMode.INPUT}
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "cap"),
+    [
+        ("reference_images", MAX_REFERENCE_IMAGES),
+        ("reference_videos", MAX_REFERENCE_VIDEOS),
+        ("reference_audio", MAX_REFERENCE_AUDIO),
+    ],
+)
+def test_reference_list_caps_match_seedance_2_5_limits(parameter_name: str, cap: int) -> None:
+    # ParameterList keeps its cap private, so assert it the way the editor sees it: the list accepts
+    # exactly `cap` children and refuses the next one.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    parameter_list = _parameter_list_by_name(node, parameter_name)
+    for _ in range(cap):
+        parameter_list.add_child_parameter()
+
+    with pytest.raises(ValueError, match=f"Maximum {cap} items allowed"):
+        parameter_list.add_child_parameter()
+
+
+def test_reference_videos_carries_upload_badge() -> None:
+    # Seedance cannot read video base64, so the node uploads each video for a public URL; the
+    # badge is how the user learns that before running.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    badge = _parameter_by_name(node, "reference_videos").get_badge()
+    assert badge is not None
+    assert badge.variant == "cloud-upload"
+
+
+# --- Parameter visibility per task -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("task", "expect_frames", "expect_references"),
+    [
+        (SeedanceTask.TEXT_TO_VIDEO, False, False),
+        (SeedanceTask.FIRST_LAST_FRAME, True, False),
+        (SeedanceTask.REFERENCE_TO_VIDEO, False, True),
+        (SeedanceTask.VIDEO_EDITING, False, True),
+        (SeedanceTask.VIDEO_EXTENSION, False, True),
+    ],
+)
+def test_media_input_visibility_follows_task(task: SeedanceTask, expect_frames: bool, expect_references: bool) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+
+    for name in ("first_frame", "last_frame"):
+        assert _parameter_by_name(node, name).ui_options.get("hide", False) is not expect_frames
+    for name in ("reference_images", "reference_videos", "reference_audio"):
+        assert _parameter_by_name(node, name).ui_options.get("hide", False) is not expect_references
+
+
+def test_last_frame_outputs_hidden_until_requested() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert _parameter_by_name(node, "last_frame_url").ui_options.get("hide") is True
+    assert _parameter_by_name(node, "last_frame_file").ui_options.get("hide") is True
+
+    node.set_parameter_value("return_last_frame", True)
+    assert _parameter_by_name(node, "last_frame_url").ui_options.get("hide", False) is False
+    assert _parameter_by_name(node, "last_frame_file").ui_options.get("hide", False) is False
+
+
+# --- Ratio / duration narrowing --------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "task",
+    [SeedanceTask.FIRST_LAST_FRAME, SeedanceTask.VIDEO_EDITING, SeedanceTask.VIDEO_EXTENSION],
+)
+def test_ratio_narrows_to_adaptive_for_constrained_tasks(task: SeedanceTask) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    assert _option_choices(node, "ratio") == list(ADAPTIVE_ONLY_RATIO_CHOICES)
+
+
+@pytest.mark.parametrize("task", [SeedanceTask.TEXT_TO_VIDEO, SeedanceTask.REFERENCE_TO_VIDEO])
+def test_ratio_offers_all_choices_for_unconstrained_tasks(task: SeedanceTask) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    assert _option_choices(node, "ratio") == list(ALL_RATIO_CHOICES)
+
+
+def test_duration_narrows_to_smart_only_for_video_editing() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.VIDEO_EDITING)
+    assert _option_choices(node, "duration") == [SMART_DURATION]
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        SeedanceTask.TEXT_TO_VIDEO,
+        SeedanceTask.FIRST_LAST_FRAME,
+        SeedanceTask.REFERENCE_TO_VIDEO,
+        SeedanceTask.VIDEO_EXTENSION,
+    ],
+)
+def test_duration_offers_full_range_for_other_tasks(task: SeedanceTask) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    assert _option_choices(node, "duration") == list(ALL_DURATION_CHOICES)
+
+
+def test_switching_task_coerces_out_of_range_ratio_and_duration() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("ratio", "16:9")
+    node.set_parameter_value("duration", 12)
+
+    node.set_parameter_value("task", SeedanceTask.VIDEO_EDITING)
+
+    assert node.get_parameter_value("ratio") == "adaptive"
+    assert node.get_parameter_value("duration") == SMART_DURATION
+
+
+# --- Validation: media matches task ----------------------------------------------------------
+
+
+def test_text_to_video_rejects_reference_inputs() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("https://public.example/reference.mp4")])
+
+    with pytest.raises(ValueError, match="reference image/video/audio inputs are only used"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_to_video_rejects_frame_inputs() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("first_frame", "data:image/png;base64,AAA")
+
+    with pytest.raises(ValueError, match="only used by the First/Last Frame task"):
+        node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.parametrize("task", [SeedanceTask.VIDEO_EDITING, SeedanceTask.VIDEO_EXTENSION])
+def test_editing_and_extension_require_a_reference_video(task: SeedanceTask) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    node.set_parameter_value("prompt", "Extend and edit the scene")
+
+    with pytest.raises(ValueError, match="requires at least one reference video"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_first_last_frame_accepts_frames_only() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.FIRST_LAST_FRAME)
+    node.set_parameter_value("prompt", "The girl turns to face the camera")
+    node.set_parameter_value("first_frame", "data:image/png;base64,AAA")
+    node.set_parameter_value("last_frame", "data:image/png;base64,BBB")
+
+    node._validate_parameters(node._get_parameters())
+
+
+def test_audio_only_reference_input_is_accepted() -> None:
+    # Seedance 2.5 accepts audio with no image or video, unlike the 2.0 series.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "Animate a scene to match @Audio 1")
+    _set_parameter_list_values(node, "reference_audio", ["data:audio/wav;base64,AAA"])
+
+    node._validate_parameters(node._get_parameters())
+
+
+# --- Validation: trigger keywords ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("task", "prompt"),
+    [
+        (SeedanceTask.VIDEO_EDITING, "Remove the background music from @Video 1"),
+        (SeedanceTask.VIDEO_EDITING, "Replace the character in @Video 1"),
+        (SeedanceTask.VIDEO_EXTENSION, "Extend @Video 1 backward"),
+        (SeedanceTask.VIDEO_EXTENSION, "Continue the story after @Video 1"),
+    ],
+)
+def test_trigger_keyword_present_passes_validation(task: SeedanceTask, prompt: str) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    node.set_parameter_value("prompt", prompt)
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("https://public.example/reference.mp4")])
+
+    node._validate_parameters(node._get_parameters())
+
+
+@pytest.mark.parametrize("task", [SeedanceTask.VIDEO_EDITING, SeedanceTask.VIDEO_EXTENSION])
+def test_missing_trigger_keyword_fails_before_submission(task: SeedanceTask) -> None:
+    # The provider only reports a task misclassification asynchronously, after queueing, so this
+    # check is what keeps the user from waiting on an avoidable failure.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    node.set_parameter_value("prompt", "A quiet street at dusk")
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("https://public.example/reference.mp4")])
+
+    with pytest.raises(ValueError, match="Include at least one of"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_reference_to_video_needs_no_trigger_keyword() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "A quiet street at dusk, styled after @Image 1")
+    _set_parameter_list_values(node, "reference_images", [ImageUrlArtifact("https://public.example/style.png")])
+
+    node._validate_parameters(node._get_parameters())
+
+
+# --- Validation: reference counts ------------------------------------------------------------
+
+
+def test_too_many_reference_images_is_rejected() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    params = node._get_parameters()
+    params["reference_images"] = [f"data:image/png;base64,{index}" for index in range(MAX_REFERENCE_IMAGES + 1)]
+
+    with pytest.raises(ValueError, match=f"up to {MAX_REFERENCE_IMAGES} reference images"):
+        node._validate_parameters(params)
+
+
+def test_too_many_reference_videos_is_rejected() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    params = node._get_parameters()
+    params["reference_videos"] = [f"https://public.example/{index}.mp4" for index in range(MAX_REFERENCE_VIDEOS + 1)]
+
+    with pytest.raises(ValueError, match=f"up to {MAX_REFERENCE_VIDEOS} reference videos"):
+        node._validate_parameters(params)
+
+
+def test_per_kind_caps_sum_to_the_documented_total_cap() -> None:
+    # The provider documents a 50-asset total alongside the per-kind caps. Because the per-kind caps
+    # sum to exactly that total, enforcing them is sufficient — this pins the arithmetic so a future
+    # bump to any one cap fails here instead of silently letting the total be exceeded.
+    assert MAX_REFERENCE_IMAGES + MAX_REFERENCE_VIDEOS + MAX_REFERENCE_AUDIO == MAX_TOTAL_REFERENCE_ASSETS
+
+
+def test_reference_lists_at_every_cap_are_accepted() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    params = node._get_parameters()
+    params["reference_images"] = [f"data:image/png;base64,{index}" for index in range(MAX_REFERENCE_IMAGES)]
+    params["reference_videos"] = [f"https://public.example/{index}.mp4" for index in range(MAX_REFERENCE_VIDEOS)]
+    params["reference_audio"] = [f"data:audio/wav;base64,{index}" for index in range(MAX_REFERENCE_AUDIO)]
+
+    node._validate_parameters(params)
+
+
+# --- Validation: ratio and duration ----------------------------------------------------------
+
+
+def test_video_editing_rejects_specified_ratio_arriving_over_a_connection() -> None:
+    # The dropdown is narrowed to adaptive, but a connected value bypasses the dropdown.
+    node = _editing_node()
+    params = node._get_parameters()
+    params["ratio"] = "16:9"
+
+    with pytest.raises(ValueError, match="only supports ratio adaptive"):
+        node._validate_parameters(params)
+
+
+def test_video_editing_rejects_specified_duration() -> None:
+    node = _editing_node()
+    params = node._get_parameters()
+    params["duration"] = 10
+
+    with pytest.raises(ValueError, match=f"only supports duration {SMART_DURATION}"):
+        node._validate_parameters(params)
+
+
+def test_out_of_range_duration_is_rejected() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    params = node._get_parameters()
+    params["duration"] = 45
+
+    with pytest.raises(ValueError, match="supports duration between 4-30 seconds"):
+        node._validate_parameters(params)
+
+
+def test_unknown_task_is_reported() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    params = node._get_parameters()
+    params["task"] = "Motion Transfer"
+
+    with pytest.raises(ValueError, match="unknown task"):
+        node._validate_parameters(params)
+
+
+# --- Payload ---------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_to_video_payload_carries_all_settings() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("prompt", "  A fox runs through a forest  ")
+    node.set_parameter_value("resolution", "480p")
+    node.set_parameter_value("ratio", "16:9")
+    node.set_parameter_value("duration", 8)
+    node.set_parameter_value("generate_audio", True)
+    node.set_parameter_value("output_format", "mov")
+    node.set_parameter_value("watermark", True)
+    node.set_parameter_value("return_last_frame", True)
+
+    payload = await node._build_payload()
+
+    assert payload == {
+        "model": SEEDANCE_2_5_MODEL_ID,
+        "resolution": "480p",
+        "ratio": "16:9",
+        "duration": 8,
+        "generate_audio": True,
+        "output_format": "mov",
+        "watermark": True,
+        "return_last_frame": True,
+        "content": [{"type": "text", "text": "A fox runs through a forest"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_first_last_frame_payload_assigns_frame_roles(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.FIRST_LAST_FRAME)
+    node.set_parameter_value("prompt", "The girl turns to face the camera")
+    node.set_parameter_value("first_frame", ImageUrlArtifact("https://public.example/first.png"))
+    node.set_parameter_value("last_frame", ImageUrlArtifact("https://public.example/last.png"))
+
+    async def fake_aread_data_uri(self: File, fallback_mime: str = "application/octet-stream") -> str:
+        return "data:image/png;base64,VALID_IMAGE"
+
+    monkeypatch.setattr(File, "aread_data_uri", fake_aread_data_uri)
+
+    payload = await node._build_payload()
+
+    assert payload["content"] == [
+        {"type": "text", "text": "The girl turns to face the camera"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,VALID_IMAGE"}, "role": "first_frame"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,VALID_IMAGE"}, "role": "last_frame"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_reference_payload_preserves_list_order_per_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    # List order is what @Image N / @Video N / @Audio N in the prompt resolve against.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "@Image 1 walks toward @Image 2 while @Audio 1 plays")
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [
+            ImageUrlArtifact("https://public.example/one.png"),
+            ImageUrlArtifact("https://public.example/two.png"),
+        ],
+    )
+    _set_parameter_list_values(
+        node,
+        "reference_videos",
+        [
+            VideoUrlArtifact("https://public.example/first.mp4"),
+            VideoUrlArtifact("https://public.example/second.mp4"),
+        ],
+    )
+    _set_parameter_list_values(node, "reference_audio", ["https://public.example/track.mp3"])
+
+    async def fake_aread_data_uri(self: File, fallback_mime: str = "application/octet-stream") -> str:
+        return f"data:image/png;base64,{fallback_mime}"
+
+    monkeypatch.setattr(File, "aread_data_uri", fake_aread_data_uri)
+
+    payload = await node._build_payload()
+
+    assert payload["content"] == [
+        {"type": "text", "text": "@Image 1 walks toward @Image 2 while @Audio 1 plays"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,image/jpeg"},
+            "role": "reference_image",
+        },
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,image/jpeg"},
+            "role": "reference_image",
+        },
+        {
+            "type": "video_url",
+            "video_url": {"url": "https://public.example/first.mp4"},
+            "role": "reference_video",
+        },
+        {
+            "type": "video_url",
+            "video_url": {"url": "https://public.example/second.mp4"},
+            "role": "reference_video",
+        },
+        {
+            "type": "audio_url",
+            "audio_url": {"url": "https://public.example/track.mp3"},
+            "role": "reference_audio",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_public_reference_video_is_uploaded_for_a_public_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Seedance rejects video base64, so a local/non-public video must be uploaded first.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "Match the motion in @Video 1")
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("/tmp/local-clip.mp4")])
+
+    monkeypatch.setattr(
+        PublicArtifactUrlParameter,
+        "get_public_url_for_parameter",
+        lambda self: "https://public.example/uploaded.mp4",
+    )
+
+    payload = await node._build_payload()
+
+    assert payload["content"][1] == {
+        "type": "video_url",
+        "video_url": {"url": "https://public.example/uploaded.mp4"},
+        "role": "reference_video",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_payload_registers_private_asset_references(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "Animate the reference portrait")
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    registered: list[tuple[str, str]] = []
+
+    async def fake_create_provider_asset(self, public_url: str, asset_kind: str, headers: dict[str, str]) -> str:
+        registered.append((public_url, asset_kind))
+        return "generated-asset-id"
+
+    monkeypatch.setattr(Seedance25VideoGeneration, "_create_provider_asset", fake_create_provider_asset)
+    monkeypatch.setattr(Seedance25VideoGeneration, "_validate_api_key", lambda self: "test-key")
+
+    payload = await node._build_payload()
+
+    assert registered == [("https://public.example/portrait.png", ASSET_KIND_IMAGE)]
+    assert payload["content"][1] == {
+        "type": "image_url",
+        "image_url": {"url": "asset://generated-asset-id"},
+        "role": "reference_image",
+    }
+
+
+# --- Private-asset gating --------------------------------------------------------------------
+
+
+def test_private_assets_inactive_when_byok_enabled() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert node._private_assets_active() is True
+
+    node.set_parameter_value("api_key_provider", True)
+    assert node._is_byok_enabled() is True
+    assert node._private_assets_active() is False
+
+
+def test_byok_rejects_private_asset_reference() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("api_key_provider", True)
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/portrait.png", asset_kind=ASSET_KIND_IMAGE)],
+    )
+
+    with pytest.raises(ValueError, match="require Griptape authentication"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_mismatched_private_asset_kind_is_rejected() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    _set_parameter_list_values(
+        node,
+        "reference_images",
+        [create_provider_asset_reference(value="https://public.example/clip.mp4", asset_kind=ASSET_KIND_VIDEO)],
+    )
+
+    with pytest.raises(ValueError, match=f"a {ASSET_KIND_VIDEO} private-asset reference is connected"):
+        node._validate_parameters(node._get_parameters())
+
+
+def test_audio_private_asset_reference_is_accepted_on_the_audio_input() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "Match the voice in @Audio 1")
+    _set_parameter_list_values(
+        node,
+        "reference_audio",
+        [create_provider_asset_reference(value="https://public.example/voice.wav", asset_kind=ASSET_KIND_AUDIO)],
+    )
+
+    node._validate_parameters(node._get_parameters())
+
+
+# --- Output format / filename ----------------------------------------------------------------
+
+
+def test_output_filename_extension_follows_output_format() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert node.get_parameter_value("output_file") == "seedance_2_5_video.mp4"
+
+    node.set_parameter_value("output_format", "mov")
+    assert node.get_parameter_value("output_file") == "seedance_2_5_video.mov"
+
+    node.set_parameter_value("output_format", "mp4")
+    assert node.get_parameter_value("output_file") == "seedance_2_5_video.mp4"
+
+
+def test_custom_output_filename_is_not_rewritten_by_output_format() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("output_file", "my_shot.mp4")
+
+    node.set_parameter_value("output_format", "mov")
+
+    assert node.get_parameter_value("output_file") == "my_shot.mp4"
+
+
+# --- Result parsing --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_result_saves_last_frame_when_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("return_last_frame", True)
+
+    downloaded: list[str] = []
+
+    async def fake_download_and_save(self, url, output_param, artifact_factory, **kwargs) -> None:
+        downloaded.append(url)
+        self.parameter_output_values[output_param] = artifact_factory(url, "video.mp4")
+
+    async def fake_download_bytes(url: str) -> bytes:
+        downloaded.append(url)
+        return b"last-frame-bytes"
+
+    saved_bytes: list[bytes] = []
+
+    class FakeSavedFile:
+        location = "project://seedance_2_5_last_frame.png"
+        name = "seedance_2_5_last_frame.png"
+
+    class FakeDestination:
+        async def awrite_bytes(self, data: bytes) -> FakeSavedFile:
+            saved_bytes.append(data)
+            return FakeSavedFile()
+
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_and_save", fake_download_and_save)
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_bytes_from_url", staticmethod(fake_download_bytes))
+    monkeypatch.setattr(node._last_frame_file, "build_file", lambda **kwargs: FakeDestination())
+
+    await node._parse_result(
+        {
+            "content": {
+                "video_url": "https://public.example/output.mp4",
+                "last_frame_url": "https://public.example/output_last.png",
+            }
+        },
+        "generation-1",
+    )
+
+    assert downloaded == ["https://public.example/output.mp4", "https://public.example/output_last.png"]
+    assert saved_bytes == [b"last-frame-bytes"]
+    assert node.parameter_output_values["last_frame_url"].value == "project://seedance_2_5_last_frame.png"
+
+
+@pytest.mark.asyncio
+async def test_parse_result_skips_last_frame_when_not_requested(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+
+    async def fake_download_and_save(self, url, output_param, artifact_factory, **kwargs) -> None:
+        self.parameter_output_values[output_param] = artifact_factory(url, "video.mp4")
+
+    def fail_if_called(url: str) -> bytes:
+        raise AssertionError("the last frame must not be downloaded unless return_last_frame is set")
+
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_and_save", fake_download_and_save)
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_bytes_from_url", staticmethod(fail_if_called))
+
+    await node._parse_result(
+        {
+            "content": {
+                "video_url": "https://public.example/output.mp4",
+                "last_frame_url": "https://public.example/output_last.png",
+            }
+        },
+        "generation-1",
+    )
+
+    assert "last_frame_url" not in node.parameter_output_values
+
+
+@pytest.mark.asyncio
+async def test_failed_last_frame_download_does_not_fail_the_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The video already succeeded (and was billed), so a missing last frame is logged, not fatal.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("return_last_frame", True)
+
+    async def fake_download_and_save(self, url, output_param, artifact_factory, **kwargs) -> None:
+        self.parameter_output_values[output_param] = artifact_factory(url, "video.mp4")
+
+    async def failing_download(url: str) -> bytes:
+        msg = "410 Gone"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_and_save", fake_download_and_save)
+    monkeypatch.setattr(Seedance25VideoGeneration, "_download_bytes_from_url", staticmethod(failing_download))
+
+    await node._parse_result(
+        {
+            "content": {
+                "video_url": "https://public.example/output.mp4",
+                "last_frame_url": "https://public.example/output_last.png",
+            }
+        },
+        "generation-1",
+    )
+
+    assert node.parameter_output_values["video_url"].value == "https://public.example/output.mp4"
+    assert "last_frame_url" not in node.parameter_output_values
+
+
+@pytest.mark.asyncio
+async def test_parse_result_reports_failure_when_no_video_url() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+
+    await node._parse_result({"content": {}}, "generation-1")
+
+    assert node.parameter_output_values["video_url"] is None
+    assert node.parameter_output_values["was_successful"] is False


### PR DESCRIPTION
## Why a new node

Seedance 2.5 (`dreamina-seedance-2-5-260628`) is not "2.0 with bigger numbers". It classifies every request into one of five task types from `content.role` **plus prompt intent**, and applies per-task constraints 2.0 doesn't have:

| Task type | `ratio` | `duration` | Extra requirement |
|---|---|---|---|
| Text-to-video | any | `[4,30]` or `-1` | — |
| First-frame / first-last-frame | **`adaptive` only** | `[4,30]` or `-1` | `role` = `first_frame` / `last_frame` |
| Reference-to-video | any | `[4,30]` or `-1` | Avoid edit/extend wording or it misclassifies |
| Video editing | **`adaptive` only** | **`-1` only** | Prompt must contain an edit keyword; input video 4–30s |
| Video extension | **`adaptive` only** | `[4,30]` or `-1` | Prompt must contain an extend keyword |

There is **no `task_type` field** — violations surface as an **asynchronous** `InvalidParameter.TaskTypeConstraint` error only after the task has queued and started processing. A node that can't distinguish these five cases can't fail fast, so users burn queue time on avoidable errors.

Add to that: 2.5-only `output_format` (mp4/mov), audio-only input (2.0 forbids it), no 1080p/4k, no `seed`/`camera_fixed`/`frames`, 30s duration, 50 reference assets. Folding all of that into the 2.0 node's three-mode selector means every tooltip, choice list, and validation branch becomes conditional on the model.

Closes #499 and #518 in favour of this approach. Both were good references — #518's `reference_videos` ParameterList rework is carried over here.

## What's in it

**`Seedance25VideoGeneration`** — a five-value `task` selector backed by a frozen `TaskConstraints` table that is the single source of truth for parameter visibility, `ratio`/`duration` narrowing, and validation. `ratio` and `duration` are `Options` (not sliders) specifically so their choice lists can be narrowed per task and an out-of-range current value coerced.

Reference inputs are three `ParameterList`s (30 images / 10 videos / 10 audio); list order is what `@Image N`, `@Video N`, and `@Audio N` resolve against in the prompt. Editing and extension validate for a trigger keyword before submission, since that wording is what the provider classifies on. Extras: `output_format` (mp4/mov, rewrites the output filename), `watermark`, `return_last_frame` (second download into `last_frame_file`; a failure there logs rather than failing the node, since the video already succeeded and was billed).

**`video/seedance_common.py`** — the private-asset (`asset://`) registration flow and media-URL helpers, behind `SeedanceProxyNode`, which both Seedance nodes now derive from. `_resolve_public_url_for_media` is taken in its #518 form (on-demand scratch upload rather than per-slot parameters), because a ParameterList of videos has no fixed slots to hang helpers off. The 2.0 node loses 403 lines and keeps its parameters, model list, capability table, and messages unchanged.

Registration: `gtc_seedance_2_5` catalog entry + `model_usage` declaration, and `Seedance25VideoGeneration: SEED` in the provider map. No `library_version` bump — that's the CI-generated PR's job.

## Two deviations from the plan, both for cause

**The 50-asset total check is unreachable.** The per-kind caps are 30 + 10 + 10 = exactly 50, so any input passing the per-kind checks already satisfies the total. I dropped the branch and replaced its test with one pinning the arithmetic, so bumping any single cap fails loudly instead of silently exceeding the total.

**Two conformance suites were silently losing coverage.** `test_griptape_proxy_node_byok.py` and `test_griptape_proxy_node_polling.py` match `GriptapeProxyNode` as a direct AST base name. Routing the 2.0 node through an intermediate base made them try to instantiate the abstract `SeedanceProxyNode` and, more importantly, **dropped `Seedance20VideoGeneration` from their coverage entirely**. Both now resolve base names to a fixed point and skip abstract classes; all three concrete Seedance nodes are collected. This is a test-infrastructure edit outside the original scope, but leaving it would mean a node quietly falling out of a library-wide gate.

## Testing

`make check` clean; `make test/unit` → **724 passed, 11 skipped**. 60 new unit tests for the 2.5 node; the 2.0 node's 44 tests pass with a 2-line import change.

Two integration workflows added and documented in `SEEDANCE_TESTING.md`: `test_seedance_2_5.py` (text-to-video) and `test_seedance_2_5_first_frame.py` (First/Last Frame with `output_format=mov`, exercising the adaptive-ratio lock).

**Draft pending end-to-end testing.** Three things need confirming against a live proxy:

- [x] **Private assets on 2.5.** `SUPPORTS_PRIVATE_ASSETS = True` follows #499's assumption, which noted it needs griptape-cloud #2144 to test. If the backend doesn't link provider assets for `dreamina-seedance-2-5-260628`, that flag needs flipping and the `SeedanceHumanReferenceAsset` wording adjusting.
- [x] **Trigger-keyword strictness.** BytePlus documents examples ("such as…"), not an exhaustive list, so a client-side check can reject a prompt the provider would have accepted. The generous keyword list plus the prompt badge is the mitigation; if it proves too strict, downgrade the editing/extension check from an error to a warning badge.
- [x] **The task cases I couldn't script** without a source video, tracked as TODOs in `SEEDANCE_TESTING.md`: Video Editing, Video Extension, `return_last_frame` wiring, reference-to-video with one image + one video, and a deliberate `ratio=16:9`-on-editing violation to confirm the client-side error fires before submission.

<img width="946" height="977" alt="Seedance_2_5_Video_editing" src="https://github.com/user-attachments/assets/4f5a56bf-9182-43bd-b973-e420bbb72289" />

<img width="1133" height="894" alt="Seedance_2_5_HumanAssetFlow" src="https://github.com/user-attachments/assets/f78278f5-418b-4083-ac22-8f04106879a4" />
