### PR TITLE
fix: cancel proxy generations when a node's execution is cancelled

### DIFF
--- a/griptape_nodes_library/proxy/griptape_proxy_node.py
+++ b/griptape_nodes_library/proxy/griptape_proxy_node.py
@@ -8,6 +8,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from contextlib import suppress
+from enum import StrEnum
 from typing import Any
 from urllib.parse import urljoin
 
@@ -41,6 +42,22 @@ HTTP_CLIENT_ERROR_MIN = 400
 HTTP_CLIENT_ERROR_MAX = 500
 # Short delay before the single retry on a transient download failure.
 DOWNLOAD_RETRY_DELAY_SECONDS = 1.0
+# The proxy accepts cancellation only while a generation is still QUEUED; it answers
+# 400 once the work has been dispatched to the provider.
+HTTP_BAD_REQUEST = 400
+# Cancellation is cleanup on the way out of a cancelled node, so it gets a short timeout.
+CANCEL_REQUEST_TIMEOUT_SECONDS = 10
+
+
+class CancelOutcome(StrEnum):
+    """What a best-effort server-side cancel request actually achieved."""
+
+    # The proxy dropped the generation while it was still queued; no billable work ran.
+    CANCELLED = "cancelled"
+    # The generation had already been dispatched, so it runs to completion and is billed.
+    ALREADY_STARTED = "already_started"
+    # The cancel request never got an answer; the generation's fate is unknown.
+    UNKNOWN = "unknown"
 
 
 class GriptapeProxyNode(SuccessFailureNode, ABC):
@@ -51,6 +68,8 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
     2. Poll generation status via GET /api/proxy/v2/generations/{generation_id}
     3. Handle terminal states (COMPLETED, FAILED, ERRORED, CANCELLED)
     4. Fetch final results from GET /api/proxy/v2/generations/{generation_id}/result
+    5. Cancel a still-queued generation via POST /api/proxy/v2/generations/{generation_id}/cancel
+       when the node's execution is cancelled
 
     Subclasses must implement:
     - _build_payload(): Build the request payload for generation submission
@@ -460,6 +479,106 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
             return self.DEFAULT_MAX_ATTEMPTS * self.DEFAULT_POLL_INTERVAL
         return max(0, int(value))
 
+    async def _request_generation_cancel(self, generation_id: str, headers: dict[str, str]) -> CancelOutcome:
+        """POST the proxy's cancel endpoint for a generation.
+
+        Never raises. Cancellation is cleanup, and a failure here must not replace
+        the reason the node is unwinding, so every failure mode collapses into a
+        ``CancelOutcome`` the caller can report.
+
+        Args:
+            generation_id: The generation to cancel
+            headers: HTTP headers including Authorization
+
+        Returns:
+            CancelOutcome: What the request achieved
+        """
+        cancel_url = urljoin(self._proxy_base, f"generations/{generation_id}/cancel")
+        self._log(f"Requesting cancellation of generation {generation_id}")
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(cancel_url, headers=headers, timeout=CANCEL_REQUEST_TIMEOUT_SECONDS)
+        except Exception as e:
+            self._log(f"Cancel request for generation {generation_id} failed: {e}")
+            return CancelOutcome.UNKNOWN
+
+        # Both the accepted and the rejected response report the generation's status, and
+        # the proxy is authoritative about it — record it so `generation_status` reflects
+        # where the work actually ended up rather than the last status polling happened to see.
+        with suppress(Exception):
+            reported_status = response.json().get("status")
+            if reported_status:
+                self.parameter_output_values["generation_status"] = reported_status
+
+        # A generation that has already left the queue cannot be cancelled. That is the
+        # expected answer whenever the work was picked up quickly, so it is reported as
+        # an outcome rather than surfaced as a node error.
+        if response.status_code == HTTP_BAD_REQUEST:
+            return CancelOutcome.ALREADY_STARTED
+        if response.is_success:
+            return CancelOutcome.CANCELLED
+
+        self._log(f"Cancel request for generation {generation_id} returned HTTP {response.status_code}")
+        return CancelOutcome.UNKNOWN
+
+    async def _cancel_generation_best_effort(self, generation_id: str, headers: dict[str, str]) -> CancelOutcome:
+        """Ask the proxy to drop a generation, then record what that achieved.
+
+        The request is shielded because the usual caller is a cancellation unwind: a
+        second ``task.cancel()`` landing on this node while the POST is in flight
+        would otherwise abandon the request before it reaches the server.
+
+        Args:
+            generation_id: The generation to cancel
+            headers: HTTP headers including Authorization
+
+        Returns:
+            CancelOutcome: What the request achieved
+        """
+        outcome = await asyncio.shield(self._request_generation_cancel(generation_id, headers))
+        self._report_cancellation(generation_id, outcome)
+        return outcome
+
+    def _report_cancellation(self, generation_id: str, outcome: CancelOutcome) -> None:
+        """Record on the node what the cancel attempt achieved.
+
+        A cancel that could not stop billable work is the case worth telling the user
+        about, so each outcome gets its own message. The generation_id is preserved so
+        a generation that outlived the cancel can still be recovered via Refresh.
+
+        Args:
+            generation_id: The generation the cancel was requested for
+            outcome: What the cancel request achieved
+
+        Raises:
+            ValueError: If the outcome is not a known CancelOutcome
+        """
+        match outcome:
+            case CancelOutcome.CANCELLED:
+                details = (
+                    f"Generation `{generation_id}` was cancelled on Griptape Cloud before it started running, "
+                    f"so it will not be billed."
+                )
+            case CancelOutcome.ALREADY_STARTED:
+                details = (
+                    f"Generation `{generation_id}` had already started and could not be cancelled. It will run to "
+                    f"completion and be billed — click the refresh icon on `generation_status` to retrieve its result."
+                )
+            case CancelOutcome.UNKNOWN:
+                details = (
+                    f"Cancellation of generation `{generation_id}` could not be confirmed. It may still be running "
+                    f"and be billed — click the refresh icon on `generation_status` to check."
+                )
+            case _:
+                msg = f"Unknown cancel outcome: {outcome!r}"
+                raise ValueError(msg)
+
+        logger.info("%s: %s", self.name, details)
+        self._set_safe_defaults()
+        self.parameter_output_values["generation_id"] = generation_id
+        self._set_status_results(was_successful=False, result_details=details)
+
     async def _poll_generation_status(self, generation_id: str, headers: dict[str, str]) -> dict[str, Any] | None:
         """Poll generation status until terminal state is reached.
 
@@ -477,50 +596,66 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         max_attempts = max(1, (timeout_s + poll_interval - 1) // poll_interval) if timeout_s > 0 else None
 
         attempt = 0
-        async with httpx.AsyncClient() as client:
-            while True:
-                try:
-                    self._log(f"Polling attempt #{attempt + 1} for generation {generation_id}")
-
-                    response = await client.get(get_url, headers=headers, timeout=60)
-                    response.raise_for_status()
-                    result_json = response.json()
-
-                    status = result_json.get("status", "unknown")
-                    self._log(f"Status: {status}")
-                    self.parameter_output_values["generation_status"] = status
-
-                    is_terminal, terminal_result = self._handle_terminal_status(status, result_json)
-                    if is_terminal:
-                        return terminal_result
-
-                    attempt += 1
-
-                    # Timeout reached (only when max_attempts is set)
-                    if max_attempts is not None and attempt >= max_attempts:
-                        break
-
-                    # Still processing (QUEUED or RUNNING), wait before next poll
-                    await asyncio.sleep(poll_interval)
-
-                except httpx.HTTPStatusError as e:
-                    self._log(f"HTTP error while polling: {e.response.status_code} - {e.response.text}")
-                    attempt += 1
-                    if max_attempts is not None and attempt >= max_attempts:
-                        self._set_safe_defaults()
-                        error_msg = f"Failed to poll generation status: HTTP {e.response.status_code}"
-                        self._set_status_results(was_successful=False, result_details=error_msg)
+        try:
+            async with httpx.AsyncClient() as client:
+                while True:
+                    # Cooperative cancellation: covers a cancel that lands between awaits,
+                    # and callers that set the flag without cancelling the asyncio task.
+                    if self.is_cancellation_requested:
+                        self._log(f"Cancellation requested while polling generation {generation_id}")
+                        await self._cancel_generation_best_effort(generation_id, headers)
                         return None
-                    await asyncio.sleep(poll_interval)
-                except Exception as e:
-                    self._log(f"Error while polling: {e}")
-                    attempt += 1
-                    if max_attempts is not None and attempt >= max_attempts:
-                        self._set_safe_defaults()
-                        error_msg = f"Failed to poll generation status: {e}"
-                        self._set_status_results(was_successful=False, result_details=error_msg)
-                        return None
-                    await asyncio.sleep(poll_interval)
+
+                    try:
+                        self._log(f"Polling attempt #{attempt + 1} for generation {generation_id}")
+
+                        response = await client.get(get_url, headers=headers, timeout=60)
+                        response.raise_for_status()
+                        result_json = response.json()
+
+                        status = result_json.get("status", "unknown")
+                        self._log(f"Status: {status}")
+                        self.parameter_output_values["generation_status"] = status
+
+                        is_terminal, terminal_result = self._handle_terminal_status(status, result_json)
+                        if is_terminal:
+                            return terminal_result
+
+                        attempt += 1
+
+                        # Timeout reached (only when max_attempts is set)
+                        if max_attempts is not None and attempt >= max_attempts:
+                            break
+
+                        # Still processing (QUEUED or RUNNING), wait before next poll
+                        await asyncio.sleep(poll_interval)
+
+                    except httpx.HTTPStatusError as e:
+                        self._log(f"HTTP error while polling: {e.response.status_code} - {e.response.text}")
+                        attempt += 1
+                        if max_attempts is not None and attempt >= max_attempts:
+                            self._set_safe_defaults()
+                            error_msg = f"Failed to poll generation status: HTTP {e.response.status_code}"
+                            self._set_status_results(was_successful=False, result_details=error_msg)
+                            return None
+                        await asyncio.sleep(poll_interval)
+                    except Exception as e:
+                        self._log(f"Error while polling: {e}")
+                        attempt += 1
+                        if max_attempts is not None and attempt >= max_attempts:
+                            self._set_safe_defaults()
+                            error_msg = f"Failed to poll generation status: {e}"
+                            self._set_status_results(was_successful=False, result_details=error_msg)
+                            return None
+                        await asyncio.sleep(poll_interval)
+        except asyncio.CancelledError:
+            # The engine cancels this node's task, which with a 5s poll interval almost
+            # always lands mid-sleep — so this, not the flag check above, is the load-bearing
+            # path. Ask the proxy to drop the generation before unwinding so queued work is
+            # not billed for a result nobody will see, then let the cancellation stand.
+            with suppress(asyncio.CancelledError):
+                await self._cancel_generation_best_effort(generation_id, headers)
+            raise
 
         # Timeout reached — preserve generation_id so the user can recover via Refresh
         self._log("Polling timed out waiting for result")
@@ -691,6 +826,13 @@ class GriptapeProxyNode(SuccessFailureNode, ABC):
         """
         # Clear execution status at the start
         self._clear_execution_status()
+        # A node's cancellation flag is only cleared by BaseNode.clear_node(), which the
+        # flow's cancel path does not reach for a node cancelled mid-resolution — so the
+        # flag outlives the run it belonged to. Left set, it would make the poll loop
+        # cancel the generation this run is about to submit. A cancellation that really
+        # applies to this run is requested after the run starts and also cancels the
+        # asyncio task, which the poll loop's CancelledError path handles.
+        self.clear_cancellation()
         self.parameter_output_values["generation_id"] = ""
         self.parameter_output_values["generation_status"] = ""
 

--- a/tests/unit/test_griptape_proxy_node_cancellation.py
+++ b/tests/unit/test_griptape_proxy_node_cancellation.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, NamedTuple
+
+import pytest
+
+from griptape_nodes_library.image.flux_2_image_generation import Flux2ImageGeneration
+from griptape_nodes_library.proxy.griptape_proxy_node import CancelOutcome
+
+HEADERS = {"Authorization": "Bearer key"}
+HTTP_OK = 200
+HTTP_BAD_REQUEST = 400
+HTTP_SERVER_ERROR = 500
+
+
+class StatusResponse:
+    def __init__(self, status: str) -> None:
+        self._status = status
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"status": self._status}
+
+
+class CancelResponse:
+    def __init__(self, status_code: int, status: str) -> None:
+        self.status_code = status_code
+        self._status = status
+
+    @property
+    def is_success(self) -> bool:
+        return HTTP_OK <= self.status_code < HTTP_BAD_REQUEST
+
+    def json(self) -> dict[str, Any]:
+        return {"status": self._status}
+
+
+class FakeAsyncClient:
+    """httpx.AsyncClient stand-in that records cancel POSTs and serves canned statuses."""
+
+    cancel_urls: list[str] = []  # noqa: RUF012
+    cancel_status_code: int = HTTP_OK
+    # Status the proxy reports back on the cancel response.
+    cancel_reported_status: str = "CANCELLED"
+    cancel_error: Exception | None = None
+    # Status the polled generation reports; QUEUED keeps the poll loop in flight.
+    poll_status: str = "QUEUED"
+
+    async def __aenter__(self) -> FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *_exc_info: Any) -> None:
+        return None
+
+    async def get(self, url: str, headers: dict[str, str], timeout: int) -> StatusResponse:  # noqa: ARG002
+        return StatusResponse(type(self).poll_status)
+
+    async def post(self, url: str, headers: dict[str, str], timeout: int) -> CancelResponse:  # noqa: ARG002
+        cls = type(self)
+        cls.cancel_urls.append(url)
+        if cls.cancel_error is not None:
+            raise cls.cancel_error
+        return CancelResponse(cls.cancel_status_code, cls.cancel_reported_status)
+
+
+class Harness(NamedTuple):
+    node: Flux2ImageGeneration
+    status_calls: list[dict[str, Any]]
+
+
+@pytest.fixture
+def harness(monkeypatch: pytest.MonkeyPatch) -> Harness:
+    """A Flux node wired to the fake HTTP client, with status writes captured."""
+    FakeAsyncClient.cancel_urls = []
+    FakeAsyncClient.cancel_status_code = HTTP_OK
+    FakeAsyncClient.cancel_reported_status = "CANCELLED"
+    FakeAsyncClient.cancel_error = None
+    FakeAsyncClient.poll_status = "QUEUED"
+    monkeypatch.setattr("griptape_nodes_library.proxy.griptape_proxy_node.httpx.AsyncClient", FakeAsyncClient)
+
+    node = Flux2ImageGeneration(name="Flux2")
+    status_calls: list[dict[str, Any]] = []
+    node._set_status_results = lambda **kwargs: status_calls.append(kwargs)  # type: ignore[method-assign]
+    return Harness(node, status_calls)
+
+
+def _cancelled_generation_ids() -> list[str]:
+    """The generation ids the fake client saw a cancel POST for."""
+    return [url.rsplit("/", 2)[-2] for url in FakeAsyncClient.cancel_urls]
+
+
+@pytest.mark.asyncio
+async def test_task_cancellation_cancels_generation_server_side(harness: Harness) -> None:
+    """Cancelling the node's task mid-sleep must POST the proxy's cancel endpoint."""
+    node = harness.node
+    task = asyncio.create_task(node._poll_generation_status("gen-1", HEADERS))
+    # One poll happens, then the loop parks in asyncio.sleep(poll_interval) — the state a
+    # user cancel almost always lands in, since the default poll interval is 5s.
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert _cancelled_generation_ids() == ["gen-1"]
+    assert harness.status_calls[-1]["was_successful"] is False
+    assert "will not be billed" in harness.status_calls[-1]["result_details"]
+    assert node.parameter_output_values["generation_id"] == "gen-1"
+    assert node.parameter_output_values["generation_status"] == "CANCELLED"
+
+
+@pytest.mark.asyncio
+async def test_cooperative_flag_cancels_generation_server_side(harness: Harness) -> None:
+    """A cancel that only sets the cooperative flag is honoured at the top of the loop."""
+    harness.node.request_cancellation()
+
+    result = await harness.node._poll_generation_status("gen-2", HEADERS)
+
+    assert result is None
+    assert _cancelled_generation_ids() == ["gen-2"]
+    assert "will not be billed" in harness.status_calls[-1]["result_details"]
+
+
+@pytest.mark.asyncio
+async def test_already_dispatched_generation_reports_billing(harness: Harness) -> None:
+    """A 400 means the work already started: expected, not an error, but the user is told it is billed."""
+    FakeAsyncClient.cancel_status_code = HTTP_BAD_REQUEST
+    FakeAsyncClient.cancel_reported_status = "RUNNING"
+    harness.node.request_cancellation()
+
+    result = await harness.node._poll_generation_status("gen-3", HEADERS)
+
+    assert result is None
+    assert harness.status_calls[-1]["was_successful"] is False
+    assert "and be billed" in harness.status_calls[-1]["result_details"]
+    # The status must report where the generation actually is, not claim a cancellation
+    # that the proxy refused.
+    assert harness.node.parameter_output_values["generation_status"] == "RUNNING"
+    # generation_id survives so the Refresh affordance can still retrieve the result.
+    assert harness.node.parameter_output_values["generation_id"] == "gen-3"
+
+
+@pytest.mark.asyncio
+async def test_failed_cancel_request_does_not_mask_cancellation(harness: Harness) -> None:
+    """A cancel POST that blows up must not replace the CancelledError that is unwinding."""
+    FakeAsyncClient.cancel_error = RuntimeError("connection reset")
+
+    task = asyncio.create_task(harness.node._poll_generation_status("gen-4", HEADERS))
+    await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "could not be confirmed" in harness.status_calls[-1]["result_details"]
+
+
+@pytest.mark.asyncio
+async def test_request_generation_cancel_outcomes(harness: Harness) -> None:
+    """Each proxy answer maps to the outcome that drives the user-facing message."""
+    node = harness.node
+    assert await node._request_generation_cancel("gen-5", HEADERS) is CancelOutcome.CANCELLED
+
+    FakeAsyncClient.cancel_status_code = HTTP_BAD_REQUEST
+    assert await node._request_generation_cancel("gen-5", HEADERS) is CancelOutcome.ALREADY_STARTED
+
+    FakeAsyncClient.cancel_status_code = HTTP_SERVER_ERROR
+    assert await node._request_generation_cancel("gen-5", HEADERS) is CancelOutcome.UNKNOWN
+
+    FakeAsyncClient.cancel_error = RuntimeError("boom")
+    assert await node._request_generation_cancel("gen-5", HEADERS) is CancelOutcome.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_stale_cancellation_flag_does_not_cancel_a_new_run(harness: Harness) -> None:
+    """A flag left set by a cancelled run must not cancel the generation the next run submits.
+
+    The engine only clears the flag in BaseNode.clear_node(), which the flow's cancel path
+    does not reach for a node cancelled mid-resolution, so a re-run starts with it still set.
+    """
+    node = harness.node
+    node.request_cancellation()
+
+    def raise_missing_key() -> str:
+        msg = "missing key"
+        raise ValueError(msg)
+
+    # Bail out immediately after the flag is cleared, so this pins the ordering: the clear
+    # has to happen before the run can reach anything that reads the flag.
+    node._validate_api_key = raise_missing_key  # type: ignore[method-assign]
+    node._handle_api_key_validation_error = lambda _e: None  # type: ignore[method-assign]
+
+    await node._process_generation()
+
+    assert node.is_cancellation_requested is False
+    assert FakeAsyncClient.cancel_urls == []
+
+
+@pytest.mark.asyncio
+async def test_completed_generation_is_not_cancelled(harness: Harness) -> None:
+    """A generation that reaches a terminal state must never be sent a cancel."""
+    FakeAsyncClient.poll_status = "COMPLETED"
+
+    result = await harness.node._poll_generation_status("gen-6", HEADERS)
+
+    assert result is not None
+    assert result["status"] == "COMPLETED"
+    assert FakeAsyncClient.cancel_urls == []


### PR DESCRIPTION
Closes #548

## Problem

Cancelling a running workflow did not cancel the model proxy generation it started. The node stopped polling locally, but the generation continued on Griptape Cloud, ran to completion, and was billed. The user saw a cancelled workflow, no result, and still paid.

`_poll_generation_status` was not cancellation-aware: it never consulted `is_cancellation_requested` and had no `asyncio.CancelledError` path, so the loop unwound without telling anyone. Griptape Cloud does expose `POST /api/proxy/v2/generations/{id}/cancel`, and nothing in this library called it.

## Change

All in `GriptapeProxyNode`, so every proxy-backed node is covered rather than just the Flux node the bug was reported against.

- **`_request_generation_cancel`** — POSTs the cancel endpoint. Never raises; every failure mode collapses into a `CancelOutcome` (`CANCELLED` / `ALREADY_STARTED` / `UNKNOWN`), because a failure here must not replace the reason the node is unwinding. It also records the status the proxy reports, which is authoritative about where the work ended up.
- **`_cancel_generation_best_effort`** — wraps the POST in `asyncio.shield`, so a second `task.cancel()` landing on the node mid-request cannot abandon it before it reaches the server.
- **`_report_cancellation`** — a distinct message per outcome. A cancel that could *not* stop billable work says so explicitly and points at the Refresh button, and `generation_id` is preserved so the result stays recoverable.
- **`_poll_generation_status`** — catches `CancelledError`, fires the cancel, and re-raises; also checks `is_cancellation_requested` at the top of each iteration.
- **`_process_generation`** — clears a stale cancellation flag at the start of each run (see below).

### Both signals, and why

The `CancelledError` path is the load-bearing one: with `DEFAULT_POLL_INTERVAL = 5`, a cancel almost always lands mid-sleep. The flag check covers a cancel delivered between awaits, and callers that set the flag without cancelling the asyncio task — `parallel_resolution.cancel_all_nodes` sets `request_cancellation()` on every tracked node but only cancels tasks present in `task_to_node`.

### The stale-flag fix

A node's cancellation flag is only cleared by `BaseNode.clear_node()`, and the flow's cancel path never reaches it for a node cancelled mid-resolution — `ParallelResolutionContext.reset(cancel=True)` only sets `node_state = NodeState.CANCELED`. So the flag outlives the run it belonged to, and without this the flag left behind by a cancelled run makes the *next* run cancel the generation it had just submitted, failing every re-run. `_process_generation` now clears it at the start. That is safe: a cancellation that genuinely applies to this run is requested after the run begins and also cancels the task, and a task cancelled before it starts never enters `aprocess` at all.

## How much this actually recovers

Worth being explicit, since it bounds the value of the fix. The proxy accepts cancellation **only while a generation is `QUEUED`**; `process_org_queue` is kicked off immediately after submission and promotes the oldest queued row unless the org is at its concurrent-generation limit. So with no concurrency pressure the window is short and the cancel will often return 400.

The fix therefore saves real money when the org is at its concurrency limit or the queue is backed up — which is exactly the case where a user is most likely to cancel — and in every other case converts a silent billing surprise into a stated one.

## Scope

- Base-class change, so all proxy nodes inherit it (51 files reference `GriptapeProxyNode`).
- The only other polling loop in the library (`video/seedance_common.py`) polls *asset upload* status before submission — no billable generation — so it is out of scope.
- A cancel arriving during the submit POST itself cannot be handled: no `generation_id` exists yet. Cancellation during result-fetch is moot, as the work is already complete and billed.

## Testing

New `tests/unit/test_griptape_proxy_node_cancellation.py` (7 tests):

- task cancel mid-sleep issues the cancel POST and still re-raises `CancelledError`
- cooperative-flag path issues the cancel POST
- a 400 reports the billing consequence and does **not** claim a cancellation the proxy refused
- a cancel POST that raises does not mask the `CancelledError` that is unwinding
- status-code → `CancelOutcome` mapping
- a stale flag does not cancel a new run (verified non-vacuous: fails with the fix removed)
- a generation that reaches a terminal state is never sent a cancel

`ruff check` and `ruff format --check` clean. Full unit suite: 876 passed, 11 pre-existing skips.

Cancel Generation

<img width="450" height="798" alt="CancelGeneration" src="https://github.com/user-attachments/assets/e541fa9b-21e1-400f-9e45-0ed1056bceb8" />

Cannot Cancel Running Generation

<img width="450" height="798" alt="CannotCancelRunning" src="https://github.com/user-attachments/assets/1b7e930e-9b39-4f03-9282-bce72a99cc35" />

Refresh After Attempted Cancel

<img width="445" height="961" alt="Refresh_Retrieve" src="https://github.com/user-attachments/assets/01860bd5-04c6-4065-9bd7-38a008de8e8c" />


## Related

#547 is **not** addressed here and is a separate bug: `generation_id` is not durable, so a completed-and-billed generation can become unrecoverable and Refresh then advises a re-run. Note that this PR increases the dependency on that fix — the `ALREADY_STARTED` and `UNKNOWN` messages both direct the user to Refresh. It is not broken at the moment the message is shown (the ID is fresh from this run), but a later re-run wipes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
