### PR TITLE
feat: add explicit output resolution to TopazImageEnhance

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -29,7 +29,7 @@
   "metadata": {
     "author": "Griptape, Inc",
     "description": "Default nodes for Griptape Nodes",
-    "library_version": "0.84.0",
+    "library_version": "0.85.0",
     "engine_version": "0.96.0",
     "tags": [
       "Griptape",
@@ -7020,13 +7020,14 @@
       "file_path": "griptape_nodes_library/image/topaz_image_enhance.py",
       "metadata": {
         "category": "image",
-        "description": "Enhance images using Topaz Labs models via Griptape model proxy. Supports enhance, denoise, and sharpen operations.",
+        "description": "Enhance and upscale images using Topaz Labs models via Griptape model proxy. Supports enhance, upscale, denoise, and sharpen operations.",
         "display_name": "Topaz Image Enhance",
         "icon": "Sparkles",
         "group": "edit",
         "tags": [
           "image",
           "enhance",
+          "upscale",
           "ai",
           "api",
           "topaz"

--- a/griptape_nodes_library/image/topaz_image_enhance.py
+++ b/griptape_nodes_library/image/topaz_image_enhance.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from contextlib import suppress
 from copy import deepcopy
+from enum import StrEnum
 from typing import Any
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterGroup, ParameterMode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
 from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
@@ -21,6 +23,7 @@ from griptape_nodes.utils.artifact_normalization import normalize_artifact_input
 
 from griptape_nodes_library.proxy import GriptapeProxyNode
 from griptape_nodes_library.proxy.provider_asset_access import resolve_proxy_api_key
+from griptape_nodes_library.utils.image_utils import get_image_dimensions_from_artifact
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -41,6 +44,44 @@ OPERATION_OPTIONS = [
     "matting",
     "tool",
 ]
+
+
+class ResizeMode(StrEnum):
+    """How the requested output resolution is derived."""
+
+    NONE = "none"
+    WIDTH = "width"
+    HEIGHT = "height"
+    WIDTH_HEIGHT = "width and height"
+    PERCENTAGE = "percentage"
+
+
+# Only these three Topaz endpoints accept output_width/output_height/crop_to_fill.
+# sharpen, sharpen-generative, denoise, restore-generative, lighting and matting
+# always emit at the input resolution.
+UPSCALE_OPERATIONS = frozenset({"enhance", "enhance-generative", "tool"})
+
+# Topaz's documented bounds for a single output dimension.
+MIN_OUTPUT_DIMENSION = 1
+MAX_OUTPUT_DIMENSION = 32_000
+
+# Topaz meters output megapixels against credits, and the rate is fixed per endpoint
+# rather than per model: everything on /enhance-gen/async is Wonder-family, everything
+# on /enhance/async and /tool/async is Gigapixel-family.
+# https://developer.topazlabs.com/getting-started/model-pricing.md
+MP_PER_CREDIT_BY_OPERATION = {
+    "enhance": 24,
+    "enhance-generative": 4,
+    "tool": 24,
+}
+
+# Parameters in the resize group. Deliberately NOT part of any per-model table (and so
+# not in ALL_MODEL_PARAMS): resize is a property of the operation, not of the model, and
+# _update_visible_params_for_model hides every ALL_MODEL_PARAMS member the selected model
+# does not declare.
+RESIZE_PARAMS = ("output_width", "output_height", "percentage", "crop_to_fill")
+
+PERCENT_SCALE = 100
 
 ENHANCE_MODELS = {
     "Standard V2": [
@@ -741,6 +782,63 @@ class TopazImageEnhance(GriptapeProxyNode):
             )
         )
 
+        # Resize / upscale controls. Shown only for the operations Topaz accepts
+        # output_width/output_height on. Defaults are a no-op: at ResizeMode.NONE nothing
+        # is added to the payload, so existing workflows send byte-identical requests.
+        with ParameterGroup(name="resize", ui_options={"collapsed": False}):
+            self.add_parameter(
+                ParameterString(
+                    name="resize_mode",
+                    default_value=ResizeMode.NONE,
+                    tooltip="How to size the output image. 'none' leaves sizing to Topaz.",
+                    allow_output=False,
+                    traits={Options(choices=[mode.value for mode in ResizeMode])},
+                )
+            )
+            self.add_parameter(
+                ParameterInt(
+                    name="output_width",
+                    default_value=None,
+                    tooltip=f"Output width in pixels ({MIN_OUTPUT_DIMENSION}-{MAX_OUTPUT_DIMENSION:,})",
+                    allow_output=False,
+                    min_val=MIN_OUTPUT_DIMENSION,
+                    max_val=MAX_OUTPUT_DIMENSION,
+                    hide=True,
+                )
+            )
+            self.add_parameter(
+                ParameterInt(
+                    name="output_height",
+                    default_value=None,
+                    tooltip=f"Output height in pixels ({MIN_OUTPUT_DIMENSION}-{MAX_OUTPUT_DIMENSION:,})",
+                    allow_output=False,
+                    min_val=MIN_OUTPUT_DIMENSION,
+                    max_val=MAX_OUTPUT_DIMENSION,
+                    hide=True,
+                )
+            )
+            self.add_parameter(
+                ParameterInt(
+                    name="percentage",
+                    default_value=200,
+                    tooltip="Output size as a percentage of the source image",
+                    allow_output=False,
+                    min_val=1,
+                    hide=True,
+                )
+            )
+            self.add_parameter(
+                ParameterBool(
+                    name="crop_to_fill",
+                    default_value=False,
+                    tooltip=(
+                        "When the requested aspect ratio differs from the source, crop to fill instead of letterboxing."
+                    ),
+                    allow_output=False,
+                    hide=True,
+                )
+            )
+
         # Output format parameter
         self.add_parameter(
             ParameterString(
@@ -803,6 +901,101 @@ class TopazImageEnhance(GriptapeProxyNode):
             else:
                 self.hide_parameter_by_name(param_name)
 
+    def _update_resize_visibility(self) -> None:
+        """Show/hide the resize controls for the current operation and resize mode.
+
+        Resize is gated on the *operation*, not the model, so this is deliberately
+        separate from _update_visible_params_for_model.
+        """
+        operation = self.get_parameter_value("operation") or "enhance"
+
+        if operation not in UPSCALE_OPERATIONS:
+            # Topaz ignores these fields on the other endpoints; don't offer them.
+            self.hide_parameter_by_name(["resize_mode", *RESIZE_PARAMS])
+            if self.get_parameter_value("resize_mode") != ResizeMode.NONE:
+                # Guarded so the resulting after_value_set doesn't recurse.
+                self.set_parameter_value("resize_mode", ResizeMode.NONE)
+            return
+
+        self.show_parameter_by_name("resize_mode")
+        mode = self.get_parameter_value("resize_mode") or ResizeMode.NONE
+
+        match mode:
+            case ResizeMode.NONE:
+                visible = ()
+            case ResizeMode.WIDTH:
+                visible = ("output_width",)
+            case ResizeMode.HEIGHT:
+                visible = ("output_height",)
+            case ResizeMode.WIDTH_HEIGHT:
+                # The only mode where the requested aspect ratio can differ from the
+                # source's, so the only mode where crop_to_fill changes anything.
+                visible = ("output_width", "output_height", "crop_to_fill")
+            case ResizeMode.PERCENTAGE:
+                visible = ("percentage",)
+            case _:
+                msg = f"Unknown resize mode: {mode!r}"
+                raise ValueError(msg)
+
+        for param_name in RESIZE_PARAMS:
+            if param_name in visible:
+                self.show_parameter_by_name(param_name)
+            else:
+                self.hide_parameter_by_name(param_name)
+
+    def _update_cost_badge(self) -> None:
+        """Show the Topaz credit cost the current resize settings imply.
+
+        Topaz bills max(1, ceil(output_megapixels / rate)) credits, where the rate is
+        fixed per endpoint. That's exact whenever the output pixel count is known from
+        values already on the node; in the modes that depend on the source's aspect
+        ratio it isn't knowable until the node runs, so say so instead of guessing.
+        """
+        param = self.get_parameter_by_name("resize_mode")
+        if param is None:
+            return
+
+        operation = self.get_parameter_value("operation") or "enhance"
+        rate = MP_PER_CREDIT_BY_OPERATION.get(operation)
+        mode = self.get_parameter_value("resize_mode") or ResizeMode.NONE
+
+        if rate is None or mode == ResizeMode.NONE:
+            param.clear_badge()
+            return
+
+        if mode == ResizeMode.WIDTH_HEIGHT:
+            width = self.get_parameter_value("output_width") or 0
+            height = self.get_parameter_value("output_height") or 0
+            if width <= 0 or height <= 0:
+                param.clear_badge()
+                return
+            credits = self._credits_for_pixels(width * height, rate)
+            param.set_badge(
+                variant="info",
+                title=f"About {credits} Topaz credit{'s' if credits != 1 else ''}",
+                message=(
+                    f"{width}x{height} is {width * height / 1_000_000:.1f} MP. This operation bills "
+                    f"{rate} MP per credit, so Topaz charges {credits} credit"
+                    f"{'s' if credits != 1 else ''}."
+                ),
+            )
+            return
+
+        param.set_badge(
+            variant="note",
+            title="Cost depends on the source image",
+            message=(
+                f"This operation bills {rate} MP of output per Topaz credit. The output pixel "
+                "count -- and so the cost -- isn't known until the node runs and reads the "
+                "source's dimensions."
+            ),
+        )
+
+    @staticmethod
+    def _credits_for_pixels(pixels: int, mp_per_credit: int) -> int:
+        """Topaz's meter: megapixels divided by the rate, rounded up, minimum one credit."""
+        return max(1, math.ceil(pixels / 1_000_000 / mp_per_credit))
+
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         super().after_value_set(parameter, value)
 
@@ -821,6 +1014,12 @@ class TopazImageEnhance(GriptapeProxyNode):
 
         if parameter.name == "model" and value:
             self._update_visible_params_for_model(value)
+
+        if parameter.name in ("operation", "resize_mode"):
+            self._update_resize_visibility()
+
+        if parameter.name in ("operation", "resize_mode", "output_width", "output_height"):
+            self._update_cost_badge()
 
     async def _process_generation(self) -> None:
         await super()._process_generation()
@@ -844,6 +1043,13 @@ class TopazImageEnhance(GriptapeProxyNode):
 
         for param_name in supported_params:
             params[param_name] = self.get_parameter_value(param_name)
+
+        # Resize is keyed on the operation, not the model, so it is not in the
+        # per-model tables and has to be collected separately.
+        if operation in UPSCALE_OPERATIONS:
+            params["resize_mode"] = self.get_parameter_value("resize_mode") or ResizeMode.NONE
+            for param_name in RESIZE_PARAMS:
+                params[param_name] = self.get_parameter_value(param_name)
 
         return params
 
@@ -885,6 +1091,18 @@ class TopazImageEnhance(GriptapeProxyNode):
                     continue
                 payload[param_name] = value
 
+        # Output sizing. Topaz accepts these only on enhance, enhance-gen and tool, and
+        # silently ignores unknown keys -- so a wrong name looks like success. They are
+        # snake_case at the top level even though the per-model settings are camelCase.
+        if operation in UPSCALE_OPERATIONS:
+            width, height = self._resolve_output_size(params)
+            if width is not None:
+                payload["output_width"] = width
+            if height is not None:
+                payload["output_height"] = height
+            if width is not None or height is not None:
+                payload["crop_to_fill"] = bool(params.get("crop_to_fill"))
+
         # Add input image
         image_input = params.get("image_input")
         if image_input:
@@ -893,6 +1111,128 @@ class TopazImageEnhance(GriptapeProxyNode):
                 payload["image"] = input_image_data
 
         return payload
+
+    def _resolve_output_size(self, params: dict[str, Any]) -> tuple[int | None, int | None]:
+        """Resolve the requested output size, or (None, None) to leave sizing to Topaz.
+
+        Every mode but NONE resolves to *both* dimensions. Topaz would happily scale a
+        missing dimension itself, but then the output pixel count -- and so the credit
+        cost -- is unknowable until the job finishes, and the proxy bills at request
+        time. Deriving the partner dimension here keeps billing exact; the value matches
+        what Topaz would have picked to within a pixel.
+        """
+        mode = params.get("resize_mode") or ResizeMode.NONE
+
+        match mode:
+            case ResizeMode.NONE:
+                return (None, None)
+            case ResizeMode.WIDTH:
+                width = self._validated_dimension(params.get("output_width"), "output_width")
+                source_width, source_height = self._source_dimensions(params)
+                height = max(1, round(width * source_height / source_width))
+                return (width, self._validated_dimension(height, "output_height"))
+            case ResizeMode.HEIGHT:
+                height = self._validated_dimension(params.get("output_height"), "output_height")
+                source_width, source_height = self._source_dimensions(params)
+                width = max(1, round(height * source_width / source_height))
+                return (self._validated_dimension(width, "output_width"), height)
+            case ResizeMode.WIDTH_HEIGHT:
+                return (
+                    self._validated_dimension(params.get("output_width"), "output_width"),
+                    self._validated_dimension(params.get("output_height"), "output_height"),
+                )
+            case ResizeMode.PERCENTAGE:
+                return self._percentage_output_size(params)
+            case _:
+                msg = f"Unknown resize mode: {mode!r}"
+                raise ValueError(msg)
+
+    def _source_dimensions(self, params: dict[str, Any]) -> tuple[int, int]:
+        """Read the source image's pixel dimensions, or raise if they can't be read.
+
+        get_image_dimensions_from_artifact reports failure as (0, 0). Treating that as
+        "skip the resize" would ship an un-upscaled image that looks like a success.
+        """
+        source_width, source_height = get_image_dimensions_from_artifact(params.get("image_input"))
+        if source_width <= 0 or source_height <= 0:
+            msg = (
+                f"{self.name}: could not read the source image's dimensions, which are required "
+                f"by the '{params.get('resize_mode')}' resize mode. Use "
+                f"'{ResizeMode.WIDTH_HEIGHT}' to request an explicit size instead."
+            )
+            raise ValueError(msg)
+        return (source_width, source_height)
+
+    def _percentage_output_size(self, params: dict[str, Any]) -> tuple[int, int]:
+        """Scale the source's dimensions by the requested percentage."""
+        percentage = params.get("percentage")
+        if not percentage or percentage <= 0:
+            msg = f"{self.name}: percentage must be greater than 0 to resize by percentage."
+            raise ValueError(msg)
+
+        source_width, source_height = self._source_dimensions(params)
+
+        scale = percentage / PERCENT_SCALE
+        return (
+            self._validated_dimension(max(1, round(source_width * scale)), "output_width"),
+            self._validated_dimension(max(1, round(source_height * scale)), "output_height"),
+        )
+
+    def _validated_dimension(self, value: Any, param_name: str) -> int:
+        """Check a single output dimension against Topaz's documented bounds."""
+        if value is None:
+            msg = f"{self.name}: {param_name} is required for the selected resize mode."
+            raise ValueError(msg)
+        if isinstance(value, bool) or not isinstance(value, int):
+            msg = f"{self.name}: {param_name} must be an integer, got {value!r}."
+            raise ValueError(msg)
+        if not MIN_OUTPUT_DIMENSION <= value <= MAX_OUTPUT_DIMENSION:
+            msg = (
+                f"{self.name}: {param_name} must be between {MIN_OUTPUT_DIMENSION} and "
+                f"{MAX_OUTPUT_DIMENSION:,}, got {value}."
+            )
+            raise ValueError(msg)
+        return value
+
+    def validate_before_node_run(self) -> list[Exception] | None:
+        """Catch resize misconfiguration before the node runs.
+
+        after_value_set does not fire while a workflow loads, so a workflow saved against
+        an older build can come back with a resize mode set on an operation that cannot
+        honour it. Fail loudly rather than silently dropping the request.
+        """
+        errors = super().validate_before_node_run() or []
+
+        operation = self.get_parameter_value("operation") or "enhance"
+        mode = self.get_parameter_value("resize_mode") or ResizeMode.NONE
+
+        if mode == ResizeMode.NONE:
+            return errors or None
+
+        if operation not in UPSCALE_OPERATIONS:
+            supported = ", ".join(sorted(UPSCALE_OPERATIONS))
+            errors.append(
+                ValueError(
+                    f"{self.name}: resize_mode is '{mode}' but the '{operation}' operation cannot "
+                    f"resize. Topaz accepts an output size only for: {supported}."
+                )
+            )
+            return errors
+
+        # Range-check whatever the mode actually requires. Percentage needs the source
+        # image, so it is left to run time.
+        required = {
+            ResizeMode.WIDTH: ("output_width",),
+            ResizeMode.HEIGHT: ("output_height",),
+            ResizeMode.WIDTH_HEIGHT: ("output_width", "output_height"),
+        }.get(mode, ())
+        for param_name in required:
+            try:
+                self._validated_dimension(self.get_parameter_value(param_name), param_name)
+            except ValueError as exc:  # noqa: PERF203
+                errors.append(exc)
+
+        return errors or None
 
     async def _process_input_image(self, image_input: Any) -> str | None:
         """Process input image and convert to base64 data URI."""

--- a/tests/unit/image/test_topaz_image_enhance.py
+++ b/tests/unit/image/test_topaz_image_enhance.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes_library.image.topaz_image_enhance import (
+    MAX_OUTPUT_DIMENSION,
+    ResizeMode,
+    TopazImageEnhance,
+)
+
+RESIZE_KEYS = ("output_width", "output_height", "crop_to_fill")
+
+
+def _node(name: str = "TopazImageEnhance") -> TopazImageEnhance:
+    return TopazImageEnhance(name=name)
+
+
+def _stub_image(node: TopazImageEnhance, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stand in for reading the source image and base64-encoding it.
+
+    The real call reaches static storage; the payload tests only care about the
+    resize keys sitting next to it.
+    """
+    node.set_parameter_value("image_input", "https://example.com/source.png")
+    monkeypatch.setattr(
+        TopazImageEnhance,
+        "_process_input_image",
+        _async_return("data:image/png;base64,AAAA"),
+    )
+
+
+def _async_return(value: object):  # noqa: ANN202
+    async def _stub(*_args: object, **_kwargs: object) -> object:
+        return value
+
+    return _stub
+
+
+def _stub_source_dimensions(monkeypatch: pytest.MonkeyPatch, width: int, height: int) -> None:
+    monkeypatch.setattr(
+        "griptape_nodes_library.image.topaz_image_enhance.get_image_dimensions_from_artifact",
+        lambda _artifact: (width, height),
+    )
+
+
+# -- backward compatibility --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_payload_carries_no_resize_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The regression test for every workflow saved before resize existed: an
+    # untouched node must send exactly what it sent before.
+    node = _node()
+    _stub_image(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    for key in RESIZE_KEYS:
+        assert key not in payload
+
+
+@pytest.mark.asyncio
+async def test_resize_mode_none_carries_no_resize_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    node.set_parameter_value("resize_mode", ResizeMode.NONE)
+    # Stale dimensions left over from a previous mode must not leak into the payload.
+    node.set_parameter_value("output_width", 4096)
+    node.set_parameter_value("output_height", 4096)
+
+    payload = await node._build_payload()
+
+    for key in RESIZE_KEYS:
+        assert key not in payload
+
+
+def test_defaults_are_none_so_the_payload_skips_them() -> None:
+    # _build_payload skips a value only when it is None; a 0 default would be sent
+    # and rejected by Topaz's 1-32000 range.
+    node = _node()
+
+    assert node.get_parameter_value("output_width") is None
+    assert node.get_parameter_value("output_height") is None
+
+
+# -- payload -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_width_and_height_emits_both_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("output_width", 3840)
+    node.set_parameter_value("output_height", 2160)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] == 3840
+    assert payload["output_height"] == 2160
+    assert payload["crop_to_fill"] is False
+
+
+@pytest.mark.asyncio
+async def test_width_only_derives_height_from_the_source_aspect(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Topaz would scale the missing dimension itself, but then the output pixel
+    # count is unknowable at request time and the proxy bills at request time.
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 960, 540)
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH)
+    node.set_parameter_value("output_width", 3840)
+    node.set_parameter_value("output_height", 9999)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] == 3840
+    assert payload["output_height"] == 2160
+
+
+@pytest.mark.asyncio
+async def test_height_only_derives_width_from_the_source_aspect(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 960, 540)
+    node.set_parameter_value("resize_mode", ResizeMode.HEIGHT)
+    node.set_parameter_value("output_height", 2160)
+    node.set_parameter_value("output_width", 9999)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] == 3840
+    assert payload["output_height"] == 2160
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [ResizeMode.WIDTH, ResizeMode.HEIGHT, ResizeMode.PERCENTAGE])
+async def test_every_resize_mode_emits_both_dimensions(monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+    # The proxy bills from width x height and rejects a lone dimension, so no mode
+    # may emit only one.
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 1000, 750)
+    node.set_parameter_value("resize_mode", mode)
+    node.set_parameter_value("output_width", 2000)
+    node.set_parameter_value("output_height", 1500)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] > 0
+    assert payload["output_height"] > 0
+
+
+@pytest.mark.asyncio
+async def test_percentage_scales_the_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 960, 540)
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 200)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] == 1920
+    assert payload["output_height"] == 1080
+
+
+@pytest.mark.asyncio
+async def test_percentage_below_100_downscales(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 1000, 500)
+    node.set_parameter_value("resize_mode", ResizeMode.PERCENTAGE)
+    node.set_parameter_value("percentage", 50)
+
+    payload = await node._build_payload()
+
+    assert payload["output_width"] == 500
+    assert payload["output_height"] == 250
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [ResizeMode.WIDTH, ResizeMode.HEIGHT, ResizeMode.PERCENTAGE])
+async def test_source_dependent_modes_raise_when_the_source_cannot_be_read(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    # get_image_dimensions_from_artifact returns (0, 0) on failure. Silently skipping
+    # the resize would ship an un-upscaled image that looks like a success.
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 0, 0)
+    node.set_parameter_value("resize_mode", mode)
+    node.set_parameter_value("output_width", 2000)
+    node.set_parameter_value("output_height", 1500)
+
+    with pytest.raises(ValueError, match="could not read the source image"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_width_and_height_does_not_need_the_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The escape hatch the other modes' error message points at.
+    node = _node()
+    _stub_image(node, monkeypatch)
+    _stub_source_dimensions(monkeypatch, 0, 0)
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("output_width", 2000)
+    node.set_parameter_value("output_height", 1500)
+
+    payload = await node._build_payload()
+
+    assert (payload["output_width"], payload["output_height"]) == (2000, 1500)
+
+
+@pytest.mark.asyncio
+async def test_crop_to_fill_is_emitted_when_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("output_width", 1000)
+    node.set_parameter_value("output_height", 1000)
+    node.set_parameter_value("crop_to_fill", True)
+
+    payload = await node._build_payload()
+
+    assert payload["crop_to_fill"] is True
+
+
+@pytest.mark.asyncio
+async def test_crop_to_fill_is_not_emitted_without_a_dimension(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    _stub_image(node, monkeypatch)
+    node.set_parameter_value("crop_to_fill", True)
+
+    payload = await node._build_payload()
+
+    assert "crop_to_fill" not in payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["denoise", "sharpen", "lighting", "matting"])
+async def test_non_resizable_operations_never_emit_resize_keys(monkeypatch: pytest.MonkeyPatch, operation: str) -> None:
+    # Topaz silently ignores unknown fields, so sending them here would bill for
+    # pixels the endpoint never produces.
+    node = _node()
+    _stub_image(node, monkeypatch)
+    node.set_parameter_value("operation", operation)
+    node.set_parameter_value("output_width", 4096)
+    node.set_parameter_value("output_height", 4096)
+
+    payload = await node._build_payload()
+
+    for key in RESIZE_KEYS:
+        assert key not in payload
+
+
+# -- validation --------------------------------------------------------------
+
+
+def test_default_node_validates_clean() -> None:
+    node = _node()
+
+    assert node.validate_before_node_run() is None
+
+
+def _force_values(node: TopazImageEnhance, monkeypatch: pytest.MonkeyPatch, **values: object) -> None:
+    """Bypass the parameters' own validation to reach the node's guards.
+
+    `min_val`/`max_val` clamp an out-of-range dimension and the `Options` trait
+    rejects an off-list operation, so `set_parameter_value` can never deliver
+    either. The guards still exist because a workflow saved against an older build
+    loads with `initial_setup=True`, which skips every hook; this is how they get
+    exercised.
+    """
+    original = node.get_parameter_value
+    monkeypatch.setattr(
+        node,
+        "get_parameter_value",
+        lambda name, *a, **kw: values.get(name, original(name, *a, **kw)),
+    )
+
+
+@pytest.mark.parametrize("value", [0, -1, MAX_OUTPUT_DIMENSION + 1])
+def test_out_of_range_dimensions_are_rejected(monkeypatch: pytest.MonkeyPatch, value: int) -> None:
+    node = _node()
+    _force_values(
+        node,
+        monkeypatch,
+        resize_mode=ResizeMode.WIDTH_HEIGHT,
+        output_width=value,
+        output_height=1024,
+    )
+
+    errors = node.validate_before_node_run() or []
+
+    assert any("output_width must be between" in str(error) for error in errors)
+
+
+def test_missing_dimension_is_rejected() -> None:
+    node = _node()
+    node.set_parameter_value("resize_mode", ResizeMode.WIDTH_HEIGHT)
+    node.set_parameter_value("output_width", 1024)
+
+    errors = node.validate_before_node_run() or []
+
+    assert any("output_height is required" in str(error) for error in errors)
+
+
+def test_resize_on_a_non_resizable_operation_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    # after_value_set does not run during workflow load, so a stale combination can
+    # reach run time. It must fail loudly rather than silently drop the resize.
+    node = _node()
+    _force_values(
+        node,
+        monkeypatch,
+        operation="denoise",
+        resize_mode=ResizeMode.WIDTH_HEIGHT,
+        output_width=1024,
+        output_height=1024,
+    )
+
+    errors = node.validate_before_node_run() or []
+
+    assert any("cannot resize" in str(error) for error in errors)
+
+
+def test_unknown_resize_mode_raises_rather_than_defaulting() -> None:
+    # The wildcard case must surface an unexpected value, not silently emit nothing.
+    node = _node()
+
+    with pytest.raises(ValueError, match="Unknown resize mode"):
+        node._resolve_output_size({"resize_mode": "4x"})
+
+
+def test_boolean_dimensions_are_rejected() -> None:
+    # True is 1 in Python; the int check has to reject bools explicitly.
+    node = _node()
+
+    with pytest.raises(ValueError, match="must be an integer"):
+        node._validated_dimension(True, "output_width")  # noqa: FBT003
+
+
+# -- credit meter ------------------------------------------------------------
+
+# Topaz's published tables, reproduced row for row. These prove the formula
+# rather than restating it.
+# https://developer.topazlabs.com/image-models/gigapixel/standard-2.md
+GIGAPIXEL_TABLE = [(1, 1), (4, 1), (8, 1), (16, 1), (24, 1), (32, 2), (40, 2), (50, 3), (64, 3), (100, 5)]
+# https://developer.topazlabs.com/image-models/wonder/standard-max.md
+WONDER_TABLE = [(1, 1), (4, 1), (8, 2), (16, 4), (24, 6), (32, 8), (40, 10), (50, 13), (64, 16), (100, 25)]
+
+
+@pytest.mark.parametrize(("megapixels", "expected"), GIGAPIXEL_TABLE)
+def test_gigapixel_credits_match_the_published_table(megapixels: int, expected: int) -> None:
+    assert TopazImageEnhance._credits_for_pixels(megapixels * 1_000_000, 24) == expected
+
+
+@pytest.mark.parametrize(("megapixels", "expected"), WONDER_TABLE)
+def test_wonder_credits_match_the_published_table(megapixels: int, expected: int) -> None:
+    assert TopazImageEnhance._credits_for_pixels(megapixels * 1_000_000, 4) == expected
+
+
+def test_credits_round_up_past_the_boundary() -> None:
+    # The case per-megapixel billing gets wrong: Topaz rounds credits, not megapixels.
+    assert TopazImageEnhance._credits_for_pixels(24 * 1_000_000, 24) == 1
+    assert TopazImageEnhance._credits_for_pixels(25 * 1_000_000, 24) == 2
+
+
+def test_credits_never_fall_below_one() -> None:
+    assert TopazImageEnhance._credits_for_pixels(1, 24) == 1


### PR DESCRIPTION
Part 1 of griptape-ai/griptape-cloud#2178. The billing half is griptape-ai/griptape-cloud#2209 — **that one must merge and its migration must apply first**, or Topaz image jobs bill 0.

## What

Topaz's enhance models *are* the upscalers, but `TopazImageEnhance` had no way to say how big the output should be — it always took whatever Autopilot picked. You couldn't target 4K, hit a print size, or do a plain 2x.

Topaz accepts three top-level **snake_case** fields — `output_width`, `output_height` (1–32000) and `crop_to_fill` — on exactly three endpoints: `/enhance/async`, `/enhance-gen/async`, `/tool/async`. There is no `upscale_factor`. This PR exposes them behind a `Resize` parameter group.

| `resize_mode` | emits |
|---|---|
| `none` (default) | nothing — today's payload, byte for byte |
| `width` | `output_width` + height derived from the source aspect ratio |
| `height` | `output_height` + width derived from the source aspect ratio |
| `width and height` | both, verbatim; `crop_to_fill` also shown |
| `percentage` | both, scaled from the source dimensions |

A badge on `resize_mode` shows the estimated Topaz credit cost using the same `max(1, ceil(output_MP / rate))` meter the cloud bills on.

## Backward compatibility

Non-breaking, and there's a test that pins it. Two things make it so:

- **`output_width`/`output_height` default to `None`, not `0`.** `_build_payload` skips a parameter only when its value is `None` — a `0` default would send `output_width=0`, violate Topaz's 1–32000 range, and fail *every existing workflow on this node*.
- **Nothing depends on a load-time callback.** Workflow load runs with `initial_setup=True`, which skips all before/after hooks, so `after_value_set` never fires. `__init__` declares the group already correct for the default `enhance` / `none` state.

Workflows serialize only parameters that have a value, so a parameter that didn't exist gets no `SetParameterValueRequest` and falls back to its default. Connections are keyed by parameter name; there is no node signature or parameter-set hash anywhere in the engine.

## Deviation from the plan

The plan had `width`-only and `height`-only send a single dimension and let Topaz scale the other. The cloud biller requires **both dimensions or neither** — a lone dimension makes output megapixels unknowable at request time, which is the exact hole the billing change closes — so those modes would have 400'd. The node now derives the partner dimension from the source aspect ratio instead. The cost is that `width`/`height` need a readable source image, like `percentage` does; `width and height` is the escape hatch when the source can't be read.

## Testing

`make check` clean. `make test/unit` → **920 passed, 11 skipped**, including 51 new tests in `tests/unit/image/test_topaz_image_enhance.py`:

- default payload contains none of `output_width`/`output_height`/`crop_to_fill` (the backcompat regression test)
- `resize_mode=none` emits nothing even with stale dimensions left in the fields
- each mode's payload; width/height derive the partner dimension; every non-`none` mode emits both
- source-unreadable raises for `width`/`height`/`percentage`; `width and height` doesn't need the source
- `crop_to_fill` only ever accompanies a dimension
- `denoise`/`sharpen`/`lighting`/`matting` never emit resize keys
- validation: out of range, missing dimension, resize on a non-resizable operation, bools rejected as dimensions
- the published Topaz credit tables, row for row

## Not done

**No live call to Topaz has been made.** Topaz *silently ignores* fields it doesn't recognize rather than rejecting them, so a snake_case/camelCase mistake in `output_width` would look exactly like success — a plausible image at the wrong size. A real 2x and a real fixed-4K run, asserting the returned image's actual dimensions, is the one check that can't be replaced by unit tests. Worth doing before this leaves draft.

Also pre-existing, noted but not fixed: `webp` is in the node's `OUTPUT_FORMAT_OPTIONS` but is not in Topaz's documented output enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
