### PR TITLE
Fix ResolveMacroPath nodes returning relative path instead of absolute

### DIFF
--- a/griptape_nodes_library/files/resolve_macro_path_base.py
+++ b/griptape_nodes_library/files/resolve_macro_path_base.py
@@ -33,7 +33,7 @@ class BaseResolveMacroPath(SuccessFailureNode):
         """Resolve a single macro path to an absolute path. Raises on malformed or unresolvable macros."""
         result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=ParsedMacro(path_str), variables={}))
         if isinstance(result, GetPathForMacroResultSuccess):
-            return str(result.resolved_path)
+            return str(result.absolute_path)
         if isinstance(result, GetPathForMacroResultFailure):
             msg = f"Could not resolve macro path '{path_str}': {result.failure_reason.value}"
             raise ValueError(msg)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,7 +7,6 @@ from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
-import griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter as public_artifact_url_parameter_module
 import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
 import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 import pytest
@@ -60,10 +59,14 @@ def stub_public_artifact_cloud_credential(monkeypatch: pytest.MonkeyPatch) -> No
     so the tests that assert credential-resolution behaviour keep control of
     the environment.
     """
+    # `resolve_cloud_credential` was removed from the engine; credentials are now
+    # resolved via PublicArtifactUrlParameter._get_secret_value. Patching at the
+    # class level so the constructor doesn't raise under _isolated_env (no real
+    # secrets available in test runs).
     monkeypatch.setattr(
-        public_artifact_url_parameter_module,
-        "resolve_cloud_credential",
-        lambda *_args, **_kwargs: "test-api-key",
+        PublicArtifactUrlParameter,
+        "_get_secret_value",
+        classmethod(lambda cls, key, default=None, *, should_error_on_not_found=False: "test-api-key"),
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import patch
 
+import griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter as public_artifact_url_parameter_module
 import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
 import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 import pytest
@@ -59,14 +60,10 @@ def stub_public_artifact_cloud_credential(monkeypatch: pytest.MonkeyPatch) -> No
     so the tests that assert credential-resolution behaviour keep control of
     the environment.
     """
-    # `resolve_cloud_credential` was removed from the engine; credentials are now
-    # resolved via PublicArtifactUrlParameter._get_secret_value. Patching at the
-    # class level so the constructor doesn't raise under _isolated_env (no real
-    # secrets available in test runs).
     monkeypatch.setattr(
-        PublicArtifactUrlParameter,
-        "_get_secret_value",
-        classmethod(lambda cls, key, default=None, *, should_error_on_not_found=False: "test-api-key"),
+        public_artifact_url_parameter_module,
+        "resolve_cloud_credential",
+        lambda *_args, **_kwargs: "test-api-key",
     )
 
 

--- a/tests/unit/files/test_resolve_macro_path.py
+++ b/tests/unit/files/test_resolve_macro_path.py
@@ -100,14 +100,14 @@ class TestResolveMacroPathProcess:
     def test_failure_clears_resolved_path(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_failure(monkeypatch)
         node.parameter_values["path"] = "{bad}/file.png"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             node.process()
         assert node.parameter_output_values["resolved_path"] == ""
 
     def test_failure_sets_was_not_successful(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_failure(monkeypatch)
         node.parameter_values["path"] = "{bad}/file.png"
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             node.process()
         assert node.parameter_output_values["was_successful"] is False
 
@@ -161,6 +161,6 @@ class TestResolveMacroPathsProcess:
     def test_failure_clears_resolved_paths(self, node: ResolveMacroPaths, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_failure(monkeypatch)
         node.parameter_values["paths"] = ["{bad}/file.png"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             node.process()
         assert node.parameter_output_values["resolved_paths"] == []

--- a/tests/unit/files/test_resolve_macro_path.py
+++ b/tests/unit/files/test_resolve_macro_path.py
@@ -1,0 +1,166 @@
+"""Unit tests for ResolveMacroPath and ResolveMacroPaths nodes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroResultFailure,
+    GetPathForMacroResultSuccess,
+    PathResolutionFailureReason,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+import griptape_nodes_library.files.resolve_macro_path_base as base_module
+from griptape_nodes_library.files.resolve_macro_path import ResolveMacroPath
+from griptape_nodes_library.files.resolve_macro_path_base import BaseResolveMacroPath
+from griptape_nodes_library.files.resolve_macro_paths import ResolveMacroPaths
+
+_RELATIVE = "inputs/my_file.png"
+_ABSOLUTE = "/workspace/inputs/my_file.png"
+
+
+@pytest.fixture(autouse=True)
+def _stub_extract(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pass string values through _extract_path_string unchanged, avoiding OSManager."""
+    monkeypatch.setattr(
+        BaseResolveMacroPath,
+        "_extract_path_string",
+        lambda self, v: str(v) if v else None,
+    )
+
+
+def _stub_success(
+    monkeypatch: pytest.MonkeyPatch,
+    absolute: str = _ABSOLUTE,
+    relative: str = _RELATIVE,
+) -> None:
+    result = GetPathForMacroResultSuccess(
+        result_details="",
+        resolved_path=Path(relative),
+        absolute_path=Path(absolute),
+    )
+    monkeypatch.setattr(
+        base_module.GriptapeNodes,
+        "handle_request",
+        staticmethod(lambda _req: result),
+    )
+
+
+def _stub_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = GetPathForMacroResultFailure(
+        result_details="",
+        failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
+    )
+    monkeypatch.setattr(
+        base_module.GriptapeNodes,
+        "handle_request",
+        staticmethod(lambda _req: result),
+    )
+
+
+# ── ResolveMacroPath ──────────────────────────────────────────────────────────
+
+
+class TestResolveMacroPathDefaults:
+    def test_path_default_is_empty(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        node = ResolveMacroPath("test")
+        assert node.get_parameter_value("path") == ""
+
+    def test_resolved_path_default_is_empty(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        node = ResolveMacroPath("test")
+        assert node.get_parameter_value("resolved_path") == ""
+
+
+class TestResolveMacroPathProcess:
+    @pytest.fixture
+    def node(self, griptape_nodes: GriptapeNodes) -> ResolveMacroPath:  # noqa: ARG002
+        return ResolveMacroPath("test")
+
+    def test_returns_absolute_path_not_relative(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression: output must come from absolute_path, not resolved_path."""
+        _stub_success(monkeypatch, absolute=_ABSOLUTE, relative=_RELATIVE)
+        node.parameter_values["path"] = "{inputs}/my_file.png"
+        node.process()
+        assert node.parameter_output_values["resolved_path"] == _ABSOLUTE
+        assert node.parameter_output_values["resolved_path"] != _RELATIVE
+
+    def test_empty_path_yields_empty_string(self, node: ResolveMacroPath) -> None:
+        node.parameter_values["path"] = ""
+        node.process()
+        assert node.parameter_output_values["resolved_path"] == ""
+
+    def test_success_sets_was_successful(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_success(monkeypatch)
+        node.parameter_values["path"] = "{inputs}/my_file.png"
+        node.process()
+        assert node.parameter_output_values["was_successful"] is True
+
+    def test_failure_clears_resolved_path(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_failure(monkeypatch)
+        node.parameter_values["path"] = "{bad}/file.png"
+        with pytest.raises(Exception):
+            node.process()
+        assert node.parameter_output_values["resolved_path"] == ""
+
+    def test_failure_sets_was_not_successful(self, node: ResolveMacroPath, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_failure(monkeypatch)
+        node.parameter_values["path"] = "{bad}/file.png"
+        with pytest.raises(Exception):
+            node.process()
+        assert node.parameter_output_values["was_successful"] is False
+
+
+# ── ResolveMacroPaths ─────────────────────────────────────────────────────────
+
+
+class TestResolveMacroPathsDefaults:
+    def test_paths_default_is_empty_list(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        node = ResolveMacroPaths("test")
+        assert node.get_parameter_value("paths") == []
+
+    def test_resolved_paths_default_is_empty_list(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+        node = ResolveMacroPaths("test")
+        assert node.get_parameter_value("resolved_paths") == []
+
+
+class TestResolveMacroPathsProcess:
+    @pytest.fixture
+    def node(self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch) -> ResolveMacroPaths:  # noqa: ARG002
+        n = ResolveMacroPaths("test")
+        # ParameterList uses get_parameter_list_value; shim it to read parameter_values directly.
+        monkeypatch.setattr(n, "get_parameter_list_value", lambda name: n.parameter_values.get(name, []))
+        return n
+
+    def test_returns_absolute_path_not_relative(self, node: ResolveMacroPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression: output must come from absolute_path, not resolved_path."""
+        _stub_success(monkeypatch, absolute=_ABSOLUTE, relative=_RELATIVE)
+        node.parameter_values["paths"] = ["{inputs}/my_file.png"]
+        node.process()
+        assert node.parameter_output_values["resolved_paths"] == [_ABSOLUTE]
+
+    def test_empty_list_yields_empty_output(self, node: ResolveMacroPaths) -> None:
+        node.parameter_values["paths"] = []
+        node.process()
+        assert node.parameter_output_values["resolved_paths"] == []
+
+    def test_resolves_multiple_paths(self, node: ResolveMacroPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_success(monkeypatch)
+        node.parameter_values["paths"] = ["{inputs}/a.png", "{inputs}/b.png"]
+        node.process()
+        assert node.parameter_output_values["resolved_paths"] == [_ABSOLUTE, _ABSOLUTE]
+
+    def test_success_reports_count_in_details(self, node: ResolveMacroPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_success(monkeypatch)
+        node.parameter_values["paths"] = ["{inputs}/a.png", "{inputs}/b.png"]
+        node.process()
+        assert node.parameter_output_values["was_successful"] is True
+        assert "2" in node.parameter_output_values["result_details"]
+
+    def test_failure_clears_resolved_paths(self, node: ResolveMacroPaths, monkeypatch: pytest.MonkeyPatch) -> None:
+        _stub_failure(monkeypatch)
+        node.parameter_values["paths"] = ["{bad}/file.png"]
+        with pytest.raises(Exception):
+            node.process()
+        assert node.parameter_output_values["resolved_paths"] == []


### PR DESCRIPTION
## Summary

- `GetPathForMacroResultSuccess` exposes both `resolved_path` (relative) and `absolute_path` (absolute); `BaseResolveMacroPath._resolve_one` was reading the wrong field
- One-line fix: `result.resolved_path` → `result.absolute_path` in the shared base helper, which fixes both `ResolveMacroPath` and `ResolveMacroPaths`
- Every other consumer in the engine (`files/file.py`, `files/directory.py`, `static_files_manager`, etc.) already uses `absolute_path` — these two nodes were the outliers

Closes #525.

## Test plan

- [ ] Run a `Resolve Macro Path` node with a macro like `{inputs}/my_file.png` and confirm the output is now a full filesystem path (e.g. `/Users/me/project/inputs/my_file.png`)
- [ ] Same for `Resolve Macro Path List` with multiple inputs
- [ ] Confirm a downstream node consuming the output can open the file without path resolution issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)