### PR TITLE
fix(utils): resolve read paths relative to workspace

### DIFF
--- a/griptape_nodes_library/utils/macro_path_utils.py
+++ b/griptape_nodes_library/utils/macro_path_utils.py
@@ -38,6 +38,12 @@ def resolve_to_macro_path(path: str) -> MacroPathResult:
     exist on disk (e.g. a remote URL), returns the original path with is_external=True
     so the caller can prompt the user to copy it into the project.
     """
+    # A data URI is not a filesystem path, and URL detection requires "://" — which a
+    # "data:opaque" URI lacks — so it would otherwise fall through to the filesystem
+    # branch and be joined onto the workspace directory as a bogus base64 path.
+    if path.startswith("data:"):
+        return MacroPathResult(resolved_path=path, is_external=True)
+
     # Already a macro path (e.g. "{inputs}/image.png") — treat as in-project
     try:
         parsed = ParsedMacro(path)
@@ -46,7 +52,16 @@ def resolve_to_macro_path(path: str) -> MacroPathResult:
     except MacroSyntaxError:
         pass
 
-    resolved = Path(path).resolve()
+    # Use `File` so a relative path anchors to the workspace directory (matching
+    # read/write behavior elsewhere in the engine).
+    resolved_str = File(path).resolve()
+
+    # A URL that `File.resolve()` did not turn into a local path is external.
+    if "://" in resolved_str:
+        return MacroPathResult(resolved_path=path, is_external=True)
+
+    # Resolve through any symlinks before AttemptMapAbsolutePathToProjectRequest.
+    resolved = Path(resolved_str).resolve()
     if resolved.exists():
         result = GriptapeNodes.handle_request(AttemptMapAbsolutePathToProjectRequest(absolute_path=resolved))
         if isinstance(result, AttemptMapAbsolutePathToProjectResultSuccess) and result.mapped_path is not None:

--- a/tests/unit/utils/test_macro_path_utils.py
+++ b/tests/unit/utils/test_macro_path_utils.py
@@ -1,0 +1,165 @@
+"""Unit tests for resolve_to_macro_path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    AttemptMapAbsolutePathToProjectResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+import griptape_nodes_library.utils.macro_path_utils as macro_path_utils_module
+from griptape_nodes_library.utils.macro_path_utils import resolve_to_macro_path
+
+
+class TestResolveToMacroPath:
+    def test_macro_with_variables_returns_unchanged_without_filesystem_access(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _fail(_request: object) -> object:
+            msg = "handle_request should not be called for a macro-with-variables input"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(macro_path_utils_module.GriptapeNodes, "handle_request", staticmethod(_fail))
+
+        result = resolve_to_macro_path("{inputs}/image.png")
+
+        assert result.resolved_path == "{inputs}/image.png"
+        assert result.is_external is False
+
+    def test_data_uri_returns_unchanged_and_is_external(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        data_uri = "data:image/png;base64,AAAA"
+
+        def _fail_handle_request(_request: object) -> object:
+            msg = "handle_request should not be called for a data URI input"
+            raise AssertionError(msg)
+
+        def _fail_file_construction(*_args: object, **_kwargs: object) -> None:
+            msg = "File() should not be constructed for a data URI input"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(macro_path_utils_module.GriptapeNodes, "handle_request", staticmethod(_fail_handle_request))
+        monkeypatch.setattr(macro_path_utils_module, "File", _fail_file_construction)
+
+        result = resolve_to_macro_path(data_uri)
+
+        assert result.resolved_path == data_uri
+        assert result.is_external is True
+
+    def test_bare_relative_path_resolves_against_workspace_not_cwd(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        workspace_dir = tmp_path / "workspace"
+        cwd_dir = tmp_path / "cwd"
+        workspace_dir.mkdir()
+        cwd_dir.mkdir()
+
+        relative_file = workspace_dir / "relative" / "foo.png"
+        relative_file.parent.mkdir(parents=True)
+        relative_file.write_bytes(b"")
+
+        monkeypatch.chdir(cwd_dir)
+        config_manager = GriptapeNodes.ConfigManager()
+        monkeypatch.setattr(config_manager, "workspace_path", workspace_dir)
+
+        captured_requests: list[AttemptMapAbsolutePathToProjectRequest] = []
+
+        def fake_handle_request(request: AttemptMapAbsolutePathToProjectRequest) -> object:
+            captured_requests.append(request)
+            return AttemptMapAbsolutePathToProjectResultSuccess(mapped_path="{inputs}/foo.png", result_details="mapped")
+
+        monkeypatch.setattr(macro_path_utils_module.GriptapeNodes, "handle_request", staticmethod(fake_handle_request))
+
+        result = resolve_to_macro_path("relative/foo.png")
+
+        assert len(captured_requests) == 1
+        assert captured_requests[0].absolute_path == relative_file.resolve()
+        assert result.resolved_path == "{inputs}/foo.png"
+        assert result.is_external is False
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="symlink creation requires elevated privileges on Windows"
+    )
+    def test_absolute_path_through_symlinked_workspace_resolves_to_real_path(
+        self,
+        monkeypatch,
+        griptape_nodes: GriptapeNodes,
+        tmp_path: Path,
+    ) -> None:
+        """Regression: a symlinked workspace component must not make an in-project file external.
+
+        End-to-end against the real engine (no stubbed `handle_request`): the engine
+        compares against a symlink-resolved workspace path, so an unresolved symlink-spelled
+        path maps to nothing and the file wrongly reports as external.
+        """
+        real_workspace_dir = tmp_path / "real_workspace"
+        real_workspace_dir.mkdir()
+        symlinked_workspace_dir = tmp_path / "workspace_link"
+        symlinked_workspace_dir.symlink_to(real_workspace_dir, target_is_directory=True)
+
+        project_file = real_workspace_dir / "inputs" / "foo.png"
+        project_file.parent.mkdir(parents=True)
+        project_file.write_bytes(b"")
+
+        config_manager = GriptapeNodes.ConfigManager()
+        monkeypatch.setattr(config_manager, "workspace_path", symlinked_workspace_dir)
+
+        absolute_path_via_symlink = str(symlinked_workspace_dir / "inputs" / "foo.png")
+
+        result = resolve_to_macro_path(absolute_path_via_symlink)
+
+        assert result.resolved_path == "{inputs}/foo.png"
+        assert result.is_external is False
+
+    def test_nonexistent_path_returns_external(self, griptape_nodes: GriptapeNodes) -> None:
+        result = resolve_to_macro_path("/definitely/does/not/exist/on/disk.png")
+
+        assert result.is_external is True
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="creates a path component containing a colon, which Windows disallows in filenames",
+    )
+    def test_url_that_survives_file_resolve_is_not_anchored_to_cwd(
+        self, griptape_nodes: GriptapeNodes, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: a URL that `File.resolve()` returns unchanged (as engine versions with
+        static-server URL mapping do for a non-static-server URL, e.g. a remote `https://`
+        address) must never be anchored to the process cwd by `Path(...).resolve()`.
+        """
+        url = "https://example.com/a.mp4"
+
+        class _FakeFile:
+            def __init__(self, path: str) -> None:
+                self._path = path
+
+            def resolve(self) -> str:
+                return self._path
+
+        monkeypatch.setattr(macro_path_utils_module, "File", _FakeFile)
+        monkeypatch.chdir(tmp_path)
+
+        # If the URL were (incorrectly) anchored to the process cwd by `Path(...).resolve()`,
+        # it would resolve to this on-disk path. Create it so the buggy code path would find
+        # "the file exists" and proceed to call `handle_request` -- which must never happen
+        # for a URL.
+        cwd_anchored_path = Path(url).resolve()
+        cwd_anchored_path.parent.mkdir(parents=True, exist_ok=True)
+        cwd_anchored_path.write_bytes(b"")
+
+        def _fail_handle_request(_request: object) -> object:
+            msg = "handle_request should not be called for a URL that survives File.resolve()"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr(macro_path_utils_module.GriptapeNodes, "handle_request", staticmethod(_fail_handle_request))
+
+        result = resolve_to_macro_path(url)
+
+        assert result.resolved_path == url
+        assert result.is_external is True


### PR DESCRIPTION
Part of griptape-ai/griptape-nodes-engine#5318.

Most, if not all, input file path parameters in nodes make use of the `resolve_to_macro_path()` utility to post-process the path.  When a non-macro relative path was given it was blindly handed to `Path.resolve()`, which would anchor the relative path on whatever the current working directory of the engine happened to be.

So use the engine's `File` utility to resolve non-macro paths in `resolve_to_macro_path()`, so that relative paths are anchored to the workspace directory instead. This matches the convention across Griptape Nodes.