### PR TITLE
feat: add VideoCapture node with webcam recording widget

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -3533,7 +3533,7 @@
         "description": "Capture video and audio from your webcam. Record, preview the playback, then accept to output a VideoUrlArtifact.",
         "display_name": "Video Capture",
         "icon": "video",
-        "group": "capture",
+        "group": "create",
         "tags": [
           "video",
           "webcam",

--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -1264,6 +1264,11 @@
       "name": "SelectFromGrid",
       "path": "widgets/SelectFromGrid/SelectFromGrid.js",
       "description": "Interactive grid selector \u2014 displays list items as thumbnails (images, video, audio, text) and lets the user click to select one or more."
+    },
+    {
+      "name": "VideoCapture",
+      "path": "widgets/VideoCapture/VideoCapture.js",
+      "description": "Webcam video capture widget \u2014 live preview, record with audio, review playback, then accept before running."
     }
   ],
   "categories": [
@@ -3517,6 +3522,25 @@
           "video",
           "audio",
           "ffmpeg"
+        ]
+      }
+    },
+    {
+      "class_name": "VideoCapture",
+      "file_path": "griptape_nodes_library/video/video_capture.py",
+      "metadata": {
+        "category": "video",
+        "description": "Capture video and audio from your webcam. Record, preview the playback, then accept to output a VideoUrlArtifact.",
+        "display_name": "Video Capture",
+        "icon": "video",
+        "group": "capture",
+        "tags": [
+          "video",
+          "webcam",
+          "camera",
+          "capture",
+          "input",
+          "record"
         ]
       }
     },

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -45,11 +45,12 @@ class VideoCapture(DataNode):
                 artifact = self._save_recording(value)
                 self.parameter_output_values["output_video"] = artifact
                 self.publish_update_to_parameter("output_video", artifact)
-                # Replace stored recording with a slim reference so the workflow
-                # never serialises the base64 blob, and signal the JS overlay to hide.
+                # Replace with a slim reference immediately — set_parameter_value triggers
+                # its own after_value_set → super() chain for the processed dict, so we
+                # return here to prevent the blob-carrying value from ever reaching super().
                 processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
                 self.set_parameter_value("recording", processed)
-                self.publish_update_to_parameter("recording", processed)
+                return
         return super().after_value_set(parameter, value)
 
     def _save_recording(self, recording: dict) -> VideoUrlArtifact:

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -1,4 +1,4 @@
-import base64
+from pathlib import Path
 
 from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterMode
@@ -6,6 +6,12 @@ from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.files.file import FileDestination
+from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    AttemptMapAbsolutePathToProjectResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.widget import Widget
 
 
@@ -35,32 +41,53 @@ class VideoCapture(DataNode):
         self._output_file = ProjectFileParameter(
             node=self,
             name="output_file",
-            default_filename="webcam_capture.webm",
+            default_filename="webcam_capture.mp4",
         )
         self._output_file.add_parameter()
 
     def after_value_set(self, parameter, value):
         if parameter.name == "recording" and isinstance(value, dict):
-            if value.get("state") == "accepted" and value.get("value"):
-                artifact = self._save_recording(value)
-                self.parameter_output_values["output_video"] = artifact
-                self.publish_update_to_parameter("output_video", artifact)
-                # Replace with a slim reference immediately — set_parameter_value triggers
-                # its own after_value_set → super() chain for the processed dict, so we
-                # return here to prevent the blob-carrying value from ever reaching super().
-                processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
-                self.set_parameter_value("recording", processed)
-                return
-        return super().after_value_set(parameter, value)
+            match value.get("state"):
+                case "requesting_upload_url":
+                    server_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+                    dest = self._output_file.build_file()
+                    # resolve() fails for CREATE_NEW situations because _index is only
+                    # computed at write time. Call the base-class write_bytes directly to
+                    # allocate the indexed path without the ProjectFileDestination macro
+                    # mapping — that gives us the raw absolute path we need for the URL.
+                    placeholder = FileDestination.write_bytes(dest, b"")
+                    abs_path = Path(placeholder.location)
+                    workspace = GriptapeNodes.ConfigManager().workspace_path
+                    rel_path = str(abs_path.relative_to(workspace))
+                    upload_url = f"{server_url}/static-uploads/{rel_path}"
+                    map_result = GriptapeNodes.handle_request(
+                        AttemptMapAbsolutePathToProjectRequest(absolute_path=abs_path)
+                    )
+                    artifact_url = (
+                        map_result.mapped_path
+                        if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess)
+                        and map_result.mapped_path
+                        else str(abs_path)
+                    )
+                    ready = {
+                        "state": "upload_ready",
+                        "_uploadUrl": upload_url,
+                        "_artifactUrl": artifact_url,
+                        "_emitSeq": value.get("_emitSeq", 0),
+                    }
+                    self.set_parameter_value("recording", ready)
+                    return
 
-    def _save_recording(self, recording: dict) -> VideoUrlArtifact:
-        raw = recording["value"]
-        if "base64," in raw:
-            raw = raw.split("base64,")[1]
-        video_bytes = base64.b64decode(raw)
-        dest = self._output_file.build_file()
-        saved = dest.write_bytes(video_bytes)
-        return VideoUrlArtifact(saved.location)
+                case "accepted":
+                    if value.get("url"):
+                        artifact = VideoUrlArtifact(value["url"])
+                        self.parameter_output_values["output_video"] = artifact
+                        self.publish_update_to_parameter("output_video", artifact)
+                        processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
+                        self.set_parameter_value("recording", processed)
+                        return
+
+        return super().after_value_set(parameter, value)
 
     def process(self) -> None:
         recording = self.get_parameter_value("recording")

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -16,6 +16,8 @@ class VideoCapture(DataNode):
         super().__init__(**kwargs)
         # Absolute path to the temp upload file; set in requesting_upload_url, consumed in accepted.
         self._pending_upload_path: Path | None = None
+        # MIME type of the recorded blob (e.g. "video/webm;codecs=vp9,opus").
+        self._pending_mime: str = "video/mp4"
 
         self.add_parameter(
             ParameterDict(
@@ -51,8 +53,11 @@ class VideoCapture(DataNode):
                     workspace = GriptapeNodes.ConfigManager().workspace_path
                     # Predictable name: no orphan files accumulate on re-record.
                     # Static server creates temp/ and writes the file on PUT.
+                    mime = value.get("_mime", "video/mp4")
+                    self._pending_mime = mime
+                    ext = ".webm" if mime.startswith("video/webm") else ".mp4"
                     safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", self.name)
-                    rel_path = f"temp/_vc_{safe_name}.mp4"
+                    rel_path = f"temp/_vc_{safe_name}{ext}"
                     self._pending_upload_path = workspace / rel_path
                     ready = {
                         "state": "upload_ready",
@@ -75,6 +80,13 @@ class VideoCapture(DataNode):
                     self._pending_upload_path = None
                     data = pending.read_bytes()
                     pending.unlink(missing_ok=True)
+                    # Coerce the output filename extension to match the recorded container.
+                    # Firefox records webm even when mp4 is the default; updating the
+                    # parameter here also corrects what the user sees in the UI.
+                    correct_ext = ".webm" if self._pending_mime.startswith("video/webm") else ".mp4"
+                    output_val = self.get_parameter_value("output_file") or ""
+                    if output_val and Path(output_val).suffix.lower() != correct_ext:
+                        self.set_parameter_value("output_file", str(Path(output_val).with_suffix(correct_ext)))
                     saved = self._output_file.build_file().write_bytes(data)
                     artifact = VideoUrlArtifact(saved.location)
                     self.parameter_output_values["output_video"] = artifact

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -14,8 +14,6 @@ from griptape_nodes.traits.widget import Widget
 class VideoCapture(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
-        # Absolute path to the temp upload file; set in requesting_upload_url, consumed in accepted.
-        self._pending_upload_path: Path | None = None
         # MIME type of the recorded blob (e.g. "video/webm;codecs=vp9,opus").
         self._pending_mime: str = "video/mp4"
 
@@ -45,20 +43,18 @@ class VideoCapture(DataNode):
         )
         self._output_file.add_parameter()
 
+    def _temp_rel_path(self) -> str:
+        ext = ".webm" if self._pending_mime.startswith("video/webm") else ".mp4"
+        safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", self.name)
+        return f"temp/_vc_{safe_name}{ext}"
+
     def after_value_set(self, parameter, value):
         if parameter.name == "recording" and isinstance(value, dict):
             match value.get("state"):
                 case "requesting_upload_url":
+                    self._pending_mime = value.get("_mime", "video/mp4")
                     server_url = GriptapeNodes.StaticFilesManager().static_server_base_url
-                    workspace = GriptapeNodes.ConfigManager().workspace_path
-                    # Predictable name: no orphan files accumulate on re-record.
-                    # Static server creates temp/ and writes the file on PUT.
-                    mime = value.get("_mime", "video/mp4")
-                    self._pending_mime = mime
-                    ext = ".webm" if mime.startswith("video/webm") else ".mp4"
-                    safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", self.name)
-                    rel_path = f"temp/_vc_{safe_name}{ext}"
-                    self._pending_upload_path = workspace / rel_path
+                    rel_path = self._temp_rel_path()
                     ready = {
                         "state": "upload_ready",
                         "_uploadUrl": f"{server_url}/static-uploads/{rel_path}",
@@ -68,8 +64,9 @@ class VideoCapture(DataNode):
                     return
 
                 case "accepted":
-                    pending = self._pending_upload_path
-                    if pending is None or not pending.exists():
+                    workspace = GriptapeNodes.ConfigManager().workspace_path
+                    temp_path = workspace / self._temp_rel_path()
+                    if not temp_path.exists():
                         error = {
                             "state": "error",
                             "message": "Upload not found. Please re-record.",
@@ -77,13 +74,12 @@ class VideoCapture(DataNode):
                         }
                         self.set_parameter_value("recording", error)
                         return
-                    self._pending_upload_path = None
-                    data = pending.read_bytes()
-                    pending.unlink(missing_ok=True)
+                    data = temp_path.read_bytes()
+                    temp_path.unlink(missing_ok=True)
                     # Coerce the output filename extension to match the recorded container.
                     # Firefox records webm even when mp4 is the default; updating the
                     # parameter here also corrects what the user sees in the UI.
-                    correct_ext = ".webm" if self._pending_mime.startswith("video/webm") else ".mp4"
+                    correct_ext = Path(temp_path).suffix.lower()
                     output_val = self.get_parameter_value("output_file") or ""
                     if output_val and Path(output_val).suffix.lower() != correct_ext:
                         self.set_parameter_value("output_file", str(Path(output_val).with_suffix(correct_ext)))

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from griptape.artifacts import VideoUrlArtifact
@@ -6,11 +7,6 @@ from griptape_nodes.exe_types.node_types import DataNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
-from griptape_nodes.files.file import FileDestination
-from griptape_nodes.retained_mode.events.project_events import (
-    AttemptMapAbsolutePathToProjectRequest,
-    AttemptMapAbsolutePathToProjectResultSuccess,
-)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.widget import Widget
 
@@ -18,6 +14,8 @@ from griptape_nodes.traits.widget import Widget
 class VideoCapture(DataNode):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        # Absolute path to the temp upload file; set in requesting_upload_url, consumed in accepted.
+        self._pending_upload_path: Path | None = None
 
         self.add_parameter(
             ParameterDict(
@@ -50,42 +48,40 @@ class VideoCapture(DataNode):
             match value.get("state"):
                 case "requesting_upload_url":
                     server_url = GriptapeNodes.StaticFilesManager().static_server_base_url
-                    dest = self._output_file.build_file()
-                    # resolve() fails for CREATE_NEW situations because _index is only
-                    # computed at write time. Call the base-class write_bytes directly to
-                    # allocate the indexed path without the ProjectFileDestination macro
-                    # mapping — that gives us the raw absolute path we need for the URL.
-                    placeholder = FileDestination.write_bytes(dest, b"")
-                    abs_path = Path(placeholder.location)
                     workspace = GriptapeNodes.ConfigManager().workspace_path
-                    rel_path = str(abs_path.relative_to(workspace))
-                    upload_url = f"{server_url}/static-uploads/{rel_path}"
-                    map_result = GriptapeNodes.handle_request(
-                        AttemptMapAbsolutePathToProjectRequest(absolute_path=abs_path)
-                    )
-                    artifact_url = (
-                        map_result.mapped_path
-                        if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess)
-                        and map_result.mapped_path
-                        else str(abs_path)
-                    )
+                    # Predictable name: no orphan files accumulate on re-record.
+                    # Static server creates temp/ and writes the file on PUT.
+                    safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", self.name)
+                    rel_path = f"temp/_vc_{safe_name}.mp4"
+                    self._pending_upload_path = workspace / rel_path
                     ready = {
                         "state": "upload_ready",
-                        "_uploadUrl": upload_url,
-                        "_artifactUrl": artifact_url,
+                        "_uploadUrl": f"{server_url}/static-uploads/{rel_path}",
                         "_emitSeq": value.get("_emitSeq", 0),
                     }
                     self.set_parameter_value("recording", ready)
                     return
 
                 case "accepted":
-                    if value.get("url"):
-                        artifact = VideoUrlArtifact(value["url"])
-                        self.parameter_output_values["output_video"] = artifact
-                        self.publish_update_to_parameter("output_video", artifact)
-                        processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
-                        self.set_parameter_value("recording", processed)
+                    pending = self._pending_upload_path
+                    if pending is None or not pending.exists():
+                        error = {
+                            "state": "error",
+                            "message": "Upload not found. Please re-record.",
+                            "_emitSeq": value.get("_emitSeq", 0),
+                        }
+                        self.set_parameter_value("recording", error)
                         return
+                    self._pending_upload_path = None
+                    data = pending.read_bytes()
+                    pending.unlink(missing_ok=True)
+                    saved = self._output_file.build_file().write_bytes(data)
+                    artifact = VideoUrlArtifact(saved.location)
+                    self.parameter_output_values["output_video"] = artifact
+                    self.publish_update_to_parameter("output_video", artifact)
+                    processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
+                    self.set_parameter_value("recording", processed)
+                    return
 
         return super().after_value_set(parameter, value)
 

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -1,0 +1,53 @@
+from griptape.artifacts import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.traits.widget import Widget
+
+from griptape_nodes_library.utils.video_utils import dict_to_video_url_artifact
+
+
+class VideoCapture(DataNode):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.add_parameter(
+            ParameterDict(
+                name="recording",
+                default_value={"state": "idle"},
+                tooltip="Webcam video capture widget. Record video, then click Accept.",
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={Widget(name="VideoCapture", library="Griptape Nodes Library")},
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="output_video",
+                tooltip="The captured video.",
+                allowed_modes={ParameterMode.OUTPUT},
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+    def after_value_set(self, parameter, value):
+        if parameter.name == "recording" and isinstance(value, dict):
+            if value.get("state") == "accepted" and value.get("value"):
+                artifact = dict_to_video_url_artifact(value)
+                self.parameter_output_values["output_video"] = artifact
+                self.publish_update_to_parameter("output_video", artifact)
+                # Replace stored recording with a slim reference — no blob, just the saved path.
+                # This prevents the base64 payload from being serialised into the workflow file.
+                processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
+                self.set_parameter_value("recording", processed)
+                self.publish_update_to_parameter("recording", processed)
+        return super().after_value_set(parameter, value)
+
+    def process(self) -> None:
+        recording = self.get_parameter_value("recording")
+        if recording and recording.get("state") == "processed" and recording.get("url"):
+            self.parameter_output_values["output_video"] = VideoUrlArtifact(recording["url"])
+            return
+        msg = "No video recorded. Use the widget to capture and accept a recording before running."
+        raise ValueError(msg)

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -1,11 +1,12 @@
+import base64
+
 from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
 from griptape_nodes.traits.widget import Widget
-
-from griptape_nodes_library.utils.video_utils import dict_to_video_url_artifact
 
 
 class VideoCapture(DataNode):
@@ -31,18 +32,34 @@ class VideoCapture(DataNode):
             )
         )
 
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="webcam_capture.webm",
+        )
+        self._output_file.add_parameter()
+
     def after_value_set(self, parameter, value):
         if parameter.name == "recording" and isinstance(value, dict):
             if value.get("state") == "accepted" and value.get("value"):
-                artifact = dict_to_video_url_artifact(value)
+                artifact = self._save_recording(value)
                 self.parameter_output_values["output_video"] = artifact
                 self.publish_update_to_parameter("output_video", artifact)
-                # Replace stored recording with a slim reference — no blob, just the saved path.
-                # This prevents the base64 payload from being serialised into the workflow file.
+                # Replace stored recording with a slim reference so the workflow
+                # never serialises the base64 blob, and signal the JS overlay to hide.
                 processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
                 self.set_parameter_value("recording", processed)
                 self.publish_update_to_parameter("recording", processed)
         return super().after_value_set(parameter, value)
+
+    def _save_recording(self, recording: dict) -> VideoUrlArtifact:
+        raw = recording["value"]
+        if "base64," in raw:
+            raw = raw.split("base64,")[1]
+        video_bytes = base64.b64decode(raw)
+        dest = self._output_file.build_file()
+        saved = dest.write_bytes(video_bytes)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> None:
         recording = self.get_parameter_value("recording")

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -16,6 +16,9 @@ class VideoCapture(DataNode):
         super().__init__(**kwargs)
         # MIME type of the recorded blob (e.g. "video/webm;codecs=vp9,opus").
         self._pending_mime: str = "video/mp4"
+        # _emitSeq of the in-flight accept; -1 when idle. Consumed on first
+        # accepted call so duplicate after_value_set calls are ignored.
+        self._expected_seq: int = -1
 
         self.add_parameter(
             ParameterDict(
@@ -53,6 +56,7 @@ class VideoCapture(DataNode):
             match value.get("state"):
                 case "requesting_upload_url":
                     self._pending_mime = value.get("_mime", "video/mp4")
+                    self._expected_seq = value.get("_emitSeq", 0)
                     server_url = GriptapeNodes.StaticFilesManager().static_server_base_url
                     rel_path = self._temp_rel_path()
                     ready = {
@@ -64,6 +68,10 @@ class VideoCapture(DataNode):
                     return
 
                 case "accepted":
+                    seq = value.get("_emitSeq", 0)
+                    if seq != self._expected_seq:
+                        return  # duplicate after_value_set call; already handled
+                    self._expected_seq = -1
                     workspace = GriptapeNodes.ConfigManager().workspace_path
                     temp_path = workspace / self._temp_rel_path()
                     if not temp_path.exists():

--- a/griptape_nodes_library/video/video_capture.py
+++ b/griptape_nodes_library/video/video_capture.py
@@ -76,19 +76,23 @@ class VideoCapture(DataNode):
                         return
                     data = temp_path.read_bytes()
                     temp_path.unlink(missing_ok=True)
+                    correct_ext = Path(temp_path).suffix.lower()
+                    saved = self._output_file.build_file().write_bytes(data)
+                    artifact = VideoUrlArtifact(saved.location)
+                    # Mark recording as processed BEFORE publishing any output updates.
+                    # publish_update_to_parameter can trigger a node re-render; if the
+                    # widget remounts while recording is still "upload_ready" it would
+                    # fire a second PUT and cause a spurious "Upload not found" error.
+                    processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
+                    self.set_parameter_value("recording", processed)
+                    self.parameter_output_values["output_video"] = artifact
+                    self.publish_update_to_parameter("output_video", artifact)
                     # Coerce the output filename extension to match the recorded container.
                     # Firefox records webm even when mp4 is the default; updating the
                     # parameter here also corrects what the user sees in the UI.
-                    correct_ext = Path(temp_path).suffix.lower()
                     output_val = self.get_parameter_value("output_file") or ""
                     if output_val and Path(output_val).suffix.lower() != correct_ext:
                         self.set_parameter_value("output_file", str(Path(output_val).with_suffix(correct_ext)))
-                    saved = self._output_file.build_file().write_bytes(data)
-                    artifact = VideoUrlArtifact(saved.location)
-                    self.parameter_output_values["output_video"] = artifact
-                    self.publish_update_to_parameter("output_video", artifact)
-                    processed = {"state": "processed", "url": artifact.value, "_emitSeq": value.get("_emitSeq", 0)}
-                    self.set_parameter_value("recording", processed)
                     return
 
         return super().after_value_set(parameter, value)

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -1,0 +1,395 @@
+import { mkIcon } from './_icons.js';
+
+const PREFERRED_MIMES = [
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp8,opus",
+  "video/webm",
+  "video/mp4",
+];
+
+function getSupportedMime() {
+  if (typeof MediaRecorder === "undefined") return "video/webm";
+  for (const t of PREFERRED_MIMES) {
+    if (MediaRecorder.isTypeSupported(t)) return t;
+  }
+  return "video/webm";
+}
+
+function fmtTime(s) {
+  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function injectStyles() {
+  if (document.getElementById("vc-styles")) return;
+  const style = document.createElement("style");
+  style.id = "vc-styles";
+  style.textContent = "@keyframes vc-spin{to{transform:rotate(360deg)}}";
+  document.head.appendChild(style);
+}
+
+function mkSelect() {
+  const sel = document.createElement("select");
+  sel.style.cssText = [
+    "flex:1", "min-width:0", "padding:4px 6px", "border-radius:5px",
+    "border:1px solid var(--border)", "background:var(--background)",
+    "color:var(--foreground)", "font-size:12px", "cursor:pointer",
+  ].join(";");
+  sel.addEventListener("pointerdown", (e) => e.stopPropagation());
+  sel.addEventListener("mousedown",   (e) => e.stopPropagation());
+  return sel;
+}
+
+function mkBtn(iconName, label, danger) {
+  const btn = document.createElement("button");
+  btn.style.cssText = [
+    "display:flex", "align-items:center", "gap:6px",
+    "padding:6px 14px", "border-radius:6px", "border:none",
+    "cursor:pointer", "font-size:13px", "font-weight:500",
+    "transition:opacity 0.15s",
+    danger ? "background:var(--destructive);color:white;"
+           : "background:rgba(0,0,0,0.65);color:white;backdrop-filter:blur(4px);",
+  ].join(";");
+  btn.appendChild(mkIcon(iconName, 14));
+  const span = document.createElement("span");
+  span.textContent = label;
+  btn.appendChild(span);
+  btn.addEventListener("pointerdown", (e) => e.stopPropagation());
+  btn.addEventListener("mousedown",   (e) => e.stopPropagation());
+  return btn;
+}
+
+export default function VideoCapture(container, props) {
+  if (container._vcInst?.wrapper?.isConnected) {
+    container._vcInst.handleUpdate(props);
+    return { cleanup: container._vcInst.cleanup, update: container._vcInst.handleUpdate };
+  }
+
+  injectStyles();
+
+  let { onChange } = props;
+  let _emitSeq = 0;
+
+  let isStreaming  = false;
+  let isRecording  = false;
+  let hasRecording = false;
+
+  let stream = null, recorder = null, chunks = [], blob = null, blobUrl = null;
+  let elapsed = 0, timer = null;
+  const mime = getSupportedMime();
+
+  let currentVideoId = "";
+  let currentAudioId = "";
+
+  // ── DOM ──────────────────────────────────────────────────────────────────
+
+  const wrapper = document.createElement("div");
+  wrapper.className = "nodrag nowheel";
+  // height:100% makes the widget fill the canvas as it's resized
+  wrapper.style.cssText = "display:flex;flex-direction:column;height:100%;padding:8px;box-sizing:border-box;";
+
+  // Video area — flex:1 so it grows to fill available height
+  const videoWrap = document.createElement("div");
+  videoWrap.style.cssText = [
+    "position:relative", "background:#111", "border-radius:8px",
+    "flex:1 1 0", "min-height:180px", "overflow:hidden",
+    "display:flex", "align-items:center", "justify-content:center",
+  ].join(";");
+
+  const video = document.createElement("video");
+  // object-fit:contain keeps the video aspect ratio; height:100% fills the flex area
+  video.style.cssText = "width:100%;height:100%;object-fit:contain;display:block;";
+  video.autoplay = true;
+  video.muted = true;
+  video.playsInline = true;
+
+  // Placeholder
+  const placeholder = document.createElement("div");
+  placeholder.style.cssText = "position:absolute;color:var(--muted-foreground);font-size:13px;text-align:center;padding:24px;user-select:none;";
+  placeholder.textContent = "Starting camera…";
+
+  // REC badge (top-left)
+  const recBadge = document.createElement("div");
+  recBadge.style.cssText = [
+    "position:absolute", "top:10px", "left:10px",
+    "background:rgba(200,0,0,0.85)", "color:#fff",
+    "font-size:11px", "font-weight:700", "padding:2px 8px",
+    "border-radius:4px", "font-family:monospace", "pointer-events:none",
+  ].join(";");
+  recBadge.hidden = true;
+
+  // Encoding overlay — shown from Accept click until Python confirms processing complete
+  const encodingOverlay = document.createElement("div");
+  encodingOverlay.style.cssText = [
+    "position:absolute", "inset:0", "z-index:10",
+    "background:rgba(0,0,0,0.75)",
+    "display:flex", "flex-direction:column",
+    "align-items:center", "justify-content:center", "gap:10px",
+    "color:white", "font-size:13px", "font-weight:500",
+    "border-radius:8px",
+  ].join(";");
+  const spinner = document.createElement("div");
+  spinner.style.cssText = "width:28px;height:28px;border:3px solid rgba(255,255,255,0.25);border-top-color:white;border-radius:50%;animation:vc-spin 0.75s linear infinite;";
+  encodingOverlay.appendChild(spinner);
+  encodingOverlay.appendChild(Object.assign(document.createElement("span"), { textContent: "Processing…" }));
+  encodingOverlay.hidden = true;
+
+  // Overlay button row (bottom of video)
+  const overlay = document.createElement("div");
+  overlay.style.cssText = "position:absolute;bottom:10px;left:0;right:0;display:flex;justify-content:center;gap:8px;flex-wrap:wrap;";
+
+  const startBtn    = mkBtn("circle",      "Start Recording", false);
+  const stopBtn     = mkBtn("square",      "Stop",            true);
+  const playPauseBtn = mkBtn("play",       "Play",            false);
+  const acceptBtn   = mkBtn("check",       "Accept",          false);
+  const discardBtn  = mkBtn("rotate-ccw",  "Re-record",       false);
+
+  overlay.append(startBtn, stopBtn, playPauseBtn, acceptBtn, discardBtn);
+  videoWrap.append(placeholder, video, recBadge, encodingOverlay, overlay);
+
+  // Device selector row — [cam icon] [cam select] [mic icon] [mic select]
+  const videoSel = mkSelect();
+  const audioSel = mkSelect();
+  const deviceRow = document.createElement("div");
+  deviceRow.style.cssText = "display:flex;align-items:center;gap:6px;margin-top:6px;transition:opacity 0.15s;";
+  deviceRow.append(mkIcon("camera", 15), videoSel, mkIcon("mic", 15), audioSel);
+
+  wrapper.append(videoWrap, deviceRow);
+  container.append(wrapper);
+
+  // ── Play/pause button sync ────────────────────────────────────────────────
+
+  function syncPlayPauseBtn() {
+    const isPaused = video.paused || video.ended;
+    // Swap icon: remove first child (svg), insert fresh one
+    playPauseBtn.removeChild(playPauseBtn.firstChild);
+    playPauseBtn.insertBefore(mkIcon(isPaused ? "play" : "pause", 14), playPauseBtn.firstChild);
+    playPauseBtn.querySelector("span").textContent = isPaused ? "Play" : "Pause";
+  }
+
+  video.addEventListener("play",  syncPlayPauseBtn);
+  video.addEventListener("pause", syncPlayPauseBtn);
+  video.addEventListener("ended", syncPlayPauseBtn);
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  function render() {
+    placeholder.hidden   = isStreaming || hasRecording;
+    video.hidden         = !isStreaming && !hasRecording;
+    startBtn.hidden      = isRecording || hasRecording;
+    startBtn.disabled    = !isStreaming;
+    stopBtn.hidden       = !isRecording;
+    playPauseBtn.hidden  = !hasRecording;
+    acceptBtn.hidden     = !hasRecording;
+    discardBtn.hidden    = !hasRecording;
+    recBadge.hidden      = !isRecording;
+    const devicesLocked       = isRecording || hasRecording;
+    videoSel.disabled         = devicesLocked;
+    audioSel.disabled         = devicesLocked;
+    deviceRow.style.opacity   = devicesLocked ? "0.4" : "1";
+    deviceRow.style.pointerEvents = devicesLocked ? "none" : "";
+  }
+
+  // ── Camera / Recording ───────────────────────────────────────────────────
+
+  async function populateDevices() {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      function repopulate(sel, list) {
+        const current = sel.value;
+        sel.innerHTML = "";
+        list.forEach((d, i) => {
+          const opt = document.createElement("option");
+          opt.value = d.deviceId;
+          opt.textContent = d.label || `Device ${i + 1}`;
+          sel.appendChild(opt);
+        });
+        if (current && [...sel.options].some((o) => o.value === current)) sel.value = current;
+      }
+      repopulate(videoSel, devices.filter((d) => d.kind === "videoinput"));
+      repopulate(audioSel, devices.filter((d) => d.kind === "audioinput"));
+      // Sync selects to the tracks the stream is actually using
+      if (stream) {
+        const vs = stream.getVideoTracks()[0]?.getSettings?.()?.deviceId;
+        const as = stream.getAudioTracks()[0]?.getSettings?.()?.deviceId;
+        if (vs) { currentVideoId = vs; videoSel.value = vs; }
+        if (as) { currentAudioId = as; audioSel.value = as; }
+      }
+    } catch { /* permission not yet granted */ }
+  }
+
+  async function switchDevices() {
+    if (isRecording || hasRecording) return;
+    currentVideoId = videoSel.value;
+    currentAudioId = audioSel.value;
+    stream?.getTracks().forEach((t) => t.stop());
+    stream = null;
+    isStreaming = false;
+    render();
+    await startCamera();
+  }
+
+  async function startCamera() {
+    try {
+      const constraints = {
+        video: currentVideoId ? { deviceId: { exact: currentVideoId } } : true,
+        audio: currentAudioId ? { deviceId: { exact: currentAudioId } } : true,
+      };
+      const s = await navigator.mediaDevices.getUserMedia(constraints);
+      if (hasRecording) { s.getTracks().forEach((t) => t.stop()); return; }
+      stream = s;
+      video.srcObject = stream;
+      video.muted = true;
+      isStreaming = true;
+      render();
+      await populateDevices();
+    } catch {
+      if (!hasRecording) placeholder.textContent = "Camera unavailable — check browser permissions.";
+    }
+  }
+
+  function startRecording() {
+    if (!stream) return;
+    chunks = [];
+    elapsed = 0;
+    recBadge.textContent = "● REC 00:00";
+    recorder = new MediaRecorder(stream, { mimeType: mime });
+    recorder.ondataavailable = (e) => { if (e.data?.size > 0) chunks.push(e.data); };
+    recorder.onstop = onStop;
+    recorder.start(100);
+    isRecording = true;
+    render();
+    timer = setInterval(() => { elapsed++; recBadge.textContent = `● REC ${fmtTime(elapsed)}`; }, 1000);
+  }
+
+  function stopRecording() {
+    clearInterval(timer);
+    if (recorder && recorder.state !== "inactive") recorder.stop();
+  }
+
+  function onStop() {
+    blob = new Blob(chunks, { type: mime });
+    if (blobUrl) URL.revokeObjectURL(blobUrl);
+    blobUrl = URL.createObjectURL(blob);
+    stream?.getTracks().forEach((t) => t.stop());
+    stream = null;
+    video.srcObject = null;
+    video.src = blobUrl;
+    video.muted = false;
+    video.loop = false;
+    video.play().catch(() => {});
+    isStreaming = false;
+    isRecording = false;
+    hasRecording = true;
+    render();
+  }
+
+  function hideEncodingOverlay() {
+    encodingOverlay.hidden = true;
+    acceptBtn.disabled = false;
+    discardBtn.disabled = false;
+    playPauseBtn.disabled = false;
+  }
+
+  function accept() {
+    if (!blob) return;
+    encodingOverlay.hidden = false;
+    acceptBtn.disabled = true;
+    discardBtn.disabled = true;
+    playPauseBtn.disabled = true;
+    // rAF ensures overlay paints before the FileReader (and WebSocket send) starts
+    requestAnimationFrame(() => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        _emitSeq++;
+        onChange?.({ state: "accepted", value: reader.result, type: mime.split(";")[0], _emitSeq });
+        // Overlay stays visible — Python will echo back state:"processed" when done
+      };
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  function discard() {
+    video.src = "";
+    video.muted = true;
+    if (blobUrl) { URL.revokeObjectURL(blobUrl); blobUrl = null; }
+    blob = null; chunks = [];
+    isStreaming = false; isRecording = false; hasRecording = false;
+    placeholder.textContent = "Starting camera…";
+    render();
+    startCamera();
+  }
+
+  function togglePlayPause() {
+    if (video.paused || video.ended) { video.currentTime = 0; video.play().catch(() => {}); }
+    else video.pause();
+  }
+
+  // ── Restore saved state ──────────────────────────────────────────────────
+
+  function restore(b64, type) {
+    try {
+      const mime64 = (type || "video/webm").split(";")[0];
+      const raw = b64.includes(",") ? b64.split(",")[1] : b64;
+      const bytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
+      blob = new Blob([bytes], { type: mime64 });
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+      blobUrl = URL.createObjectURL(blob);
+      video.srcObject = null;
+      video.src = blobUrl;
+      video.muted = false;
+      video.loop = false;
+      video.play().catch(() => {});
+      isStreaming = false; isRecording = false; hasRecording = true;
+      render();
+      return true;
+    } catch { return false; }
+  }
+
+  // ── handleUpdate ─────────────────────────────────────────────────────────
+
+  function handleUpdate(newProps) {
+    onChange = newProps.onChange;
+    const v = newProps.value ?? {};
+    // Python echoes this after dict_to_video_url_artifact completes — hide overlay
+    if (v.state === "processed") { hideEncodingOverlay(); return; }
+    if ((v._emitSeq || 0) <= _emitSeq) return;
+    if ((v.state === "recorded" || v.state === "accepted") && v.value && !hasRecording)
+      restore(v.value, v.type);
+  }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+
+  function cleanup() {
+    clearInterval(timer);
+    navigator.mediaDevices.removeEventListener("devicechange", populateDevices);
+    if (recorder && recorder.state !== "inactive") { recorder.onstop = null; recorder.stop(); }
+    stream?.getTracks().forEach((t) => t.stop());
+    if (blobUrl) URL.revokeObjectURL(blobUrl);
+    video.src = ""; video.srcObject = null;
+    wrapper.remove();
+    delete container._vcInst;
+  }
+
+  // ── Wire up & init ────────────────────────────────────────────────────────
+
+  startBtn.addEventListener("click",    startRecording);
+  stopBtn.addEventListener("click",     stopRecording);
+  playPauseBtn.addEventListener("click", togglePlayPause);
+  acceptBtn.addEventListener("click",   accept);
+  discardBtn.addEventListener("click",  discard);
+  videoSel.addEventListener("change",   switchDevices);
+  audioSel.addEventListener("change",   switchDevices);
+  navigator.mediaDevices.addEventListener("devicechange", populateDevices);
+
+  container._vcInst = { handleUpdate, cleanup, wrapper };
+
+  const init = props.value ?? {};
+  if ((init.state === "recorded" || init.state === "accepted") && init.value) {
+    if (!restore(init.value, init.type)) startCamera();
+  } else {
+    startCamera();
+  }
+
+  render();
+  return { cleanup, update: handleUpdate };
+}

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -338,27 +338,6 @@ export default function VideoCapture(container, props) {
     else video.pause();
   }
 
-  // ── Restore saved state ──────────────────────────────────────────────────
-
-  function restore(b64, type) {
-    try {
-      const mime64 = (type || "video/webm").split(";")[0];
-      const raw = b64.includes(",") ? b64.split(",")[1] : b64;
-      const bytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
-      blob = new Blob([bytes], { type: mime64 });
-      if (blobUrl) URL.revokeObjectURL(blobUrl);
-      blobUrl = URL.createObjectURL(blob);
-      video.srcObject = null;
-      video.src = blobUrl;
-      video.muted = false;
-      video.loop = false;
-      video.play().catch(() => {});
-      isStreaming = false; isRecording = false; hasRecording = true;
-      render();
-      return true;
-    } catch { return false; }
-  }
-
   // ── handleUpdate ─────────────────────────────────────────────────────────
 
   function handleUpdate(newProps) {
@@ -400,12 +379,7 @@ export default function VideoCapture(container, props) {
 
   container._vcInst = { handleUpdate, cleanup, wrapper };
 
-  const init = props.value ?? {};
-  if ((init.state === "recorded" || init.state === "accepted") && init.value) {
-    if (!restore(init.value, init.type)) startCamera();
-  } else {
-    startCamera();
-  }
+  startCamera();
 
   render();
   return { cleanup, update: handleUpdate };

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -360,9 +360,6 @@ export default function VideoCapture(container, props) {
     if (v.state === "processed") { hideEncodingOverlay(); return; }
     // Python responds to requesting_upload_url with the PUT destination and artifact path
     if (v.state === "upload_ready" && v._uploadUrl) { doUpload(v._uploadUrl, v._artifactUrl); return; }
-    if ((v._emitSeq || 0) < _emitSeq) return;
-    if ((v.state === "recorded" || v.state === "accepted") && v.value && !hasRecording)
-      restore(v.value, v.type);
   }
 
   // ── Cleanup ───────────────────────────────────────────────────────────────

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -75,6 +75,7 @@ export default function VideoCapture(container, props) {
   let isRecording  = false;
   let hasRecording = false;
 
+  let _uploading = false;
   let stream = null, recorder = null, chunks = [], blob = null, blobUrl = null;
   let elapsed = 0, timer = null;
   const mime = getSupportedMime();
@@ -306,16 +307,22 @@ export default function VideoCapture(container, props) {
     });
   }
 
-  function doUpload(uploadUrl, artifactUrl) {
+  function doUpload(uploadUrl) {
+    if (_uploading) return;
+    _uploading = true;
     fetch(uploadUrl, { method: "PUT", body: blob })
       .then((r) => { if (!r.ok) throw new Error(r.statusText); })
       .then(() => {
-        onChange?.({ state: "accepted", url: artifactUrl, _emitSeq });
+        onChange?.({ state: "accepted", _emitSeq });
       })
-      .catch(() => hideEncodingOverlay());
+      .catch(() => {
+        _uploading = false;
+        hideEncodingOverlay();
+      });
   }
 
   function discard() {
+    _uploading = false;
     video.src = "";
     video.muted = true;
     if (blobUrl) { URL.revokeObjectURL(blobUrl); blobUrl = null; }
@@ -358,8 +365,13 @@ export default function VideoCapture(container, props) {
     onChange = newProps.onChange;
     const v = newProps.value ?? {};
     if (v.state === "processed") { hideEncodingOverlay(); return; }
-    // Python responds to requesting_upload_url with the PUT destination and artifact path
-    if (v.state === "upload_ready" && v._uploadUrl) { doUpload(v._uploadUrl, v._artifactUrl); return; }
+    if (v.state === "error") {
+      spinner.hidden = true;
+      encodingOverlay.querySelector("span").textContent = v.message || "Upload failed.";
+      setTimeout(hideEncodingOverlay, 4000);
+      return;
+    }
+    if (v.state === "upload_ready" && v._uploadUrl) { doUpload(v._uploadUrl); return; }
   }
 
   // ── Cleanup ───────────────────────────────────────────────────────────────

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -150,7 +150,7 @@ export default function VideoCapture(container, props) {
   const videoSel = mkSelect();
   const audioSel = mkSelect();
   const deviceRow = document.createElement("div");
-  deviceRow.style.cssText = "display:flex;align-items:center;gap:6px;margin-top:6px;transition:opacity 0.15s;";
+  deviceRow.style.cssText = "display:flex;align-items:center;gap:6px;margin-top:6px;transition:opacity 0.15s;color:var(--muted-foreground);";
   deviceRow.append(mkIcon("camera", 15), videoSel, mkIcon("mic", 15), audioSel);
 
   wrapper.append(videoWrap, deviceRow);

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -303,7 +303,7 @@ export default function VideoCapture(container, props) {
     requestAnimationFrame(() => {
       _emitSeq++;
       // Ask Python for an upload URL; Python responds with state:"upload_ready"
-      onChange?.({ state: "requesting_upload_url", _emitSeq });
+      onChange?.({ state: "requesting_upload_url", _mime: mime, _emitSeq });
     });
   }
 

--- a/widgets/VideoCapture/VideoCapture.js
+++ b/widgets/VideoCapture/VideoCapture.js
@@ -1,18 +1,20 @@
 import { mkIcon } from './_icons.js';
 
 const PREFERRED_MIMES = [
+  "video/mp4;codecs=avc1,mp4a.40.2",
+  "video/mp4;codecs=avc1",
+  "video/mp4",
   "video/webm;codecs=vp9,opus",
   "video/webm;codecs=vp8,opus",
   "video/webm",
-  "video/mp4",
 ];
 
 function getSupportedMime() {
-  if (typeof MediaRecorder === "undefined") return "video/webm";
+  if (typeof MediaRecorder === "undefined") return "video/mp4";
   for (const t of PREFERRED_MIMES) {
     if (MediaRecorder.isTypeSupported(t)) return t;
   }
-  return "video/webm";
+  return "video/mp4";
 }
 
 function fmtTime(s) {
@@ -296,16 +298,21 @@ export default function VideoCapture(container, props) {
     acceptBtn.disabled = true;
     discardBtn.disabled = true;
     playPauseBtn.disabled = true;
-    // rAF ensures overlay paints before the FileReader (and WebSocket send) starts
+    // rAF ensures overlay paints before the WebSocket send starts
     requestAnimationFrame(() => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        _emitSeq++;
-        onChange?.({ state: "accepted", value: reader.result, type: mime.split(";")[0], _emitSeq });
-        // Overlay stays visible — Python will echo back state:"processed" when done
-      };
-      reader.readAsDataURL(blob);
+      _emitSeq++;
+      // Ask Python for an upload URL; Python responds with state:"upload_ready"
+      onChange?.({ state: "requesting_upload_url", _emitSeq });
     });
+  }
+
+  function doUpload(uploadUrl, artifactUrl) {
+    fetch(uploadUrl, { method: "PUT", body: blob })
+      .then((r) => { if (!r.ok) throw new Error(r.statusText); })
+      .then(() => {
+        onChange?.({ state: "accepted", url: artifactUrl, _emitSeq });
+      })
+      .catch(() => hideEncodingOverlay());
   }
 
   function discard() {
@@ -350,9 +357,10 @@ export default function VideoCapture(container, props) {
   function handleUpdate(newProps) {
     onChange = newProps.onChange;
     const v = newProps.value ?? {};
-    // Python echoes this after dict_to_video_url_artifact completes — hide overlay
     if (v.state === "processed") { hideEncodingOverlay(); return; }
-    if ((v._emitSeq || 0) <= _emitSeq) return;
+    // Python responds to requesting_upload_url with the PUT destination and artifact path
+    if (v.state === "upload_ready" && v._uploadUrl) { doUpload(v._uploadUrl, v._artifactUrl); return; }
+    if ((v._emitSeq || 0) < _emitSeq) return;
     if ((v.state === "recorded" || v.state === "accepted") && v.value && !hasRecording)
       restore(v.value, v.type);
   }

--- a/widgets/VideoCapture/_icons.js
+++ b/widgets/VideoCapture/_icons.js
@@ -1,0 +1,29 @@
+// Lucide SVG icon paths (MIT licensed)
+
+export const ICON_PATHS = {
+  circle:    `<circle cx="12" cy="12" r="10"/>`,
+  square:    `<rect width="18" height="18" x="3" y="3" rx="2" ry="2"/>`,
+  check:     `<path d="M20 6 9 17l-5-5"/>`,
+  play:      `<polygon points="5 3 19 12 5 21 5 3"/>`,
+  pause:     `<rect width="4" height="16" x="6" y="4"/><rect width="4" height="16" x="14" y="4"/>`,
+  "rotate-ccw": `<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>`,
+  "trash-2": `<path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/>`,
+  "camera-off": `<line x1="2" x2="22" y1="2" y2="22"/><path d="M7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16"/><path d="M9.5 4h5L17 7h3a2 2 0 0 1 2 2v7.5"/><path d="M14.121 15.121A3 3 0 1 1 9.88 10.88"/>`,
+  camera:    `<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/>`,
+  mic:       `<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/>`,
+};
+
+export function mkIcon(name, size = 15) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", size);
+  svg.setAttribute("height", size);
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.style.cssText = "display:block;flex-shrink:0;pointer-events:none;";
+  svg.innerHTML = ICON_PATHS[name] || "";
+  return svg;
+}

--- a/widgets/VideoCapture/_icons.js
+++ b/widgets/VideoCapture/_icons.js
@@ -7,8 +7,6 @@ export const ICON_PATHS = {
   play:      `<polygon points="5 3 19 12 5 21 5 3"/>`,
   pause:     `<rect width="4" height="16" x="6" y="4"/><rect width="4" height="16" x="14" y="4"/>`,
   "rotate-ccw": `<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>`,
-  "trash-2": `<path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/>`,
-  "camera-off": `<line x1="2" x2="22" y1="2" y2="22"/><path d="M7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16"/><path d="M9.5 4h5L17 7h3a2 2 0 0 1 2 2v7.5"/><path d="M14.121 15.121A3 3 0 1 1 9.88 10.88"/>`,
   camera:    `<path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/>`,
   mic:       `<path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/>`,
 };


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/14e0b7cd-6f3a-4bf1-9b2b-63e3622a460b


- Adds a `VideoCapture` node that captures video and audio from the user's webcam and outputs a `VideoUrlArtifact`
- Custom JS widget handles live preview, recording with audio, playback review, and accept/re-record flow
- Accepts video via HTTP PUT to the static file server (raw bytes, no base64) — avoids WebSocket size limits for longer recordings
- Output path managed by `ProjectFileParameter`, respecting the project's `SAVE_NODE_OUTPUT` situation

## How it works

1. User records → clicks Accept
2. Widget requests an upload URL from Python via the WebSocket (`state: "requesting_upload_url"`)
3. Python allocates the indexed file path and returns a signed PUT URL + portable artifact path
4. Widget PUTs the raw MP4 blob directly to the static file server
5. Widget sends the artifact URL back to Python; Python emits the `VideoUrlArtifact` output

Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/1243

## Test plan

- [ ] Add a VideoCapture node to a workflow
- [ ] Grant camera/mic permissions when prompted
- [ ] Record a clip, stop, review playback
- [ ] Click Accept — encoding overlay appears, then hides when processing completes
- [ ] `output_video` port emits a `VideoUrlArtifact` pointing to the saved `.mp4`
- [ ] Re-record (discard) and accept again — new indexed file created, output updates
- [ ] Change `output_file` parameter to a custom filename — saved to that name
- [ ] Run the node in a workflow — output propagates downstream correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)