### PR TITLE
feat: add LTX 2.5 models to the LTX video nodes

### DIFF
--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -29,6 +29,8 @@ __all__ = ["LTXAudioToVideoGeneration"]
 MODEL_MAPPING = {
     "LTX 2 Pro": "ltx-2-pro",
     "LTX 2.3 Pro": "ltx-2-3-pro",
+    "LTX 2.5 Pro": "ltx-2-5-pro",
+    "LTX 2.5 Fast": "ltx-2-5-fast",
 }
 
 
@@ -39,7 +41,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         - audio (AudioArtifact|AudioUrlArtifact|str): Input audio (required, base64 data URI format)
         - prompt (str): Text prompt for video generation (required)
         - image (ImageArtifact|ImageUrlArtifact|str): Input image (optional, base64 data URI format)
-        - resolution (str): Video resolution (1920x1080)
+        - resolution (str): Video resolution (1920x1080 or 1080x1920)
         - guidance_scale (float): Guidance scale for generation (1-50, optional)
 
     Outputs:
@@ -64,7 +66,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
                 default_value="LTX 2 Pro",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2.3 Pro"])},
+                traits={Options(choices=["LTX 2 Pro", "LTX 2.3 Pro", "LTX 2.5 Pro", "LTX 2.5 Fast"])},
             )
         )
         self.add_parameter(
@@ -109,7 +111,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
                 default_value="1920x1080",
                 tooltip="Video resolution",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["1920x1080"])},
+                traits={Options(choices=["1920x1080", "1080x1920"])},
             )
         )
 

--- a/griptape_nodes_library/video/ltx_audio_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_audio_to_video_generation.py
@@ -63,7 +63,7 @@ class LTXAudioToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2 Pro",
+                default_value="LTX 2.5 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=["LTX 2 Pro", "LTX 2.3 Pro", "LTX 2.5 Pro", "LTX 2.5 Fast"])},

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -183,7 +183,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2.3 Fast",
+                default_value="LTX 2.5 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={

--- a/griptape_nodes_library/video/ltx_image_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_image_to_video_generation.py
@@ -28,6 +28,8 @@ MODEL_MAPPING = {
     "LTX 2 Fast": "ltx-2-fast",
     "LTX 2.3 Pro": "ltx-2-3-pro",
     "LTX 2.3 Fast": "ltx-2-3-fast",
+    "LTX 2.5 Pro": "ltx-2-5-pro",
+    "LTX 2.5 Fast": "ltx-2-5-fast",
 }
 
 # Camera motion options
@@ -39,6 +41,7 @@ CAMERA_MOTION_OPTIONS = [
     "dolly_right",
     "jib_up",
     "jib_down",
+    "focus_shift",
 ]
 
 
@@ -47,9 +50,10 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
 
     Inputs:
         - image (ImageArtifact|ImageUrlArtifact|str): Input image (required, base64 data URI format)
+        - last_frame (ImageArtifact|ImageUrlArtifact|str): Optional last frame image to interpolate toward
         - prompt (str): Text prompt for video generation (required)
-        - model (str): Model to use (LTX 2 Pro, LTX 2 Fast, LTX 2.3 Pro, or LTX 2.3 Fast)
-        - resolution (str): Video resolution (1920x1080, 2560x1440, or 3840x2160)
+        - model (str): Model to use (LTX 2 Pro, LTX 2 Fast, LTX 2.3 Pro, LTX 2.3 Fast, LTX 2.5 Pro, or LTX 2.5 Fast)
+        - resolution (str): Video resolution (model-dependent, 1280x720 up to 3840x2160, landscape or portrait)
         - duration (int): Video length in seconds
         - fps (int): Frames per second (default: 25)
         - camera_motion (str): Camera movement type (default: static)
@@ -95,12 +99,81 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
         }
     }
 
+    # LTX 2.5 inverts the tiers: Fast reaches 1440p/4K and long durations, Pro caps at 1080p
+    FAST_2_5_MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
+        "resolutions": {
+            "1920x1080": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "1080x1920": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "1280x720": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "720x1280": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "2560x1440": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1440x2560": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "3840x2160": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "2160x3840": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+        }
+    }
+
+    PRO_2_5_MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
+        "resolutions": {
+            "1920x1080": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1080x1920": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1280x720": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "720x1280": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+        }
+    }
+
     # Model capability definitions
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "ltx-2-fast": FAST_MODEL_CAPABILITIES,
         "ltx-2-3-fast": FAST_MODEL_CAPABILITIES,
         "ltx-2-pro": PRO_MODEL_CAPABILITIES,
         "ltx-2-3-pro": PRO_MODEL_CAPABILITIES,
+        "ltx-2-5-fast": FAST_2_5_MODEL_CAPABILITIES,
+        "ltx-2-5-pro": PRO_2_5_MODEL_CAPABILITIES,
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -113,7 +186,18 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
                 default_value="LTX 2.3 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},
+                traits={
+                    Options(
+                        choices=[
+                            "LTX 2 Pro",
+                            "LTX 2 Fast",
+                            "LTX 2.3 Pro",
+                            "LTX 2.3 Fast",
+                            "LTX 2.5 Pro",
+                            "LTX 2.5 Fast",
+                        ]
+                    )
+                },
             )
         )
         self.add_parameter(
@@ -138,13 +222,36 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
             )
         )
 
+        self.add_parameter(
+            ParameterImage(
+                name="last_frame",
+                tooltip="Optional last frame image; the video interpolates from the input image to this frame. Accepts ImageArtifact, ImageUrlArtifact, URL, or Base64.",
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+                ui_options={"display_name": "Last Frame Image"},
+            )
+        )
+
         with ParameterGroup(name="Generation Settings") as gen_settings_group:
             ParameterString(
                 name="resolution",
                 default_value="1920x1080",
                 tooltip="Video resolution",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["1920x1080", "2560x1440", "3840x2160"])},
+                traits={
+                    Options(
+                        choices=[
+                            "1920x1080",
+                            "2560x1440",
+                            "3840x2160",
+                            "1280x720",
+                            "720x1280",
+                            "1080x1920",
+                            "1440x2560",
+                            "2160x3840",
+                        ]
+                    )
+                },
             )
 
             ParameterInt(
@@ -160,7 +267,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
                 default_value=25,
                 tooltip="Frames per second",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[25, 50])},
+                traits={Options(choices=[24, 25, 48, 50])},
             )
 
             ParameterString(
@@ -273,6 +380,7 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
             "prompt": self.get_parameter_value("prompt") or "",
             "model": self.get_parameter_value("model") or "LTX 2 Fast",
             "image_uri": await self._prepare_image_data_url_async(self.get_parameter_value("image")),
+            "last_frame_uri": await self._prepare_image_data_url_async(self.get_parameter_value("last_frame")),
             "resolution": self.get_parameter_value("resolution") or "1920x1080",
             "duration": self.get_parameter_value("duration") or 6,
             "fps": self.get_parameter_value("fps") or 25,
@@ -358,6 +466,8 @@ class LTXImageToVideoGeneration(GriptapeProxyNode):
             "camera_motion": params["camera_motion"],
             "generate_audio": bool(params["generate_audio"]),
         }
+        if params["last_frame_uri"]:
+            payload["last_frame_uri"] = params["last_frame_uri"]
 
         return payload
 

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -179,7 +179,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         self.add_parameter(
             ParameterString(
                 name="model",
-                default_value="LTX 2.3 Fast",
+                default_value="LTX 2.5 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={

--- a/griptape_nodes_library/video/ltx_text_to_video_generation.py
+++ b/griptape_nodes_library/video/ltx_text_to_video_generation.py
@@ -26,6 +26,8 @@ MODEL_MAPPING = {
     "LTX 2 Fast": "ltx-2-fast",
     "LTX 2.3 Pro": "ltx-2-3-pro",
     "LTX 2.3 Fast": "ltx-2-3-fast",
+    "LTX 2.5 Pro": "ltx-2-5-pro",
+    "LTX 2.5 Fast": "ltx-2-5-fast",
 }
 
 # Camera motion options
@@ -37,6 +39,7 @@ CAMERA_MOTION_OPTIONS = [
     "dolly_right",
     "jib_up",
     "jib_down",
+    "focus_shift",
 ]
 
 
@@ -45,8 +48,8 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
 
     Inputs:
         - prompt (str): Text prompt for video generation (required)
-        - model (str): Model to use (LTX 2 Pro, LTX 2 Fast, LTX 2.3 Pro, or LTX 2.3 Fast)
-        - resolution (str): Video resolution (1920x1080, 2560x1440, or 3840x2160)
+        - model (str): Model to use (LTX 2 Pro, LTX 2 Fast, LTX 2.3 Pro, LTX 2.3 Fast, LTX 2.5 Pro, or LTX 2.5 Fast)
+        - resolution (str): Video resolution (model-dependent, 1280x720 up to 3840x2160, landscape or portrait)
         - duration (int): Video length in seconds
         - fps (int): Frames per second (default: 25)
         - camera_motion (str): Camera movement type (default: static)
@@ -92,12 +95,81 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
         }
     }
 
+    # LTX 2.5 inverts the tiers: Fast reaches 1440p/4K and long durations, Pro caps at 1080p
+    FAST_2_5_MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
+        "resolutions": {
+            "1920x1080": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "1080x1920": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "1280x720": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "720x1280": {
+                "fps": {
+                    24: [6, 8, 10, 12, 14, 16, 18, 20],
+                    25: [6, 8, 10, 12, 14, 16, 18, 20],
+                    48: [6, 8, 10],
+                    50: [6, 8, 10],
+                },
+            },
+            "2560x1440": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1440x2560": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "3840x2160": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "2160x3840": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 48: [6, 8, 10], 50: [6, 8, 10]},
+            },
+        }
+    }
+
+    PRO_2_5_MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
+        "resolutions": {
+            "1920x1080": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1080x1920": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "1280x720": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+            "720x1280": {
+                "fps": {24: [6, 8, 10], 25: [6, 8, 10], 50: [6, 8, 10]},
+            },
+        }
+    }
+
     # Model capability definitions
     MODEL_CAPABILITIES: ClassVar[dict[str, Any]] = {
         "ltx-2-fast": FAST_MODEL_CAPABILITIES,
         "ltx-2-3-fast": FAST_MODEL_CAPABILITIES,
         "ltx-2-pro": PRO_MODEL_CAPABILITIES,
         "ltx-2-3-pro": PRO_MODEL_CAPABILITIES,
+        "ltx-2-5-fast": FAST_2_5_MODEL_CAPABILITIES,
+        "ltx-2-5-pro": PRO_2_5_MODEL_CAPABILITIES,
     }
 
     def __init__(self, **kwargs: Any) -> None:
@@ -110,7 +182,18 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
                 default_value="LTX 2.3 Fast",
                 tooltip="Model to use for video generation",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["LTX 2 Pro", "LTX 2 Fast", "LTX 2.3 Pro", "LTX 2.3 Fast"])},
+                traits={
+                    Options(
+                        choices=[
+                            "LTX 2 Pro",
+                            "LTX 2 Fast",
+                            "LTX 2.3 Pro",
+                            "LTX 2.3 Fast",
+                            "LTX 2.5 Pro",
+                            "LTX 2.5 Fast",
+                        ]
+                    )
+                },
             )
         )
 
@@ -132,7 +215,20 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
                 default_value="1920x1080",
                 tooltip="Video resolution",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=["1920x1080", "2560x1440", "3840x2160"])},
+                traits={
+                    Options(
+                        choices=[
+                            "1920x1080",
+                            "2560x1440",
+                            "3840x2160",
+                            "1280x720",
+                            "720x1280",
+                            "1080x1920",
+                            "1440x2560",
+                            "2160x3840",
+                        ]
+                    )
+                },
             )
 
             ParameterInt(
@@ -148,7 +244,7 @@ class LTXTextToVideoGeneration(GriptapeProxyNode):
                 default_value=25,
                 tooltip="Frames per second",
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
-                traits={Options(choices=[25, 50])},
+                traits={Options(choices=[24, 25, 48, 50])},
             )
             ParameterString(
                 name="camera_motion",

--- a/tests/integration/test_ltx_text_to_video_generation_2_5.py
+++ b/tests/integration/test_ltx_text_to_video_generation_2_5.py
@@ -1,0 +1,232 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_ltx_text_to_video_generation_2_5"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "StartFlow"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# is_internal = true
+# ///
+"""Integration test for LTX 2.5 text-to-video generation."""
+
+import argparse
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Testing Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    gen_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTXTextToVideoGeneration",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    start_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="StartFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="Start Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(start_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="prompt",
+                default_value="",
+                tooltip="Prompt",
+                type="str",
+                input_types=["any"],
+                output_type="str",
+                ui_options={"display_name": "Prompt", "multiline": True},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+
+    # LTX 2.5 Fast at 1280x720, 24 fps, 6 seconds is the cheapest supported combination.
+    with GriptapeNodes.ContextManager().node(gen_node):
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="model", value="LTX 2.5 Fast"))
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="resolution", value="1280x720"))
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="fps", value=24))
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="duration", value=6))
+
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=start_node,
+            source_parameter_name="prompt",
+            target_node_name=gen_node,
+            target_parameter_name="prompt",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=gen_node,
+            source_parameter_name="video_url",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser(description="Test LTX 2.5 text-to-video generation")
+    parser.add_argument("--storage-backend", choices=["local", "gtc"], default="local")
+    parser.add_argument("--project-file-path", default=None)
+    parser.add_argument("--json-input", default=None)
+    parser.add_argument("--prompt", default=None)
+    args = parser.parse_args()
+
+    test_prompt = args.prompt or "Gentle ocean waves rolling onto a sandy beach at sunrise"
+
+    if args.json_input is not None:
+        flow_input = json.loads(args.json_input)
+    else:
+        flow_input = {"Start Flow": {"prompt": test_prompt}}
+
+    workflow_output = execute_workflow(
+        input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path
+    )
+    print(workflow_output)


### PR DESCRIPTION
Adds LTX 2.5 Pro and LTX 2.5 Fast to the standard library's LTX nodes wherever the provider supports them: `LTXTextToVideoGeneration`, `LTXImageToVideoGeneration`, and `LTXAudioToVideoGeneration`. The extend and retake nodes are intentionally untouched because the provider only offers those operations on LTX 2.3.

Related proxy-side work: https://github.com/griptape-ai/griptape-cloud/pull/2187

## Changes

**Text-to-video and image-to-video**
- `MODEL_MAPPING` gains `LTX 2.5 Pro` -> `ltx-2-5-pro` and `LTX 2.5 Fast` -> `ltx-2-5-fast`
- New per-model capability tables matching the provider's 2.5 support matrix. Note the tier inversion versus 2.3: on 2.5, **Fast** is the variant that reaches 1440p/4K and 12-20 s durations, while **Pro** caps at 1080p and 10 s
- New resolutions: `1280x720`/`720x1280` (new 720p tier) plus portrait variants of 1080p/1440p/4K
- `fps` choices extended to 24/25/48/50 (48/50 limited to 6/8/10 s; validity is enforced per model/resolution by the existing `_validate_model_params` capability check). The parameter default stays 25 because 24 fps is not valid on the 2.0/2.3 models that remain the node default
- `camera_motion` gains `focus_shift`
- Image-to-video gains an optional `last_frame` image input, sent as `last_frame_uri` only when provided (video interpolates from the input image to that frame)

**Audio-to-video**
- Both 2.5 models added (2.5 is the first LTX version with a Fast audio-to-video variant)
- `1080x1920` portrait resolution added. Video length continues to be driven by the input audio (2-20 s for 2.5 Fast, 2-10 s for 2.5 Pro); there are no duration/fps/camera-motion fields on this endpoint

`duration` is always sent as an explicit integer; the proxy rejects null/auto duration.

Out of scope, per the issue's "possible direction" note: the capability tables remain duplicated per node. This change follows the existing per-node table pattern used by prior LTX version bumps; consolidating the tables is left as a separate refactor.

## Sources

- https://docs.ltx.io/models/ltx-2-5
- https://docs.ltx.io/openapi.json
- Verified live against the LTX API and through the Griptape Cloud proxy (see below)


Run locally against the proxy branch: LTX 2.5 Fast text-to-video at 1280x720/24 fps/6 s completed and the output video passed the file assertion.

Closes #530
Blocked by https://github.com/griptape-ai/griptape-cloud/pull/2187