### PR TITLE
Add TopazVideoConvertHdr for SDR-to-HDR conversion via Topaz Hyperion

### DIFF
--- a/griptape_nodes_library.json
+++ b/griptape_nodes_library.json
@@ -767,6 +767,18 @@
                 "family": "Topaz",
                 "provider_model_id": "topaz-video-ast-2",
                 "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "gtc_topaz_video_hyp_2": {
+                "display_name": "Topaz Hyperion 2",
+                "family": "Topaz",
+                "provider_model_id": "topaz-video-hyp-2",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
+              },
+              "gtc_topaz_video_hyp_2_5": {
+                "display_name": "Topaz Hyperion 2.5",
+                "family": "Topaz",
+                "provider_model_id": "topaz-video-hyp-2.5",
+                "key_support": "SUPPORTS_CUSTOMER_KEY_OR_GRIPTAPE_KEY"
               }
             }
           },
@@ -2937,6 +2949,37 @@
               "gtc_topaz_video_slp_2_5",
               "gtc_topaz_video_slp_2_6",
               "gtc_topaz_video_ast_2"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "class_name": "TopazVideoConvertHdr",
+      "file_path": "griptape_nodes_library/video/topaz_video_convert_hdr.py",
+      "metadata": {
+        "category": "video",
+        "description": "Convert an SDR video to HDR using Topaz Hyperion via the Griptape model proxy. Billed per frame.",
+        "display_name": "Topaz Video Convert HDR",
+        "icon": "Sparkles",
+        "group": "edit",
+        "tags": [
+          "video",
+          "hdr",
+          "sdr",
+          "convert",
+          "tone-mapping",
+          "ai",
+          "api",
+          "topaz",
+          "hyperion"
+        ],
+        "declarations": [
+          {
+            "type": "model_usage",
+            "model_ids": [
+              "gtc_topaz_video_hyp_2",
+              "gtc_topaz_video_hyp_2_5"
             ]
           }
         ]

--- a/griptape_nodes_library/proxy/proxy_api_key_providers.py
+++ b/griptape_nodes_library/proxy/proxy_api_key_providers.py
@@ -145,6 +145,7 @@ _NODE_PROVIDER_CONFIGS = {
     "SeedreamImageGeneration": SEED,
     "SoraVideoGeneration": OPENAI,
     "TopazImageEnhance": TOPAZ,
+    "TopazVideoConvertHdr": TOPAZ,
     "TopazVideoUpscale": TOPAZ,
     "TranscribeAudio": OPENAI,
     "TripoImageTo3DGeneration": TRIPO,

--- a/griptape_nodes_library/video/topaz_video_common.py
+++ b/griptape_nodes_library/video/topaz_video_common.py
@@ -1,0 +1,134 @@
+"""Shared plumbing for the Topaz video nodes.
+
+Topaz's video API takes one request shape -- ``source`` / ``output`` / ``filters`` --
+regardless of which model runs. Everything here is about *that shape* rather than about
+any one model: mapping a file to Topaz's ``source.container`` enum, probing the source
+with ffprobe, deriving a frame count the API will accept, and the pixel-area threshold
+the per-frame billing tiers turn on.
+
+What differs per model -- resize modes, creative controls, frame caps, output encoding --
+stays in the node modules.
+
+Everything here is a module-level pure function, following ``seedance_common``: none of it
+needs node state beyond a name to put in an error message, so none of it is a mixin. The
+nodes keep thin methods that delegate, which is also what lets a test monkeypatch
+``SomeNode._probe_source`` and have it take effect.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from griptape_nodes.files.file import File, FileLoadError
+
+from griptape_nodes_library.media import coerce_media_url_or_data_uri
+from griptape_nodes_library.utils.ffmpeg_utils import extract_video_metadata_structured
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from griptape_nodes_library.utils.ffmpeg_utils import VideoMetadata
+
+__all__ = [
+    "CONTAINER_BY_TOKEN",
+    "TIER_1080P_MAX_PIXELS",
+    "derive_container",
+    "frame_count",
+    "probe_source",
+    "to_even",
+]
+
+# Topaz's source.container enum is exactly mp4/mov/mkv:
+# https://developer.topazlabs.com/reference/api-endpoints/video/create-request.md
+#
+# ffprobe's format_name can't tell these apart -- mp4 and mov both report
+# "mov,mp4,m4a,3gp,3g2,mj2", and mkv and webm both report "matroska,webm" (which
+# isn't even a valid Topaz value) -- so container is derived from the file
+# extension (or, for a data URI, the MIME subtype) instead. See derive_container.
+CONTAINER_BY_TOKEN: dict[str, str] = {
+    "mp4": "mp4",
+    "m4v": "mp4",
+    "mov": "mov",
+    "qt": "mov",
+    "quicktime": "mov",
+    "mkv": "mkv",
+    "matroska": "mkv",
+    "x-matroska": "mkv",
+}
+
+# Every per-frame Topaz video model bills in two rate tiers, chosen by output pixel
+# *area*, not height. A portrait 1080x1920 output bills as 1080p; 1921x1080 already
+# bills as 4K. Starlight, Astra and Hyperion all share this threshold.
+# https://developer.topazlabs.com/getting-started/model-pricing
+TIER_1080P_MAX_PIXELS = 1920 * 1080
+
+
+def probe_source(video_input: Any, *, node_name: str) -> VideoMetadata:
+    """Resolve the input to a local path and probe it with ffprobe.
+
+    Resolving through ``File`` first is what makes ``{inputs}/clip.mp4`` macro
+    paths work; handing the raw value to ffprobe silently fails for those.
+    """
+    video_url = coerce_media_url_or_data_uri(video_input, kind="video")
+    if not video_url:
+        msg = f"{node_name} could not resolve the input video."
+        raise ValueError(msg)
+
+    try:
+        resolved_path = File(video_url).resolve()
+    except FileLoadError as e:
+        msg = f"{node_name} could not resolve video path {video_url!r}: {e}"
+        raise ValueError(msg) from e
+
+    return extract_video_metadata_structured(str(resolved_path))
+
+
+def derive_container(video_input: Any, *, node_name: str) -> str:
+    """Map the input video to Topaz's exact ``source.container`` enum (mp4/mov/mkv).
+
+    Deliberately independent of ``probe_source``/``VideoMetadata``: it only needs
+    the raw parameter value, and calling the same cheap, pure
+    ``coerce_media_url_or_data_uri`` helper here keeps this check from being
+    silently bypassed by tests that stub ``probe_source`` wholesale.
+    """
+    video_url = coerce_media_url_or_data_uri(video_input, kind="video") or ""
+    if video_url.startswith("data:"):
+        header = video_url.removeprefix("data:").split(",", 1)[0]
+        token = header.split(";", 1)[0].split("/", 1)[-1].lower()
+    else:
+        token = Path(urlsplit(video_url).path).suffix.lstrip(".").lower()
+
+    container = CONTAINER_BY_TOKEN.get(token)
+    if container is None:
+        found = token or "no extension"
+        msg = f"{node_name}: Topaz only accepts mp4, mov, or mkv source video, but got {found!r}."
+        raise ValueError(msg)
+    return container
+
+
+def frame_count(metadata: VideoMetadata) -> int:
+    """Derive the source frame count, which the proxy requires and never defaults.
+
+    ffprobe omits ``nb_frames`` for plenty of ordinary MP4s, so fall back to
+    duration x frame rate rather than letting the request 400 downstream.
+
+    Returns 0 when neither is available; the caller decides what to say about it.
+    """
+    nb_frames = metadata.frame_details.optional_nb_frames
+    if nb_frames and nb_frames > 0:
+        return nb_frames
+
+    duration = metadata.file_details.optional_duration
+    frame_rate = metadata.frame_details.frame_rate
+    if duration and duration > 0 and frame_rate > 0:
+        return math.ceil(duration * frame_rate)
+
+    return 0
+
+
+def to_even(value: int) -> int:
+    """Round down to an even number -- odd dimensions break yuv420 encoding."""
+    return max(2, value - (value % 2))

--- a/griptape_nodes_library/video/topaz_video_convert_hdr.py
+++ b/griptape_nodes_library/video/topaz_video_convert_hdr.py
@@ -1,0 +1,582 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from griptape.artifacts.video_url_artifact import VideoUrlArtifact
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_parameter import (
+    PublicArtifactUrlParameter,
+)
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.traits.options import Options
+
+from griptape_nodes_library.proxy import GriptapeProxyNode
+from griptape_nodes_library.utils.ffmpeg_utils import VideoMetadata
+from griptape_nodes_library.video.topaz_video_common import (
+    derive_container,
+    frame_count,
+    probe_source,
+    to_even,
+)
+
+logger = logging.getLogger("griptape_nodes")
+
+__all__ = ["TopazVideoConvertHdr"]
+
+# Both versions are registered in the proxy at the same price and the same request
+# shape. 2.5 is the newer model and the default; 2 is kept selectable because 2.5 is
+# absent from Topaz's own credit calculator and may not yet be live on the REST API.
+MODEL_MAPPING = {
+    "Hyperion 2.5": "topaz-video-hyp-2.5",
+    "Hyperion 2": "topaz-video-hyp-2",
+}
+
+DEFAULT_MODEL = "Hyperion 2.5"
+
+# Topaz documents no Hyperion-specific frame cap, unlike Astra's explicit 9000/450.
+# This is the platform-wide job cap, which is also what the proxy clamps billing to.
+# Our conservative choice rather than a published Hyperion limit.
+MAX_HYPERION_FRAMES = 9000
+
+
+class OutputFormat(StrEnum):
+    """How the HDR result is encoded.
+
+    Values are the display spelling so they interpolate straight into badge prose and
+    read correctly in the dropdown.
+    """
+
+    H265_MAIN10 = "H.265 Main10 (mp4)"
+    PRORES_422_HQ = "ProRes 422 HQ (mov)"
+
+
+@dataclass(frozen=True)
+class OutputEncoding:
+    """The three ``output`` fields one format choice fans out to, plus its size ceiling.
+
+    Kept as one table rather than three conditionals: the encoder, the profile and the
+    container have to agree -- a ProRes stream in an mp4 is not a thing -- and splitting
+    them invites exactly that mismatch.
+    """
+
+    video_encoder: str
+    video_profile: str
+    container: str
+    # Topaz's per-encoder maximum output dimension. Hyperion does not scale, so this
+    # only bites on an unusually large source, but H.265 tops out well below ProRes.
+    # https://developer.topazlabs.com/reference/api-endpoints/video/create-request
+    max_dimension: int
+    file_extension: str
+
+
+OUTPUT_ENCODINGS: dict[OutputFormat, OutputEncoding] = {
+    # "Main10" is the 10-bit H.265 profile. 8-bit "Main" is not offered: banding in
+    # smooth gradients is the classic 8-bit HDR failure, and it would waste the
+    # conversion.
+    OutputFormat.H265_MAIN10: OutputEncoding(
+        video_encoder="H265",
+        video_profile="Main10",
+        container="mp4",
+        max_dimension=8192,
+        file_extension="mp4",
+    ),
+    # ProRes is the mastering path Topaz's own Hyperion page advertises. Note that
+    # `videoEncoder`'s published enum is [AV1, H264, H265, VP9] and omits ProRes, while
+    # two sibling fields in the *same* schema document it -- `videoProfile` lists the
+    # four 422 profiles and the resolution table gives ProRes a 16386 ceiling. The enum
+    # is assumed stale, the same way `source.external.provider`'s was. Unverified
+    # against the live API; if Topaz rejects it, drop this entry.
+    OutputFormat.PRORES_422_HQ: OutputEncoding(
+        video_encoder="ProRes",
+        video_profile="422 HQ",
+        container="mov",
+        max_dimension=16386,
+        file_extension="mov",
+    ),
+}
+
+DEFAULT_OUTPUT_FORMAT = OutputFormat.H265_MAIN10
+
+
+def _default_filename(output_format: OutputFormat) -> str:
+    """Default output filename for a format, so the extension tracks the container."""
+    return f"topaz_video_convert_hdr.{OUTPUT_ENCODINGS[output_format].file_extension}"
+
+
+# ffprobe's spellings for transfer characteristics and primaries that mean the source
+# is already HDR. Hyperion would still run -- and still bill -- but it would be
+# tone-mapping something that does not need it.
+HDR_TRANSFERS = frozenset({"smpte2084", "arib-std-b67", "smpte428", "bt2020-10", "bt2020-12"})
+HDR_PRIMARIES = frozenset({"bt2020"})
+
+# ffprobe reports progressive footage as "progressive"; anything else here is some
+# flavour of interlacing. Topaz notes that SDR-to-HDR "does not operate well with
+# interlaced footage".
+PROGRESSIVE_FIELD_ORDER = "progressive"
+
+COST_BADGE_MESSAGE = (
+    "Hyperion is metered **per frame**, not per second.\n\n"
+    "Two rate tiers, picked by output pixel area:\n"
+    "- **1080p** (up to 1920x1080) — the cheaper tier\n"
+    "- **4K** (anything larger) — roughly **2.2x** the 1080p rate\n\n"
+    "Hyperion costs about **2x Starlight** per frame on both tiers, which makes it one "
+    "of the more expensive video models here. Because it converts rather than scales, "
+    "the output resolution matches the source — so the tier is decided by the clip you "
+    "feed it, not by a setting on this node.\n\n"
+    "A 10-second 30fps clip is 300 frames whichever tier it lands in.\n\n"
+    "[Topaz model pricing](https://developer.topazlabs.com/getting-started/model-pricing)"
+)
+
+HDR_PREVIEW_CAVEAT = (
+    "The saved file is HDR (BT.2020 primaries, PQ transfer). Preview surfaces that "
+    "assume SDR may render it darker or flatter than it really is — check the file "
+    "itself rather than the thumbnail."
+)
+
+
+class TopazVideoConvertHdr(GriptapeProxyNode):
+    """Convert an SDR video to HDR with Topaz Hyperion via the Griptape Cloud model proxy.
+
+    Hyperion is a tone-mapper, not an upscaler: it takes no creative controls, does not
+    change the resolution or the frame rate, and tags the output BT.2020/PQ itself.
+    Hyperion 1 exposed an explicit ``transferFunction`` (pq/hlg); 2 and 2.5 dropped it,
+    so there is no transfer selector to offer.
+
+    Inputs:
+        - video (VideoUrlArtifact): source SDR video to convert
+
+    Outputs:
+        - video_output (VideoUrlArtifact): the HDR video, saved to project storage
+        - generation_id (str): Griptape Cloud generation id
+        - provider_response (dict): the provider's result payload
+        - was_successful (bool) / result_details (str): execution status
+    """
+
+    SERVICE_NAME = "Griptape"
+    API_KEY_NAME = "GT_CLOUD_API_KEY"
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.category = "video"
+        self.description = (
+            "Convert an SDR video to HDR using Topaz Hyperion via the Griptape model proxy. "
+            "Billed per frame -- see the cost note on the model parameter."
+        )
+
+        # Advisories raised while probing the source (already-HDR input, interlacing).
+        # Collected rather than raised: both are real cases a user may mean to run.
+        self._advisories: list[str] = []
+
+        # INPUTS / PROPERTIES
+
+        model_param = ParameterString(
+            name="model",
+            default_value=DEFAULT_MODEL,
+            tooltip="Topaz Hyperion version to convert with. Both versions are priced identically.",
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            traits={Options(choices=list(MODEL_MAPPING.keys()))},
+        )
+        self.add_parameter(model_param)
+
+        # Topaz downloads the source itself rather than receiving it in the request
+        # body -- a video is far too large to base64 into JSON. This uploads the
+        # input to Griptape Cloud storage and hands back a public URL, which
+        # `_build_payload` passes through as `source.external`. An input that is
+        # already a public http(s) URL is passed through without re-uploading.
+        self._public_video_url_parameter = PublicArtifactUrlParameter(
+            node=self,
+            artifact_url_parameter=ParameterVideo(
+                name="video",
+                tooltip="Source SDR video to convert to HDR",
+                allowed_modes={ParameterMode.INPUT},
+                hide_property=True,
+                ui_options={"display_name": "input video"},
+            ),
+            disclaimer_message="Topaz Labs fetches the video from this URL to perform the conversion.",
+        )
+        self._public_video_url_parameter.add_input_parameters()
+
+        output_format_param = ParameterString(
+            name="output_format",
+            default_value=DEFAULT_OUTPUT_FORMAT,
+            tooltip=(
+                "How to encode the HDR result. H.265 Main10 plays in more places; "
+                "ProRes 422 HQ is the mastering format."
+            ),
+            allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            traits={Options(choices=[f.value for f in OutputFormat])},
+        )
+        self.add_parameter(output_format_param)
+
+        # OUTPUTS
+
+        self.add_parameter(
+            ParameterDict(
+                name="provider_response",
+                tooltip="Response from API (latest polling response)",
+                allowed_modes={ParameterMode.OUTPUT},
+                hide_property=True,
+                hide=True,
+            )
+        )
+
+        self.add_parameter(
+            ParameterVideo(
+                name="video_output",
+                tooltip="The HDR video",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+                settable=False,
+                ui_options={"pulse_on_run": True},
+            )
+        )
+
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename=_default_filename(DEFAULT_OUTPUT_FORMAT),
+        )
+        self._output_file.add_parameter()
+
+        self._create_status_parameters(
+            result_details_tooltip="Details about the conversion result or any errors",
+            result_details_placeholder="Conversion status and details will appear here.",
+            parameter_group_initially_collapsed=True,
+        )
+
+        self.set_initial_node_size(height=360)
+        # After every add_parameter: setting a badge on a name that does not exist yet
+        # silently no-ops, which would leave the cost note missing with no error to
+        # point at.
+        self._update_cost_badge()
+        self._update_format_badge()
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def aprocess(self) -> None:
+        try:
+            await super().aprocess()
+        finally:
+            # Only once polling has finished: Topaz fetches the source from this
+            # URL when the job starts, so deleting it any earlier would pull the
+            # video out from under a queued job.
+            self._public_video_url_parameter.delete_uploaded_artifact()
+
+    # -- model routing -----------------------------------------------------
+
+    def _get_api_model_id(self) -> str:
+        model_name = self.get_parameter_value("model") or DEFAULT_MODEL
+        return MODEL_MAPPING.get(model_name, MODEL_MAPPING[DEFAULT_MODEL])
+
+    def _encoding(self) -> OutputEncoding:
+        """The encoder/profile/container triple for the selected format.
+
+        Raises rather than defaulting: an unmapped value means OutputFormat and
+        OUTPUT_ENCODINGS have drifted, and silently encoding to the wrong container is
+        worse than a loud failure. The Options trait makes an off-list value
+        unreachable from the UI anyway.
+        """
+        selected = self.get_parameter_value("output_format") or DEFAULT_OUTPUT_FORMAT
+        try:
+            output_format = OutputFormat(selected)
+        except ValueError:
+            msg = f"{self.name}: unknown output format {selected!r}."
+            raise ValueError(msg) from None
+
+        encoding = OUTPUT_ENCODINGS.get(output_format)
+        if encoding is None:
+            msg = f"{self.name}: no encoding is registered for {output_format!r}."
+            raise ValueError(msg)
+        return encoding
+
+    # -- UI reactions ------------------------------------------------------
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        super().after_value_set(parameter, value)
+
+        # Unlike the match statements elsewhere in this file, the wildcard here must be
+        # a no-op rather than a raise: `parameter.name` is an open set -- `video`,
+        # `output_file` and every status parameter also land here.
+        match parameter.name:
+            case "output_format":
+                self._update_format_badge()
+                if isinstance(value, str):
+                    self._sync_output_filename(value)
+            case _:
+                return
+
+    def _sync_output_filename(self, output_format: str) -> None:
+        """Rewrite the output filename's extension to match the chosen container.
+
+        Only rewrites while the filename is still one of the format-derived defaults, so a
+        filename the user typed is never clobbered.
+        """
+        current_value = self.get_parameter_value("output_file")
+        default_filenames = {_default_filename(fmt) for fmt in OutputFormat}
+        if current_value not in default_filenames:
+            return
+
+        try:
+            updated_value = _default_filename(OutputFormat(output_format))
+        except ValueError:
+            return
+
+        if current_value == updated_value:
+            return
+
+        self.set_parameter_value("output_file", updated_value)
+        self.publish_update_to_parameter("output_file", updated_value)
+
+    def _update_cost_badge(self) -> None:
+        param = self.get_parameter_by_name("model")
+        if param is None:
+            return
+
+        param.set_badge(variant="warning", title="Billed per frame", message=COST_BADGE_MESSAGE)
+
+    def _update_format_badge(self) -> None:
+        param = self.get_parameter_by_name("output_format")
+        if param is None:
+            return
+
+        match OutputFormat(self.get_parameter_value("output_format") or DEFAULT_OUTPUT_FORMAT):
+            case OutputFormat.H265_MAIN10:
+                param.set_badge(
+                    variant="info",
+                    title="10-bit H.265 in an mp4",
+                    message=(f"Widely playable, and small enough to move around. {HDR_PREVIEW_CAVEAT}"),
+                )
+            case OutputFormat.PRORES_422_HQ:
+                param.set_badge(
+                    variant="warning",
+                    title="Large mastering files",
+                    message=(
+                        "ProRes 422 HQ is the format Topaz recommends for grading, and is "
+                        "many times larger than H.265. A `.mov` will not play in a browser "
+                        f"preview at all. {HDR_PREVIEW_CAVEAT}"
+                    ),
+                )
+            case output_format:
+                msg = f"Unknown output format: {output_format!r}"
+                raise ValueError(msg)
+
+    # -- source probing ----------------------------------------------------
+
+    def _probe_source(self, video_input: Any) -> VideoMetadata:
+        """Probe the source with ffprobe. See ``topaz_video_common.probe_source``."""
+        return probe_source(video_input, node_name=self.name)
+
+    def _derive_container(self, video_input: Any) -> str:
+        """Map the input to Topaz's container enum. See ``topaz_video_common.derive_container``."""
+        return derive_container(video_input, node_name=self.name)
+
+    @staticmethod
+    def _frame_count(metadata: VideoMetadata) -> int:
+        """Derive the source frame count. See ``topaz_video_common.frame_count``."""
+        return frame_count(metadata)
+
+    def _source_advisories(self, metadata: VideoMetadata) -> list[str]:
+        """Flag sources Hyperion will process but probably should not be given.
+
+        Both cases warn rather than block. A file mislabelled as BT.2020 is a real
+        thing, and so is deliberately re-running a conversion; refusing either would
+        be worse than saying so.
+        """
+        advisories: list[str] = []
+        color = metadata.color_details
+
+        transfer = (color.optional_color_transfer or "").lower()
+        primaries = (color.optional_color_primaries or "").lower()
+        if transfer in HDR_TRANSFERS or primaries in HDR_PRIMARIES:
+            advisories.append(
+                f"The source already looks like HDR (transfer {transfer or 'unset'!r}, "
+                f"primaries {primaries or 'unset'!r}). Hyperion converts SDR footage; "
+                "running it on HDR input still bills for every frame."
+            )
+
+        field_order = (color.optional_field_order or "").lower()
+        if field_order and field_order != PROGRESSIVE_FIELD_ORDER:
+            advisories.append(
+                f"The source reports interlaced field order {field_order!r}. Topaz notes "
+                "that SDR-to-HDR conversion does not operate well on interlaced footage; "
+                "deinterlace it first for a usable result."
+            )
+
+        return advisories
+
+    def _output_resolution(self, source_width: int, source_height: int) -> tuple[int, int]:
+        """Hyperion converts rather than scales, so the output matches the source.
+
+        Topaz requires ``output.resolution`` regardless, and the proxy reads it to pick
+        the billing tier, so it is echoed back rather than omitted.
+        """
+        width, height = to_even(source_width), to_even(source_height)
+
+        max_dimension = self._encoding().max_dimension
+        if width > max_dimension or height > max_dimension:
+            encoding = self._encoding()
+            msg = (
+                f"{self.name}: the source is {source_width}x{source_height}, over the "
+                f"{max_dimension}-pixel limit for {encoding.video_encoder}. Choose a "
+                "different output format or downscale the source first."
+            )
+            raise ValueError(msg)
+
+        return width, height
+
+    # -- request -----------------------------------------------------------
+
+    async def _build_payload(self) -> dict[str, Any]:
+        video = self.get_parameter_value("video")
+        if not video:
+            msg = f"{self.name} requires an input video to convert."
+            raise ValueError(msg)
+
+        container = self._derive_container(video)
+
+        # ffprobe is synchronous and can take a moment on a long clip; keep it off
+        # the event loop.
+        metadata = await asyncio.to_thread(self._probe_source, video)
+
+        source_width = metadata.dimensions.width
+        source_height = metadata.dimensions.height
+
+        source_frames = self._frame_count(metadata)
+        if source_frames <= 0:
+            msg = (
+                f"{self.name} could not determine the frame count of the input video. "
+                "Topaz requires it, and neither nb_frames nor duration x frame rate was "
+                "available from the file."
+            )
+            raise ValueError(msg)
+
+        if source_frames > MAX_HYPERION_FRAMES:
+            msg = (
+                f"{self.name}: the input video has {source_frames} frames, over the "
+                f"{MAX_HYPERION_FRAMES:,}-frame job limit. Trim or split the video first."
+            )
+            raise ValueError(msg)
+
+        output_width, output_height = self._output_resolution(source_width, source_height)
+
+        self._advisories = self._source_advisories(metadata)
+        for advisory in self._advisories:
+            logger.warning("%s: %s", self.name, advisory)
+
+        # Upload after probing: the probe needs the original local path, and there
+        # is no point paying for an upload if the file turns out to be unusable.
+        video_url = self._public_video_url_parameter.get_public_url_for_parameter()
+        if not video_url:
+            msg = f"{self.name} could not produce a public URL for the input video."
+            raise ValueError(msg)
+
+        source: dict[str, Any] = {
+            "container": container,
+            "frameCount": source_frames,
+            "frameRate": metadata.frame_details.frame_rate,
+            "resolution": {"width": source_width, "height": source_height},
+            # Topaz fetches the video from this URL itself. `provider` is required and
+            # must be one of r2/s3/web-url -- it labels the transport, not the host, so
+            # `web-url` is correct for the Azure Blob SAS URL the upload hands back.
+            "external": {"provider": "web-url", "presignedUrl": video_url},
+        }
+        if metadata.file_details.optional_duration:
+            source["duration"] = metadata.file_details.optional_duration
+        if metadata.file_details.optional_file_size:
+            source["size"] = metadata.file_details.optional_file_size
+
+        encoding = self._encoding()
+
+        logger.info(
+            "%s converting %dx%d (%d frames) to HDR as %s/%s",
+            self.name,
+            source_width,
+            source_height,
+            source_frames,
+            encoding.video_encoder,
+            encoding.video_profile,
+        )
+
+        # `output` carries the encoder triple but not `frameRate`, `audioCodec` or
+        # `audioTransfer`, which the published schema marks required. The live
+        # validator does not enforce them -- TopazVideoUpscale ships sending only
+        # `resolution` -- and guessing an audio disposition for a source whose audio
+        # streams we have not probed is the worse risk.
+        return {
+            "source": source,
+            "output": {
+                "resolution": {"width": output_width, "height": output_height},
+                "videoEncoder": encoding.video_encoder,
+                "videoProfile": encoding.video_profile,
+                "container": encoding.container,
+            },
+        }
+        # No `filters`: Hyperion accepts no creative controls, and the proxy stamps the
+        # routed model code onto the filters it synthesizes itself. Sending our own
+        # would only risk the "filters[].model must match the requested model"
+        # rejection.
+
+    # -- result ------------------------------------------------------------
+
+    async def _parse_result(self, result_json: dict[str, Any], _generation_id: str) -> None:
+        raw_bytes = result_json.get("raw_bytes")
+        if isinstance(raw_bytes, (bytes, bytearray)):
+            await self._handle_binary_video_response(bytes(raw_bytes))
+            return
+
+        # `download.url` is Topaz's documented shape for a completed generation.
+        await self._download_and_save(
+            result_json["download"]["url"],
+            "video_output",
+            lambda v, n: VideoUrlArtifact(value=v, name=n),
+            media_kind="video",
+            action="converted to HDR",
+        )
+
+    async def _handle_binary_video_response(self, video_bytes: bytes) -> None:
+        """Save video bytes served directly by the proxy rather than via a URL."""
+        if not video_bytes:
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"{self.name}: the conversion completed but no video data was received.",
+            )
+            return
+
+        try:
+            dest = self._output_file.build_file()
+            saved = await dest.awrite_bytes(video_bytes)
+        except (OSError, PermissionError) as e:
+            logger.error("%s failed to save the converted video: %s", self.name, e)
+            self._set_safe_defaults()
+            self._set_status_results(
+                was_successful=False,
+                result_details=f"{self.name}: the conversion succeeded but saving the video failed: {e}",
+            )
+            return
+
+        self.parameter_output_values["video_output"] = VideoUrlArtifact(value=saved.location, name=saved.name)
+        self._set_status_results(
+            was_successful=True,
+            result_details=f"Conversion successful. Video saved as {saved.name}. {HDR_PREVIEW_CAVEAT}",
+        )
+
+    def _handle_payload_build_error(self, e: Exception) -> None:
+        if isinstance(e, ValueError):
+            self._set_safe_defaults()
+            self._set_status_results(was_successful=False, result_details=str(e))
+            self._handle_failure_exception(e)
+            return
+
+        super()._handle_payload_build_error(e)
+
+    def _set_safe_defaults(self) -> None:
+        self.parameter_output_values["generation_id"] = ""
+        self.parameter_output_values["provider_response"] = None
+        self.parameter_output_values["video_output"] = None

--- a/griptape_nodes_library/video/topaz_video_upscale.py
+++ b/griptape_nodes_library/video/topaz_video_upscale.py
@@ -4,9 +4,7 @@ import asyncio
 import logging
 import math
 from enum import StrEnum
-from pathlib import Path
 from typing import Any
-from urllib.parse import urlsplit
 
 from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
@@ -19,13 +17,18 @@ from griptape_nodes.exe_types.param_types.parameter_float import ParameterFloat
 from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
 
-from griptape_nodes_library.media import coerce_media_url_or_data_uri
 from griptape_nodes_library.proxy import GriptapeProxyNode
-from griptape_nodes_library.utils.ffmpeg_utils import VideoMetadata, extract_video_metadata_structured
+from griptape_nodes_library.utils.ffmpeg_utils import VideoMetadata
+from griptape_nodes_library.video.topaz_video_common import (
+    TIER_1080P_MAX_PIXELS,
+    derive_container,
+    frame_count,
+    probe_source,
+    to_even,
+)
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -75,29 +78,6 @@ MAX_ASTRA_FRAMES = 9000
 # A prompt drops Astra's ceiling by 20x. As with Starlight the proxy only clamps what
 # it *bills*; the job still reaches Topaz, which rejects it.
 MAX_ASTRA_FRAMES_WITH_PROMPT = 450
-
-# Topaz's source.container enum is exactly mp4/mov/mkv:
-# https://developer.topazlabs.com/reference/api-endpoints/video/create-request.md
-#
-# ffprobe's format_name can't tell these apart -- mp4 and mov both report
-# "mov,mp4,m4a,3gp,3g2,mj2", and mkv and webm both report "matroska,webm" (which
-# isn't even a valid Topaz value) -- so container is derived from the file
-# extension (or, for a data URI, the MIME subtype) instead. See _derive_container.
-CONTAINER_BY_TOKEN: dict[str, str] = {
-    "mp4": "mp4",
-    "m4v": "mp4",
-    "mov": "mov",
-    "qt": "mov",
-    "quicktime": "mov",
-    "mkv": "mkv",
-    "matroska": "mkv",
-    "x-matroska": "mkv",
-}
-
-# Both families bill in two rate tiers, chosen by output pixel *area*, not height. A
-# portrait 1080x1920 output bills as 1080p; 1921x1080 already bills as 4K.
-# https://developer.topazlabs.com/getting-started/model-pricing
-TIER_1080P_MAX_PIXELS = 1920 * 1080
 
 # Topaz's documented hard output ceiling for Starlight (distinct from the 1080p/4K
 # billing-tier boundary above): https://docs.topazlabs.com/video-ai/project-starlight
@@ -600,68 +580,22 @@ class TopazVideoUpscale(GriptapeProxyNode):
     # -- source probing ----------------------------------------------------
 
     def _probe_source(self, video_input: Any) -> VideoMetadata:
-        """Resolve the input to a local path and probe it with ffprobe.
-
-        Resolving through ``File`` first is what makes ``{inputs}/clip.mp4`` macro
-        paths work; handing the raw value to ffprobe silently fails for those.
-        """
-        video_url = coerce_media_url_or_data_uri(video_input, kind="video")
-        if not video_url:
-            msg = f"{self.name} could not resolve the input video."
-            raise ValueError(msg)
-
-        try:
-            resolved_path = File(video_url).resolve()
-        except FileLoadError as e:
-            msg = f"{self.name} could not resolve video path {video_url!r}: {e}"
-            raise ValueError(msg) from e
-
-        return extract_video_metadata_structured(str(resolved_path))
+        """Probe the source with ffprobe. See ``topaz_video_common.probe_source``."""
+        return probe_source(video_input, node_name=self.name)
 
     def _derive_container(self, video_input: Any) -> str:
-        """Map the input video to Topaz's exact ``source.container`` enum (mp4/mov/mkv).
-
-        Deliberately independent of ``_probe_source``/``VideoMetadata``: it only needs
-        the raw parameter value, and calling the same cheap, pure
-        ``coerce_media_url_or_data_uri`` helper here keeps this check from being
-        silently bypassed by tests that stub ``_probe_source`` wholesale.
-        """
-        video_url = coerce_media_url_or_data_uri(video_input, kind="video") or ""
-        if video_url.startswith("data:"):
-            header = video_url.removeprefix("data:").split(",", 1)[0]
-            token = header.split(";", 1)[0].split("/", 1)[-1].lower()
-        else:
-            token = Path(urlsplit(video_url).path).suffix.lstrip(".").lower()
-
-        container = CONTAINER_BY_TOKEN.get(token)
-        if container is None:
-            found = token or "no extension"
-            msg = f"{self.name}: Topaz only accepts mp4, mov, or mkv source video, but got {found!r}."
-            raise ValueError(msg)
-        return container
+        """Map the input to Topaz's container enum. See ``topaz_video_common.derive_container``."""
+        return derive_container(video_input, node_name=self.name)
 
     @staticmethod
     def _frame_count(metadata: VideoMetadata) -> int:
-        """Derive the source frame count, which the proxy requires and never defaults.
-
-        ffprobe omits ``nb_frames`` for plenty of ordinary MP4s, so fall back to
-        duration x frame rate rather than letting the request 400 downstream.
-        """
-        nb_frames = metadata.frame_details.optional_nb_frames
-        if nb_frames and nb_frames > 0:
-            return nb_frames
-
-        duration = metadata.file_details.optional_duration
-        frame_rate = metadata.frame_details.frame_rate
-        if duration and duration > 0 and frame_rate > 0:
-            return math.ceil(duration * frame_rate)
-
-        return 0
+        """Derive the source frame count. See ``topaz_video_common.frame_count``."""
+        return frame_count(metadata)
 
     @staticmethod
     def _to_even(value: int) -> int:
-        """Round down to an even number -- odd dimensions break yuv420 encoding."""
-        return max(2, value - (value % 2))
+        """Round down to an even number. See ``topaz_video_common.to_even``."""
+        return to_even(value)
 
     def _output_resolution(self, source_width: int, source_height: int) -> tuple[int, int]:
         mode = self.get_parameter_value("resize_mode") or ResizeMode.PERCENTAGE

--- a/tests/unit/video/test_topaz_video_convert_hdr.py
+++ b/tests/unit/video/test_topaz_video_convert_hdr.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes_library.proxy.proxy_api_key_providers import _NODE_PROVIDER_CONFIGS
+from griptape_nodes_library.utils.ffmpeg_utils import (
+    ColorDetails,
+    Dimensions,
+    FileDetails,
+    FrameDetails,
+    VideoMetadata,
+)
+from griptape_nodes_library.video.topaz_video_convert_hdr import (
+    DEFAULT_MODEL,
+    DEFAULT_OUTPUT_FORMAT,
+    MAX_HYPERION_FRAMES,
+    MODEL_MAPPING,
+    OUTPUT_ENCODINGS,
+    OutputFormat,
+    TopazVideoConvertHdr,
+)
+
+
+def _metadata(
+    *,
+    width: int = 1920,
+    height: int = 1080,
+    nb_frames: int | None = 300,
+    duration: float | None = 10.0,
+    frame_rate: float = 30.0,
+    file_size: int | None = 1234,
+    color_transfer: str | None = None,
+    color_primaries: str | None = None,
+    field_order: str | None = None,
+) -> VideoMetadata:
+    return VideoMetadata(
+        file_details=FileDetails(
+            codec_name="h264",
+            codec_type="video",
+            optional_duration=duration,
+            optional_file_size=file_size,
+        ),
+        dimensions=Dimensions(
+            width=width,
+            height=height,
+            aspect_ratio_decimal=width / height,
+            aspect_ratio_string="16:9",
+        ),
+        color_details=ColorDetails(
+            optional_color_transfer=color_transfer,
+            optional_color_primaries=color_primaries,
+            optional_field_order=field_order,
+        ),
+        frame_details=FrameDetails(
+            r_frame_rate=f"{int(frame_rate)}/1",
+            avg_frame_rate=f"{int(frame_rate)}/1",
+            time_base="1/30000",
+            frame_rate=frame_rate,
+            optional_nb_frames=nb_frames,
+        ),
+    )
+
+
+def _node(name: str = "TopazVideoConvertHdr") -> TopazVideoConvertHdr:
+    return TopazVideoConvertHdr(name=name)
+
+
+def _stub_probe(monkeypatch: pytest.MonkeyPatch, metadata: VideoMetadata) -> None:
+    monkeypatch.setattr(
+        TopazVideoConvertHdr,
+        "_probe_source",
+        lambda self, video_input: metadata,  # noqa: ARG005
+    )
+
+
+PUBLIC_URL = "https://acct.blob.core.windows.net/bucket/clip.mp4?sig=abc"
+
+
+def _stub_public_url(
+    node: TopazVideoConvertHdr, monkeypatch: pytest.MonkeyPatch, value: str | None = PUBLIC_URL
+) -> None:
+    """Stand in for the upload to Griptape Cloud storage.
+
+    The real call presigns a URL over the network; the node only cares that it
+    gets one back to hand to Topaz as `source.external`.
+    """
+    monkeypatch.setattr(
+        node._public_video_url_parameter,
+        "get_public_url_for_parameter",
+        lambda: value,
+    )
+
+
+# -- model routing -----------------------------------------------------------
+
+
+def test_default_model_routes_to_hyperion_2_5() -> None:
+    node = _node()
+
+    assert node.get_parameter_value("model") == DEFAULT_MODEL
+    assert node._get_api_model_id() == "topaz-video-hyp-2.5"
+
+
+def test_hyperion_2_is_selectable() -> None:
+    node = _node()
+    node.set_parameter_value("model", "Hyperion 2")
+
+    assert node._get_api_model_id() == "topaz-video-hyp-2"
+
+
+def test_unknown_model_falls_back_to_the_default() -> None:
+    # The Options trait makes this unreachable from the UI, but a workflow file
+    # carrying a stale name must not route to an empty model id.
+    node = _node()
+    node.set_parameter_value("model", "Hyperion 9")
+
+    assert node._get_api_model_id() == MODEL_MAPPING[DEFAULT_MODEL]
+
+
+def test_every_model_is_declared_in_the_byok_registry() -> None:
+    # Missing from _NODE_PROVIDER_CONFIGS the node silently loses its BYOK
+    # parameters -- no error, just a node that can only use the Griptape key.
+    assert _NODE_PROVIDER_CONFIGS["TopazVideoConvertHdr"].provider_id == "topaz"
+
+
+# -- output format mapping ---------------------------------------------------
+
+
+def test_every_output_format_has_an_encoding() -> None:
+    # OutputFormat and OUTPUT_ENCODINGS are two tables that must not drift;
+    # _encoding() raises on a miss, and this catches it at test time.
+    assert set(OUTPUT_ENCODINGS) == set(OutputFormat)
+
+
+def test_default_format_is_h265_main10_in_mp4() -> None:
+    node = _node()
+    encoding = node._encoding()
+
+    assert node.get_parameter_value("output_format") == DEFAULT_OUTPUT_FORMAT
+    assert (encoding.video_encoder, encoding.video_profile, encoding.container) == ("H265", "Main10", "mp4")
+
+
+def test_prores_maps_to_a_mov() -> None:
+    node = _node()
+    node.set_parameter_value("output_format", OutputFormat.PRORES_422_HQ)
+    encoding = node._encoding()
+
+    assert (encoding.video_encoder, encoding.video_profile, encoding.container) == ("ProRes", "422 HQ", "mov")
+
+
+def test_unknown_output_format_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The Options trait silently discards an off-list value, so this is only
+    # reachable through a stale workflow file -- but encoding to the wrong
+    # container is worse than a loud failure, so the guard has to hold.
+    node = _node()
+    monkeypatch.setattr(node, "get_parameter_value", lambda _name: "AV1 (webm)")
+
+    with pytest.raises(ValueError, match="unknown output format"):
+        node._encoding()
+
+
+def test_the_options_trait_discards_an_off_list_format() -> None:
+    node = _node()
+    node.set_parameter_value("output_format", "AV1 (webm)")
+
+    assert node.get_parameter_value("output_format") == DEFAULT_OUTPUT_FORMAT
+
+
+def test_output_filename_tracks_the_container() -> None:
+    node = _node()
+    assert node.get_parameter_value("output_file") == "topaz_video_convert_hdr.mp4"
+
+    node.set_parameter_value("output_format", OutputFormat.PRORES_422_HQ)
+    assert node.get_parameter_value("output_file") == "topaz_video_convert_hdr.mov"
+
+    node.set_parameter_value("output_format", OutputFormat.H265_MAIN10)
+    assert node.get_parameter_value("output_file") == "topaz_video_convert_hdr.mp4"
+
+
+def test_a_user_typed_filename_is_never_clobbered() -> None:
+    node = _node()
+    node.set_parameter_value("output_file", "my_graded_master.mp4")
+    node.set_parameter_value("output_format", OutputFormat.PRORES_422_HQ)
+
+    assert node.get_parameter_value("output_file") == "my_graded_master.mp4"
+
+
+# -- output resolution -------------------------------------------------------
+
+
+def test_output_resolution_echoes_the_source() -> None:
+    # Hyperion converts rather than scales, so there is no resize to apply.
+    node = _node()
+
+    assert node._output_resolution(1920, 1080) == (1920, 1080)
+    assert node._output_resolution(3840, 2160) == (3840, 2160)
+
+
+def test_output_resolution_is_rounded_to_even() -> None:
+    node = _node()
+
+    assert node._output_resolution(1921, 1081) == (1920, 1080)
+
+
+def test_output_resolution_rejects_a_source_over_the_encoder_limit() -> None:
+    node = _node()
+
+    with pytest.raises(ValueError, match="over the 8192-pixel limit for H265"):
+        node._output_resolution(10000, 4000)
+
+
+def test_prores_accepts_a_source_h265_cannot_hold() -> None:
+    node = _node()
+    node.set_parameter_value("output_format", OutputFormat.PRORES_422_HQ)
+
+    assert node._output_resolution(10000, 4000) == (10000, 4000)
+
+
+# -- payload -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"] == {
+        "container": "mp4",
+        "frameCount": 300,
+        "frameRate": 30.0,
+        "resolution": {"width": 1920, "height": 1080},
+        "duration": 10.0,
+        "size": 1234,
+        "external": {"provider": "web-url", "presignedUrl": PUBLIC_URL},
+    }
+    assert payload["output"] == {
+        "resolution": {"width": 1920, "height": 1080},
+        "videoEncoder": "H265",
+        "videoProfile": "Main10",
+        "container": "mp4",
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_payload_carries_the_prores_triple(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    node.set_parameter_value("output_format", OutputFormat.PRORES_422_HQ)
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["output"]["videoEncoder"] == "ProRes"
+    assert payload["output"]["videoProfile"] == "422 HQ"
+    assert payload["output"]["container"] == "mov"
+
+
+@pytest.mark.asyncio
+async def test_build_payload_omits_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Hyperion takes no creative controls, and the proxy stamps the routed model
+    # code onto the filters it synthesizes itself.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "filters" not in payload
+    assert "model" not in payload
+
+
+@pytest.mark.asyncio
+async def test_build_payload_sends_no_video_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The whole point of source.external: the video never travels in the body.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "video" not in payload
+    assert payload["source"]["external"]["presignedUrl"] == PUBLIC_URL
+
+
+@pytest.mark.asyncio
+async def test_build_payload_omits_absent_optional_source_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(duration=None, file_size=None))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert "duration" not in payload["source"]
+    assert "size" not in payload["source"]
+
+
+@pytest.mark.asyncio
+async def test_build_payload_derives_frame_count_from_duration(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=None, duration=4.5, frame_rate=24.0))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["frameCount"] == 108
+
+
+@pytest.mark.asyncio
+async def test_build_payload_requires_a_video() -> None:
+    node = _node()
+
+    with pytest.raises(ValueError, match="requires an input video"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_rejects_underivable_frame_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=None, duration=None, frame_rate=0.0))
+    _stub_public_url(node, monkeypatch)
+
+    with pytest.raises(ValueError, match="could not determine the frame count"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_rejects_clips_over_the_frame_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_HYPERION_FRAMES + 1))
+    _stub_public_url(node, monkeypatch)
+
+    with pytest.raises(ValueError, match="over the 9,000-frame job limit"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_rejected_input_is_never_uploaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Uploading costs a round trip and cloud storage, so the cheap local checks
+    # have to run first. A clip over the frame cap must be rejected before it is
+    # ever sent anywhere.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(nb_frames=MAX_HYPERION_FRAMES + 1))
+
+    calls: list[None] = []
+
+    def _record() -> str:
+        calls.append(None)
+        return PUBLIC_URL
+
+    monkeypatch.setattr(node._public_video_url_parameter, "get_public_url_for_parameter", _record)
+
+    with pytest.raises(ValueError, match="over the 9,000-frame job limit"):
+        await node._build_payload()
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_build_payload_raises_when_no_public_url_is_produced(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch, value=None)
+
+    with pytest.raises(ValueError, match="could not produce a public URL"):
+        await node._build_payload()
+
+
+@pytest.mark.asyncio
+async def test_build_payload_derives_the_container_from_a_mov_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mov")
+    _stub_probe(monkeypatch, _metadata())
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["container"] == "mov"
+
+
+# -- source advisories -------------------------------------------------------
+
+
+def test_no_advisories_for_ordinary_progressive_sdr() -> None:
+    node = _node()
+
+    assert (
+        node._source_advisories(_metadata(color_transfer="bt709", color_primaries="bt709", field_order="progressive"))
+        == []
+    )
+
+
+def test_an_unprobed_source_raises_no_advisories() -> None:
+    # ffprobe leaves all three fields unset on plenty of ordinary files; an unset
+    # value must not read as HDR or as interlaced.
+    node = _node()
+
+    assert node._source_advisories(_metadata()) == []
+
+
+def test_pq_transfer_is_flagged_as_already_hdr() -> None:
+    node = _node()
+
+    advisories = node._source_advisories(_metadata(color_transfer="smpte2084"))
+
+    assert len(advisories) == 1
+    assert "already looks like HDR" in advisories[0]
+
+
+def test_bt2020_primaries_are_flagged_as_already_hdr() -> None:
+    node = _node()
+
+    advisories = node._source_advisories(_metadata(color_primaries="bt2020"))
+
+    assert len(advisories) == 1
+    assert "already looks like HDR" in advisories[0]
+
+
+def test_interlaced_footage_is_flagged() -> None:
+    node = _node()
+
+    advisories = node._source_advisories(_metadata(field_order="tt"))
+
+    assert len(advisories) == 1
+    assert "interlaced" in advisories[0]
+
+
+def test_both_advisories_can_fire_at_once() -> None:
+    node = _node()
+
+    assert len(node._source_advisories(_metadata(color_transfer="smpte2084", field_order="bff"))) == 2
+
+
+@pytest.mark.asyncio
+async def test_an_already_hdr_source_is_still_converted(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The advisory warns; it must not block. A file mislabelled BT.2020 is real,
+    # and so is deliberately re-running a conversion.
+    node = _node()
+    node.set_parameter_value("video", "{inputs}/clip.mp4")
+    _stub_probe(monkeypatch, _metadata(color_transfer="smpte2084"))
+    _stub_public_url(node, monkeypatch)
+
+    payload = await node._build_payload()
+
+    assert payload["source"]["frameCount"] == 300
+    assert node._advisories
+
+
+# -- result parsing -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_parse_result_downloads_from_the_documented_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `download.url` is Topaz's documented shape for a completed generation.
+    node = _node()
+    captured: dict = {}
+
+    async def fake_download_and_save(self, download_url, *_args, **_kwargs) -> None:  # noqa: ARG001
+        captured["url"] = download_url
+
+    monkeypatch.setattr(TopazVideoConvertHdr, "_download_and_save", fake_download_and_save)
+
+    await node._parse_result({"status": "complete", "download": {"url": "https://topaz.example/out.mp4"}}, "gen-1")
+
+    assert captured["url"] == "https://topaz.example/out.mp4"
+
+
+@pytest.mark.asyncio
+async def test_parse_result_takes_the_binary_branch_for_raw_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    node = _node()
+    captured: dict = {}
+
+    async def fake_binary(self, video_bytes: bytes) -> None:  # noqa: ARG001
+        captured["bytes"] = video_bytes
+
+    monkeypatch.setattr(TopazVideoConvertHdr, "_handle_binary_video_response", fake_binary)
+
+    await node._parse_result({"raw_bytes": b"\x00\x01"}, "gen-1")
+
+    assert captured["bytes"] == b"\x00\x01"
+
+
+@pytest.mark.asyncio
+async def test_empty_binary_response_fails_cleanly() -> None:
+    node = _node()
+
+    await node._handle_binary_video_response(b"")
+
+    assert node.parameter_output_values["was_successful"] is False
+    assert node.parameter_output_values["video_output"] is None
+
+
+def test_payload_build_error_triggers_failure_exception() -> None:
+    # _handle_failure_exception is what raises when the failure output has no
+    # outgoing connection -- without it a ValueError guard sets was_successful=False
+    # and quietly dead-ends the flow instead of crashing with immediate feedback.
+    node = _node()
+    err = ValueError("boom")
+    with patch.object(node, "_handle_failure_exception") as mock_failure:
+        node._handle_payload_build_error(err)
+    mock_failure.assert_called_once_with(err)
+
+
+def test_set_safe_defaults_clears_every_output() -> None:
+    node = _node()
+    node._set_safe_defaults()
+
+    assert node.parameter_output_values["generation_id"] == ""
+    assert node.parameter_output_values["provider_response"] is None
+    assert node.parameter_output_values["video_output"] is None


### PR DESCRIPTION
Adds `TopazVideoConvertHdr`, a node that converts an SDR video to HDR with Topaz Hyperion through the Griptape Cloud model proxy.

Node half of griptape-ai/griptape-cloud#2205. **Blocked on griptape-ai/griptape-cloud#2208** — the node 400s at client construction until the proxy knows the model ids.

> **Base branch is `feature/topaz-astra-2`, not `main`.** That branch is still in review, rewrites 456 lines of `topaz_video_upscale.py`, and adds the `gtc_topaz_video_ast_2` catalog entry; branching from `main` conflicts in both files. Rebase once Astra merges.

## Why a new node rather than a mode on `TopazVideoUpscale`

There is no SDR-to-HDR conversion anywhere in the library today. The only HDR path is `LTXVideoToVideoHDR` — a generative model on a different provider that emits a ZIP of per-frame EXRs rather than a playable file.

Hyperion is a tone-mapper. It takes no creative controls, does not resize, and tags BT.2020/PQ itself, so it shares almost nothing with the upscale UI: no resize modes, no prompt, no tier badge branches.

## What it exposes — and what it deliberately does not

| | |
|---|---|
| `model` | Hyperion 2.5 (default) / Hyperion 2 |
| `video` | source SDR clip, uploaded and handed to Topaz as `source.external` |
| `output_format` | H.265 Main10 (mp4), default · ProRes 422 HQ (mov) |

**No transfer-function control.** Hyperion 1 had `transferFunction` (`pq`/`hlg`); 2 and 2.5 dropped it, and the schema has no color field of any kind. The model tags the output itself, so there is nothing for the node to offer and nothing for it to promise beyond what `ffprobe` shows.

**No resize.** Hyperion converts rather than scales, so `output.resolution` echoes the probed source. Topaz requires the field regardless, and the proxy reads it to pick the billing tier.

`output_format` is the one real choice, and it fans out to three request fields — `videoEncoder`, `videoProfile`, `container` — through a single table. A ProRes stream in an mp4 is not a thing, and three separate conditionals would eventually produce one.

## Both model ids

`hyp-2` and `hyp-2.5` are the same price, the same request shape, and the same activity types. `hyp-2.5` is absent from Topaz's own credit calculator and their launch post says "coming soon to Topaz Video", so it is not yet certain it is live on the REST API. Carrying both costs two catalog entries and covers either answer — and satisfies griptape-ai/griptape-cloud#1970, which asked for Hyperion 2 specifically.

## Advisories, not gates

The probe flags two cases and lets the run proceed:

- source already reports `smpte2084` / `bt2020` — converting it bills every frame for a no-op
- source reports interlaced field order — Topaz notes SDR→HDR "does not operate well with interlaced footage"

Both warn rather than block. A file mislabelled BT.2020 is real, and so is deliberately re-running a conversion; refusing either would be worse than saying so.

## ProRes is an assumption

`videoEncoder`'s published enum is `[AV1, H264, H265, VP9]` and omits ProRes — while two sibling fields in the *same* schema document it: `videoProfile` lists the four 422 profiles, and the resolution table gives ProRes a 16386 ceiling. The enum is assumed stale, the same way `source.external.provider`'s was (its real list `r2, s3, web-url` was only recoverable from the validator's error string).

**Not verified against the live API.** If Topaz rejects it, the fix is deleting one entry from `OUTPUT_ENCODINGS`.

## Shared module

`topaz_video_common.py` holds the source plumbing `TopazVideoUpscale` already had — `probe_source`, `derive_container`, `frame_count`, `to_even`, `CONTAINER_BY_TOKEN`, `TIER_1080P_MAX_PIXELS` — following the `seedance_common` precedent (module-level pure functions, no mixin). The upscale node keeps thin delegating methods, so its behaviour and its 70 existing tests are unchanged.

The neighbouring modules were checked and are all wrong homes: `public_video_url_mixin.py` is LTX-specific (its reason for existing is a base64 fallback tier Topaz never uses), `base_video_processor.py` is a local ffmpeg base with no proxy involvement, and `media/` is for genuinely provider-agnostic helpers.

## Also

`TopazVideoConvertHdr` is registered in `_NODE_PROVIDER_CONFIGS`. Skipping that **silently** drops the BYOK parameters — no error, just a node that can only ever use the Griptape key.

The result details say plainly that an HDR preview may look wrong while the file is correct. A BT.2020 PQ file is exactly what griptape-ai/griptape-vsl-gui#2724 renders too dark, and a ProRes `.mov` will not preview in a browser at all.

## Cost

Hyperion bills **per frame**, in two tiers by output pixel area (a portrait 1080x1920 bills as 1080p), at roughly **2× Starlight** — one of the more expensive video models here. The frame cap is 9,000, matching what the proxy clamps billing to; Topaz publishes no Hyperion-specific limit, so that is our conservative choice, and it fails in `_build_payload` before the upload rather than after.

## Testing

- `tests/unit/video/test_topaz_video_convert_hdr.py` — 39 tests: payload shape, format→encoder/profile/container mapping, output resolution and the per-encoder size ceiling, frame-count derivation and cap, "rejected input is never uploaded", the two advisories, filename tracking the container (and never clobbering a user-typed one), and the `_parse_result` binary-vs-`download.url` split
- `tests/unit` — 945 passed, 11 skipped
- `make check` — clean

Not yet run end to end. The acceptance criterion is `ffprobe -show_streams` on the output reporting `color_transfer=smpte2084` and `color_primaries=bt2020` — that is what distinguishes real HDR from a wide container holding SDR content, and it needs a live key and a paid job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)