### PR TITLE
feat: add aspect ratio resize mode to RescaleImage node

### DIFF
--- a/griptape_nodes_library/image/rescale_image.py
+++ b/griptape_nodes_library/image/rescale_image.py
@@ -1,8 +1,10 @@
+from math import gcd
 from typing import Any
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterGroup
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.color_picker import ColorPicker
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
@@ -19,6 +21,7 @@ class RescaleImage(BaseImageProcessor):
     RESIZE_MODE_HEIGHT = "height"
     RESIZE_MODE_PERCENTAGE = "percentage"
     RESIZE_MODE_WIDTH_HEIGHT = "width and height"
+    RESIZE_MODE_ASPECT_RATIO = "aspect ratio"
 
     # Target size constants (for width/height modes)
     MIN_TARGET_SIZE = 1
@@ -46,6 +49,7 @@ class RescaleImage(BaseImageProcessor):
                 self.hide_parameter_by_name("target_size")
                 self.hide_parameter_by_name("target_width")
                 self.hide_parameter_by_name("target_height")
+                self.hide_parameter_by_name("aspect_ratio")
                 self.hide_parameter_by_name("fit_mode")
                 self.hide_parameter_by_name("background_color")
             elif value == self.RESIZE_MODE_WIDTH_HEIGHT:
@@ -53,6 +57,16 @@ class RescaleImage(BaseImageProcessor):
                 self.hide_parameter_by_name("target_size")
                 self.show_parameter_by_name("target_width")
                 self.show_parameter_by_name("target_height")
+                self.hide_parameter_by_name("aspect_ratio")
+                self.show_parameter_by_name("fit_mode")
+                # Background color visibility will be controlled by fit_mode
+                self.hide_parameter_by_name("background_color")
+            elif value == self.RESIZE_MODE_ASPECT_RATIO:
+                self.hide_parameter_by_name("percentage_scale")
+                self.hide_parameter_by_name("target_size")
+                self.hide_parameter_by_name("target_width")
+                self.hide_parameter_by_name("target_height")
+                self.show_parameter_by_name("aspect_ratio")
                 self.show_parameter_by_name("fit_mode")
                 # Background color visibility will be controlled by fit_mode
                 self.hide_parameter_by_name("background_color")
@@ -61,6 +75,7 @@ class RescaleImage(BaseImageProcessor):
                 self.show_parameter_by_name("target_size")
                 self.hide_parameter_by_name("target_width")
                 self.hide_parameter_by_name("target_height")
+                self.hide_parameter_by_name("aspect_ratio")
                 self.hide_parameter_by_name("fit_mode")
                 self.hide_parameter_by_name("background_color")
         elif parameter.name == "fit_mode":
@@ -87,6 +102,7 @@ class RescaleImage(BaseImageProcessor):
                         self.RESIZE_MODE_HEIGHT,
                         self.RESIZE_MODE_WIDTH_HEIGHT,
                         self.RESIZE_MODE_PERCENTAGE,
+                        self.RESIZE_MODE_ASPECT_RATIO,
                     ]
                 )
             )
@@ -127,7 +143,27 @@ class RescaleImage(BaseImageProcessor):
             )
             target_height_param.add_trait(Slider(min_val=self.MIN_TARGET_SIZE, max_val=self.MAX_TARGET_SIZE))
 
-            # Fit mode parameter (for width and height mode)
+            # Aspect ratio parameter (for aspect ratio mode)
+            ParameterString(
+                name="aspect_ratio",
+                default_value="16:9",
+                placeholder_text="16:9",
+                tooltip=(
+                    "Target aspect ratio. Use ratio notation (e.g. 16:9) or a decimal scalar (e.g. 1.77). "
+                    "The image is resized to match this ratio using the selected fit mode."
+                ),
+                traits={
+                    Button(
+                        icon="scan",
+                        size="icon",
+                        variant="secondary",
+                        on_click=self._on_detect_ratio_clicked,
+                        tooltip="Detect aspect ratio from input image",
+                    )
+                },
+            )
+
+            # Fit mode parameter (for width and height mode
             fit_mode_param = ParameterString(
                 name="fit_mode",
                 default_value=self.FIT_MODE_FIT,
@@ -167,12 +203,39 @@ class RescaleImage(BaseImageProcessor):
         self.hide_parameter_by_name("target_size")
         self.hide_parameter_by_name("target_width")
         self.hide_parameter_by_name("target_height")
+        self.hide_parameter_by_name("aspect_ratio")
         self.hide_parameter_by_name("fit_mode")
         self.hide_parameter_by_name("background_color")
 
     def _get_processing_description(self) -> str:
         """Get description of what this processor does."""
         return "image rescaling"
+
+    def _parse_aspect_ratio(self, ratio_str: str) -> float:
+        """Parse an aspect ratio string to a float scalar.
+
+        Accepts ratio notation (e.g. '16:9') or a decimal scalar (e.g. '1.77').
+        """
+        if ":" in ratio_str:
+            parts = ratio_str.split(":")
+            if len(parts) != 2:  # noqa: PLR2004
+                msg = f"Invalid ratio '{ratio_str}'. Use ratio notation like '16:9' or a scalar like '1.77'."
+                raise ValueError(msg)
+            try:
+                w = float(parts[0].strip())
+                h = float(parts[1].strip())
+            except ValueError:
+                msg = f"Invalid ratio '{ratio_str}'. Use ratio notation like '16:9' or a scalar like '1.77'."
+                raise ValueError(msg) from None
+            if h == 0:
+                msg = f"Invalid ratio '{ratio_str}': denominator cannot be zero."
+                raise ValueError(msg)
+            return w / h
+        try:
+            return float(ratio_str.strip())
+        except ValueError:
+            msg = f"Invalid aspect ratio '{ratio_str}'. Provide a ratio (e.g. '16:9') or a scalar (e.g. '1.77')."
+            raise ValueError(msg) from None
 
     def _process_image(self, pil_image: Image.Image, **kwargs) -> Image.Image:
         """Process the PIL image by rescaling it."""
@@ -181,6 +244,7 @@ class RescaleImage(BaseImageProcessor):
         percentage_scale = kwargs.get("percentage_scale", self.DEFAULT_PERCENTAGE_SCALE)
         target_width = kwargs.get("target_width", self.DEFAULT_TARGET_SIZE)
         target_height = kwargs.get("target_height", self.DEFAULT_TARGET_SIZE)
+        aspect_ratio_str = kwargs.get("aspect_ratio", "16:9")
         fit_mode = kwargs.get("fit_mode", self.FIT_MODE_FIT)
         background_color = kwargs.get("background_color", "transparent")
         resample_filter = kwargs.get("resample_filter", "lanczos")
@@ -212,6 +276,25 @@ class RescaleImage(BaseImageProcessor):
             resize_config = {
                 "target_width": target_width,
                 "target_height": target_height,
+                "fit_mode": fit_mode,
+                "background_color": background_color,
+                "resample_constant": resample_constant,
+            }
+            resized_image = self._resize_with_fit_mode(pil_image, resize_config)
+        elif resize_mode == self.RESIZE_MODE_ASPECT_RATIO:
+            # Derive target dimensions from the desired ratio, then apply fit mode
+            target_ratio = self._parse_aspect_ratio(aspect_ratio_str)
+            if target_ratio >= 1:
+                # Landscape/square — keep width, compute height
+                tw = pil_image.width
+                th = max(1, round(pil_image.width / target_ratio))
+            else:
+                # Portrait — keep height, compute width
+                th = pil_image.height
+                tw = max(1, round(pil_image.height * target_ratio))
+            resize_config = {
+                "target_width": tw,
+                "target_height": th,
                 "fit_mode": fit_mode,
                 "background_color": background_color,
                 "resample_constant": resample_constant,
@@ -380,6 +463,15 @@ class RescaleImage(BaseImageProcessor):
                 msg = f"{self.name} - Target height must be between {self.MIN_TARGET_SIZE} and {self.MAX_TARGET_SIZE}, got {target_height}"
                 exceptions.append(ValueError(msg))
 
+        # Validate aspect ratio string for aspect ratio mode
+        if resize_mode == self.RESIZE_MODE_ASPECT_RATIO:
+            aspect_ratio_str = self.get_parameter_value("aspect_ratio")
+            if aspect_ratio_str is not None:
+                try:
+                    self._parse_aspect_ratio(aspect_ratio_str)
+                except ValueError as e:
+                    exceptions.append(e)
+
         return exceptions if exceptions else None
 
     def _get_custom_parameters(self) -> dict[str, Any]:
@@ -390,6 +482,7 @@ class RescaleImage(BaseImageProcessor):
             "percentage_scale": self.get_parameter_value("percentage_scale"),
             "target_width": self.get_parameter_value("target_width"),
             "target_height": self.get_parameter_value("target_height"),
+            "aspect_ratio": self.get_parameter_value("aspect_ratio"),
             "fit_mode": self.get_parameter_value("fit_mode"),
             "background_color": self.get_parameter_value("background_color"),
             "resample_filter": self.get_parameter_value("resample_filter"),
@@ -398,3 +491,31 @@ class RescaleImage(BaseImageProcessor):
     def _get_output_suffix(self, **kwargs) -> str:  # noqa: ARG002
         """Get output filename suffix."""
         return "_rescaled"
+
+    def _on_detect_ratio_clicked(
+        self,
+        button: Button,  # noqa: ARG002
+        button_details: ButtonDetailsMessagePayload,
+    ) -> NodeMessageResult | None:
+        """Detect the input image's aspect ratio and populate the aspect_ratio parameter."""
+        from griptape_nodes_library.utils.image_utils import load_pil_from_url
+
+        image = self.get_parameter_value("input_image")
+        if image is None:
+            return NodeMessageResult(success=False, details="No input image connected.", response=button_details)
+
+        try:
+            if hasattr(image, "to_dict"):
+                from griptape_nodes_library.utils.image_utils import dict_to_image_url_artifact
+
+                image = dict_to_image_url_artifact(image.to_dict())
+
+            pil_image = load_pil_from_url(image.value)
+            w, h = pil_image.width, pil_image.height
+            divisor = gcd(w, h)
+            ratio_str = f"{w // divisor}:{h // divisor}"
+            self.set_parameter_value("aspect_ratio", ratio_str)
+            self.publish_update_to_parameter("aspect_ratio", ratio_str)
+            return NodeMessageResult(success=True, details=f"Detected ratio: {ratio_str}", response=button_details)
+        except Exception as e:
+            return NodeMessageResult(success=False, details=f"Failed to detect ratio: {e}", response=button_details)


### PR DESCRIPTION
## Summary

- Adds a new `aspect ratio` resize mode to the `RescaleImage` node
- Accepts the target ratio as ratio notation (`16:9`) or a decimal scalar (`1.77`)
- Reuses the existing `fit_mode` (fit/fill/stretch) via `_resize_with_fit_mode` — no parallel resize path
- Adds a scan button on the `aspect_ratio` parameter that auto-detects the ratio from the connected input image using GCD reduction

Closes #295

## Test plan

- [ ] Switch `resize_mode` to `aspect ratio` — verify `aspect_ratio` and `fit_mode` params appear, others hide
- [ ] Enter `16:9` → landscape image resizes to 16:9 ratio
- [ ] Enter `1.77` → same result as above (scalar path)
- [ ] Enter `9:16` → portrait crop/letterbox/stretch behaves correctly per fit mode
- [ ] Each fit mode (fit/fill/stretch) produces expected output
- [ ] Click the scan button with an input image connected → `aspect_ratio` field populates with GCD-reduced ratio
- [ ] Click the scan button with no input image → graceful failure message
- [ ] Enter garbage string (e.g. `foo`) → validation error surfaced before run

🤖 Generated with [Claude Code](https://claude.com/claude-code)