### PR TITLE
Use resolve_cloud_credential across all nodes

### DIFF
--- a/griptape_nodes_library/agents/agent.py
+++ b/griptape_nodes_library/agents/agent.py
@@ -57,6 +57,10 @@ from griptape_nodes_library.utils.agent_utils import (
     unwrap_agent,
     wrap_agent,
 )
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.model_invocation import require_model_invocation_sync
 from griptape_nodes_library.utils.provider_selection_component import ProviderSelectionComponent
@@ -701,10 +705,14 @@ class Agent(ControlNode):
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Performs pre-run validation checks for the node.
 
-        The Griptape Cloud API key is only required when the node would fall back
+        A Griptape Cloud credential is only required when the node would fall back
         to the default Griptape Cloud prompt driver. A connected agent carries its
         own driver, and a connected prompt driver (Prompt Model Config) supplies its
-        own credentials, so neither needs the cloud key.
+        own credentials, so neither needs the cloud credential.
+
+        Either credential is accepted: a Griptape Nodes License or a Griptape Cloud
+        API key. Griptape Cloud's chat endpoints authenticate a License, so a
+        license-only user (no `GT_CLOUD_API_KEY` at all) must not be blocked here.
 
         Returns:
             A list of Exception objects if validation fails, otherwise None.
@@ -716,11 +724,11 @@ class Agent(ControlNode):
         if not self._provider.uses_griptape_cloud_driver():
             return None
 
-        # Check to see if the API key is set.
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        # Check to see if either credential is set.
+        api_key = resolve_cloud_api_key()
 
         if not api_key:
-            msg = f"{API_KEY_ENV_VAR} is not defined"
+            msg = missing_credential_message("run the Agent")
             exceptions.append(KeyError(msg))
             return exceptions
 
@@ -790,7 +798,7 @@ class Agent(ControlNode):
         include_details = self.get_parameter_value("include_details")
         default_prompt_driver = GriptapeCloudPromptDriver(
             model=DEFAULT_MODEL,
-            api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+            api_key=resolve_cloud_api_key(),
             stream=True,
         )
 
@@ -907,7 +915,7 @@ class Agent(ControlNode):
                 args = {k: v for k, v in args.items() if v is not None}
                 prompt_driver = GriptapeCloudPromptDriver(
                     model=model_input,
-                    api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                    api_key=resolve_cloud_api_key(),
                     **args,
                 )
             else:

--- a/griptape_nodes_library/config/base_driver.py
+++ b/griptape_nodes_library/config/base_driver.py
@@ -110,7 +110,14 @@ class BaseDriver(DataNode):
     # Internal Helper Methods
     # -----------------------------------------------------------------------------
 
-    def _display_api_key_message(self, service_name: str, api_key_env_var: str, api_key_url: str | None) -> None:
+    def _display_api_key_message(
+        self,
+        service_name: str,
+        api_key_env_var: str,
+        api_key_url: str | None,
+        *,
+        credential_present: bool | None = None,
+    ) -> None:
         """Checks if the API key exists in the node configuration, displays a message if not.
 
         This method checks if the API key for a specific service is present
@@ -122,13 +129,20 @@ class BaseDriver(DataNode):
             api_key_env_var: The name of the key variable within the service config.
             api_key_url: An optional URL for users to visit to obtain the key,
                          included in the error message if provided.
+            credential_present: Overrides the `api_key_env_var` lookup when the
+                service accepts a credential other than that secret. Griptape Cloud
+                nodes pass the License-aware result so a license-only user is not
+                shown a "requires an API key" warning for a node that works.
 
         Returns:
             bool: True if the API key exists and is not empty, False otherwise.
         """
         message_param = self.get_parameter_by_name("message")
         if message_param is not None:
-            api_key = GriptapeNodes.SecretsManager().get_secret(api_key_env_var)
+            if credential_present is None:
+                api_key = GriptapeNodes.SecretsManager().get_secret(api_key_env_var)
+            else:
+                api_key = credential_present
             msg = f"⚠️ This node requires an API key from {service_name}\nPlease visit {api_key_url} to obtain a valid key and update your settings."
             message_param.default_value = msg
             ui_options = message_param.ui_options
@@ -139,7 +153,13 @@ class BaseDriver(DataNode):
             message_param.ui_options = ui_options
 
     def _validate_api_key(
-        self, service_name: str, api_key_env_var: str, api_key_url: str | None
+        self,
+        service_name: str,
+        api_key_env_var: str,
+        api_key_url: str | None,
+        *,
+        resolved_credential: str | None = None,
+        missing_credential_msg: str | None = None,
     ) -> list[Exception] | None:
         """Validates the presence and non-emptiness of a specific API key in config.
 
@@ -151,6 +171,15 @@ class BaseDriver(DataNode):
             api_key_env_var: The name of the key variable within the service config.
             api_key_url: An optional URL for users to visit to obtain the key,
                      included in the error message if provided.
+            resolved_credential: The already-resolved credential, for services that
+                accept something other than the `api_key_env_var` secret. Griptape
+                Cloud nodes pass the License-aware result, since a license-only user
+                has no `GT_CLOUD_API_KEY` and must not be blocked. When omitted, the
+                `api_key_env_var` secret is looked up as before.
+            missing_credential_msg: Replaces the default "API Key (...) is missing"
+                wording. Pass this whenever `resolved_credential` is supplied, so the
+                message names the credentials the service actually accepts rather
+                than pointing at one secret the user may not be meant to set.
 
         Returns:
             A list of exceptions (KeyError or ValueError) if validation fails,
@@ -158,18 +187,27 @@ class BaseDriver(DataNode):
         """
         exceptions = []
 
-        api_key = GriptapeNodes.SecretsManager().get_secret(api_key_env_var)
+        if resolved_credential is None:
+            api_key = GriptapeNodes.SecretsManager().get_secret(api_key_env_var)
+        else:
+            api_key = resolved_credential
         if not api_key:
-            msg = f"API Key ('{api_key_env_var}') for service '{service_name}' is missing."
-            if api_key_url:
-                msg += f" Please visit {api_key_url} to obtain a valid key and update your settings."
+            if missing_credential_msg is not None:
+                msg = missing_credential_msg
             else:
-                msg += " Please provide a valid API key in your settings."
+                msg = f"API Key ('{api_key_env_var}') for service '{service_name}' is missing."
+                if api_key_url:
+                    msg += f" Please visit {api_key_url} to obtain a valid key and update your settings."
+                else:
+                    msg += " Please provide a valid API key in your settings."
             exceptions.append(KeyError(msg))
 
         # Display a message to the user if the API key is missing or empty.
         self._display_api_key_message(
-            service_name=service_name, api_key_env_var=api_key_env_var, api_key_url=api_key_url
+            service_name=service_name,
+            api_key_env_var=api_key_env_var,
+            api_key_url=api_key_url,
+            credential_present=None if resolved_credential is None else bool(api_key),
         )
 
         return exceptions if exceptions else None

--- a/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
+++ b/griptape_nodes_library/config/image/griptape_cloud_image_driver.py
@@ -4,11 +4,14 @@ from griptape.drivers.image_generation.griptape_cloud import (
     GriptapeCloudImageGenerationDriver as GtGriptapeCloudImageGenerationDriver,
 )
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.config.image.base_image_driver import BaseImageDriver
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 
 # --- Constants ---
 
@@ -101,7 +104,7 @@ class GriptapeCloudImage(BaseImageDriver):
         specific_args = {}
 
         # Retrieve the mandatory API key.
-        specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        specific_args["api_key"] = resolve_cloud_api_key()
 
         specific_args["quality"] = self.get_parameter_value("quality")
 
@@ -119,4 +122,8 @@ class GriptapeCloudImage(BaseImageDriver):
             service_name=SERVICE,
             api_key_env_var=API_KEY_ENV_VAR,
             api_key_url=API_KEY_URL,
+            # Griptape Cloud accepts a License as well as an API key; a license-only
+            # user has no GT_CLOUD_API_KEY, so resolve both before deciding.
+            resolved_credential=resolve_cloud_api_key(),
+            missing_credential_msg=missing_credential_message("configure the Griptape Cloud image driver"),
         )

--- a/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
+++ b/griptape_nodes_library/config/prompt/griptape_cloud_prompt.py
@@ -18,10 +18,14 @@ from griptape_nodes.drivers.cloud_models import (
     O_SERIES_MODELS,
 )
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes.traits.button import Button
 
 from griptape_nodes_library.config.prompt.base_prompt import BasePrompt
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 
 # --- Constants ---
 
@@ -160,7 +164,7 @@ class GriptapeCloudPrompt(BasePrompt):
         specific_args = {}
 
         # Retrieve the mandatory API key.
-        specific_args["api_key"] = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        specific_args["api_key"] = resolve_cloud_api_key()
 
         # Get the selected model.
         model = self.get_parameter_value("model")
@@ -215,6 +219,10 @@ class GriptapeCloudPrompt(BasePrompt):
             service_name=SERVICE,
             api_key_env_var=API_KEY_ENV_VAR,
             api_key_url=API_KEY_URL,
+            # Griptape Cloud accepts a License as well as an API key; a license-only
+            # user has no GT_CLOUD_API_KEY, so resolve both before deciding.
+            resolved_credential=resolve_cloud_api_key(),
+            missing_credential_msg=missing_credential_message("configure the Griptape Cloud prompt driver"),
         )
 
     def _list_models(self) -> tuple[list[str], str]:
@@ -230,7 +238,7 @@ class GriptapeCloudPrompt(BasePrompt):
         # Fetch the list of available models from the Griptape Cloud API.
         response = requests.get(
             CHAT_MODELS_URL,
-            headers={"Authorization": f"Bearer {GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)}"},
+            headers={"Authorization": f"Bearer {resolve_cloud_api_key()}"},
             timeout=10,
         )
         response.raise_for_status()

--- a/griptape_nodes_library/image/create_image.py
+++ b/griptape_nodes_library/image/create_image.py
@@ -13,12 +13,15 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
 from griptape_nodes_library.utils.agent_utils import restore_provider_driver, unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.model_invocation import require_model_invocation_sync
 
@@ -153,13 +156,13 @@ class GenerateImage(ControlNode):
     def validate_before_workflow_run(self) -> list[Exception] | None:
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/871
         exceptions = []
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        api_key = resolve_cloud_api_key()
         if not api_key:
             # If we have an agent or a driver, the lack of API key will be surfaced on them, not us.
             agent_val = self.parameter_values.get("agent", None)
             driver_val = self.parameter_values.get("driver", None)
             if agent_val is None and driver_val is None:
-                msg = f"{API_KEY_ENV_VAR} is not defined"
+                msg = missing_credential_message("generate an image")
                 exceptions.append(KeyError(msg))
 
         # Validate that we have a prompt.
@@ -233,7 +236,7 @@ class GenerateImage(ControlNode):
         if not agent_input:
             prompt_driver = GriptapeCloudPromptDriver(
                 model="gpt-4o",
-                api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                api_key=resolve_cloud_api_key(),
                 stream=True,
             )
             agent = GtAgent(prompt_driver=prompt_driver)
@@ -293,7 +296,7 @@ IMPORTANT: Output must be a single, raw prompt string for an image generation mo
             driver = GriptapeCloudImageGenerationDriver(
                 model=model_input,
                 image_size=self.get_parameter_value("image_size"),
-                api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                api_key=resolve_cloud_api_key(),
                 # Don't retry on HTTP errors, we want to fail fast.
                 ignored_exception_types=(requests.exceptions.HTTPError,),
             )
@@ -301,7 +304,7 @@ IMPORTANT: Output must be a single, raw prompt string for an image generation mo
             driver = GriptapeCloudImageGenerationDriver(
                 model=DEFAULT_MODEL,
                 image_size=self.get_parameter_value("image_size"),
-                api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                api_key=resolve_cloud_api_key(),
                 ignored_exception_types=(requests.HTTPError,),
             )
 

--- a/griptape_nodes_library/image/describe_image.py
+++ b/griptape_nodes_library/image/describe_image.py
@@ -32,6 +32,10 @@ from griptape_nodes_library.utils.agent_utils import (
     unwrap_agent,
     wrap_agent,
 )
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 from griptape_nodes_library.utils.error_utils import try_throw_error
 from griptape_nodes_library.utils.image_utils import load_image_from_url_artifact
 from griptape_nodes_library.utils.model_invocation import require_model_invocation_sync
@@ -263,9 +267,9 @@ class DescribeImage(ControlNode):
         exceptions = []
         if not self._provider.uses_griptape_cloud_driver():
             return None
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        api_key = resolve_cloud_api_key()
         if not api_key:
-            msg = f"{API_KEY_ENV_VAR} is not defined"
+            msg = missing_credential_message("describe an image")
             exceptions.append(KeyError(msg))
             return exceptions
         return exceptions if exceptions else None
@@ -350,7 +354,7 @@ class DescribeImage(ControlNode):
 
         default_prompt_driver = GriptapeCloudPromptDriver(
             model=DEFAULT_MODEL,
-            api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+            api_key=resolve_cloud_api_key(),
             stream=False,  # TODO: enable once https://github.com/griptape-ai/griptape-cloud/issues/1593 is resolved
         )
 
@@ -432,7 +436,7 @@ class DescribeImage(ControlNode):
                 model_input = DEFAULT_MODEL
             prompt_driver = GriptapeCloudPromptDriver(
                 model=model_input,
-                api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+                api_key=resolve_cloud_api_key(),
                 stream=False,  # TODO: enable once https://github.com/griptape-ai/griptape-cloud/issues/1593 is resolved
             )
             agent = GtAgent(prompt_driver=prompt_driver, output_schema=pydantic_schema)

--- a/griptape_nodes_library/tasks/base_task.py
+++ b/griptape_nodes_library/tasks/base_task.py
@@ -3,8 +3,8 @@ from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
 from griptape.events import ActionChunkEvent, FinishStructureRunEvent, StartStructureRunEvent, TextChunkEvent
 from griptape.structures import Agent, Structure
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+from griptape_nodes_library.utils.cloud_credential_utils import resolve_cloud_api_key
 from griptape_nodes_library.utils.model_invocation import require_model_invocation_sync
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -20,7 +20,7 @@ class BaseTask(ControlNode):
     def create_driver(self, model: str = "gpt-4.1") -> GriptapeCloudPromptDriver:
         return GriptapeCloudPromptDriver(
             model=model,
-            api_key=GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR),
+            api_key=resolve_cloud_api_key(),
             stream=True,
         )
 

--- a/griptape_nodes_library/tasks/mcp_task.py
+++ b/griptape_nodes_library/tasks/mcp_task.py
@@ -12,12 +12,13 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterList, Parame
 from griptape_nodes.exe_types.node_types import AsyncResult, SuccessFailureNode
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent
 from griptape_nodes_library.utils.agent_utils import build_tools, restore_provider_driver, unwrap_agent, wrap_agent
+from griptape_nodes_library.utils.cloud_credential_utils import resolve_cloud_api_key
 from griptape_nodes_library.utils.mcp_utils import (
     create_mcp_tool,
     get_available_mcp_servers,
@@ -380,7 +381,7 @@ class MCPTaskNode(SuccessFailureNode):
         """Create a GriptapeCloudPromptDriver."""
         return GriptapeCloudPromptDriver(
             model=model,
-            api_key=GriptapeNodes.SecretsManager().get_secret("GT_CLOUD_API_KEY"),
+            api_key=resolve_cloud_api_key(),
             stream=True,
         )
 

--- a/griptape_nodes_library/text/random_text.py
+++ b/griptape_nodes_library/text/random_text.py
@@ -14,6 +14,10 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.agents.griptape_nodes_agent import GriptapeNodesAgent as GtAgent
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 from griptape_nodes_library.utils.model_invocation import require_model_invocation_sync
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
@@ -218,9 +222,9 @@ class RandomText(DataNode):
 
     def _initialize_agent(self) -> None:
         """Initialize the Griptape Agent for text generation."""
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        api_key = resolve_cloud_api_key()
         if not api_key:
-            msg = f"{API_KEY_ENV_VAR} is not defined"
+            msg = missing_credential_message("generate random text")
             raise KeyError(msg)
 
         prompt_driver = GriptapeCloudPromptDriver(model=MODEL, api_key=api_key, stream=True)

--- a/griptape_nodes_library/tools/extraction_tool.py
+++ b/griptape_nodes_library/tools/extraction_tool.py
@@ -2,9 +2,12 @@ from griptape.drivers.prompt.griptape_cloud import GriptapeCloudPromptDriver
 from griptape.engines import CsvExtractionEngine, JsonExtractionEngine
 from griptape.rules import Rule
 from griptape.tools import ExtractionTool as GtExtractionTool
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 from griptape_nodes_library.tools.base_tool import BaseTool
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 
 API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
 SERVICE = "Griptape"
@@ -42,9 +45,9 @@ class StructuredDataExtractor(BaseTool):
         exceptions = []
         if self.parameter_values.get("prompt_driver", None):
             return exceptions
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        api_key = resolve_cloud_api_key()
         if not api_key:
-            msg = f"{API_KEY_ENV_VAR} is not defined"
+            msg = missing_credential_message("create the Extraction tool")
             exceptions.append(KeyError(msg))
             return exceptions
         return exceptions if exceptions else None

--- a/griptape_nodes_library/tools/file_manager_tool.py
+++ b/griptape_nodes_library/tools/file_manager_tool.py
@@ -6,6 +6,9 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 from griptape_nodes_library.tools.base_tool import BaseTool
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    resolve_cloud_api_key,
+)
 
 LOCATIONS = ["Workspace Directory", "GriptapeCloud"]
 
@@ -18,7 +21,7 @@ class FileManager(BaseTool):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self.api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        self.api_key = resolve_cloud_api_key()
         self.bucket_list = self.get_bucket_list()
         self.bucket_map = dict(self.bucket_list)
         self.workdir = GriptapeNodes.ConfigManager().get_config_value("workspace_directory")

--- a/griptape_nodes_library/utils/agent_utils.py
+++ b/griptape_nodes_library/utils/agent_utils.py
@@ -15,6 +15,8 @@ from griptape.rules import Rule, Ruleset
 from griptape.tasks import PromptTask
 from griptape_nodes.drivers.cloud_models import ProviderID
 
+from griptape_nodes_library.utils.cloud_credential_utils import resolve_cloud_api_key
+
 
 # ---------------------------------------------------------------------------
 # Temporary monkey-patch — remove when https://github.com/griptape-ai/griptape/pull/2200 is merged and released.
@@ -269,7 +271,9 @@ def build_tool_from_config(config: dict) -> object:
         if file_location == "GriptapeCloud":
             from griptape.drivers.file_manager.griptape_cloud import GriptapeCloudFileManagerDriver
 
-            api_key = GriptapeNodes.SecretsManager().get_secret("GT_CLOUD_API_KEY")
+            # A License is a valid Griptape Cloud credential; a license-only user has
+            # no GT_CLOUD_API_KEY to read.
+            api_key = resolve_cloud_api_key()
             bucket_id = config.get("bucket_id", "")
             driver = GriptapeCloudFileManagerDriver(api_key=api_key, bucket_id=bucket_id)
         else:

--- a/griptape_nodes_library/utils/cloud_credential_utils.py
+++ b/griptape_nodes_library/utils/cloud_credential_utils.py
@@ -1,0 +1,66 @@
+"""Resolve the bearer credential for Griptape Cloud, License or API key.
+
+Griptape Cloud accepts two kinds of credential: a Griptape Cloud API key
+(``GT_CLOUD_API_KEY``, a ``gt-`` prefixed key) and a Griptape Nodes License
+(``GRIPTAPE_NODES_LICENSE``, a JWT the desktop app writes into the engine's global
+``.env``). A license-only user has no API key at all, so any node that reads
+``GT_CLOUD_API_KEY`` directly is unusable for them -- it fails validation with
+"GT_CLOUD_API_KEY is not defined" and points them at a knob they are not meant to set.
+
+The endpoints these nodes call all authenticate a License via the control plane's
+``LicenseAuthMixin``: ``api/chat/messages`` and ``api/chat/messages/stream`` (prompt
+drivers), ``api/images/generations`` and ``api/images/variations`` (image drivers), and
+``api/buckets`` (the FileManager tool).
+
+This wraps the engine's ``resolve_cloud_credential`` rather than reimplementing the
+precedence, and adds the ``""`` coercion the driver call sites need. Two things it is
+deliberately NOT for:
+
+- **BYOK provider keys.** ``OPENAI_API_KEY``, ``ANTHROPIC_API_KEY``, and friends are
+  the user's own provider credentials; a Griptape License says nothing about them.
+- **The model proxy.** Proxy nodes resolve through ``resolve_proxy_api_key`` in
+  ``griptape_nodes_library.proxy.provider_asset_access``, which additionally honors the
+  proxy-scoped ``GT_CLOUD_PROXY_API_KEY`` override.
+"""
+
+from __future__ import annotations
+
+from griptape_nodes.drivers.cloud_credentials import (
+    MISSING_CREDENTIAL_MESSAGE,
+    resolve_cloud_credential,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+__all__ = [
+    "MISSING_CREDENTIAL_MESSAGE",
+    "missing_credential_message",
+    "resolve_cloud_api_key",
+]
+
+API_KEY_ENV_VAR = "GT_CLOUD_API_KEY"
+"""Secret holding the Griptape Cloud API key. The License is checked first."""
+
+
+def resolve_cloud_api_key() -> str:
+    """Return the Griptape Cloud bearer credential, preferring a License.
+
+    Returns ``""`` rather than ``None`` when neither credential is set, because the
+    driver fields this feeds are typed ``str`` and interpolated straight into an
+    ``Authorization`` header. Callers must not treat ``""`` as their failure signal:
+    report a missing credential from ``validate_before_workflow_run`` (see
+    :func:`missing_credential_message`), which runs before any request is sent.
+    """
+    return resolve_cloud_credential(GriptapeNodes.SecretsManager(), secret_name=API_KEY_ENV_VAR) or ""
+
+
+def missing_credential_message(attempted: str) -> str:
+    """Build the user-facing "no Cloud credential" message for a failed action.
+
+    Names both credentials, so a license-only user is not sent after an API key they
+    are not meant to have.
+
+    Args:
+        attempted: What the node was trying to do, as a sentence fragment starting
+            with a verb -- e.g. ``"run the Agent"`` or ``"describe an image"``.
+    """
+    return f"Attempted to {attempted}. Failed because {MISSING_CREDENTIAL_MESSAGE}"

--- a/griptape_nodes_library/video/split_video.py
+++ b/griptape_nodes_library/video/split_video.py
@@ -14,9 +14,13 @@ from griptape_nodes.exe_types.param_components.project_file_parameter import Pro
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.files.file import File
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes, logger
+from griptape_nodes.retained_mode.griptape_nodes import logger
 from griptape_nodes.traits.options import Options
 
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
 from griptape_nodes_library.utils.ffmpeg_utils import (
     build_video_segment_cmd,
     detect_video_properties,
@@ -197,9 +201,9 @@ class SplitVideo(SuccessFailureNode):
         self.split_videos_list.clear_list()
 
     def _parse_timecodes_with_agent(self, timecodes_str: str) -> str:
-        api_key = GriptapeNodes.SecretsManager().get_secret(API_KEY_ENV_VAR)
+        api_key = resolve_cloud_api_key()
         if not api_key:
-            error_msg = f"No API key found for {SERVICE}. Please set {API_KEY_ENV_VAR} environment variable."
+            error_msg = missing_credential_message("parse the timecodes")
             raise ValueError(error_msg)
 
         prompt_driver = GriptapeCloudPromptDriver(

--- a/tests/unit/agents/test_agent_model_invocation_gating.py
+++ b/tests/unit/agents/test_agent_model_invocation_gating.py
@@ -31,7 +31,9 @@ class _FakeDeclaration:
 
 def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
     class _FakeSecrets:
-        def get_secret(self, _name: str) -> str | None:
+        # Accepts **kwargs because the Cloud credential resolver passes
+        # should_error_on_not_found= when probing for the License.
+        def get_secret(self, _name: str, **_kwargs: object) -> str | None:
             return value
 
     monkeypatch.setattr(agent_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())

--- a/tests/unit/agents/test_agent_validation.py
+++ b/tests/unit/agents/test_agent_validation.py
@@ -3,18 +3,26 @@ from __future__ import annotations
 import pytest
 from griptape.drivers.prompt.base_prompt_driver import BasePromptDriver
 
-from griptape_nodes_library.agents.agent import API_KEY_ENV_VAR, Agent
+from griptape_nodes_library.agents.agent import Agent
+
+_LICENSE = "header.payload.signature"
+"""A Griptape Nodes License is a JWT: three dot-separated segments."""
 
 
-def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    """Make the engine's SecretsManager return *value* for any secret lookup."""
-    import griptape_nodes_library.agents.agent as agent_module
+def _stub_secrets(monkeypatch: pytest.MonkeyPatch, secrets: dict[str, str]) -> None:
+    """Make the engine's SecretsManager resolve only the names in *secrets*.
+
+    Stubbed at the SecretsManager rather than at ``resolve_cloud_api_key`` so the
+    License-before-API-key precedence is exercised for real, and so a test can model
+    a license-only user by simply omitting ``GT_CLOUD_API_KEY``.
+    """
+    import griptape_nodes_library.utils.cloud_credential_utils as cloud_credential_utils
 
     class _FakeSecrets:
-        def get_secret(self, _name: str) -> str | None:
-            return value
+        def get_secret(self, name: str, **_kwargs: object) -> str | None:
+            return secrets.get(name)
 
-    monkeypatch.setattr(agent_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
+    monkeypatch.setattr(cloud_credential_utils.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
 
 
 def _stub_params(agent_node: Agent, monkeypatch: pytest.MonkeyPatch, *, model: object, agent: object) -> None:
@@ -44,23 +52,36 @@ def _fake_prompt_driver() -> BasePromptDriver:
     return _FakeDriver(model="fake-model", tokenizer=None)  # type: ignore[arg-type]
 
 
-def test_validation_fails_when_cloud_key_missing_and_default_driver_used(
+def test_validation_fails_when_no_credential_and_default_driver_used(
     agent_node: Agent, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _stub_secret(monkeypatch, None)
+    _stub_secrets(monkeypatch, {})
     _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent=None)
 
     exceptions = agent_node.validate_before_workflow_run()
 
     assert exceptions is not None
     assert len(exceptions) == 1
-    assert API_KEY_ENV_VAR in str(exceptions[0])
+    # Names both credentials, so a license-only user is not sent after an API key.
+    message = str(exceptions[0])
+    assert "license" in message.lower()
+    assert "GT_CLOUD_API_KEY" in message
 
 
 def test_validation_passes_when_cloud_key_present_and_default_driver_used(
     agent_node: Agent, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _stub_secret(monkeypatch, "gt-cloud-key")
+    _stub_secrets(monkeypatch, {"GT_CLOUD_API_KEY": "gt-cloud-key"})
+    _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent=None)
+
+    assert agent_node.validate_before_workflow_run() is None
+
+
+def test_validation_passes_with_license_and_no_api_key(agent_node: Agent, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A license-only user has no GT_CLOUD_API_KEY at all. Griptape Cloud's chat
+    # endpoints authenticate a License, so the Agent must run. Regression test for
+    # the "'GT_CLOUD_API_KEY is not defined'" ResolveNode failure.
+    _stub_secrets(monkeypatch, {"GRIPTAPE_NODES_LICENSE": _LICENSE})
     _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent=None)
 
     assert agent_node.validate_before_workflow_run() is None
@@ -71,7 +92,7 @@ def test_validation_skips_cloud_key_when_prompt_driver_connected(
 ) -> None:
     # A connected Prompt Model Config (e.g. Anthropic) carries its own credentials,
     # so the Griptape Cloud key must not be required. Regression test for issue #71.
-    _stub_secret(monkeypatch, None)
+    _stub_secrets(monkeypatch, {})
     _stub_params(agent_node, monkeypatch, model=_fake_prompt_driver(), agent=None)
 
     assert agent_node.validate_before_workflow_run() is None
@@ -79,7 +100,7 @@ def test_validation_skips_cloud_key_when_prompt_driver_connected(
 
 def test_validation_skips_cloud_key_when_agent_connected(agent_node: Agent, monkeypatch: pytest.MonkeyPatch) -> None:
     # A connected agent carries its own driver, so the cloud key is not required.
-    _stub_secret(monkeypatch, None)
+    _stub_secrets(monkeypatch, {})
     _stub_params(agent_node, monkeypatch, model="claude-sonnet-4-6", agent={"type": "Agent"})
 
     assert agent_node.validate_before_workflow_run() is None

--- a/tests/unit/image/test_create_image_model_access.py
+++ b/tests/unit/image/test_create_image_model_access.py
@@ -19,11 +19,13 @@ from griptape_nodes_library.image.create_image import GenerateImage
 
 
 def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    class _FakeSecrets:
-        def get_secret(self, _name: str) -> str | None:
-            return value
+    """Stub the node's Griptape Cloud credential lookup.
 
-    monkeypatch.setattr(create_image_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
+    Patched at the node's import site rather than via the SecretsManager: the node
+    resolves a License *or* an API key through `resolve_cloud_api_key`, so stubbing
+    one secret name no longer covers it.
+    """
+    monkeypatch.setattr(create_image_module, "resolve_cloud_api_key", lambda: value or "")
 
 
 @pytest.fixture

--- a/tests/unit/image/test_create_image_model_invocation_gating.py
+++ b/tests/unit/image/test_create_image_model_invocation_gating.py
@@ -31,11 +31,13 @@ class _FakeDeclaration:
 
 
 def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
-    class _FakeSecrets:
-        def get_secret(self, _name: str) -> str | None:
-            return value
+    """Stub the node's Griptape Cloud credential lookup.
 
-    monkeypatch.setattr(create_image_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
+    Patched at the node's import site rather than via the SecretsManager: the node
+    resolves a License *or* an API key through `resolve_cloud_api_key`, so stubbing
+    one secret name no longer covers it.
+    """
+    monkeypatch.setattr(create_image_module, "resolve_cloud_api_key", lambda: value or "")
 
 
 @pytest.fixture

--- a/tests/unit/image/test_describe_image_model_invocation_gating.py
+++ b/tests/unit/image/test_describe_image_model_invocation_gating.py
@@ -31,7 +31,9 @@ class _FakeDeclaration:
 
 def _stub_secret(monkeypatch: pytest.MonkeyPatch, value: str | None) -> None:
     class _FakeSecrets:
-        def get_secret(self, _name: str) -> str | None:
+        # Accepts **kwargs because the Cloud credential resolver passes
+        # should_error_on_not_found= when probing for the License.
+        def get_secret(self, _name: str, **_kwargs: object) -> str | None:
             return value
 
     monkeypatch.setattr(describe_image_module.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())

--- a/tests/unit/utils/test_cloud_credential_utils.py
+++ b/tests/unit/utils/test_cloud_credential_utils.py
@@ -1,0 +1,57 @@
+"""Griptape Cloud credential resolution: License or API key, License first."""
+
+from __future__ import annotations
+
+import pytest
+
+import griptape_nodes_library.utils.cloud_credential_utils as cloud_credential_utils
+from griptape_nodes_library.utils.cloud_credential_utils import (
+    missing_credential_message,
+    resolve_cloud_api_key,
+)
+
+_LICENSE = "header.payload.signature"
+"""A Griptape Nodes License is a JWT: three dot-separated segments."""
+
+
+def _stub_secrets(monkeypatch: pytest.MonkeyPatch, secrets: dict[str, str]) -> None:
+    class _FakeSecrets:
+        def get_secret(self, name: str, **_kwargs: object) -> str | None:
+            return secrets.get(name)
+
+    monkeypatch.setattr(cloud_credential_utils.GriptapeNodes, "SecretsManager", lambda: _FakeSecrets())
+
+
+def test_resolves_api_key_when_only_api_key_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_secrets(monkeypatch, {"GT_CLOUD_API_KEY": "gt-the-api-key"})
+
+    assert resolve_cloud_api_key() == "gt-the-api-key"
+
+
+def test_resolves_license_when_no_api_key_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The license-only user this whole module exists for.
+    _stub_secrets(monkeypatch, {"GRIPTAPE_NODES_LICENSE": _LICENSE})
+
+    assert resolve_cloud_api_key() == _LICENSE
+
+
+def test_license_wins_when_both_are_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_secrets(monkeypatch, {"GRIPTAPE_NODES_LICENSE": _LICENSE, "GT_CLOUD_API_KEY": "gt-the-api-key"})
+
+    assert resolve_cloud_api_key() == _LICENSE
+
+
+def test_returns_empty_string_when_no_credential(monkeypatch: pytest.MonkeyPatch) -> None:
+    # "" not None: the value feeds driver `api_key` fields typed `str`.
+    _stub_secrets(monkeypatch, {})
+
+    assert resolve_cloud_api_key() == ""
+
+
+def test_missing_credential_message_names_both_credentials() -> None:
+    message = missing_credential_message("run the Agent")
+
+    assert message.startswith("Attempted to run the Agent. Failed because ")
+    # A license-only user must not be sent after an API key alone.
+    assert "license" in message.lower()
+    assert "GT_CLOUD_API_KEY" in message


### PR DESCRIPTION
Some nodes like Agent would incorrectly error when running in license mode due to hard-checks against the API key env var. cloud_credential_utils exists to address this exact issue