### PR TITLE
feat: expose 1080p and declare the omni reference task type for Seedance 2.5

### DIFF
--- a/griptape_nodes_library/video/seedance_2_5_video_generation.py
+++ b/griptape_nodes_library/video/seedance_2_5_video_generation.py
@@ -50,7 +50,7 @@ MIN_DURATION = 4
 MAX_DURATION = 30
 SMART_DURATION = -1
 
-RESOLUTION_CHOICES = ["480p", "720p"]
+RESOLUTION_CHOICES = ["480p", "720p", "1080p"]
 OUTPUT_FORMAT_CHOICES = ["mp4", "mov"]
 DEFAULT_OUTPUT_FORMAT = "mp4"
 OUTPUT_FILENAME_BASE = "seedance_2_5_video"
@@ -74,10 +74,10 @@ SUPPORTS_PRIVATE_ASSETS = True
 class SeedanceTask(StrEnum):
     """The five task types Seedance 2.5 classifies a request into.
 
-    The provider infers the task from ``content.role`` plus the prompt's intent — there is no
-    ``task_type`` field — and applies per-task constraints to ``ratio`` and ``duration``. A
-    violation is reported asynchronously, after the task has queued, so this node makes the task
-    an explicit choice and validates its constraints before submitting.
+    The provider infers the task from ``content.role`` plus the prompt's intent, and applies
+    per-task constraints to ``ratio`` and ``duration``. This node makes the task an explicit
+    choice, validates its constraints before submitting, and declares the three reference
+    subtasks to the provider through ``omni_reference_task_type``.
     """
 
     TEXT_TO_VIDEO = "Text to Video"
@@ -85,6 +85,20 @@ class SeedanceTask(StrEnum):
     REFERENCE_TO_VIDEO = "Reference to Video"
     VIDEO_EDITING = "Video Editing"
     VIDEO_EXTENSION = "Video Extension"
+
+
+class OmniReferenceTaskType(StrEnum):
+    """The ``omni_reference_task_type`` values Seedance 2.5 accepts for omni reference tasks.
+
+    Declaring the subtask makes the provider validate that subtask's ratio/duration constraints
+    synchronously, when the task is submitted, instead of asynchronously after it has queued. The
+    provider's ``auto`` default is deliberately absent: omitting the field is equivalent to it,
+    and the node always knows which task the user selected.
+    """
+
+    REFERENCE = "reference"
+    EDIT = "edit"
+    EXTEND = "extend"
 
 
 @dataclass(frozen=True)
@@ -99,6 +113,8 @@ class TaskConstraints:
         duration_choices: The ``duration`` values the provider accepts for this task.
         trigger_keywords: Words the prompt must contain for the provider to classify the request
             as this task. Empty when the task needs no prompt trigger.
+        omni_reference_task_type: The subtask name to declare to the provider for this task, or
+            None for the tasks that are not omni reference tasks.
     """
 
     allows_frames: bool
@@ -107,6 +123,7 @@ class TaskConstraints:
     ratio_choices: tuple[str, ...]
     duration_choices: tuple[int, ...]
     trigger_keywords: tuple[str, ...]
+    omni_reference_task_type: str | None
 
 
 # Single source of truth for the per-task constraints, straight from the Seedance 2.5
@@ -119,6 +136,7 @@ TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
         ratio_choices=ALL_RATIO_CHOICES,
         duration_choices=ALL_DURATION_CHOICES,
         trigger_keywords=(),
+        omni_reference_task_type=None,
     ),
     SeedanceTask.FIRST_LAST_FRAME: TaskConstraints(
         allows_frames=True,
@@ -128,6 +146,8 @@ TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
         ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
         duration_choices=ALL_DURATION_CHOICES,
         trigger_keywords=(),
+        # Its own task type, declared through content.role rather than a reference subtask.
+        omni_reference_task_type=None,
     ),
     SeedanceTask.REFERENCE_TO_VIDEO: TaskConstraints(
         allows_frames=False,
@@ -136,6 +156,7 @@ TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
         ratio_choices=ALL_RATIO_CHOICES,
         duration_choices=ALL_DURATION_CHOICES,
         trigger_keywords=(),
+        omni_reference_task_type=OmniReferenceTaskType.REFERENCE,
     ),
     SeedanceTask.VIDEO_EDITING: TaskConstraints(
         allows_frames=False,
@@ -145,6 +166,7 @@ TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
         ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
         duration_choices=SMART_ONLY_DURATION_CHOICES,
         trigger_keywords=("edit", "add", "delete", "remove", "modify", "replace", "change"),
+        omni_reference_task_type=OmniReferenceTaskType.EDIT,
     ),
     SeedanceTask.VIDEO_EXTENSION: TaskConstraints(
         allows_frames=False,
@@ -154,6 +176,7 @@ TASK_CONSTRAINTS: dict[SeedanceTask, TaskConstraints] = {
         ratio_choices=ADAPTIVE_ONLY_RATIO_CHOICES,
         duration_choices=ALL_DURATION_CHOICES,
         trigger_keywords=("extend", "continue"),
+        omni_reference_task_type=OmniReferenceTaskType.EXTEND,
     ),
 }
 
@@ -162,9 +185,9 @@ PROMPT_TIPS_MESSAGE = (
     "follow the order of the reference lists below.\n\n"
     "Audio cues use special characters: () for music, <> for sound effects, {} for dialogue, "
     "and 【】 for subtitles.\n\n"
-    "Video Editing and Video Extension are classified from the prompt, so the prompt must name "
-    "what you want done — e.g. 'Remove everyone in @Video 1 except the protagonist' or "
-    "'Extend @Video 1 backward'."
+    "The provider checks the prompt against the selected task, so for Video Editing and Video "
+    "Extension the prompt must name what you want done — e.g. 'Remove everyone in @Video 1 "
+    "except the protagonist' or 'Extend @Video 1 backward'."
 )
 
 REFERENCE_VIDEO_UPLOAD_MESSAGE = (
@@ -193,8 +216,10 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
     Seedance 2.5 classifies each request into one of five task types from the media roles and the
     prompt's intent, and locks `ratio`/`duration` per task. The `task` parameter makes that choice
     explicit so the node can show the right inputs, narrow the settings to the values the provider
-    accepts, and reject a mismatched request before it is queued (the provider only reports task
-    constraint violations asynchronously, after the task starts processing).
+    accepts, and reject a mismatched request before it is queued. For the three reference subtasks
+    the node also declares the task via `omni_reference_task_type`, which moves the provider's own
+    constraint checks to submission time; a prompt that contradicts the declared task is still
+    only reported asynchronously, after the task starts processing.
 
     Tasks:
     - Text to Video: prompt only
@@ -206,7 +231,7 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
     Inputs:
         - prompt (str): Text prompt for the video
         - task (str): One of the five Seedance 2.5 task types (default: Text to Video)
-        - resolution (str): Output resolution (default: 720p, options: 480p, 720p)
+        - resolution (str): Output resolution (default: 720p, options: 480p, 720p, 1080p)
         - ratio (str): Output aspect ratio (default: adaptive)
         - duration (int): Video duration in seconds (4-30, or -1 to let the model choose)
         - generate_audio (bool): Generate audio with video (default: False)
@@ -350,7 +375,11 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
             ParameterString(
                 name="resolution",
                 default_value="720p",
-                tooltip="Output resolution (480p or 720p)",
+                tooltip=(
+                    "Output resolution: 480p, 720p, or 1080p. 1080p output uses 10-bit color depth and "
+                    "H.265/HEVC encoding, which some players cannot open — try VLC or mpv if the video "
+                    "will not play."
+                ),
                 allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
                 traits={Options(choices=list(RESOLUTION_CHOICES))},
             )
@@ -645,6 +674,7 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
         self._validate_media_matches_task(params, task, constraints)
         self._validate_reference_counts(params)
         self._validate_trigger_keywords(params, task, constraints)
+        self._validate_resolution(params)
         self._validate_ratio_and_duration(params, task, constraints)
 
         # Private-asset references require Griptape auth (not BYOK). Gate first so the user gets a
@@ -687,6 +717,15 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
             )
             raise ValueError(msg)
 
+        # The provider defines a reference task as content carrying at least one reference asset. With
+        # none, the request is a text-to-video that contradicts the declared task type.
+        if constraints.omni_reference_task_type == OmniReferenceTaskType.REFERENCE and not has_references:
+            msg = (
+                f"{self.name}: the {task} task requires at least one reference image, video, or audio "
+                f"input. Connect a reference, or switch the task to {SeedanceTask.TEXT_TO_VIDEO.value}."
+            )
+            raise ValueError(msg)
+
     def _validate_reference_counts(self, params: dict[str, Any]) -> None:
         """Raise if any reference list exceeds the provider's cap for that kind.
 
@@ -707,8 +746,9 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
     def _validate_trigger_keywords(self, params: dict[str, Any], task: str, constraints: TaskConstraints) -> None:
         """Raise if the prompt lacks a keyword the provider needs to classify this task.
 
-        Seedance 2.5 derives Video Editing and Video Extension from the prompt's intent, so a
-        prompt with no such wording is classified as a different task and rejected asynchronously.
+        Declaring the task through ``omni_reference_task_type`` does not remove this check: the
+        provider still derives the task from the prompt's intent while processing, and fails the
+        task asynchronously if its own reading disagrees with what the node declared.
         """
         if not constraints.trigger_keywords:
             return
@@ -723,6 +763,18 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
             f"reference video. Include at least one of: {keywords}."
         )
         raise ValueError(msg)
+
+    def _validate_resolution(self, params: dict[str, Any]) -> None:
+        """Raise if resolution is outside what the provider accepts.
+
+        The dropdown is already restricted to the supported values, but the value can arrive over a
+        connection. Resolution is task-independent for Seedance 2.5 — every task supports all three.
+        """
+        resolution = params.get("resolution")
+        if resolution not in RESOLUTION_CHOICES:
+            accepted = ", ".join(RESOLUTION_CHOICES)
+            msg = f"{self.name}: Seedance 2.5 supports resolution {accepted}, got {resolution!r}."
+            raise ValueError(msg)
 
     def _validate_ratio_and_duration(self, params: dict[str, Any], task: str, constraints: TaskConstraints) -> None:
         """Raise if ratio or duration is outside what the provider accepts for this task.
@@ -833,6 +885,12 @@ class Seedance25VideoGeneration(SeedanceProxyNode):
             payload["watermark"] = bool(params["watermark"])
         if params["return_last_frame"] is not None:
             payload["return_last_frame"] = bool(params["return_last_frame"])
+
+        # Declaring the reference subtask makes the provider check that subtask's ratio/duration
+        # constraints at submission instead of after the task queues, and stops it reclassifying a
+        # reference request as an edit or extension because of incidental prompt wording.
+        if omni_task_type := _get_task_constraints(params["task"]).omni_reference_task_type:
+            payload["omni_reference_task_type"] = omni_task_type
 
         content_list: list[dict[str, Any]] = [{"type": "text", "text": params["prompt"].strip()}]
         await self._add_media_inputs_async(content_list, params)

--- a/tests/integration/SEEDANCE_TESTING.md
+++ b/tests/integration/SEEDANCE_TESTING.md
@@ -127,9 +127,10 @@ python tests/integration/test_seedance_2_5_first_frame.py --storage-backend gtc
 - ✓ Text to Video task
 - ✓ First/Last Frame task, `ratio` locked to adaptive
 - ✓ `mov` output format (2.5 only)
-- ✓ 480p/720p resolution (no 1080p/4k)
+- ✓ 480p/720p/1080p resolution (no 4k)
 - ✓ Duration 4-30 seconds
 - ✓ Smart duration (-1)
+- ✓ `omni_reference_task_type` declared for the three reference subtasks
 
 ### Feature Validation
 - ✓ Parameter visibility based on model selection

--- a/tests/integration/test_seedance_2_5.py
+++ b/tests/integration/test_seedance_2_5.py
@@ -35,6 +35,10 @@ GriptapeNodes.handle_request(
     RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
 )
 
+# The graph is built at import time, so the tier is set here rather than from an argument. Change it
+# to "1080p" to exercise that tier, which the provider encodes as 10-bit H.265/HEVC.
+RESOLUTION = "720p"
+
 context_manager = GriptapeNodes.ContextManager()
 if not context_manager.has_current_workflow():
     context_manager.push_workflow(file_path=__file__)
@@ -122,6 +126,7 @@ with GriptapeNodes.ContextManager().flow(flow_name):
     with GriptapeNodes.ContextManager().node(gen_node):
         GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="task", value="Text to Video"))
         GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="duration", value=4))
+        GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="resolution", value=RESOLUTION))
 
     GriptapeNodes.handle_request(
         CreateConnectionRequest(

--- a/tests/unit/video/test_seedance_2_5_video_generation.py
+++ b/tests/unit/video/test_seedance_2_5_video_generation.py
@@ -24,8 +24,11 @@ from griptape_nodes_library.video.seedance_2_5_video_generation import (
     MAX_REFERENCE_IMAGES,
     MAX_REFERENCE_VIDEOS,
     MAX_TOTAL_REFERENCE_ASSETS,
+    RESOLUTION_CHOICES,
     SEEDANCE_2_5_MODEL_ID,
     SMART_DURATION,
+    TASK_CONSTRAINTS,
+    OmniReferenceTaskType,
     Seedance25VideoGeneration,
     SeedanceTask,
 )
@@ -199,6 +202,26 @@ def test_switching_task_coerces_out_of_range_ratio_and_duration() -> None:
     assert node.get_parameter_value("duration") == SMART_DURATION
 
 
+# --- Resolution ------------------------------------------------------------------------------
+
+
+def test_resolution_dropdown_offers_every_supported_tier() -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    assert _option_choices(node, "resolution") == ["480p", "720p", "1080p"]
+
+
+@pytest.mark.parametrize("task", list(SeedanceTask))
+def test_resolution_choices_do_not_depend_on_the_task(task: SeedanceTask) -> None:
+    # Unlike ratio and duration, the provider documents resolution with no per-task constraint, so
+    # switching tasks must never narrow the tiers or coerce the selected one.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("resolution", "1080p")
+    node.set_parameter_value("task", task)
+
+    assert _option_choices(node, "resolution") == RESOLUTION_CHOICES
+    assert node.get_parameter_value("resolution") == "1080p"
+
+
 # --- Validation: media matches task ----------------------------------------------------------
 
 
@@ -247,6 +270,17 @@ def test_audio_only_reference_input_is_accepted() -> None:
     _set_parameter_list_values(node, "reference_audio", ["data:audio/wav;base64,AAA"])
 
     node._validate_parameters(node._get_parameters())
+
+
+def test_reference_to_video_requires_at_least_one_reference() -> None:
+    # The provider defines a reference task by the presence of a reference asset, so with none the
+    # request would contradict the task the node declares.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", SeedanceTask.REFERENCE_TO_VIDEO)
+    node.set_parameter_value("prompt", "A quiet street at dusk")
+
+    with pytest.raises(ValueError, match="requires at least one reference image, video, or audio"):
+        node._validate_parameters(node._get_parameters())
 
 
 # --- Validation: trigger keywords ------------------------------------------------------------
@@ -373,6 +407,28 @@ def test_unknown_task_is_reported() -> None:
         node._validate_parameters(params)
 
 
+# --- Validation: resolution ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("resolution", ["4k", "1080P", "720", "", None])
+def test_unsupported_resolution_arriving_over_a_connection_is_rejected(resolution: str | None) -> None:
+    # The dropdown only offers supported tiers, but a connected value bypasses the dropdown.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    params = node._get_parameters()
+    params["resolution"] = resolution
+
+    with pytest.raises(ValueError, match="supports resolution 480p, 720p, 1080p"):
+        node._validate_parameters(params)
+
+
+@pytest.mark.parametrize("resolution", RESOLUTION_CHOICES)
+def test_every_offered_resolution_passes_validation(resolution: str) -> None:
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("resolution", resolution)
+
+    node._validate_parameters(node._get_parameters())
+
+
 # --- Payload ---------------------------------------------------------------------------------
 
 
@@ -401,6 +457,18 @@ async def test_text_to_video_payload_carries_all_settings() -> None:
         "return_last_frame": True,
         "content": [{"type": "text", "text": "A fox runs through a forest"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_1080p_reaches_the_payload_verbatim() -> None:
+    # The tier drives the provider's encoding and our billing rate, so it must pass through as-is.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("prompt", "A fox runs through a forest")
+    node.set_parameter_value("resolution", "1080p")
+
+    payload = await node._build_payload()
+
+    assert payload["resolution"] == "1080p"
 
 
 @pytest.mark.asyncio
@@ -537,6 +605,49 @@ async def test_build_payload_registers_private_asset_references(monkeypatch: pyt
         "image_url": {"url": "asset://generated-asset-id"},
         "role": "reference_image",
     }
+
+
+# --- Omni reference task type ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task", "prompt", "expected"),
+    [
+        (SeedanceTask.REFERENCE_TO_VIDEO, "A street at dusk, styled after @Image 1", "reference"),
+        (SeedanceTask.VIDEO_EDITING, "Remove the background music from @Video 1", "edit"),
+        (SeedanceTask.VIDEO_EXTENSION, "Extend @Video 1 backward", "extend"),
+    ],
+)
+async def test_reference_subtasks_are_declared_to_the_provider(task: SeedanceTask, prompt: str, expected: str) -> None:
+    # Declaring the subtask is what moves the provider's ratio/duration checks to submission time.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    node.set_parameter_value("prompt", prompt)
+    _set_parameter_list_values(node, "reference_videos", [VideoUrlArtifact("https://public.example/reference.mp4")])
+
+    payload = await node._build_payload()
+
+    assert payload["omni_reference_task_type"] == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task", [SeedanceTask.TEXT_TO_VIDEO, SeedanceTask.FIRST_LAST_FRAME])
+async def test_non_reference_tasks_omit_the_task_type(task: SeedanceTask) -> None:
+    # Neither is an omni reference task, and omitting the field is what the provider treats as auto.
+    node = Seedance25VideoGeneration(name="Seedance25")
+    node.set_parameter_value("task", task)
+    node.set_parameter_value("prompt", "A fox runs through a forest")
+
+    payload = await node._build_payload()
+
+    assert "omni_reference_task_type" not in payload
+
+
+def test_every_task_declares_a_value_the_provider_accepts() -> None:
+    accepted = {None, *OmniReferenceTaskType}
+    for task, constraints in TASK_CONSTRAINTS.items():
+        assert constraints.omni_reference_task_type in accepted, task
 
 
 # --- Private-asset gating --------------------------------------------------------------------


### PR DESCRIPTION
Closes #524
Closes https://github.com/griptape-ai/internal/issues/193

BytePlus has published two additions to the Dreamina Seedance 2.5 API that
`Seedance25VideoGeneration` was not using yet. This picks up both, since they touch the same
handful of methods in one file.

## 1. Expose the 1080p tier

`RESOLUTION_CHOICES` was `["480p", "720p"]`, so the tier was simply unreachable from the UI.
It is now `["480p", "720p", "1080p"]`, and the `resolution` tooltip carries the caveat the
vendor documents for that tier: 1080p output uses 10-bit color depth and H.265/HEVC encoding,
which some playback environments cannot open. Worth surfacing in the UI because the failure
looks like a corrupt file rather than a codec mismatch — VLC and mpv both play it.

**Why this stays a flat constant.** `resolution` is documented as a flat request parameter
with three values and a `720p` default; the per-task constraint tables restrict only `ratio`
and `duration`, never resolution. So there is no resolution dimension added to
`TASK_CONSTRAINTS`, and the 2.0 node's `SeedanceModelCapabilities` / `_supports_1080p`
machinery is deliberately not ported here — that exists because the 2.0 node hosts four model
variants with different ceilings. 2.5 is a single model. There is a parametrized test
asserting the choices are identical across all five tasks, as the regression guard for that
decision.

## 2. Declare `omni_reference_task_type`

The node has always modeled the five task types internally (`SeedanceTask` +
`TASK_CONSTRAINTS`), but had no way to *tell* the provider which one it meant — the API had no
such field. Now it does. A new `OmniReferenceTaskType` StrEnum and a
`TaskConstraints.omni_reference_task_type` field let `_build_payload` declare the subtask for
the three omni reference tasks (`reference` / `edit` / `extend`) and omit it for the other two.

Two things this buys:

- The provider validates that subtask's ratio/duration constraints **synchronously, at
  submission**, instead of asynchronously after the task has queued and the user has waited
  on it.
- It stops the provider reclassifying a Reference to Video request as an edit or extension
  because of incidental prompt wording. Today a reference request whose prompt happens to
  contain "add" or "change" can be re-derived as Video Editing, which then fails that task's
  `adaptive` / `-1` locks async.

The enum has three members, not four: omitting the field is equivalent to the provider's
`auto` default, and the node always knows which task the user selected, so `auto` would be
dead code. The docstring says so.

**The prompt trigger-keyword check stays** — that was the open question in #524. Declaring the
type moves *ratio* and *duration* violations to synchronous rejection, but the model still
re-derives the task from the prompt at processing time and raises an async
`InvalidParameter.TaskTypeMismatch` on disagreement, and the vendor's own configuration steps
for `edit` and `extend` still list required prompt keywords. `_validate_trigger_keywords` is
the only thing catching that before submission. What changed is the framing in its docstring,
not the check.

## 3. Two validation additions

**Reference to Video now requires at least one reference asset — behavior change, please look
at this one.** The provider *defines* a reference task as content carrying at least one asset
with role `reference_image`, `reference_video`, or `reference_audio`. The node let the task be
selected with all three lists empty, in which case it submitted a text-only request that the
provider classifies as text-to-video — a silently mislabeled task, and the one combination the
docs leave unspecified once `reference` is declared. A graph that selects Reference to Video
with nothing attached works today and will now fail locally, before any request is sent, with
a message naming Text to Video as the alternative. That is the intent: fail immediately and
say what to do, rather than quietly generate something other than the task that was picked.

**`_validate_resolution`, a connection backstop.** The node had no resolution validation at
all; the dropdown restricts the choices, but the value can arrive over an INPUT connection and
was forwarded verbatim. The 2.0 node has per-value backstops for exactly this. Resolution is
task-independent, so this is one flat membership check.

## Docstrings corrected

Four docstrings were made false by this change, not merely stale in tone — `SeedanceTask`
("there is no `task_type` field"), the class docstring ("the provider only reports task
constraint violations asynchronously"), `_validate_trigger_keywords`, and
`PROMPT_TIPS_MESSAGE`. All four now describe the behavior as it is.

## Testing

- `make check` clean — format, lint, pyright (0 errors), json.
- `make test/unit` → **766 passed, 11 skipped**. The 2.5 unit file goes 60 → 82 tests.
- `test_text_to_video_payload_carries_all_settings` asserts the entire payload dict and stayed
  green untouched, so it is already the regression guard that Text to Video omits the new key.
- Manual e2e against a local proxy: 1080p Text to Video generates and plays; a 720p run in the
  same session is unaffected; `omni_reference_task_type` reaches the provider.
- `tests/integration/test_seedance_2_5.py` gained a `RESOLUTION` module constant (the graph is
  built at import time, so the tier is set there rather than from a CLI flag) and sets
  `resolution` alongside `task` and `duration`. `SEEDANCE_TESTING.md`'s 2.5 coverage list is
  updated.
