### PR TITLE
Add Topaz Astra 2 support to TopazVideoUpscale

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -761,6 +761,12 @@
                 "family": "Topaz",
                 "provider_model_id": "topaz-video-slp-2.6",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "gtc_topaz_video_ast_2": {
+                "display_name": "Topaz Astra 2",
+                "family": "Topaz",
+                "provider_model_id": "topaz-video-ast-2",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               }
             }
           },
@@ -2909,7 +2915,7 @@
       "file_path": "griptape_nodes_library/video/topaz_video_upscale.py",
       "metadata": {
         "category": "video",
-        "description": "Upscale a video using Topaz Starlight Precise generative upscaling via the Griptape model proxy. Billed per frame.",
+        "description": "Upscale a video using Topaz Starlight Precise or Astra 2 generative upscaling via the Griptape model proxy. Billed per frame.",
         "display_name": "Topaz Video Upscale",
         "icon": "Sparkles",
         "group": "edit",
@@ -2917,16 +2923,20 @@
           "video",
           "upscale",
           "enhance",
+          "generative",
           "ai",
           "api",
-          "topaz"
+          "topaz",
+          "starlight",
+          "astra"
         ],
         "declarations": [
           {
             "type": "model_usage",
             "model_ids": [
               "gtc_topaz_video_slp_2_5",
-              "gtc_topaz_video_slp_2_6"
+              "gtc_topaz_video_slp_2_6",
+              "gtc_topaz_video_ast_2"
             ]
           }
         ]

--- a/griptape_nodes_library/video/topaz_video_upscale.py
+++ b/griptape_nodes_library/video/topaz_video_upscale.py
@@ -13,6 +13,7 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 )
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
@@ -31,33 +32,122 @@ __all__ = ["TopazVideoUpscale"]
 MODEL_MAPPING = {
     "Starlight Precise 2.6": "topaz-video-slp-2.6",
     "Starlight Precise 2.5": "topaz-video-slp-2.5",
+    "Astra 2": "topaz-video-ast-2",
 }
 
 DEFAULT_MODEL = "Starlight Precise 2.6"
+
+
+class TopazVideoFamily(StrEnum):
+    """Which Topaz video model family a selection belongs to.
+
+    The frame cap, the creative controls and the 4K rate spread are all properties of
+    the family rather than of the individual version. The values are the display
+    spelling so they interpolate straight into badge and error prose.
+    """
+
+    STARLIGHT = "Starlight"
+    ASTRA = "Astra"
+
+
+# Kept as a second table rather than folded into MODEL_MAPPING: a flat
+# `display name -> api id` MODEL_MAPPING is the convention across every video node in
+# this library, and reshaping it here would cost more than it buys for three entries.
+# `test_every_model_has_a_registered_family` guards the two against drifting.
+MODEL_FAMILIES = {
+    "Starlight Precise 2.6": TopazVideoFamily.STARLIGHT,
+    "Starlight Precise 2.5": TopazVideoFamily.STARLIGHT,
+    "Astra 2": TopazVideoFamily.ASTRA,
+}
+
+# Astra's creative controls. These ride *inside* a `filters` entry rather than at the
+# top level of the payload. Starlight accepts none of them.
+ASTRA_FILTER_PARAMS = ("prompt", "creativity", "sharp", "realism")
 
 # Topaz caps a Starlight job at 9000 frames. The proxy clamps the *billed* volume to
 # match, so exceeding it does not overcharge -- but Topaz still rejects the job, and
 # failing here is cheaper than discovering it after the upload.
 MAX_STARLIGHT_FRAMES = 9000
 
-# Starlight has two rate tiers, chosen by output pixel *area*, not height. A portrait
-# 1080x1920 output bills as 1080p; 1921x1080 already bills as 4K.
+MAX_ASTRA_FRAMES = 9000
+# A prompt drops Astra's ceiling by 20x. As with Starlight the proxy only clamps what
+# it *bills*; the job still reaches Topaz, which rejects it.
+MAX_ASTRA_FRAMES_WITH_PROMPT = 450
+
+# Both families bill in two rate tiers, chosen by output pixel *area*, not height. A
+# portrait 1080x1920 output bills as 1080p; 1921x1080 already bills as 4K.
 # https://developer.topazlabs.com/getting-started/model-pricing
-STARLIGHT_1080P_MAX_PIXELS = 1920 * 1080
+TIER_1080P_MAX_PIXELS = 1920 * 1080
 
 # Topaz's documented hard output ceiling for Starlight (distinct from the 1080p/4K
 # billing-tier boundary above): https://docs.topazlabs.com/video-ai/project-starlight
 STARLIGHT_MAX_OUTPUT_PIXELS = 3840 * 2160
 
-COST_BADGE_MESSAGE = (
-    "Starlight is metered **per frame**, not per second, and costs far more than "
+# What the 4K tier costs relative to the 1080p tier, as UI prose.
+RATE_SPREADS = {
+    TopazVideoFamily.STARLIGHT: "2.2x",
+    TopazVideoFamily.ASTRA: "1.67x",
+}
+
+# How the two families compare *to each other* per frame, at the same tier. Griptape
+# Cloud bills Astra 13,000 credits/frame at 1080p against Starlight's 4,992, and 21,667
+# against 10,908 at 4K -- so Astra is the pricier model by 2.6x and 2.0x respectively.
+# (griptape-cloud credits migrations 0087 and 0088.)
+#
+# This is spelled out in the badge because the RATE_SPREADS above are *within* a family
+# and invite exactly the wrong read on their own: Astra's 1.67x is the smaller number
+# but the more expensive model.
+ASTRA_VS_STARLIGHT_1080P = "2.6x"
+ASTRA_VS_STARLIGHT_4K = "2x"
+
+# Topaz publishes a hard output ceiling for Starlight and none for Astra, and the proxy
+# enforces neither -- so Astra maps to None rather than to an invented limit that would
+# reject jobs Topaz may well accept.
+MAX_OUTPUT_PIXELS: dict[TopazVideoFamily, int | None] = {
+    TopazVideoFamily.STARLIGHT: STARLIGHT_MAX_OUTPUT_PIXELS,
+    TopazVideoFamily.ASTRA: None,
+}
+
+_COST_BADGE_TEMPLATE = (
+    "{family} is metered **per frame**, not per second, and costs far more than "
     "Topaz's non-generative video models.\n\n"
     "Two rate tiers, picked by output pixel area:\n"
     "- **1080p** (up to 1920x1080) — the cheaper tier\n"
-    "- **4K** (anything larger) — roughly **2.2x** the 1080p rate\n\n"
-    "A 10-second 30fps clip is 300 frames whichever tier it lands in.\n\n"
+    "- **4K** (anything larger) — roughly **{spread}** the 1080p rate\n\n"
+    "{cross_model}\n\n"
+    "A 10-second 30fps clip is 300 frames whichever tier it lands in.{extra}\n\n"
     "[Topaz model pricing](https://developer.topazlabs.com/getting-started/model-pricing)"
 )
+
+COST_BADGE_MESSAGES = {
+    TopazVideoFamily.STARLIGHT: _COST_BADGE_TEMPLATE.format(
+        family=TopazVideoFamily.STARLIGHT,
+        spread=RATE_SPREADS[TopazVideoFamily.STARLIGHT],
+        cross_model=(
+            f"Starlight is the cheaper of the two models here: Astra 2 costs about "
+            f"**{ASTRA_VS_STARLIGHT_1080P}** as much per frame at 1080p, and about "
+            f"**{ASTRA_VS_STARLIGHT_4K}** as much at 4K."
+        ),
+        extra="",
+    ),
+    TopazVideoFamily.ASTRA: _COST_BADGE_TEMPLATE.format(
+        family=TopazVideoFamily.ASTRA,
+        spread=RATE_SPREADS[TopazVideoFamily.ASTRA],
+        # The second sentence is doing real work: the 1.67x above is smaller than
+        # Starlight's 2.2x, so quoting it alone reads as "Astra is cheaper" when Astra
+        # is in fact the pricier model on both tiers.
+        cross_model=(
+            f"Astra costs about **{ASTRA_VS_STARLIGHT_1080P} Starlight** per frame at 1080p, and "
+            f"about **{ASTRA_VS_STARLIGHT_4K} Starlight** at 4K. The "
+            f"{RATE_SPREADS[TopazVideoFamily.ASTRA]} above is Astra's own 4K premium, not a "
+            "comparison with Starlight."
+        ),
+        extra=(
+            f"\n\nTopaz caps an Astra job at {MAX_ASTRA_FRAMES:,} frames — or "
+            f"**{MAX_ASTRA_FRAMES_WITH_PROMPT}** once a prompt is set."
+        ),
+    ),
+}
 
 
 class ResizeMode(StrEnum):
@@ -70,7 +160,11 @@ class ResizeMode(StrEnum):
 
 
 class TopazVideoUpscale(GriptapeProxyNode):
-    """Upscale a video with Topaz Starlight Precise via the Griptape Cloud model proxy.
+    """Upscale a video with Topaz Starlight Precise or Astra 2 via the Griptape Cloud model proxy.
+
+    Both families share the source probing, the resize modes and the per-frame billing
+    tiers. Astra additionally accepts four creative controls (prompt, creativity, sharp,
+    realism), which are shown only while an Astra model is selected.
 
     Inputs:
         - video (VideoUrlArtifact): source video to upscale (sent as a base64 data URI)
@@ -89,8 +183,8 @@ class TopazVideoUpscale(GriptapeProxyNode):
         super().__init__(**kwargs)
         self.category = "video"
         self.description = (
-            "Upscale a video using Topaz Starlight Precise via the Griptape model proxy. "
-            "Billed per frame -- see the cost note on the model parameter."
+            "Upscale a video using Topaz Starlight Precise or Astra 2 via the Griptape model "
+            "proxy. Billed per frame -- see the cost note on the model parameter."
         )
 
         # INPUTS / PROPERTIES
@@ -98,16 +192,61 @@ class TopazVideoUpscale(GriptapeProxyNode):
         model_param = ParameterString(
             name="model",
             default_value=DEFAULT_MODEL,
-            tooltip="Starlight Precise model to upscale with",
+            tooltip="Topaz video model to upscale with. Astra adds creative controls; Starlight does not.",
             allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
             traits={Options(choices=list(MODEL_MAPPING.keys()))},
         )
-        model_param.set_badge(
-            variant="warning",
-            title="Billed per frame",
-            message=COST_BADGE_MESSAGE,
-        )
         self.add_parameter(model_param)
+
+        # Astra only. Hidden by default because the default model is Starlight, and
+        # declaring them hidden matters beyond tidiness: a visible prompt box under
+        # Starlight would silently do nothing, since Starlight sends no filters at all.
+        prompt_param = ParameterString(
+            name="prompt",
+            default_value="",
+            tooltip=(
+                "Astra only. A description of the detail to generate. Setting one drops Topaz's "
+                f"frame cap from {MAX_ASTRA_FRAMES:,} to {MAX_ASTRA_FRAMES_WITH_PROMPT}."
+            ),
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            multiline=True,
+            placeholder_text="Optional: describe the detail Astra should generate...",
+            hide=True,
+        )
+        self.add_parameter(prompt_param)
+
+        creativity_param = ParameterFloat(
+            name="creativity",
+            default_value=0.5,
+            tooltip="Astra only. 0.0 stays faithful to the source; 1.0 invents the most new detail.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        creativity_param.add_trait(Slider(min_val=0.0, max_val=1.0))
+        self.add_parameter(creativity_param)
+
+        sharp_param = ParameterFloat(
+            name="sharp",
+            default_value=0.5,
+            tooltip="Astra only. Pre-enhance sharpness: 0.0 blurs, 0.5 passes through unchanged, 1.0 sharpens.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        sharp_param.add_trait(Slider(min_val=0.0, max_val=1.0))
+        self.add_parameter(sharp_param)
+
+        # Topaz documents a default for `sharp` but not for `realism`; 0.5 is our own
+        # midpoint choice, picked so the slider is WYSIWYG rather than to match an
+        # unpublished provider default.
+        realism_param = ParameterFloat(
+            name="realism",
+            default_value=0.5,
+            tooltip="Astra only. Biases the generated detail toward photorealism (0.0-1.0).",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            hide=True,
+        )
+        realism_param.add_trait(Slider(min_val=0.0, max_val=1.0))
+        self.add_parameter(realism_param)
 
         # Topaz downloads the source itself rather than receiving it in the request
         # body -- a video is far too large to base64 into JSON. This uploads the
@@ -211,6 +350,12 @@ class TopazVideoUpscale(GriptapeProxyNode):
         )
 
         self.set_initial_node_size(height=400)
+        # All four run here, after every add_parameter: show/hide silently no-ops on a
+        # name that does not exist yet, so refreshing earlier would leave Astra's
+        # controls hidden forever with no error to point at.
+        self._update_model_visibility()
+        self._update_cost_badge()
+        self._update_prompt_badge()
         self._update_tier_badge()
 
     # -- lifecycle ---------------------------------------------------------
@@ -230,28 +375,120 @@ class TopazVideoUpscale(GriptapeProxyNode):
         model_name = self.get_parameter_value("model") or DEFAULT_MODEL
         return MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
 
+    def _family(self) -> TopazVideoFamily:
+        """Which family the selected model belongs to.
+
+        Raises rather than defaulting: an unmapped name means MODEL_MAPPING and
+        MODEL_FAMILIES have drifted, and quietly billing at another model's rate is a
+        worse outcome than a loud failure. The Options trait makes an off-list value
+        unreachable from the UI anyway.
+        """
+        model_name = self.get_parameter_value("model") or DEFAULT_MODEL
+        family = MODEL_FAMILIES.get(model_name)
+        if family is None:
+            msg = f"{self.name}: no model family is registered for {model_name!r}."
+            raise ValueError(msg)
+        return family
+
+    def _has_prompt(self) -> bool:
+        """Whether a prompt will actually reach Topaz.
+
+        Mirrors the proxy's own truthiness test on ``filters[].prompt`` so the cap
+        enforced here can never disagree with the cap the proxy bills against.
+        """
+        return bool((self.get_parameter_value("prompt") or "").strip())
+
     # -- UI reactions ------------------------------------------------------
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         super().after_value_set(parameter, value)
 
-        if parameter.name == "resize_mode":
-            match value:
-                case ResizeMode.WIDTH | ResizeMode.HEIGHT:
-                    self.show_parameter_by_name("target_size")
-                    self.hide_parameter_by_name(["target_width", "target_height", "percentage"])
-                case ResizeMode.WIDTH_HEIGHT:
-                    self.hide_parameter_by_name(["target_size", "percentage"])
-                    self.show_parameter_by_name(["target_width", "target_height"])
-                case ResizeMode.PERCENTAGE:
-                    self.hide_parameter_by_name(["target_size", "target_width", "target_height"])
-                    self.show_parameter_by_name("percentage")
-                case _:
-                    msg = f"Unknown resize mode: {value!r}"
-                    raise ValueError(msg)
+        # Unlike the other match statements in this file, the wildcard here must be a
+        # no-op rather than a raise: `parameter.name` is an open set -- `video`,
+        # `output_file` and every status parameter also land here.
+        match parameter.name:
+            case "model":
+                self._update_model_visibility()
+                self._update_cost_badge()
+                self._update_prompt_badge()
+                self._update_tier_badge()
+            case "resize_mode":
+                self._update_resize_visibility(value)
+                self._update_tier_badge()
+            case "target_size" | "target_width" | "target_height" | "percentage":
+                self._update_tier_badge()
+            case "prompt":
+                self._update_prompt_badge()
+            case _:
+                return
 
-        if parameter.name in ("resize_mode", "target_size", "target_width", "target_height", "percentage"):
-            self._update_tier_badge()
+    def _update_resize_visibility(self, mode: Any) -> None:
+        match mode:
+            case ResizeMode.WIDTH | ResizeMode.HEIGHT:
+                self.show_parameter_by_name("target_size")
+                self.hide_parameter_by_name(["target_width", "target_height", "percentage"])
+            case ResizeMode.WIDTH_HEIGHT:
+                self.hide_parameter_by_name(["target_size", "percentage"])
+                self.show_parameter_by_name(["target_width", "target_height"])
+            case ResizeMode.PERCENTAGE:
+                self.hide_parameter_by_name(["target_size", "target_width", "target_height"])
+                self.show_parameter_by_name("percentage")
+            case _:
+                msg = f"Unknown resize mode: {mode!r}"
+                raise ValueError(msg)
+
+    def _update_model_visibility(self) -> None:
+        """Show the creative controls only for the family that accepts them."""
+        match self._family():
+            case TopazVideoFamily.ASTRA:
+                self.show_parameter_by_name(list(ASTRA_FILTER_PARAMS))
+            case TopazVideoFamily.STARLIGHT:
+                self.hide_parameter_by_name(list(ASTRA_FILTER_PARAMS))
+            case family:
+                msg = f"Unknown model family: {family!r}"
+                raise ValueError(msg)
+
+    def _update_cost_badge(self) -> None:
+        param = self.get_parameter_by_name("model")
+        if param is None:
+            return
+
+        param.set_badge(
+            variant="warning",
+            title="Billed per frame",
+            message=COST_BADGE_MESSAGES[self._family()],
+        )
+
+    def _update_prompt_badge(self) -> None:
+        """State Astra's prompt-dependent frame cap while the graph is still being wired.
+
+        The source frame count is not knowable in the editor -- the video usually
+        arrives over a connection and is not probed until the node runs -- so this
+        states the cap rather than testing against it. ``_build_payload`` remains the
+        authority that actually enforces it.
+        """
+        param = self.get_parameter_by_name("prompt")
+        if param is None or self._family() is not TopazVideoFamily.ASTRA:
+            return
+
+        if self._has_prompt():
+            param.set_badge(
+                variant="warning",
+                title=f"Caps this job at {MAX_ASTRA_FRAMES_WITH_PROMPT} frames",
+                message=(
+                    f"Topaz caps a *prompted* Astra job at {MAX_ASTRA_FRAMES_WITH_PROMPT} frames "
+                    f"(~15 seconds at 30fps). Clear the prompt to allow up to {MAX_ASTRA_FRAMES:,}."
+                ),
+            )
+        else:
+            param.set_badge(
+                variant="note",
+                title=f"A prompt drops the cap to {MAX_ASTRA_FRAMES_WITH_PROMPT} frames",
+                message=(
+                    f"Without a prompt Astra accepts up to {MAX_ASTRA_FRAMES:,} frames. Adding one "
+                    f"drops Topaz's cap to {MAX_ASTRA_FRAMES_WITH_PROMPT} (~15 seconds at 30fps)."
+                ),
+            )
 
     def _update_tier_badge(self) -> None:
         """Show which billing tier the current settings land in.
@@ -266,6 +503,9 @@ class TopazVideoUpscale(GriptapeProxyNode):
             return
 
         mode = self.get_parameter_value("resize_mode") or ResizeMode.PERCENTAGE
+        family = self._family()
+        spread = RATE_SPREADS[family]
+        max_pixels = MAX_OUTPUT_PIXELS[family]
 
         match mode:
             case ResizeMode.WIDTH | ResizeMode.HEIGHT:
@@ -286,24 +526,32 @@ class TopazVideoUpscale(GriptapeProxyNode):
                     return
 
                 pixels = width * height
-                if pixels > STARLIGHT_MAX_OUTPUT_PIXELS:
+                if max_pixels is not None and pixels > max_pixels:
                     param.set_badge(
                         variant="error",
                         title="Exceeds Topaz's output limit",
                         message=(
-                            f"{width}x{height} is {pixels:,} pixels, over Topaz's "
-                            f"{STARLIGHT_MAX_OUTPUT_PIXELS:,}-pixel (3840x2160) hard limit. The node "
-                            "will fail rather than submit this to Topaz."
+                            f"{width}x{height} is {pixels:,} pixels, over {family}'s "
+                            f"{max_pixels:,}-pixel (3840x2160) hard limit. The node will fail "
+                            "rather than submit this to Topaz."
                         ),
                     )
-                elif pixels > STARLIGHT_1080P_MAX_PIXELS:
+                elif pixels > TIER_1080P_MAX_PIXELS:
+                    # Astra reaches here with no ceiling of its own, so say so rather
+                    # than let an unusually large request look fully sanctioned.
+                    unbounded = (
+                        ""
+                        if max_pixels is not None
+                        else f" Topaz documents no output ceiling for {family}, so a very large "
+                        "request may still be refused by the provider."
+                    )
                     param.set_badge(
                         variant="warning",
                         title="4K billing tier",
                         message=(
                             f"{width}x{height} is {pixels:,} pixels, over the "
-                            f"{STARLIGHT_1080P_MAX_PIXELS:,}-pixel 1080p limit. This bills at the 4K "
-                            "per-frame rate, about 2.2x the 1080p rate."
+                            f"{TIER_1080P_MAX_PIXELS:,}-pixel 1080p limit. This bills at the 4K "
+                            f"per-frame rate, about {spread} the 1080p rate.{unbounded}"
                         ),
                     )
                 else:
@@ -315,14 +563,14 @@ class TopazVideoUpscale(GriptapeProxyNode):
             case ResizeMode.PERCENTAGE:
                 percentage = self.get_parameter_value("percentage") or 200
                 multiplier = percentage / 100
-                threshold = math.isqrt(int(STARLIGHT_1080P_MAX_PIXELS // (multiplier * multiplier)))
+                threshold = math.isqrt(int(TIER_1080P_MAX_PIXELS // (multiplier * multiplier)))
                 param.set_badge(
                     variant="note",
                     title="Billing tier depends on the source",
                     message=(
                         f"At {percentage}%, any source larger than roughly {threshold}x{threshold} "
-                        f"produces a 4K-tier output (over {STARLIGHT_1080P_MAX_PIXELS:,} output pixels), "
-                        "at about 2.2x the 1080p rate."
+                        f"produces a 4K-tier output (over {TIER_1080P_MAX_PIXELS:,} output pixels), "
+                        f"at about {spread} the 1080p rate."
                     ),
                 )
             case _:
@@ -412,10 +660,13 @@ class TopazVideoUpscale(GriptapeProxyNode):
                 msg = f"Unknown resize mode: {mode!r}"
                 raise ValueError(msg)
 
-        if width * height > STARLIGHT_MAX_OUTPUT_PIXELS:
+        # Astra maps to None here: Topaz publishes no output ceiling for it and the
+        # proxy enforces none, so there is nothing to check against.
+        max_pixels = MAX_OUTPUT_PIXELS[self._family()]
+        if max_pixels is not None and width * height > max_pixels:
             msg = (
                 f"{self.name}: computed output {width}x{height} exceeds Topaz's "
-                f"{STARLIGHT_MAX_OUTPUT_PIXELS:,}-pixel (3840x2160) hard limit."
+                f"{max_pixels:,}-pixel (3840x2160) hard limit."
             )
             raise ValueError(msg)
 
@@ -445,10 +696,11 @@ class TopazVideoUpscale(GriptapeProxyNode):
             )
             raise ValueError(msg)
 
-        if frame_count > MAX_STARLIGHT_FRAMES:
+        max_frames = self._max_frames()
+        if frame_count > max_frames:
             msg = (
-                f"{self.name}: the input video has {frame_count} frames, over Starlight's "
-                f"{MAX_STARLIGHT_FRAMES}-frame limit. Trim or split the video first."
+                f"{self.name}: the input video has {frame_count} frames, over {self._family()}'s "
+                f"{max_frames}-frame limit{self._frame_cap_hint()}. Trim or split the video first."
             )
             raise ValueError(msg)
 
@@ -486,14 +738,67 @@ class TopazVideoUpscale(GriptapeProxyNode):
             output_height,
         )
 
-        # `filters` is deliberately omitted: the proxy synthesizes
-        # [{"model": <routed code>}] when it is absent, and sending our own only
-        # risks the "filters[].model must match the requested model" rejection --
-        # the code there is the id minus its "topaz-video-" prefix.
-        return {
+        payload: dict[str, Any] = {
             "source": source,
             "output": {"resolution": {"width": output_width, "height": output_height}},
         }
+
+        filters = self._build_filters()
+        if filters is not None:
+            payload["filters"] = filters
+
+        return payload
+
+    def _build_filters(self) -> list[dict[str, Any]] | None:
+        """Astra's creative controls, as the single ``filters`` entry Topaz expects.
+
+        No ``model`` key is sent. The proxy passes filter dicts through verbatim and
+        stamps the routed code onto the first entry itself when none carries one, so
+        omitting it sidesteps the "filters[].model must match the requested model"
+        rejection -- and means this node never has to know that the code is the id
+        minus its "topaz-video-" prefix.
+
+        Returns None rather than an empty list for Starlight: the proxy rejects
+        ``filters: []`` outright, and omitting the key is what Starlight does today.
+        """
+        match self._family():
+            case TopazVideoFamily.STARLIGHT:
+                return None
+            case TopazVideoFamily.ASTRA:
+                # float() because a value arriving over a connection or a workflow
+                # round-trip can be an int, and `json.dumps(1)` emits `1` against a
+                # field Topaz documents as a decimal.
+                creative: dict[str, Any] = {
+                    "creativity": float(self.get_parameter_value("creativity")),
+                    "sharp": float(self.get_parameter_value("sharp")),
+                    "realism": float(self.get_parameter_value("realism")),
+                }
+                # Omitted rather than sent blank: the proxy decides whether the job is
+                # "prompted" -- and which frame cap to bill against -- from the
+                # truthiness of this key.
+                prompt = (self.get_parameter_value("prompt") or "").strip()
+                if prompt:
+                    creative["prompt"] = prompt
+                return [creative]
+            case family:
+                msg = f"Unknown model family: {family!r}"
+                raise ValueError(msg)
+
+    def _max_frames(self) -> int:
+        match self._family():
+            case TopazVideoFamily.STARLIGHT:
+                return MAX_STARLIGHT_FRAMES
+            case TopazVideoFamily.ASTRA:
+                return MAX_ASTRA_FRAMES_WITH_PROMPT if self._has_prompt() else MAX_ASTRA_FRAMES
+            case family:
+                msg = f"Unknown model family: {family!r}"
+                raise ValueError(msg)
+
+    def _frame_cap_hint(self) -> str:
+        """Name the way out when the cap is the prompt's doing rather than the clip's."""
+        if self._family() is TopazVideoFamily.ASTRA and self._has_prompt():
+            return f" for a prompted job (clearing the prompt raises it to {MAX_ASTRA_FRAMES:,})"
+        return ""
 
     # -- result ------------------------------------------------------------
 

--- a/griptape_nodes_library/video/topaz_video_upscale.py
+++ b/griptape_nodes_library/video/topaz_video_upscale.py
@@ -4,7 +4,9 @@ import asyncio
 import logging
 import math
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
@@ -73,6 +75,24 @@ MAX_ASTRA_FRAMES = 9000
 # A prompt drops Astra's ceiling by 20x. As with Starlight the proxy only clamps what
 # it *bills*; the job still reaches Topaz, which rejects it.
 MAX_ASTRA_FRAMES_WITH_PROMPT = 450
+
+# Topaz's source.container enum is exactly mp4/mov/mkv:
+# https://developer.topazlabs.com/reference/api-endpoints/video/create-request.md
+#
+# ffprobe's format_name can't tell these apart -- mp4 and mov both report
+# "mov,mp4,m4a,3gp,3g2,mj2", and mkv and webm both report "matroska,webm" (which
+# isn't even a valid Topaz value) -- so container is derived from the file
+# extension (or, for a data URI, the MIME subtype) instead. See _derive_container.
+CONTAINER_BY_TOKEN: dict[str, str] = {
+    "mp4": "mp4",
+    "m4v": "mp4",
+    "mov": "mov",
+    "qt": "mov",
+    "quicktime": "mov",
+    "mkv": "mkv",
+    "matroska": "mkv",
+    "x-matroska": "mkv",
+}
 
 # Both families bill in two rate tiers, chosen by output pixel *area*, not height. A
 # portrait 1080x1920 output bills as 1080p; 1921x1080 already bills as 4K.
@@ -598,6 +618,28 @@ class TopazVideoUpscale(GriptapeProxyNode):
 
         return extract_video_metadata_structured(str(resolved_path))
 
+    def _derive_container(self, video_input: Any) -> str:
+        """Map the input video to Topaz's exact ``source.container`` enum (mp4/mov/mkv).
+
+        Deliberately independent of ``_probe_source``/``VideoMetadata``: it only needs
+        the raw parameter value, and calling the same cheap, pure
+        ``coerce_media_url_or_data_uri`` helper here keeps this check from being
+        silently bypassed by tests that stub ``_probe_source`` wholesale.
+        """
+        video_url = coerce_media_url_or_data_uri(video_input, kind="video") or ""
+        if video_url.startswith("data:"):
+            header = video_url.removeprefix("data:").split(",", 1)[0]
+            token = header.split(";", 1)[0].split("/", 1)[-1].lower()
+        else:
+            token = Path(urlsplit(video_url).path).suffix.lstrip(".").lower()
+
+        container = CONTAINER_BY_TOKEN.get(token)
+        if container is None:
+            found = token or "no extension"
+            msg = f"{self.name}: Topaz only accepts mp4, mov, or mkv source video, but got {found!r}."
+            raise ValueError(msg)
+        return container
+
     @staticmethod
     def _frame_count(metadata: VideoMetadata) -> int:
         """Derive the source frame count, which the proxy requires and never defaults.
@@ -680,6 +722,8 @@ class TopazVideoUpscale(GriptapeProxyNode):
             msg = f"{self.name} requires an input video to upscale."
             raise ValueError(msg)
 
+        container = self._derive_container(video)
+
         # ffprobe is synchronous and can take a moment on a long clip; keep it off
         # the event loop.
         metadata = await asyncio.to_thread(self._probe_source, video)
@@ -714,7 +758,7 @@ class TopazVideoUpscale(GriptapeProxyNode):
             raise ValueError(msg)
 
         source: dict[str, Any] = {
-            "container": "mp4",
+            "container": container,
             "frameCount": frame_count,
             "frameRate": metadata.frame_details.frame_rate,
             "resolution": {"width": source_width, "height": source_height},
@@ -849,6 +893,7 @@ class TopazVideoUpscale(GriptapeProxyNode):
         if isinstance(e, ValueError):
             self._set_safe_defaults()
             self._set_status_results(was_successful=False, result_details=str(e))
+            self._handle_failure_exception(e)
             return
 
         super()._handle_payload_build_error(e)

--- a/tests/integration/test_topaz_video_upscale_astra.py
+++ b/tests/integration/test_topaz_video_upscale_astra.py
@@ -1,0 +1,252 @@
+# /// script
+# dependencies = []
+# [tool.griptape-nodes]
+# name = "test_topaz_video_upscale_astra"
+# schema_version = "0.16.0"
+# engine_version_created_with = "0.77.3"
+# node_libraries_referenced = [["Griptape Nodes Library", "0.67.0"], ["Griptape Nodes Testing Library", "0.1.0"]]
+# node_types_used = [["Griptape Nodes Testing Library", "AssertFileExists"], ["Griptape Nodes Library", "EndFlow"], ["Griptape Nodes Library", "LTXTextToVideoGeneration"], ["Griptape Nodes Library", "TopazVideoUpscale"], ["Griptape Nodes Library", "ToText"]]
+# is_griptape_provided = false
+# is_template = false
+# is_internal = true
+# ///
+import asyncio
+import logging
+from pathlib import Path
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+GriptapeNodes.handle_request(
+    RegisterLibraryFromFileRequest(library_name="Griptape Nodes Library", perform_discovery_if_not_found=True)
+)
+
+context_manager = GriptapeNodes.ContextManager()
+if not context_manager.has_current_workflow():
+    context_manager.push_workflow(file_path=__file__)
+
+flow_name = GriptapeNodes.handle_request(
+    CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False, metadata={})
+).flow_name
+
+with GriptapeNodes.ContextManager().flow(flow_name):
+    ltx_t2v_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="LTXTextToVideoGeneration",
+            specific_library_name="Griptape Nodes Library",
+            node_name="LTX Text To Video Generation",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    upscale_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="TopazVideoUpscale",
+            specific_library_name="Griptape Nodes Library",
+            node_name="TopazVideoUpscale",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    to_text_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="ToText",
+            specific_library_name="Griptape Nodes Library",
+            node_name="To Text",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    assert_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="AssertFileExists",
+            specific_library_name="Griptape Nodes Testing Library",
+            node_name="Assert File Exists",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    end_node = GriptapeNodes.handle_request(
+        CreateNodeRequest(
+            node_type="EndFlow",
+            specific_library_name="Griptape Nodes Library",
+            node_name="End Flow",
+            metadata={},
+            initial_setup=True,
+        )
+    ).node_name
+    with GriptapeNodes.ContextManager().node(end_node):
+        GriptapeNodes.handle_request(
+            AddParameterToNodeRequest(
+                parameter_name="str",
+                default_value="",
+                tooltip="Result",
+                type="str",
+                input_types=["str"],
+                output_type="str",
+                ui_options={},
+                parent_container_name="",
+                initial_setup=True,
+            )
+        )
+    with GriptapeNodes.ContextManager().node(ltx_t2v_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=ltx_t2v_node,
+                value="A ball bouncing",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    # Astra is metered per frame and the 4K tier costs ~1.67x the 1080p one, so this
+    # run is deliberately the cheapest shape the graph can produce: LTX's smallest
+    # output (1920x1080, 25fps, 6s = 150 frames), upscaled to 1920x1080 so it stays
+    # under the 1080p pixel ceiling. A larger target here would be 4K-tier.
+    #
+    # The prompt is what this workflow exists to exercise: `filters` passthrough is
+    # the one part of the Astra design that unit tests cannot verify, because it rests
+    # on the proxy forwarding our filter dict verbatim and stamping the model code onto
+    # it itself. A prompt drops Topaz's cap to 450 frames, which 150 clears easily.
+    with GriptapeNodes.ContextManager().node(upscale_node):
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="model",
+                node_name=upscale_node,
+                value="Astra 2",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="prompt",
+                node_name=upscale_node,
+                value="A ball bouncing, crisp rubber texture",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="resize_mode",
+                node_name=upscale_node,
+                value="width and height",
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="target_width",
+                node_name=upscale_node,
+                value=1920,
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(
+                parameter_name="target_height",
+                node_name=upscale_node,
+                value=1080,
+                initial_setup=True,
+                is_output=False,
+            )
+        )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=ltx_t2v_node,
+            source_parameter_name="video_url",
+            target_node_name=upscale_node,
+            target_parameter_name="video",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=upscale_node,
+            source_parameter_name="output_file",
+            target_node_name=to_text_node,
+            target_parameter_name="from",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=to_text_node,
+            source_parameter_name="output",
+            target_node_name=assert_node,
+            target_parameter_name="file_path",
+            initial_setup=True,
+        )
+    )
+    GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=assert_node,
+            source_parameter_name="result_details",
+            target_node_name=end_node,
+            target_parameter_name="str",
+            initial_setup=True,
+        )
+    )
+
+
+def _ensure_workflow_context():
+    context_manager = GriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level_flow_result = GriptapeNodes.handle_request(GetTopLevelFlowRequest())
+        if (
+            isinstance(top_level_flow_result, GetTopLevelFlowResultSuccess)
+            and top_level_flow_result.flow_name is not None
+        ):
+            flow_manager = GriptapeNodes.FlowManager()
+            flow_obj = flow_manager.get_flow_by_name(top_level_flow_result.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def execute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    return asyncio.run(
+        aexecute_workflow(
+            input=input,
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            workflow_executor=workflow_executor,
+            pickle_control_flow_result=pickle_control_flow_result,
+        )
+    )
+
+
+async def aexecute_workflow(
+    input, storage_backend="local", project_file_path=None, workflow_executor=None, pickle_control_flow_result=False
+):
+    _ensure_workflow_context()
+    storage_backend_enum = StorageBackend(storage_backend)
+    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
+    workflow_executor = workflow_executor or LocalWorkflowExecutor(
+        storage_backend=storage_backend_enum,
+        project_file_path=project_file_path_resolved,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
+    return executor.output
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    workflow_output = execute_workflow(input={})
+    print(workflow_output)

--- a/tests/unit/video/test_topaz_video_upscale.py
+++ b/tests/unit/video/test_topaz_video_upscale.py
@@ -10,10 +10,15 @@ from griptape_nodes_library.utils.ffmpeg_utils import (
     VideoMetadata,
 )
 from griptape_nodes_library.video.topaz_video_upscale import (
+    ASTRA_FILTER_PARAMS,
+    ASTRA_VS_STARLIGHT_1080P,
+    MAX_ASTRA_FRAMES,
+    MAX_ASTRA_FRAMES_WITH_PROMPT,
     MAX_STARLIGHT_FRAMES,
+    MODEL_FAMILIES,
     MODEL_MAPPING,
-    STARLIGHT_1080P_MAX_PIXELS,
     STARLIGHT_MAX_OUTPUT_PIXELS,
+    TIER_1080P_MAX_PIXELS,
     ResizeMode,
     TopazVideoUpscale,
 )
@@ -54,6 +59,17 @@ def _metadata(
 
 def _node(name: str = "TopazVideoUpscale") -> TopazVideoUpscale:
     return TopazVideoUpscale(name=name)
+
+
+ASTRA_MODEL = "Astra 2"
+STARLIGHT_MODEL = "Starlight Precise 2.6"
+
+
+def _astra_node(name: str = "TopazVideoUpscale") -> TopazVideoUpscale:
+    """A node switched to Astra through the normal setter, so the UI reactions fire."""
+    node = _node(name)
+    node.set_parameter_value("model", ASTRA_MODEL)
+    return node
 
 
 def _stub_probe(monkeypatch: pytest.MonkeyPatch, metadata: VideoMetadata) -> None:
@@ -146,7 +162,9 @@ def test_odd_source_still_yields_even_output() -> None:
 
 
 def test_output_exceeding_the_hard_cap_raises() -> None:
+    # The cap is now Starlight's alone, so pin the model rather than lean on the default.
     node = _node()
+    node.set_parameter_value("model", STARLIGHT_MODEL)
     node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
     node.set_parameter_value("percentage", 200)
 
@@ -276,6 +294,21 @@ async def test_build_payload_omits_filters(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 @pytest.mark.asyncio
+async def test_starlight_payload_has_only_source_and_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The regression lock for the Astra merge: adding a second model family must not
+    # change a single byte of what Starlight sends. Asserting the exact key set (rather
+    # than "filters" not in payload) catches any new top-level key, not just that one.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert set(payload) == {"source", "output"}
+
+
+@pytest.mark.asyncio
 async def test_build_payload_omits_absent_optional_source_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     node = _node()
     node.set_parameter_value("video", "{inputs}/clip.mp4")
@@ -372,6 +405,19 @@ def test_default_model_is_the_newer_starlight() -> None:
 def test_every_mapped_model_is_prefixed() -> None:
     for model_id in MODEL_MAPPING.values():
         assert model_id.startswith("topaz-video-")
+
+
+def test_astra_routes_to_its_own_proxy_id() -> None:
+    node = _node()
+    node.set_parameter_value("model", ASTRA_MODEL)
+
+    assert node._get_api_model_id() == "topaz-video-ast-2"
+
+
+def test_every_model_has_a_registered_family() -> None:
+    # MODEL_FAMILIES is a second table beside MODEL_MAPPING, so drift between them is
+    # the failure mode. _family() raises on a miss; this catches it at test time.
+    assert MODEL_FAMILIES.keys() == MODEL_MAPPING.keys()
 
 
 # -- result parsing -----------------------------------------------------------
@@ -492,7 +538,7 @@ def test_tier_boundary_is_pixel_area_not_height() -> None:
     assert badge.variant == "info"
 
     node.set_parameter_value("target_width", 1922)
-    assert 1922 * 1920 > STARLIGHT_1080P_MAX_PIXELS
+    assert 1922 * 1920 > TIER_1080P_MAX_PIXELS
     badge = resize_mode_param.get_badge()
     assert badge is not None
     assert badge.variant == "warning"
@@ -540,3 +586,344 @@ def test_height_only_shows_a_source_dependent_note_badge() -> None:
 
     assert badge is not None
     assert badge.variant == "note"
+
+
+# -- Astra: filters ----------------------------------------------------------
+
+
+async def _astra_payload(monkeypatch: pytest.MonkeyPatch, node: TopazVideoUpscale) -> dict:
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+    return await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_astra_payload_carries_the_creative_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = await _astra_payload(monkeypatch, _astra_node())
+
+    assert payload["filters"] == [{"creativity": 0.5, "sharp": 0.5, "realism": 0.5}]
+
+
+@pytest.mark.asyncio
+async def test_astra_filters_omit_the_model_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy stamps the routed model code onto filters[0] when no entry carries one.
+    # Sending our own would risk the "filters[].model must match" rejection and would
+    # force this node to know that the code is the api id minus its "topaz-video-" prefix.
+    payload = await _astra_payload(monkeypatch, _astra_node())
+
+    assert "model" not in payload["filters"][0]
+
+
+@pytest.mark.asyncio
+async def test_astra_filters_are_never_an_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy rejects `filters: []` outright ("must be a non-empty array when provided"),
+    # so the key is either absent or populated -- never present and empty.
+    payload = await _astra_payload(monkeypatch, _astra_node())
+
+    assert payload["filters"]
+
+
+@pytest.mark.asyncio
+async def test_astra_creative_values_reach_the_filter_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _astra_node()
+    node.set_parameter_value("creativity", 0.9)
+    node.set_parameter_value("sharp", 0.1)
+    node.set_parameter_value("realism", 0.75)
+
+    payload = await _astra_payload(monkeypatch, node)
+
+    assert payload["filters"][0]["creativity"] == 0.9
+    assert payload["filters"][0]["sharp"] == 0.1
+    assert payload["filters"][0]["realism"] == 0.75
+
+
+@pytest.mark.asyncio
+async def test_astra_creative_values_are_sent_as_floats(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A value arriving over a connection or a workflow round-trip can be an int, and
+    # `json.dumps(1)` emits `1` against a field Topaz documents as a decimal.
+    node = _astra_node()
+    node.set_parameter_value("creativity", 1)
+    node.set_parameter_value("sharp", 0)
+
+    payload = await _astra_payload(monkeypatch, node)
+
+    assert isinstance(payload["filters"][0]["creativity"], float)
+    assert isinstance(payload["filters"][0]["sharp"], float)
+
+
+@pytest.mark.asyncio
+async def test_astra_filters_include_a_nonempty_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _astra_node()
+    node.set_parameter_value("prompt", "a bouncing ball")
+
+    payload = await _astra_payload(monkeypatch, node)
+
+    assert payload["filters"][0]["prompt"] == "a bouncing ball"
+
+
+@pytest.mark.asyncio
+async def test_astra_filters_omit_a_whitespace_only_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy decides whether a job is "prompted" -- and which frame cap to bill
+    # against -- from the truthiness of this key, so a blank one must not be sent.
+    node = _astra_node()
+    node.set_parameter_value("prompt", "   \n ")
+
+    payload = await _astra_payload(monkeypatch, node)
+
+    assert "prompt" not in payload["filters"][0]
+
+
+# -- Astra: frame caps -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_astra_accepts_up_to_the_unprompted_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _astra_node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_ASTRA_FRAMES))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["frameCount"] == MAX_ASTRA_FRAMES
+
+
+@pytest.mark.asyncio
+async def test_astra_rejects_one_frame_over_the_unprompted_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _astra_node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_ASTRA_FRAMES + 1))
+    _stub_public_url(node, monkeypatch)
+
+    with pytest.raises(ValueError, match="over Astra's"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_drops_astras_cap_to_450(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 500 frames is fine unprompted and rejected once a prompt is set -- the whole
+    # point of enforcing this client-side, since the proxy only clamps what it bills.
+    node = _astra_node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_ASTRA_FRAMES_WITH_PROMPT + 50))
+    _stub_public_url(node, monkeypatch)
+
+    assert (await node._build_payload())["source"]["frameCount"] == MAX_ASTRA_FRAMES_WITH_PROMPT + 50
+
+    node.set_parameter_value("prompt", "a bouncing ball")
+
+    with pytest.raises(ValueError, match="clearing the prompt"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_a_whitespace_prompt_does_not_lower_the_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The cap enforced here has to agree with the cap the proxy bills against, and the
+    # proxy's test is truthiness of filters[].prompt -- which a blank string fails.
+    node = _astra_node()
+    node.set_parameter_value("prompt", "   ")
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_ASTRA_FRAMES_WITH_PROMPT + 50))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["frameCount"] == MAX_ASTRA_FRAMES_WITH_PROMPT + 50
+
+
+@pytest.mark.asyncio
+async def test_astra_prompt_cap_rejects_before_uploading(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Same discipline as the Starlight case: the cheap local check must run before the
+    # upload, or a rejected job still costs a round trip and cloud storage.
+    node = _astra_node()
+    node.set_parameter_value("prompt", "a bouncing ball")
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_ASTRA_FRAMES_WITH_PROMPT + 1))
+
+    calls: list[None] = []
+
+    def _record() -> str:
+        calls.append(None)
+        return PUBLIC_URL
+
+    monkeypatch.setattr(node._public_video_url_parameter, "get_public_url_for_parameter", _record)
+
+    with pytest.raises(ValueError, match="over Astra's"):
+        await node._build_payload()
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_starlights_frame_cap_is_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Astra's prompt-dependent cap must not leak into Starlight, which has no prompt
+    # at all and keeps its flat 9000.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_STARLIGHT_FRAMES))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["frameCount"] == MAX_STARLIGHT_FRAMES
+
+
+# -- Astra: output resolution ------------------------------------------------
+
+
+def test_astra_has_no_hard_output_cap() -> None:
+    # Topaz documents no output ceiling for Astra and the proxy enforces none, so the
+    # node must not invent one and reject a job Topaz may well accept.
+    node = _astra_node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+
+    assert node._output_resolution(3840, 2160) == (7680, 4320)
+
+
+def test_starlight_still_enforces_the_hard_output_cap() -> None:
+    node = _astra_node()
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+    node.set_parameter_value("model", STARLIGHT_MODEL)
+
+    with pytest.raises(ValueError, match="hard limit"):
+        node._output_resolution(3840, 2160)
+
+
+# -- Astra: badges -----------------------------------------------------------
+
+
+def _model_badge_message(node: TopazVideoUpscale) -> str:
+    param = node.get_parameter_by_name("model")
+    assert param is not None
+    badge = param.get_badge()
+    assert badge is not None
+    return badge.message or ""
+
+
+def test_the_cost_badge_names_the_selected_familys_rate_spread() -> None:
+    node = _node()
+    assert "2.2x" in _model_badge_message(node)
+
+    node.set_parameter_value("model", ASTRA_MODEL)
+    assert "1.67x" in _model_badge_message(node)
+
+
+def test_both_cost_badges_compare_the_two_models_to_each_other() -> None:
+    # The within-family spreads invite the wrong read on their own -- Astra's 1.67x is
+    # the smaller number but the pricier model -- so both badges have to state the
+    # cross-model ratio outright.
+    node = _node()
+    assert ASTRA_VS_STARLIGHT_1080P in _model_badge_message(node)
+
+    node.set_parameter_value("model", ASTRA_MODEL)
+    assert ASTRA_VS_STARLIGHT_1080P in _model_badge_message(node)
+
+
+def test_astras_badge_disowns_its_own_spread_as_a_cross_model_figure() -> None:
+    message = _model_badge_message(_astra_node())
+
+    assert "not a comparison with Starlight" in message
+
+
+def test_switching_back_to_starlight_restores_its_cost_badge() -> None:
+    node = _astra_node()
+    node.set_parameter_value("model", STARLIGHT_MODEL)
+
+    message = _model_badge_message(node)
+    assert "2.2x" in message
+    assert "1.67x" not in message
+
+
+def test_astra_over_4k_warns_about_the_tier_without_calling_it_an_error() -> None:
+    # The same shape that gives Starlight a red "exceeds the limit" badge is merely an
+    # expensive-tier warning for Astra, which has no documented ceiling.
+    node = _astra_node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("target_width", 3840)
+    node.set_parameter_value("target_height", 2160)
+
+    resize_mode_param = node.get_parameter_by_name("resize_mode")
+    assert resize_mode_param is not None
+    badge = resize_mode_param.get_badge()
+
+    assert badge is not None
+    assert badge.variant == "warning"
+    assert "no output ceiling" in (badge.message or "")
+
+
+def _prompt_badge_variant(node: TopazVideoUpscale) -> str | None:
+    param = node.get_parameter_by_name("prompt")
+    assert param is not None
+    badge = param.get_badge()
+    assert badge is not None
+    return badge.variant
+
+
+def test_the_prompt_badge_states_the_cap_before_one_is_typed() -> None:
+    # The source frame count is not knowable in the editor, so the badge states the
+    # cap rather than testing against it.
+    assert _prompt_badge_variant(_astra_node()) == "note"
+
+
+def test_typing_a_prompt_escalates_the_badge_to_a_warning() -> None:
+    node = _astra_node()
+    node.set_parameter_value("prompt", "a bouncing ball")
+
+    assert _prompt_badge_variant(node) == "warning"
+
+
+def test_clearing_the_prompt_returns_the_badge_to_a_note() -> None:
+    node = _astra_node()
+    node.set_parameter_value("prompt", "a bouncing ball")
+    node.set_parameter_value("prompt", "")
+
+    assert _prompt_badge_variant(node) == "note"
+
+
+# -- Astra: parameter visibility ---------------------------------------------
+
+
+def _hidden(node: TopazVideoUpscale, name: str) -> bool:
+    param = node.get_parameter_by_name(name)
+    assert param is not None
+    return param.ui_options.get("hide") is True
+
+
+def test_the_creative_controls_are_hidden_on_a_fresh_starlight_node() -> None:
+    # Not just tidiness: a visible prompt box under Starlight would silently do
+    # nothing, because Starlight sends no filters at all.
+    node = _node()
+
+    for name in ASTRA_FILTER_PARAMS:
+        assert _hidden(node, name), f"{name} should be hidden for Starlight"
+
+
+def test_selecting_astra_reveals_the_creative_controls() -> None:
+    node = _astra_node()
+
+    for name in ASTRA_FILTER_PARAMS:
+        assert not _hidden(node, name), f"{name} should be visible for Astra"
+
+
+def test_switching_back_to_starlight_hides_them_again() -> None:
+    node = _astra_node()
+    node.set_parameter_value("model", STARLIGHT_MODEL)
+
+    for name in ASTRA_FILTER_PARAMS:
+        assert _hidden(node, name), f"{name} should be hidden again for Starlight"
+
+
+def test_selecting_astra_does_not_disturb_the_resize_fields() -> None:
+    # The two visibility rules are independent; switching models must not reset the
+    # resize UI the user has already set up.
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("model", ASTRA_MODEL)
+
+    assert not _hidden(node, "target_width")
+    assert not _hidden(node, "target_height")
+    assert _hidden(node, "percentage")
+    assert _hidden(node, "target_size")

--- a/tests/unit/video/test_topaz_video_upscale.py
+++ b/tests/unit/video/test_topaz_video_upscale.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from griptape_nodes_library.utils.ffmpeg_utils import (
@@ -384,6 +386,76 @@ async def test_build_payload_raises_when_no_public_url_is_produced(monkeypatch: 
 
     with pytest.raises(ValueError, match="could not produce a public URL"):
         await node._build_payload()
+
+
+def test_payload_build_error_triggers_failure_exception() -> None:
+    # _handle_failure_exception is what raises when the failure output has no
+    # outgoing connection -- without it a ValueError guard sets was_successful=False
+    # and quietly dead-ends the flow instead of crashing with immediate feedback.
+    node = _node()
+    err = ValueError("boom")
+    with patch.object(node, "_handle_failure_exception") as mock_failure:
+        node._handle_payload_build_error(err)
+    mock_failure.assert_called_once_with(err)
+
+
+# -- container derivation -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_container_is_derived_from_the_extension(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mov")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["container"] == "mov"
+
+
+@pytest.mark.asyncio
+async def test_container_defaults_map_mp4_variants(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.m4v")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["container"] == "mp4"
+
+
+@pytest.mark.asyncio
+async def test_container_derived_from_data_uri_mime_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "data:video/quicktime;base64,AAAA")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["container"] == "mov"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_container_raises_before_uploading(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.webm")
+    _stub_probe(monkeypatch, _metadata())
+
+    calls: list[None] = []
+
+    def _record() -> str:
+        calls.append(None)
+        return PUBLIC_URL
+
+    monkeypatch.setattr(node._public_video_url_parameter, "get_public_url_for_parameter", _record)
+
+    with pytest.raises(ValueError, match="only accepts mp4, mov, or mkv"):
+        await node._build_payload()
+
+    assert calls == []
 
 
 # -- model routing -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Folds Topaz Astra 2 into the existing `TopazVideoUpscale` node as a third model option (rather than a separate node), since it shares the same resolution UI, source probing, and upload/result plumbing as Starlight.
- Adds Astra's four creative filters (`creativity`, `prompt`, `sharp`, `realism`), its prompt-dependent frame cap (9000 unprompted / 450 prompted), and no output-resolution ceiling (Topaz publishes none for Astra).
- Extends the cost badge to state the cross-model comparison explicitly, since the within-family 4K multipliers (1.67x for Astra, 2.2x for Starlight) invite the wrong read on which model actually costs more per frame.
- Addresses two review comments left on the original TopazVideoUpscale PR (#546) by @cjkindel:
  - `_handle_payload_build_error` now calls `_handle_failure_exception`, matching `topaz_image_enhance.py` and `flux_image_generation.py`, so validation failures raise (rather than silently dead-ending the flow) when no failure edge is wired.
  - `source.container` is now derived from the video's extension (or MIME type for a data URI) instead of being hardcoded to `"mp4"`. Deriving it from ffprobe's `optional_format_name` (as originally suggested) turned out to be unreliable -- mp4/mov share one demuxer string and mkv/webm share another -- so extension-based mapping with a pre-upload rejection of unsupported containers is used instead.

## Testing

- `uv run pytest tests/unit/video/test_topaz_video_upscale.py -q` -- 70 passed
- `uv run pytest tests/unit -q` -- full unit suite passes
- `make check` -- format, ruff, pyright, and JSON manifest checks all clean
- Added an integration workflow (`tests/integration/test_topaz_video_upscale_astra.py`) exercising an Astra 2 run end-to-end, since the `filters` passthrough shape can't be verified by unit tests alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)