### PR TITLE
feat: add TopazVideoUpscale node

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -749,6 +749,18 @@
                 "family": "Topaz",
                 "provider_model_id": "topaz-tool",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "gtc_topaz_video_slp_2_5": {
+                "display_name": "Topaz Starlight Precise 2.5",
+                "family": "Topaz",
+                "provider_model_id": "topaz-video-slp-2.5",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "gtc_topaz_video_slp_2_6": {
+                "display_name": "Topaz Starlight Precise 2.6",
+                "family": "Topaz",
+                "provider_model_id": "topaz-video-slp-2.6",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               }
             }
           },
@@ -2887,6 +2899,34 @@
             "model_ids": [
               "gtc_ltx_2_pro",
               "gtc_ltx_2_3_pro"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "class_name": "TopazVideoUpscale",
+      "file_path": "griptape_nodes_library/video/topaz_video_upscale.py",
+      "metadata": {
+        "category": "video",
+        "description": "Upscale a video using Topaz Starlight Precise generative upscaling via the Griptape model proxy. Billed per frame.",
+        "display_name": "Topaz Video Upscale",
+        "icon": "Sparkles",
+        "group": "edit",
+        "tags": [
+          "video",
+          "upscale",
+          "enhance",
+          "ai",
+          "api",
+          "topaz"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_topaz_video_slp_2_5",
+              "gtc_topaz_video_slp_2_6"
             ]
           }
         ]

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -145,6 +145,7 @@ _NODE_PROVIDER_CONFIGS = {
     "SeedreamImageGeneration": SEED,
     "SoraVideoGeneration": OPENAI,
     "TopazImageEnhance": TOPAZ,
+    "TopazVideoUpscale": TOPAZ,
     "TranscribeAudio": OPENAI,
     "TripoImageTo3DGeneration": TRIPO,
     "TripoMultiviewTo3DGeneration": TRIPO,

--- a/griptape_nodes_library/video/topaz_video_upscale.py
+++ b/griptape_nodes_library/video/topaz_video_upscale.py
@@ -1,0 +1,554 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from enum import StrEnum
+from typing import Any
+
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.files.file import File, FileLoadError
+from griptape_nodes.traits.options import Options
+from griptape_nodes.traits.slider import Slider
+
+from griptape_nodes_library.media import coerce_media_url_or_data_uri
+from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.utils.ffmpeg_utils import VideoMetadata, extract_video_metadata_structured
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["TopazVideoUpscale"]
+
+MODEL_MAPPING = {
+    "Starlight Precise 2.6": "topaz-video-slp-2.6",
+    "Starlight Precise 2.5": "topaz-video-slp-2.5",
+}
+
+DEFAULT_MODEL = "Starlight Precise 2.6"
+
+# Topaz caps a Starlight job at 9000 frames. The proxy clamps the *billed* volume to
+# match, so exceeding it does not overcharge -- but Topaz still rejects the job, and
+# failing here is cheaper than discovering it after the upload.
+MAX_STARLIGHT_FRAMES = 9000
+
+# Starlight has two rate tiers, chosen by output pixel *area*, not height. A portrait
+# 1080x1920 output bills as 1080p; 1921x1080 already bills as 4K.
+# https://developer.topazlabs.com/getting-started/model-pricing
+STARLIGHT_1080P_MAX_PIXELS = 1920 * 1080
+
+# Topaz's documented hard output ceiling for Starlight (distinct from the 1080p/4K
+# billing-tier boundary above): https://docs.topazlabs.com/video-ai/project-starlight
+STARLIGHT_MAX_OUTPUT_PIXELS = 3840 * 2160
+
+COST_BADGE_MESSAGE = (
+    "Starlight is metered **per frame**, not per second, and costs far more than "
+    "Topaz's non-generative video models.\n\n"
+    "Two rate tiers, picked by output pixel area:\n"
+    "- **1080p** (up to 1920x1080) — the cheaper tier\n"
+    "- **4K** (anything larger) — roughly **2.2x** the 1080p rate\n\n"
+    "A 10-second 30fps clip is 300 frames whichever tier it lands in.\n\n"
+    "[Topaz model pricing](https://developer.topazlabs.com/getting-started/model-pricing)"
+)
+
+
+class ResizeMode(StrEnum):
+    """How the output resolution is derived from the source."""
+
+    WIDTH = "width"
+    HEIGHT = "height"
+    WIDTH_HEIGHT = "width and height"
+    PERCENTAGE = "percentage"
+
+
+class TopazVideoUpscale(GriptapeProxyNode):
+    """Upscale a video with Topaz Starlight Precise via the Griptape Cloud model proxy.
+
+    Inputs:
+        - video (VideoUrlArtifact): source video to upscale (sent as a base64 data URI)
+
+    Outputs:
+        - video_output (VideoUrlArtifact): the upscaled video, saved to project storage
+        - generation_id (str): Griptape Cloud generation id
+        - provider_response (dict): the provider's result payload
+        - was_successful (bool) / result_details (str): execution status
+    """
+
+    SERVICE_NAME = "Griptape"
+    API_KEY_NAME = "GT_CLOUD_API_KEY"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "video"
+        self.description = (
+            "Upscale a video using Topaz Starlight Precise via the Griptape model proxy. "
+            "Billed per frame -- see the cost note on the model parameter."
+        )
+
+        # INPUTS / PROPERTIES
+
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Starlight Precise model to upscale with",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            traits={Options(choices=list(MODEL_MAPPING.keys()))},
+        )
+        model_param.set_badge(
+            variant="warning",
+            title="Billed per frame",
+            message=COST_BADGE_MESSAGE,
+        )
+        self.add_parameter(model_param)
+
+        # Topaz downloads the source itself rather than receiving it in the request
+        # body -- a video is far too large to base64 into JSON. This uploads the
+        # input to Griptape Cloud storage and hands back a public URL, which
+        # `_build_payload` passes through as `source.external`. An input that is
+        # already a public http(s) URL is passed through without re-uploading.
+        self._public_video_url_parameter = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
+                name="video",
+                tooltip="Source video to upscale",
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+                ui_options={"display_name": "input video"},
+            ),
+            disclaimer_message="Topaz Labs fetches the video from this URL to perform the upscale.",
+        )
+        self._public_video_url_parameter.add_input_parameters()
+
+        resize_mode_param = ParameterString(
+            name="resize_mode",
+            default_value=ResizeMode.PERCENTAGE,
+            tooltip="How to derive the output resolution from the source. Output size selects the billing tier.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            traits={Options(choices=[m.value for m in ResizeMode])},
+        )
+        self.add_parameter(resize_mode_param)
+
+        target_size_param = ParameterInt(
+            name="target_size",
+            default_value=1920,
+            tooltip="Target size in pixels for the width or height mode. The other dimension scales to preserve aspect ratio.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        target_size_param.add_trait(Slider(min_val=2, max_val=3840))
+        self.add_parameter(target_size_param)
+
+        target_width_param = ParameterInt(
+            name="target_width",
+            default_value=3840,
+            tooltip="Output width in pixels. Rounded down to an even number.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        target_width_param.add_trait(Slider(min_val=2, max_val=3840))
+        self.add_parameter(target_width_param)
+
+        target_height_param = ParameterInt(
+            name="target_height",
+            default_value=2160,
+            tooltip="Output height in pixels. Rounded down to an even number.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        target_height_param.add_trait(Slider(min_val=2, max_val=2160))
+        self.add_parameter(target_height_param)
+
+        percentage_param = ParameterInt(
+            name="percentage",
+            default_value=200,
+            tooltip="Upscale the source resolution by this percentage (e.g. 200 doubles it).",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+        )
+        percentage_param.add_trait(Slider(min_val=100, max_val=400))
+        self.add_parameter(percentage_param)
+
+        # OUTPUTS
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Response from API (latest polling response)",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="video_output",
+                tooltip="The upscaled video",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="topaz_video_upscale.mp4",
+        )
+        self._output_file.add_parameter()
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the upscale result or any errors",
+            result_details_placeholder="Upscale status and details will appear here.",
+            parameter_group_initially_collapsed=True,
+        )
+
+        self.set_initial_node_size(height=400)
+        self._update_tier_badge()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def aprocess(self) -> None:
+        try:
+            await super().aprocess()
+        finally:
+            # Only once polling has finished: Topaz fetches the source from this
+            # URL when the job starts, so deleting it any earlier would pull the
+            # video out from under a queued job.
+            self._public_video_url_parameter.delete_uploaded_artifact()
+
+    # -- model routing -----------------------------------------------------
+
+    def _get_api_model_id(self) -> str:
+        model_name = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
+
+    # -- UI reactions ------------------------------------------------------
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        super().after_value_set(parameter, value)
+
+        if parameter.name == "resize_mode":
+            match value:
+                case ResizeMode.WIDTH | ResizeMode.HEIGHT:
+                    self.show_parameter_by_name("target_size")
+                    self.hide_parameter_by_name(["target_width", "target_height", "percentage"])
+                case ResizeMode.WIDTH_HEIGHT:
+                    self.hide_parameter_by_name(["target_size", "percentage"])
+                    self.show_parameter_by_name(["target_width", "target_height"])
+                case ResizeMode.PERCENTAGE:
+                    self.hide_parameter_by_name(["target_size", "target_width", "target_height"])
+                    self.show_parameter_by_name("percentage")
+                case _:
+                    msg = f"Unknown resize mode: {value!r}"
+                    raise ValueError(msg)
+
+        if parameter.name in ("resize_mode", "target_size", "target_width", "target_height", "percentage"):
+            self._update_tier_badge()
+
+    def _update_tier_badge(self) -> None:
+        """Show which billing tier the current settings land in.
+
+        For width-and-height and percentage modes the tier is exact -- it depends only
+        on numbers already on the node. For width/height-only modes it depends on the
+        source's aspect ratio, which is not known until the node runs, so say what to
+        watch out for instead of guessing.
+        """
+        param = self.get_parameter_by_name("resize_mode")
+        if param is None:
+            return
+
+        mode = self.get_parameter_value("resize_mode") or ResizeMode.PERCENTAGE
+
+        match mode:
+            case ResizeMode.WIDTH | ResizeMode.HEIGHT:
+                param.set_badge(
+                    variant="note",
+                    title="Billing tier depends on the source",
+                    message=(
+                        "The other dimension scales to preserve the source's aspect ratio, so the "
+                        "output pixel count -- and which billing tier it lands in -- isn't known "
+                        "until the node runs."
+                    ),
+                )
+            case ResizeMode.WIDTH_HEIGHT:
+                width = self.get_parameter_value("target_width") or 0
+                height = self.get_parameter_value("target_height") or 0
+                if width <= 0 or height <= 0:
+                    param.clear_badge()
+                    return
+
+                pixels = width * height
+                if pixels > STARLIGHT_MAX_OUTPUT_PIXELS:
+                    param.set_badge(
+                        variant="error",
+                        title="Exceeds Topaz's output limit",
+                        message=(
+                            f"{width}x{height} is {pixels:,} pixels, over Topaz's "
+                            f"{STARLIGHT_MAX_OUTPUT_PIXELS:,}-pixel (3840x2160) hard limit. The node "
+                            "will fail rather than submit this to Topaz."
+                        ),
+                    )
+                elif pixels > STARLIGHT_1080P_MAX_PIXELS:
+                    param.set_badge(
+                        variant="warning",
+                        title="4K billing tier",
+                        message=(
+                            f"{width}x{height} is {pixels:,} pixels, over the "
+                            f"{STARLIGHT_1080P_MAX_PIXELS:,}-pixel 1080p limit. This bills at the 4K "
+                            "per-frame rate, about 2.2x the 1080p rate."
+                        ),
+                    )
+                else:
+                    param.set_badge(
+                        variant="info",
+                        title="1080p billing tier",
+                        message=f"{width}x{height} is {pixels:,} pixels, within the cheaper 1080p tier.",
+                    )
+            case ResizeMode.PERCENTAGE:
+                percentage = self.get_parameter_value("percentage") or 200
+                multiplier = percentage / 100
+                threshold = math.isqrt(int(STARLIGHT_1080P_MAX_PIXELS // (multiplier * multiplier)))
+                param.set_badge(
+                    variant="note",
+                    title="Billing tier depends on the source",
+                    message=(
+                        f"At {percentage}%, any source larger than roughly {threshold}x{threshold} "
+                        f"produces a 4K-tier output (over {STARLIGHT_1080P_MAX_PIXELS:,} output pixels), "
+                        "at about 2.2x the 1080p rate."
+                    ),
+                )
+            case _:
+                msg = f"Unknown resize mode: {mode!r}"
+                raise ValueError(msg)
+
+    # -- source probing ----------------------------------------------------
+
+    def _probe_source(self, video_input: Any) -> VideoMetadata:
+        """Resolve the input to a local path and probe it with ffprobe.
+
+        Resolving through ``File`` first is what makes ``{inputs}/clip.mp4`` macro
+        paths work; handing the raw value to ffprobe silently fails for those.
+        """
+        video_url = coerce_media_url_or_data_uri(video_input, kind="video")
+        if not video_url:
+            msg = f"{self.name} could not resolve the input video."
+            raise ValueError(msg)
+
+        try:
+            resolved_path = File(video_url).resolve()
+        except FileLoadError as e:
+            msg = f"{self.name} could not resolve video path {video_url!r}: {e}"
+            raise ValueError(msg) from e
+
+        return extract_video_metadata_structured(str(resolved_path))
+
+    @staticmethod
+    def _frame_count(metadata: VideoMetadata) -> int:
+        """Derive the source frame count, which the proxy requires and never defaults.
+
+        ffprobe omits ``nb_frames`` for plenty of ordinary MP4s, so fall back to
+        duration x frame rate rather than letting the request 400 downstream.
+        """
+        nb_frames = metadata.frame_details.optional_nb_frames
+        if nb_frames and nb_frames > 0:
+            return nb_frames
+
+        duration = metadata.file_details.optional_duration
+        frame_rate = metadata.frame_details.frame_rate
+        if duration and duration > 0 and frame_rate > 0:
+            return math.ceil(duration * frame_rate)
+
+        return 0
+
+    @staticmethod
+    def _to_even(value: int) -> int:
+        """Round down to an even number -- odd dimensions break yuv420 encoding."""
+        return max(2, value - (value % 2))
+
+    def _output_resolution(self, source_width: int, source_height: int) -> tuple[int, int]:
+        mode = self.get_parameter_value("resize_mode") or ResizeMode.PERCENTAGE
+
+        match mode:
+            case ResizeMode.WIDTH:
+                target = self.get_parameter_value("target_size") or 0
+                if target <= 0:
+                    msg = f"{self.name} needs a positive target size when resize_mode is width (got {target})."
+                    raise ValueError(msg)
+                height = round(source_height * (target / source_width))
+                width, height = self._to_even(int(target)), self._to_even(height)
+            case ResizeMode.HEIGHT:
+                target = self.get_parameter_value("target_size") or 0
+                if target <= 0:
+                    msg = f"{self.name} needs a positive target size when resize_mode is height (got {target})."
+                    raise ValueError(msg)
+                width = round(source_width * (target / source_height))
+                width, height = self._to_even(width), self._to_even(int(target))
+            case ResizeMode.WIDTH_HEIGHT:
+                target_width = self.get_parameter_value("target_width") or 0
+                target_height = self.get_parameter_value("target_height") or 0
+                if target_width <= 0 or target_height <= 0:
+                    msg = (
+                        f"{self.name} needs a positive target width and height when resize_mode is "
+                        f"'width and height' (got {target_width}x{target_height})."
+                    )
+                    raise ValueError(msg)
+                width, height = self._to_even(int(target_width)), self._to_even(int(target_height))
+            case ResizeMode.PERCENTAGE:
+                pct = self.get_parameter_value("percentage") or 0
+                if pct <= 0:
+                    msg = f"{self.name} needs a positive percentage (got {pct})."
+                    raise ValueError(msg)
+                width = self._to_even(int(source_width * pct / 100))
+                height = self._to_even(int(source_height * pct / 100))
+            case _:
+                msg = f"Unknown resize mode: {mode!r}"
+                raise ValueError(msg)
+
+        if width * height > STARLIGHT_MAX_OUTPUT_PIXELS:
+            msg = (
+                f"{self.name}: computed output {width}x{height} exceeds Topaz's "
+                f"{STARLIGHT_MAX_OUTPUT_PIXELS:,}-pixel (3840x2160) hard limit."
+            )
+            raise ValueError(msg)
+
+        return width, height
+
+    # -- request -----------------------------------------------------------
+
+    async def _build_payload(self) -> dict[str, Any]:
+        video = self.get_parameter_value("video")
+        if not video:
+            msg = f"{self.name} requires an input video to upscale."
+            raise ValueError(msg)
+
+        # ffprobe is synchronous and can take a moment on a long clip; keep it off
+        # the event loop.
+        metadata = await asyncio.to_thread(self._probe_source, video)
+
+        source_width = metadata.dimensions.width
+        source_height = metadata.dimensions.height
+
+        frame_count = self._frame_count(metadata)
+        if frame_count <= 0:
+            msg = (
+                f"{self.name} could not determine the frame count of the input video. "
+                "Topaz requires it, and neither nb_frames nor duration x frame rate was "
+                "available from the file."
+            )
+            raise ValueError(msg)
+
+        if frame_count > MAX_STARLIGHT_FRAMES:
+            msg = (
+                f"{self.name}: the input video has {frame_count} frames, over Starlight's "
+                f"{MAX_STARLIGHT_FRAMES}-frame limit. Trim or split the video first."
+            )
+            raise ValueError(msg)
+
+        output_width, output_height = self._output_resolution(source_width, source_height)
+
+        # Upload after probing: the probe needs the original local path, and there
+        # is no point paying for an upload if the file turns out to be unusable.
+        video_url = self._public_video_url_parameter.get_public_url_for_parameter()
+        if not video_url:
+            msg = f"{self.name} could not produce a public URL for the input video."
+            raise ValueError(msg)
+
+        source: dict[str, Any] = {
+            "container": "mp4",
+            "frameCount": frame_count,
+            "frameRate": metadata.frame_details.frame_rate,
+            "resolution": {"width": source_width, "height": source_height},
+            # Topaz fetches the video from this URL itself. `provider` is required and
+            # must be one of r2/s3/web-url -- it labels the transport, not the host, so
+            # `web-url` is correct for the Azure Blob SAS URL the upload hands back.
+            "external": {"provider": "web-url", "presignedUrl": video_url},
+        }
+        if metadata.file_details.optional_duration:
+            source["duration"] = metadata.file_details.optional_duration
+        if metadata.file_details.optional_file_size:
+            source["size"] = metadata.file_details.optional_file_size
+
+        logger.info(
+            "%s upscaling %dx%d (%d frames) to %dx%d",
+            self.name,
+            source_width,
+            source_height,
+            frame_count,
+            output_width,
+            output_height,
+        )
+
+        # `filters` is deliberately omitted: the proxy synthesizes
+        # [{"model": <routed code>}] when it is absent, and sending our own only
+        # risks the "filters[].model must match the requested model" rejection --
+        # the code there is the id minus its "topaz-video-" prefix.
+        return {
+            "source": source,
+            "output": {"resolution": {"width": output_width, "height": output_height}},
+        }
+
+    # -- result ------------------------------------------------------------
+
+    async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
+        raw_bytes = result_json.get("raw_bytes")
+        if isinstance(raw_bytes, (bytes, bytearray)):
+            await self._handle_binary_video_response(bytes(raw_bytes))
+            return
+
+        # `download.url` is Topaz's documented shape for a completed generation.
+        await self._download_and_save(
+            result_json["download"]["url"],
+            "video_output",
+            lambda v, n: VideoUrlArtifact(value=v, name=n),
+            media_kind="video",
+            action="upscaled",
+        )
+
+    async def _handle_binary_video_response(self, video_bytes: bytes) -> None:
+        """Save video bytes served directly by the proxy rather than via a URL."""
+        if not video_bytes:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"{self.name}: the upscale completed but no video data was received.",
+            )
+            return
+
+        try:
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(video_bytes)
+        except (OSError, PermissionError) as e:
+            logger.error("%s failed to save the upscaled video: %s", self.name, e)
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"{self.name}: the upscale succeeded but saving the video failed: {e}",
+            )
+            return
+
+        self.parameter_output_values["video_output"] = VideoUrlArtifact(value=saved.location, name=saved.name)
+        self._set_status_results(
+            was_successful=True,
+            result_details=f"Upscale successful. Video saved as {saved.name}.",
+        )
+
+    def _handle_payload_build_error(self, e: Exception) -> None:
+        if isinstance(e, ValueError):
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details=str(e))
+            return
+
+        super()._handle_payload_build_error(e)
+
+    def _set_safe_defaults(self) -> None:
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["video_output"] = None

--- a/tests/integration/test_topaz_video_upscale.py
+++ b/tests/integration/test_topaz_video_upscale.py
@@ -1,0 +1,229 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_topaz_video_upscale"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "TopazVideoUpscale"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# is_internal = true
+# ///
+import asyncio
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    ltx_t2v_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    upscale_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="TopazVideoUpscale",
+            specific_library_name="Griptape Nodes Library",
+            node_name="TopazVideoUpscale",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(ltx_t2v_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_t2v_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    # Starlight is metered per frame and the 4K tier costs ~2.2x the 1080p one, so
+    # this run is deliberately the cheapest shape the graph can produce: LTX's
+    # smallest output (1920x1080, 25fps, 6s = 150 frames), upscaled to 1920x1080 so
+    # it stays under the 1080p pixel ceiling. A larger target here would be 4K-tier.
+    with GriptapeNodes.ContextManager().node(upscale_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="resize_mode",
+                node_name=upscale_node,
+                value="width and height",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="target_width",
+                node_name=upscale_node,
+                value=1920,
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="target_height",
+                node_name=upscale_node,
+                value=1080,
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_t2v_node,
+            source_parameter_name="video_url",
+            target_node_name=upscale_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=upscale_node,
+            source_parameter_name="output_file",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    workflow_output = execute_workflow(input={})
+    print(workflow_output)

--- a/tests/unit/video/test_topaz_video_upscale.py
+++ b/tests/unit/video/test_topaz_video_upscale.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes_library.utils.ffmpeg_utils import (
+    ColorDetails,
+    Dimensions,
+    FileDetails,
+    FrameDetails,
+    VideoMetadata,
+)
+from griptape_nodes_library.video.topaz_video_upscale import (
+    MAX_STARLIGHT_FRAMES,
+    MODEL_MAPPING,
+    STARLIGHT_1080P_MAX_PIXELS,
+    STARLIGHT_MAX_OUTPUT_PIXELS,
+    ResizeMode,
+    TopazVideoUpscale,
+)
+
+
+def _metadata(
+    *,
+    width: int = 960,
+    height: int = 540,
+    nb_frames: int | None = 300,
+    duration: float | None = 10.0,
+    frame_rate: float = 30.0,
+    file_size: int | None = 1234,
+) -> VideoMetadata:
+    return VideoMetadata(
+        file_details=FileDetails(
+            codec_name="h264",
+            codec_type="video",
+            optional_duration=duration,
+            optional_file_size=file_size,
+        ),
+        dimensions=Dimensions(
+            width=width,
+            height=height,
+            aspect_ratio_decimal=width / height,
+            aspect_ratio_string="16:9",
+        ),
+        color_details=ColorDetails(),
+        frame_details=FrameDetails(
+            r_frame_rate=f"{int(frame_rate)}/1",
+            avg_frame_rate=f"{int(frame_rate)}/1",
+            time_base="1/30000",
+            frame_rate=frame_rate,
+            optional_nb_frames=nb_frames,
+        ),
+    )
+
+
+def _node(name: str = "TopazVideoUpscale") -> TopazVideoUpscale:
+    return TopazVideoUpscale(name=name)
+
+
+def _stub_probe(monkeypatch: pytest.MonkeyPatch, metadata: VideoMetadata) -> None:
+    monkeypatch.setattr(
+        TopazVideoUpscale,
+        "_probe_source",
+        lambda self, video_input: metadata,  # noqa: ARG005
+    )
+
+
+PUBLIC_URL = "https://acct.blob.core.windows.net/bucket/clip.mp4?sig=abc"
+
+
+def _stub_public_url(node: TopazVideoUpscale, monkeypatch: pytest.MonkeyPatch, value: str | None = PUBLIC_URL) -> None:
+    """Stand in for the upload to Griptape Cloud storage.
+
+    The real call presigns a URL over the network; the node only cares that it
+    gets one back to hand to Topaz as `source.external`.
+    """
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: value,
+    )
+
+
+# -- output resolution -------------------------------------------------------
+
+
+def test_percentage_200_doubles_the_source() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+
+    assert node._output_resolution(960, 540) == (1920, 1080)
+
+
+def test_percentage_400_quadruples_the_source() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 400)
+
+    assert node._output_resolution(960, 540) == (3840, 2160)
+
+
+def test_width_and_height_uses_the_typed_dimensions() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("target_width", 2560)
+    node.set_parameter_value("target_height", 1440)
+
+    assert node._output_resolution(960, 540) == (2560, 1440)
+
+
+def test_width_only_preserves_aspect_ratio() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH)
+    node.set_parameter_value("target_size", 1920)
+
+    assert node._output_resolution(960, 540) == (1920, 1080)
+
+
+def test_height_only_preserves_aspect_ratio() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.HEIGHT)
+    node.set_parameter_value("target_size", 1080)
+
+    assert node._output_resolution(960, 540) == (1920, 1080)
+
+
+def test_odd_dimensions_are_rounded_down_to_even() -> None:
+    # Odd dimensions break yuv420 encoding, so they must never reach the provider.
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("target_width", 1921)
+    node.set_parameter_value("target_height", 1081)
+
+    assert node._output_resolution(960, 540) == (1920, 1080)
+
+
+def test_odd_source_still_yields_even_output() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+
+    width, height = node._output_resolution(961, 541)
+
+    assert width % 2 == 0
+    assert height % 2 == 0
+
+
+def test_output_exceeding_the_hard_cap_raises() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+
+    with pytest.raises(ValueError, match="hard limit"):
+        # Doubling an already-4K source vastly exceeds the 3840x2160 cap.
+        node._output_resolution(3840, 2160)
+
+
+def _force_values(node: TopazVideoUpscale, monkeypatch: pytest.MonkeyPatch, **values: object) -> None:
+    """Bypass the parameters' own validation to reach _output_resolution's guards.
+
+    `min_val=2` clamps a zero width and the `Options` trait rejects an off-list
+    mode, so `set_parameter_value` can never deliver either. The guards still
+    exist to keep a bad value from reaching Topaz; this is how they get exercised.
+    """
+    original = node.get_parameter_value
+    monkeypatch.setattr(
+        node,
+        "get_parameter_value",
+        lambda name, *a, **kw: values.get(name, original(name, *a, **kw)),
+    )
+
+
+def test_width_and_height_without_dimensions_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _force_values(node, monkeypatch, resize_mode=ResizeMode.WIDTH_HEIGHT, target_width=0)
+
+    with pytest.raises(ValueError, match="positive target width and height"):
+        node._output_resolution(960, 540)
+
+
+def test_unknown_resize_mode_raises_rather_than_defaulting(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The wildcard case must surface an unexpected value, not silently pick percentage.
+    node = _node()
+    _force_values(node, monkeypatch, resize_mode="8x")
+
+    with pytest.raises(ValueError, match="Unknown resize mode"):
+        node._output_resolution(960, 540)
+
+
+# -- frame count -------------------------------------------------------------
+
+
+def test_frame_count_prefers_nb_frames() -> None:
+    assert TopazVideoUpscale._frame_count(_metadata(nb_frames=297)) == 297
+
+
+def test_frame_count_falls_back_to_duration_times_rate() -> None:
+    # ffprobe omits nb_frames for plenty of ordinary MP4s, and the proxy requires
+    # frameCount with no default -- the fallback is what keeps those from 400ing.
+    metadata = _metadata(nb_frames=None, duration=10.0, frame_rate=29.97)
+
+    assert TopazVideoUpscale._frame_count(metadata) == 300  # ceil(299.7)
+
+
+def test_frame_count_is_zero_when_nothing_is_derivable() -> None:
+    metadata = _metadata(nb_frames=None, duration=None, frame_rate=0.0)
+
+    assert TopazVideoUpscale._frame_count(metadata) == 0
+
+
+# -- payload -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"] == {
+        "container": "mp4",
+        "frameCount": 300,
+        "frameRate": 30.0,
+        "resolution": {"width": 960, "height": 540},
+        "duration": 10.0,
+        "size": 1234,
+        "external": {"provider": "web-url", "presignedUrl": PUBLIC_URL},
+    }
+    assert payload["output"] == {"resolution": {"width": 1920, "height": 1080}}
+
+
+@pytest.mark.asyncio
+async def test_build_payload_sends_no_video_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The whole point of source.external: the video never travels in the body.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "video" not in payload
+
+
+@pytest.mark.asyncio
+async def test_build_payload_wraps_the_url_in_a_web_url_descriptor(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy rejects a bare string, and Topaz requires `provider` to be one of
+    # r2/s3/web-url. `web-url` is the honest label for an Azure Blob SAS URL.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["external"] == {"provider": "web-url", "presignedUrl": PUBLIC_URL}
+
+
+@pytest.mark.asyncio
+async def test_build_payload_omits_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy synthesizes filters from the routed model id. Sending our own only
+    # risks the "filters[].model must match the requested model" rejection.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "filters" not in payload
+
+
+@pytest.mark.asyncio
+async def test_build_payload_omits_absent_optional_source_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(duration=None, file_size=None))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "duration" not in payload["source"]
+    assert "size" not in payload["source"]
+    assert payload["source"]["frameCount"] == 300
+
+
+@pytest.mark.asyncio
+async def test_build_payload_requires_a_video() -> None:
+    node = _node()
+
+    with pytest.raises(ValueError, match="requires an input video"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_rejects_underivable_frame_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=None, duration=None, frame_rate=0.0))
+    _stub_public_url(node, monkeypatch)
+
+    with pytest.raises(ValueError, match="could not determine the frame count"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_rejects_clips_over_the_frame_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_STARLIGHT_FRAMES + 1))
+    _stub_public_url(node, monkeypatch)
+
+    with pytest.raises(ValueError, match="over Starlight's"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_rejected_input_is_never_uploaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Uploading costs a round trip and cloud storage, so the cheap local checks
+    # have to run first. A clip over the frame cap must be rejected before it is
+    # ever sent anywhere.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_STARLIGHT_FRAMES + 1))
+
+    calls: list[None] = []
+
+    def _record() -> str:
+        calls.append(None)
+        return PUBLIC_URL
+
+    monkeypatch.setattr(node._public_video_url_parameter, "get_public_url_for_parameter", _record)
+
+    with pytest.raises(ValueError, match="over Starlight's"):
+        await node._build_payload()
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_when_no_public_url_is_produced(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch, value=None)
+
+    with pytest.raises(ValueError, match="could not produce a public URL"):
+        await node._build_payload()
+
+
+# -- model routing -----------------------------------------------------------
+
+
+def test_model_id_is_the_full_prefixed_route() -> None:
+    # The URL id keeps the "topaz-video-" prefix and the version dot; only the
+    # body's filters[].model uses the bare code, which we do not send.
+    node = _node()
+    node.set_parameter_value("model", "Starlight Precise 2.5")
+
+    assert node._get_api_model_id() == "topaz-video-slp-2.5"
+
+
+def test_default_model_is_the_newer_starlight() -> None:
+    assert _node()._get_api_model_id() == "topaz-video-slp-2.6"
+
+
+def test_every_mapped_model_is_prefixed() -> None:
+    for model_id in MODEL_MAPPING.values():
+        assert model_id.startswith("topaz-video-")
+
+
+# -- result parsing -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_result_downloads_from_the_documented_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `download.url` is Topaz's documented shape for a completed generation.
+    node = _node()
+    captured: dict = {}
+
+    async def fake_download_and_save(self, download_url, *_args, **_kwargs) -> None:  # noqa: ARG001
+        captured["url"] = download_url
+
+    monkeypatch.setattr(TopazVideoUpscale, "_download_and_save", fake_download_and_save)
+
+    await node._parse_result(
+        {"status": "complete", "download": {"url": "https://topaz.example/out.mp4"}}, "gen-1"
+    )
+
+    assert captured["url"] == "https://topaz.example/out.mp4"
+
+
+# -- UI reactions ------------------------------------------------------------
+
+
+def test_resize_mode_reveals_the_matching_fields() -> None:
+    node = _node()
+    target_size = node.get_parameter_by_name("target_size")
+    target_width = node.get_parameter_by_name("target_width")
+    target_height = node.get_parameter_by_name("target_height")
+    percentage = node.get_parameter_by_name("percentage")
+    assert target_size is not None
+    assert target_width is not None
+    assert target_height is not None
+    assert percentage is not None
+
+    # Default mode is percentage.
+    assert target_size.ui_options.get("hide") is True
+    assert target_width.ui_options.get("hide") is True
+    assert target_height.ui_options.get("hide") is True
+    assert percentage.ui_options.get("hide") is not True
+
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH)
+    assert target_size.ui_options.get("hide") is not True
+    assert target_width.ui_options.get("hide") is True
+    assert target_height.ui_options.get("hide") is True
+    assert percentage.ui_options.get("hide") is True
+
+    node.set_parameter_value("resize_mode", ResizeMode.HEIGHT)
+    assert target_size.ui_options.get("hide") is not True
+    assert target_width.ui_options.get("hide") is True
+    assert target_height.ui_options.get("hide") is True
+    assert percentage.ui_options.get("hide") is True
+
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    assert target_size.ui_options.get("hide") is True
+    assert target_width.ui_options.get("hide") is not True
+    assert target_height.ui_options.get("hide") is not True
+    assert percentage.ui_options.get("hide") is True
+
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    assert target_size.ui_options.get("hide") is True
+    assert target_width.ui_options.get("hide") is True
+    assert target_height.ui_options.get("hide") is True
+    assert percentage.ui_options.get("hide") is not True
+
+
+def test_model_carries_a_cost_badge() -> None:
+    # Starlight is metered per frame; the issue asks for that to be visible.
+    badge = _node().get_parameter_by_name("model").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "warning"
+
+
+def test_width_and_height_near_4k_warns_about_the_expensive_tier() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("target_width", 3200)
+    node.set_parameter_value("target_height", 1800)
+
+    badge = node.get_parameter_by_name("resize_mode").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "warning"
+    assert "4K" in (badge.title or "")
+
+
+def test_width_and_height_1080p_reports_the_cheaper_tier() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("target_width", 1920)
+    node.set_parameter_value("target_height", 1080)
+
+    badge = node.get_parameter_by_name("resize_mode").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "info"
+
+
+def test_tier_boundary_is_pixel_area_not_height() -> None:
+    # 1080x1920 portrait is the same pixel count as 1920x1080, so it stays in the
+    # cheap tier; 1921x1080 crosses it.
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+
+    node.set_parameter_value("target_width", 1080)
+    node.set_parameter_value("target_height", 1920)
+    assert node.get_parameter_by_name("resize_mode").get_badge().variant == "info"
+
+    node.set_parameter_value("target_width", 1922)
+    assert 1922 * 1920 > STARLIGHT_1080P_MAX_PIXELS
+    assert node.get_parameter_by_name("resize_mode").get_badge().variant == "warning"
+
+
+def test_width_and_height_over_hard_cap_shows_error_badge(monkeypatch: pytest.MonkeyPatch) -> None:
+    # target_width/target_height are themselves capped at 3840/2160, so their product
+    # can never exceed STARLIGHT_MAX_OUTPUT_PIXELS through normal UI values -- force it
+    # to exercise the defensive badge branch anyway.
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    _force_values(node, monkeypatch, target_width=3840, target_height=3840)
+
+    assert 3840 * 3840 > STARLIGHT_MAX_OUTPUT_PIXELS
+    node._update_tier_badge()
+    badge = node.get_parameter_by_name("resize_mode").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "error"
+
+
+def test_width_only_shows_a_source_dependent_note_badge() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH)
+    node.set_parameter_value("target_size", 1920)
+
+    badge = node.get_parameter_by_name("resize_mode").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "note"
+
+
+def test_height_only_shows_a_source_dependent_note_badge() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.HEIGHT)
+    node.set_parameter_value("target_size", 1080)
+
+    badge = node.get_parameter_by_name("resize_mode").get_badge()
+
+    assert badge is not None
+    assert badge.variant == "note"

--- a/tests/unit/video/test_topaz_video_upscale.py
+++ b/tests/unit/video/test_topaz_video_upscale.py
@@ -388,9 +388,7 @@ async def test_parse_result_downloads_from_the_documented_shape(monkeypatch: pyt
 
     monkeypatch.setattr(TopazVideoUpscale, "_download_and_save", fake_download_and_save)
 
-    await node._parse_result(
-        {"status": "complete", "download": {"url": "https://topaz.example/out.mp4"}}, "gen-1"
-    )
+    await node._parse_result({"status": "complete", "download": {"url": "https://topaz.example/out.mp4"}}, "gen-1")
 
     assert captured["url"] == "https://topaz.example/out.mp4"
 
@@ -442,7 +440,9 @@ def test_resize_mode_reveals_the_matching_fields() -> None:
 
 def test_model_carries_a_cost_badge() -> None:
     # Starlight is metered per frame; the issue asks for that to be visible.
-    badge = _node().get_parameter_by_name("model").get_badge()
+    model_param = _node().get_parameter_by_name("model")
+    assert model_param is not None
+    badge = model_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "warning"
@@ -454,7 +454,9 @@ def test_width_and_height_near_4k_warns_about_the_expensive_tier() -> None:
     node.set_parameter_value("target_width", 3200)
     node.set_parameter_value("target_height", 1800)
 
-    badge = node.get_parameter_by_name("resize_mode").get_badge()
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "warning"
@@ -467,7 +469,9 @@ def test_width_and_height_1080p_reports_the_cheaper_tier() -> None:
     node.set_parameter_value("target_width", 1920)
     node.set_parameter_value("target_height", 1080)
 
-    badge = node.get_parameter_by_name("resize_mode").get_badge()
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "info"
@@ -478,14 +482,20 @@ def test_tier_boundary_is_pixel_area_not_height() -> None:
     # cheap tier; 1921x1080 crosses it.
     node = _node()
     node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
 
     node.set_parameter_value("target_width", 1080)
     node.set_parameter_value("target_height", 1920)
-    assert node.get_parameter_by_name("resize_mode").get_badge().variant == "info"
+    badge = resize_mode_param.get_badge()
+    assert badge is not None
+    assert badge.variant == "info"
 
     node.set_parameter_value("target_width", 1922)
     assert 1922 * 1920 > STARLIGHT_1080P_MAX_PIXELS
-    assert node.get_parameter_by_name("resize_mode").get_badge().variant == "warning"
+    badge = resize_mode_param.get_badge()
+    assert badge is not None
+    assert badge.variant == "warning"
 
 
 def test_width_and_height_over_hard_cap_shows_error_badge(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -498,7 +508,9 @@ def test_width_and_height_over_hard_cap_shows_error_badge(monkeypatch: pytest.Mo
 
     assert 3840 * 3840 > STARLIGHT_MAX_OUTPUT_PIXELS
     node._update_tier_badge()
-    badge = node.get_parameter_by_name("resize_mode").get_badge()
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "error"
@@ -509,7 +521,9 @@ def test_width_only_shows_a_source_dependent_note_badge() -> None:
     node.set_parameter_value("resize_mode", ResizeMode.WIDTH)
     node.set_parameter_value("target_size", 1920)
 
-    badge = node.get_parameter_by_name("resize_mode").get_badge()
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "note"
@@ -520,7 +534,9 @@ def test_height_only_shows_a_source_dependent_note_badge() -> None:
     node.set_parameter_value("resize_mode", ResizeMode.HEIGHT)
     node.set_parameter_value("target_size", 1080)
 
-    badge = node.get_parameter_by_name("resize_mode").get_badge()
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
 
     assert badge is not None
     assert badge.variant == "note"


### PR DESCRIPTION
## Summary

- Adds `TopazVideoUpscale`, a new node that upscales video with Topaz Starlight Precise via the Griptape Cloud model proxy.

Closes #538

## Changes

- New `TopazVideoUpscale` node (`griptape_nodes_library/video/topaz_video_upscale.py`) supporting Starlight Precise 2.5/2.6, with a `resize_mode` UI (width / height / width and height / percentage) mirroring `ResizeVideo`'s pattern.
- Live billing-tier badges (1080p vs. 4K) on the resolution parameters, plus a hard-cap guard at Topaz's documented 3840x2160 output ceiling so the node fails fast instead of submitting a job Topaz will reject.
- Result parsing reads the video URL from Topaz's documented `download.url` response shape.
- Registers the node in `griptape_nodes_library.json` (including the two Topaz Starlight model IDs) and wires it into `proxy_api_key_providers.py`.
- Unit tests (`tests/unit/video/test_topaz_video_upscale.py`) covering resize-mode math, badge behavior, payload building, and result parsing; an integration test (`tests/integration/test_topaz_video_upscale.py`) exercising the node end-to-end via a workflow graph.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run pytest tests/unit/video/test_topaz_video_upscale.py -q` — 35 passed
- [x] Ran a real Topaz upscale job end-to-end and confirmed the returned video downloads and plays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)